### PR TITLE
feat: update Spring AI dependency to 1.0.0-M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<spring-boot.version>3.3.3</spring-boot.version>
 
 		<!-- Spring AI -->
-		<spring-ai.version>1.0.0-M2</spring-ai.version>
+		<spring-ai.version>1.0.0-M3</spring-ai.version>
 		<dashscope-sdk-java.version>2.15.1</dashscope-sdk-java.version>
 
 		<!-- plugin versions -->

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
@@ -16,17 +16,20 @@
 
 package com.alibaba.cloud.ai.advisor;
 
-import org.springframework.ai.chat.client.AdvisedRequest;
-import org.springframework.ai.chat.client.RequestResponseAdvisor;
+import org.springframework.ai.chat.client.advisor.api.*;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentRetriever;
 import org.springframework.ai.model.Content;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -37,7 +40,7 @@ import java.util.stream.Collectors;
  * @since 1.0.0-M2
  */
 
-public class DocumentRetrievalAdvisor implements RequestResponseAdvisor {
+public class DocumentRetrievalAdvisor implements CallAroundAdvisor, StreamAroundAdvisor {
 
 	private static final String DEFAULT_USER_TEXT_ADVISE = """
 			请记住以下材料，他们可能对回答问题有帮助。
@@ -46,24 +49,85 @@ public class DocumentRetrievalAdvisor implements RequestResponseAdvisor {
 			---------------------
 			""";
 
+	private static final int DEFAULT_ORDER = 0;
+
 	public static String RETRIEVED_DOCUMENTS = "documents";
 
 	private final DocumentRetriever retriever;
 
 	private final String userTextAdvise;
 
+	private final boolean protectFromBlocking;
+
+	private final int order;
+
 	public DocumentRetrievalAdvisor(DocumentRetriever retriever) {
-		this.retriever = retriever;
-		this.userTextAdvise = DEFAULT_USER_TEXT_ADVISE;
+		this(retriever, DEFAULT_USER_TEXT_ADVISE);
 	}
 
 	public DocumentRetrievalAdvisor(DocumentRetriever retriever, String userTextAdvise) {
+		this(retriever, userTextAdvise, true);
+	}
+
+	public DocumentRetrievalAdvisor(DocumentRetriever retriever, String userTextAdvise, boolean protectFromBlocking) {
+		this(retriever, userTextAdvise, protectFromBlocking, DEFAULT_ORDER);
+	}
+
+	public DocumentRetrievalAdvisor(DocumentRetriever retriever, String userTextAdvise, boolean protectFromBlocking,
+			int order) {
 		this.retriever = retriever;
 		this.userTextAdvise = userTextAdvise;
+		this.protectFromBlocking = protectFromBlocking;
+		this.order = order;
 	}
 
 	@Override
-	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
+	public AdvisedResponse aroundCall(AdvisedRequest advisedRequest, CallAroundAdvisorChain chain) {
+
+		advisedRequest = this.before(advisedRequest);
+
+		AdvisedResponse advisedResponse = chain.nextAroundCall(advisedRequest);
+
+		return this.after(advisedResponse);
+	}
+
+	@Override
+	public Flux<AdvisedResponse> aroundStream(AdvisedRequest advisedRequest, StreamAroundAdvisorChain chain) {
+
+		// This can be executed by both blocking and non-blocking Threads
+		// E.g. a command line or Tomcat blocking Thread implementation
+		// or by a WebFlux dispatch in a non-blocking manner.
+		Flux<AdvisedResponse> advisedResponses = (this.protectFromBlocking) ?
+		// @formatter:off
+				Mono.just(advisedRequest)
+						.publishOn(Schedulers.boundedElastic())
+						.map(this::before)
+						.flatMapMany(request -> chain.nextAroundStream(request))
+				: chain.nextAroundStream(this.before(advisedRequest));
+		// @formatter:on
+
+		return advisedResponses.map(ar -> {
+			if (onFinishReason().test(ar)) {
+				ar = after(ar);
+			}
+			return ar;
+		});
+	}
+
+	@Override
+	public String getName() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	private AdvisedRequest before(AdvisedRequest request) {
+
+		var context = new HashMap<>(request.adviseContext());
+
 		List<Document> documents = retriever.retrieve(request.userText());
 
 		context.put(RETRIEVED_DOCUMENTS, documents);
@@ -79,21 +143,35 @@ public class DocumentRetrievalAdvisor implements RequestResponseAdvisor {
 			.withSystemText(this.userTextAdvise)
 			.withSystemParams(advisedUserParams)
 			.withUserText(request.userText())
+			.withAdviseContext(context)
 			.build();
 	}
 
-	@Override
-	public ChatResponse adviseResponse(ChatResponse response, Map<String, Object> context) {
-		ChatResponse.Builder chatResponseBuilder = ChatResponse.builder().from(response);
-		return chatResponseBuilder.withMetadata(RETRIEVED_DOCUMENTS, context.get(RETRIEVED_DOCUMENTS)).build();
+	private AdvisedResponse after(AdvisedResponse advisedResponse) {
+		ChatResponse.Builder chatResponseBuilder = ChatResponse.builder()
+			.from(advisedResponse.response())
+			.withMetadata(RETRIEVED_DOCUMENTS, advisedResponse.adviseContext().get(RETRIEVED_DOCUMENTS));
+		return new AdvisedResponse(chatResponseBuilder.build(), advisedResponse.adviseContext());
 	}
 
-	@Override
-	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxResponse, Map<String, Object> context) {
-		return fluxResponse.map(cr -> {
-			ChatResponse.Builder chatResponseBuilder = ChatResponse.builder().from(cr);
-			return chatResponseBuilder.withMetadata(RETRIEVED_DOCUMENTS, context.get(RETRIEVED_DOCUMENTS)).build();
-		});
+	/**
+	 * Controls whether {@link DocumentRetrievalAdvisor#after(AdvisedResponse)} should be
+	 * executed.<br />
+	 * Called only on Flux elements that contain a finish reason. Usually the last element
+	 * in the Flux. The response advisor can modify the elements before they are returned
+	 * to the client.<br />
+	 * Inspired by
+	 * {@link org.springframework.ai.chat.client.advisor.QuestionAnswerAdvisor}.
+	 */
+	private Predicate<AdvisedResponse> onFinishReason() {
+
+		return (advisedResponse) -> advisedResponse.response()
+			.getResults()
+			.stream()
+			.filter(result -> result != null && result.getMetadata() != null
+					&& StringUtils.hasText(result.getMetadata().getFinishReason()))
+			.findFirst()
+			.isPresent();
 	}
 
 }

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/RetrievalRerankAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/RetrievalRerankAdvisor.java
@@ -21,8 +21,7 @@ import com.alibaba.cloud.ai.model.RerankModel;
 import com.alibaba.cloud.ai.model.RerankResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.chat.client.AdvisedRequest;
-import org.springframework.ai.chat.client.RequestResponseAdvisor;
+import org.springframework.ai.chat.client.advisor.api.*;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.model.Content;
@@ -34,8 +33,11 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
@@ -48,7 +50,7 @@ import static java.util.stream.Collectors.toList;
  * @since 1.0.0-M2
  */
 
-public class RetrievalRerankAdvisor implements RequestResponseAdvisor {
+public class RetrievalRerankAdvisor implements CallAroundAdvisor, StreamAroundAdvisor {
 
 	private static final Logger logger = LoggerFactory.getLogger(RetrievalRerankAdvisor.class);
 
@@ -64,6 +66,8 @@ public class RetrievalRerankAdvisor implements RequestResponseAdvisor {
 
 	private static final Double DEFAULT_MIN_SCORE = 0.1;
 
+	private static final int DEFAULT_ORDER = 0;
+
 	private final VectorStore vectorStore;
 
 	private final RerankModel rerankModel;
@@ -73,6 +77,10 @@ public class RetrievalRerankAdvisor implements RequestResponseAdvisor {
 	private final SearchRequest searchRequest;
 
 	private final Double minScore;
+
+	private final boolean protectFromBlocking;
+
+	private final int order;
 
 	public static final String RETRIEVED_DOCUMENTS = "qa_retrieved_documents";
 
@@ -94,6 +102,16 @@ public class RetrievalRerankAdvisor implements RequestResponseAdvisor {
 
 	public RetrievalRerankAdvisor(VectorStore vectorStore, RerankModel rerankModel, SearchRequest searchRequest,
 			String userTextAdvise, Double minScore) {
+		this(vectorStore, rerankModel, searchRequest, userTextAdvise, minScore, true);
+	}
+
+	public RetrievalRerankAdvisor(VectorStore vectorStore, RerankModel rerankModel, SearchRequest searchRequest,
+			String userTextAdvise, Double minScore, boolean protectFromBlocking) {
+		this(vectorStore, rerankModel, searchRequest, userTextAdvise, minScore, protectFromBlocking, DEFAULT_ORDER);
+	}
+
+	public RetrievalRerankAdvisor(VectorStore vectorStore, RerankModel rerankModel, SearchRequest searchRequest,
+			String userTextAdvise, Double minScore, boolean protectFromBlocking, int order) {
 		Assert.notNull(vectorStore, "The vectorStore must not be null!");
 		Assert.notNull(rerankModel, "The rerankModel must not be null!");
 		Assert.notNull(searchRequest, "The searchRequest must not be null!");
@@ -104,53 +122,51 @@ public class RetrievalRerankAdvisor implements RequestResponseAdvisor {
 		this.userTextAdvise = userTextAdvise;
 		this.searchRequest = searchRequest;
 		this.minScore = minScore;
+		this.protectFromBlocking = protectFromBlocking;
+		this.order = order;
 	}
 
 	@Override
-	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
-		// 1. Advise the system text.
-		String advisedUserText = request.userText() + System.lineSeparator() + this.userTextAdvise;
+	public AdvisedResponse aroundCall(AdvisedRequest advisedRequest, CallAroundAdvisorChain chain) {
 
-		var searchRequestToUse = SearchRequest.from(this.searchRequest)
-			.withQuery(request.userText())
-			.withFilterExpression(doGetFilterExpression(context));
+		advisedRequest = this.before(advisedRequest);
 
-		// 2. Search for similar documents in the vector store.
-		logger.debug("searchRequestToUse: {}", searchRequestToUse);
-		List<Document> documents = this.vectorStore.similaritySearch(searchRequestToUse);
-		logger.debug("retrieved documents: {}", documents);
+		AdvisedResponse advisedResponse = chain.nextAroundCall(advisedRequest);
 
-		// 3. Rerank documents for query
-		documents = doRerank(request, documents);
-
-		context.put(RETRIEVED_DOCUMENTS, documents);
-
-		// 4. Create the context from the documents.
-		String documentContext = documents.stream()
-			.map(Content::getContent)
-			.collect(Collectors.joining(System.lineSeparator()));
-
-		// 5. Advise the user parameters.
-		Map<String, Object> advisedUserParams = new HashMap<>(request.userParams());
-		advisedUserParams.put("question_answer_context", documentContext);
-
-		return AdvisedRequest.from(request).withUserText(advisedUserText).withUserParams(advisedUserParams).build();
+		return this.after(advisedResponse);
 	}
 
 	@Override
-	public ChatResponse adviseResponse(ChatResponse response, Map<String, Object> context) {
-		ChatResponse.Builder chatResponseBuilder = ChatResponse.builder().from(response);
-		chatResponseBuilder.withMetadata(RETRIEVED_DOCUMENTS, context.get(RETRIEVED_DOCUMENTS));
-		return chatResponseBuilder.build();
-	}
+	public Flux<AdvisedResponse> aroundStream(AdvisedRequest advisedRequest, StreamAroundAdvisorChain chain) {
 
-	@Override
-	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxResponse, Map<String, Object> context) {
-		return fluxResponse.map(cr -> {
-			ChatResponse.Builder chatResponseBuilder = ChatResponse.builder().from(cr);
-			chatResponseBuilder.withMetadata(RETRIEVED_DOCUMENTS, context.get(RETRIEVED_DOCUMENTS));
-			return chatResponseBuilder.build();
+		// This can be executed by both blocking and non-blocking Threads
+		// E.g. a command line or Tomcat blocking Thread implementation
+		// or by a WebFlux dispatch in a non-blocking manner.
+		Flux<AdvisedResponse> advisedResponses = (this.protectFromBlocking) ?
+		// @formatter:off
+				Mono.just(advisedRequest)
+						.publishOn(Schedulers.boundedElastic())
+						.map(this::before)
+						.flatMapMany(request -> chain.nextAroundStream(request))
+				: chain.nextAroundStream(this.before(advisedRequest));
+		// @formatter:on
+
+		return advisedResponses.map(ar -> {
+			if (onFinishReason().test(ar)) {
+				ar = after(ar);
+			}
+			return ar;
 		});
+	}
+
+	@Override
+	public String getName() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
 	}
 
 	protected Filter.Expression doGetFilterExpression(Map<String, Object> context) {
@@ -180,6 +196,70 @@ public class RetrievalRerankAdvisor implements RequestResponseAdvisor {
 			.sorted(Comparator.comparingDouble(DocumentWithScore::getScore).reversed())
 			.map(DocumentWithScore::getDocument)
 			.collect(toList());
+	}
+
+	private AdvisedRequest before(AdvisedRequest request) {
+
+		var context = new HashMap<>(request.adviseContext());
+
+		// 1. Advise the system text.
+		String advisedUserText = request.userText() + System.lineSeparator() + this.userTextAdvise;
+
+		var searchRequestToUse = SearchRequest.from(this.searchRequest)
+			.withQuery(request.userText())
+			.withFilterExpression(doGetFilterExpression(context));
+
+		// 2. Search for similar documents in the vector store.
+		logger.debug("searchRequestToUse: {}", searchRequestToUse);
+		List<Document> documents = this.vectorStore.similaritySearch(searchRequestToUse);
+		logger.debug("retrieved documents: {}", documents);
+
+		// 3. Rerank documents for query
+		documents = doRerank(request, documents);
+
+		context.put(RETRIEVED_DOCUMENTS, documents);
+
+		// 4. Create the context from the documents.
+		String documentContext = documents.stream()
+			.map(Content::getContent)
+			.collect(Collectors.joining(System.lineSeparator()));
+
+		// 5. Advise the user parameters.
+		Map<String, Object> advisedUserParams = new HashMap<>(request.userParams());
+		advisedUserParams.put("question_answer_context", documentContext);
+
+		return AdvisedRequest.from(request)
+			.withUserText(advisedUserText)
+			.withUserParams(advisedUserParams)
+			.withAdviseContext(context)
+			.build();
+	}
+
+	private AdvisedResponse after(AdvisedResponse advisedResponse) {
+		ChatResponse.Builder chatResponseBuilder = ChatResponse.builder()
+			.from(advisedResponse.response())
+			.withMetadata(RETRIEVED_DOCUMENTS, advisedResponse.adviseContext().get(RETRIEVED_DOCUMENTS));
+		return new AdvisedResponse(chatResponseBuilder.build(), advisedResponse.adviseContext());
+	}
+
+	/**
+	 * Controls whether {@link RetrievalRerankAdvisor#after(AdvisedResponse)} should be
+	 * executed.<br />
+	 * Called only on Flux elements that contain a finish reason. Usually the last element
+	 * in the Flux. The response advisor can modify the elements before they are returned
+	 * to the client.<br />
+	 * Inspired by
+	 * {@link org.springframework.ai.chat.client.advisor.QuestionAnswerAdvisor}.
+	 */
+	private Predicate<AdvisedResponse> onFinishReason() {
+
+		return (advisedResponse) -> advisedResponse.response()
+			.getResults()
+			.stream()
+			.filter(result -> result != null && result.getMetadata() != null
+					&& StringUtils.hasText(result.getMetadata().getFinishReason()))
+			.findFirst()
+			.isPresent();
 	}
 
 }

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
@@ -45,7 +45,7 @@ public class DashScopeChatProperties extends DashScopeParentProperties {
 	/**
 	 * Default temperature speed.
 	 */
-	private static final Float DEFAULT_TEMPERATURE = 0.8f;
+	private static final Double DEFAULT_TEMPERATURE = 0.8d;
 
 	/**
 	 * Enable Dashscope ai chat client.

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/agent/DashScopeAgentOptions.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/agent/DashScopeAgentOptions.java
@@ -48,7 +48,7 @@ public class DashScopeAgentOptions implements ChatOptions {
 	}
 
 	@Override
-	public Float getFrequencyPenalty() {
+	public Double getFrequencyPenalty() {
 		return null;
 	}
 
@@ -58,7 +58,7 @@ public class DashScopeAgentOptions implements ChatOptions {
 	}
 
 	@Override
-	public Float getPresencePenalty() {
+	public Double getPresencePenalty() {
 		return null;
 	}
 
@@ -68,13 +68,13 @@ public class DashScopeAgentOptions implements ChatOptions {
 	}
 
 	@Override
-	public Float getTemperature() {
-		return 0f;
+	public Double getTemperature() {
+		return 0d;
 	}
 
 	@Override
-	public Float getTopP() {
-		return 0f;
+	public Double getTopP() {
+		return 0d;
 	}
 
 	@Override

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -853,9 +853,9 @@ public class DashScopeApi {
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public record ChatCompletionRequestParameter(@JsonProperty("result_format") String resultFormat,
 			@JsonProperty("seed") Integer seed, @JsonProperty("max_tokens") Integer maxTokens,
-			@JsonProperty("top_p") Float topP, @JsonProperty("top_k") Integer topK,
-			@JsonProperty("repetition_penalty") Float repetitionPenalty,
-			@JsonProperty("presence_penalty") Float presencePenalty, @JsonProperty("temperature") Float temperature,
+			@JsonProperty("top_p") Double topP, @JsonProperty("top_k") Integer topK,
+			@JsonProperty("repetition_penalty") Double repetitionPenalty,
+			@JsonProperty("presence_penalty") Double presencePenalty, @JsonProperty("temperature") Double temperature,
 			@JsonProperty("stop") List<Object> stop, @JsonProperty("enable_search") Boolean enableSearch,
 			@JsonProperty("incremental_output") Boolean incrementalOutput,
 			@JsonProperty("tools") List<FunctionTool> tools, @JsonProperty("tool_choice") Object toolChoice,

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -67,7 +67,7 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 		this(dashscopeApi,
 				DashScopeChatOptions.builder()
 					.withModel(DashScopeApi.DEFAULT_CHAT_MODEL)
-					.withTemperature(0.7f)
+					.withTemperature(0.7d)
 					.build());
 	}
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -1,9 +1,6 @@
 package com.alibaba.cloud.ai.dashscope.chat;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -33,7 +30,7 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
    * 用于控制随机性和多样性的程度。具体来说，temperature值控制了生成文本时对每个候选词的概率分布进行平滑的程度。较高的temperature值会降低概率分布的峰值，使得更多的低概率词被选择，生成结果更加多样化；而较低的temperature值则会增强概率分布的峰值，使得高概率词更容易被选择，生成结果更加确定。
    * 取值范围：[0, 2)，系统默认值0.85。不建议取值为0，无意义。
    */
-  private @JsonProperty("temperature") Float temperature;
+  private @JsonProperty("temperature") Double temperature;
 
   /**
    * 生成时使用的随机数种子，用户控制模型生成内容的随机性。seed支持无符号64位整数。在使用seed时，模型将尽可能生成相同或相似的结果，但目前不保证每次生成的结果完全相同。
@@ -43,7 +40,7 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   /**
    * 生成时，核采样方法的概率阈值。例如，取值为0.8时，仅保留累计概率之和大于等于0.8的概率分布中的token，作为随机采样的候选集。取值范围为（0,1.0)，取值越大，生成的随机性越高；取值越低，生成的随机性越低。默认值为0.8。注意，取值不要大于等于1
    */
-  private @JsonProperty("top_p") Float topP;
+  private @JsonProperty("top_p") Double topP;
 
   /**
    * 生成时，采样候选集的大小。例如，取值为50时，仅将单次生成中得分最高的50个token组成随机采样的候选集。取值越大，生成的随机性越高；取值越小，生成的确定性越高。注意：如果top_k参数为空或者top_k的值大于100，表示不启用top_k策略，此时仅有top_p策略生效，默认是空。
@@ -77,7 +74,7 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   private @JsonProperty("incremental_output") Boolean incrementalOutput = true;
 
   /** 用于控制模型生成时的重复度。提高repetition_penalty时可以降低模型生成的重复度。1.0表示不做惩罚。默认为1.1。 */
-  private @JsonProperty("repetition_penalty") Float repetitionPenalty;
+  private @JsonProperty("repetition_penalty") Double repetitionPenalty;
 
   /** 模型可选调用的工具列表。目前仅支持function，并且即使输入多个function，模型仅会选择其中一个生成结果。模型根据tools参数内容可以生产函数调用的参数 */
   private @JsonProperty("tools") List<DashScopeApi.FunctionTool> tools;
@@ -113,13 +110,17 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
    */
   @NestedConfigurationProperty @JsonIgnore private Set<String> functions = new HashSet<>();
 
+  @NestedConfigurationProperty
+  @JsonIgnore
+  private Map<String, Object> toolContext;
+
   public String getModel() {
     return model;
-  }@Override public Float getFrequencyPenalty() {
+  }@Override public Double getFrequencyPenalty() {
     return null;
     }@Override public Integer getMaxTokens() {
     return null;
-    }@Override public Float getPresencePenalty() {
+    }@Override public Double getPresencePenalty() {
     return null;
     }@Override public List<String> getStopSequences() {
     return null;
@@ -138,22 +139,22 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   }
 
   @Override
-  public Float getTemperature() {
+  public Double getTemperature() {
     return this.temperature;
   }
 
-  public void setTemperature(Float temperature) {
+  public void setTemperature(Double temperature) {
     this.temperature = temperature;
   }
 
   @Override
-  public Float getTopP() {
+  public Double getTopP() {
     return this.topP;
   }@Override public ChatOptions copy() {
     return DashScopeChatOptions.fromOptions(this);
     }
 
-  public void setTopP(Float topP) {
+  public void setTopP(Double topP) {
     this.topP = topP;
   }
 
@@ -182,11 +183,11 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
     this.enableSearch = enableSearch;
   }
 
-  public Float getRepetitionPenalty() {
+  public Double getRepetitionPenalty() {
     return repetitionPenalty;
   }
 
-  public void setRepetitionPenalty(Float repetitionPenalty) {
+  public void setRepetitionPenalty(Double repetitionPenalty) {
     this.repetitionPenalty = repetitionPenalty;
   }
 
@@ -234,11 +235,25 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
     this.functions = functions;
   }
 
+  @Override
+  public Map<String,Object> getToolContext() {
+    return this.toolContext;
+  }
+
+  @Override
+  public void setToolContext(Map<String,Object> toolContext) {
+    this.toolContext = toolContext;
+  }
+
   public Boolean getIncrementalOutput() {
     return incrementalOutput;
-}public void setIncrementalOutput(Boolean incrementalOutput) {
+  }
+
+  public void setIncrementalOutput(Boolean incrementalOutput) {
     this.incrementalOutput = incrementalOutput;
-}public static DashscopeChatOptionsBuilder builder() {
+  }
+
+  public static DashscopeChatOptionsBuilder builder() {
     return new DashscopeChatOptionsBuilder();
   }
 
@@ -254,12 +269,12 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
       return this;
     }
 
-    public DashscopeChatOptionsBuilder withTemperature(Float temperature) {
+    public DashscopeChatOptionsBuilder withTemperature(Double temperature) {
       this.options.temperature = temperature;
       return this;
     }
 
-    public DashscopeChatOptionsBuilder withTopP(Float topP) {
+    public DashscopeChatOptionsBuilder withTopP(Double topP) {
       this.options.topP = topP;
       return this;
     }
@@ -279,7 +294,7 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
       return this;
     }
 
-    public DashscopeChatOptionsBuilder withRepetitionPenalty(Float repetitionPenalty) {
+    public DashscopeChatOptionsBuilder withRepetitionPenalty(Double repetitionPenalty) {
       this.options.repetitionPenalty = repetitionPenalty;
       return this;
     }
@@ -327,6 +342,16 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
       return this;
     }
 
+    public DashscopeChatOptionsBuilder withToolContext(Map<String, Object> toolContext) {
+      if (this.options.toolContext == null) {
+        this.options.toolContext = toolContext;
+      }
+      else {
+        this.options.toolContext.putAll(toolContext);
+      }
+      return this;
+    }
+
     public DashScopeChatOptions build() {
       return this.options;
     }
@@ -346,6 +371,7 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
         .withFunctions(fromOptions.getFunctions())
         .withRepetitionPenalty(fromOptions.getRepetitionPenalty())
         .withTools(fromOptions.getTools())
+        .withToolContext(fromOptions.getToolContext())
         .build();
   }
 }

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/evaluation/LaajEvaluator.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/evaluation/LaajEvaluator.java
@@ -67,7 +67,7 @@ public abstract class LaajEvaluator implements Evaluator {
 		return evaluationRequest.getResponseContent();
 	}
 
-	protected String doGetSupportingData(EvaluationRequest evaluationRequest) {
+	public String doGetSupportingData(EvaluationRequest evaluationRequest) {
 		List<Content> data = evaluationRequest.getDataList();
 		return data.stream()
 			.filter(node -> node != null && node.getContent() != null)


### PR DESCRIPTION
### Describe what this PR does / why we need it
Update Spring AI dependency to 1.0.0-M3 and refactor the expired implementations of some components.

### Does this pull request fix one issue?

NONE

### Describe how you did it
1. Update dependency in pom.xml.
2. Replace the implementation interfaces of `DocumentRetrievalAdvisor`, `RetrievalRerankAdvisor`, and `DashScopeDocumentRetrievalAdvisor` with `CallAroundAdvisor` and `StreamAroundAdvisor` to substitute the deprecated `RequestResponseAdvisor`.
3. Replace the `Float` fields in `ModelOptions` with `Double`, according to [related issue](https://github.com/spring-projects/spring-ai/issues/712).