### PR TITLE
feat: add DashScopeChatModel call and stream observability

### DIFF
--- a/spring-ai-alibaba-core/pom.xml
+++ b/spring-ai-alibaba-core/pom.xml
@@ -105,6 +105,12 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -150,7 +150,11 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 						return buildGeneration(choice, metadata);
 					}).toList();
 
-					return new ChatResponse(generations, from(completionEntity.getBody()));
+					ChatResponse response = new ChatResponse(generations, from(completionEntity.getBody()));
+
+					observationContext.setResponse(response);
+
+					return response;
 				});
 
 		if (isToolCall(chatResponse,

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+import com.alibaba.cloud.ai.dashscope.chat.observation.DashScopeChatModelObservationConvention;
 import com.alibaba.cloud.ai.dashscope.metadata.DashScopeAiUsage;
 import com.alibaba.cloud.ai.observation.conventions.AiProvider;
 import io.micrometer.observation.Observation;
@@ -21,7 +22,6 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.observation.ChatModelObservationContext;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
-import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
 import reactor.core.publisher.Flux;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi.*;
@@ -61,7 +61,7 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 
 	private static final Logger logger = LoggerFactory.getLogger(DashScopeChatModel.class);
 
-	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
+	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DashScopeChatModelObservationConvention();
 
 	/** Low-level access to the DashScope API */
 	private final DashScopeApi dashscopeApi;

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -10,8 +10,18 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.metadata.DashScopeAiUsage;
+import com.alibaba.cloud.ai.observation.conventions.AiProvider;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.model.*;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.chat.observation.ChatModelObservationConvention;
+import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
 import reactor.core.publisher.Flux;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi.*;
@@ -25,10 +35,6 @@ import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
-import org.springframework.ai.chat.model.AbstractToolCallSupport;
-import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.ModelOptionsUtils;
@@ -55,14 +61,26 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 
 	private static final Logger logger = LoggerFactory.getLogger(DashScopeChatModel.class);
 
+	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
+
 	/** Low-level access to the DashScope API */
 	private final DashScopeApi dashscopeApi;
 
 	/** The retry template used to retry the OpenAI API calls. */
 	public final RetryTemplate retryTemplate;
 
+	/**
+	 * Observation registry used for instrumentation.
+	 */
+	private final ObservationRegistry observationRegistry;
+
 	/** The default options used for the chat completion requests. */
 	private DashScopeChatOptions defaultOptions;
+
+	/**
+	 * Conventions to use for generating observations.
+	 */
+	private ChatModelObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
 
 	public DashScopeChatModel(DashScopeApi dashscopeApi) {
 		this(dashscopeApi,
@@ -77,7 +95,13 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 	}
 
 	public DashScopeChatModel(DashScopeApi dashscopeApi, DashScopeChatOptions options,
-			FunctionCallbackContext functionCallbackContext, RetryTemplate retryTemplate) {
+							  FunctionCallbackContext functionCallbackContext, RetryTemplate retryTemplate) {
+		this(dashscopeApi, options, functionCallbackContext, retryTemplate, ObservationRegistry.NOOP);
+	}
+
+	public DashScopeChatModel(DashScopeApi dashscopeApi, DashScopeChatOptions options,
+			FunctionCallbackContext functionCallbackContext, RetryTemplate retryTemplate,
+							  ObservationRegistry observationRegistry) {
 		super(functionCallbackContext);
 		Assert.notNull(dashscopeApi, "DashScopeApi must not be null");
 		Assert.notNull(options, "Options must not be null");
@@ -86,35 +110,48 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 		this.dashscopeApi = dashscopeApi;
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
+		this.observationRegistry = observationRegistry;
 	}
 
 	@Override
 	public ChatResponse call(Prompt prompt) {
-		DashScopeApi.ChatCompletionRequest request = createRequest(prompt, false);
 
-		ResponseEntity<ChatCompletion> completionEntity = this.retryTemplate
-			.execute(ctx -> this.dashscopeApi.chatCompletionEntity(request));
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+				.prompt(prompt)
+				.provider(AiProvider.DASHSCOPE.value())
+				.requestOptions(prompt.getOptions() != null ? prompt.getOptions() : this.defaultOptions)
+				.build();
 
-		var chatCompletion = completionEntity.getBody();
+		ChatResponse chatResponse = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION
+				.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
+						this.observationRegistry)
+				.observe(() -> {
+					DashScopeApi.ChatCompletionRequest request = createRequest(prompt, false);
 
-		if (chatCompletion == null) {
-			logger.warn("No chat completion returned for prompt: {}", prompt);
-			return new ChatResponse(List.of());
-		}
+					ResponseEntity<ChatCompletion> completionEntity = this.retryTemplate
+							.execute(ctx -> this.dashscopeApi.chatCompletionEntity(request));
 
-		List<ChatCompletionOutput.Choice> choices = chatCompletion.output().choices();
+					var chatCompletion = completionEntity.getBody();
 
-		List<Generation> generations = choices.stream().map(choice -> {
-			// @formatter:off
-			Map<String, Object> metadata = Map.of(
-					"id", chatCompletion.requestId(),
-					"role", choice.message().role() != null ? choice.message().role().name() : "",
-					"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "");
-			// @formatter:on
-			return buildGeneration(choice, metadata);
-		}).toList();
+					if (chatCompletion == null) {
+						logger.warn("No chat completion returned for prompt: {}", prompt);
+						return new ChatResponse(List.of());
+					}
 
-		ChatResponse chatResponse = new ChatResponse(generations, from(completionEntity.getBody()));
+					List<ChatCompletionOutput.Choice> choices = chatCompletion.output().choices();
+
+					List<Generation> generations = choices.stream().map(choice -> {
+						// @formatter:off
+						Map<String, Object> metadata = Map.of(
+								"id", chatCompletion.requestId(),
+								"role", choice.message().role() != null ? choice.message().role().name() : "",
+								"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "");
+						// @formatter:on
+						return buildGeneration(choice, metadata);
+					}).toList();
+
+					return new ChatResponse(generations, from(completionEntity.getBody()));
+				});
 
 		if (isToolCall(chatResponse,
 				Set.of(ChatCompletionFinishReason.TOOL_CALLS.name(), ChatCompletionFinishReason.STOP.name()))) {
@@ -134,62 +171,81 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 
 	@Override
 	public Flux<ChatResponse> stream(Prompt prompt) {
-		ChatCompletionRequest request = createRequest(prompt, true);
 
-		Flux<ChatCompletionChunk> completionChunks = this.retryTemplate
-			.execute(ctx -> this.dashscopeApi.chatCompletionStream(request));
+		return Flux.deferContextual(contextView -> {
+			ChatCompletionRequest request = createRequest(prompt, true);
 
-		// For chunked responses, only the first chunk contains the choice role.
-		// The rest of the chunks with same ID share the same role.
-		ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
+			Flux<ChatCompletionChunk> completionChunks = this.retryTemplate
+					.execute(ctx -> this.dashscopeApi.chatCompletionStream(request));
 
-		// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
-		// the function call handling logic.
-		Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
-			.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
-				try {
-					@SuppressWarnings("null")
-					String requestId = chatCompletion2.requestId();
+			// For chunked responses, only the first chunk contains the choice role.
+			// The rest of the chunks with same ID share the same role.
+			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
+
+			ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+					.prompt(prompt)
+					.provider(AiProvider.DASHSCOPE.value())
+					.requestOptions(prompt.getOptions() != null ? prompt.getOptions() : this.defaultOptions)
+					.build();
+
+			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(
+					this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
+					this.observationRegistry);
+
+			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
+
+			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
+			// the function call handling logic.
+			Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
+					.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+						try {
+							@SuppressWarnings("null")
+							String requestId = chatCompletion2.requestId();
+
+							// @formatter:off
+							List<Generation> generations = chatCompletion2.output().choices().stream().map(choice -> {
+								if (choice.message().role() != null) {
+									roleMap.putIfAbsent(requestId, choice.message().role().name());
+								}
+								Map<String, Object> metadata = Map.of(
+										"id", chatCompletion2.requestId(),
+										"role", roleMap.getOrDefault(requestId, ""),
+										"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "");
+								return buildGeneration(choice, metadata);
+							}).toList();
+							// @formatter:on
+
+							if (chatCompletion2.usage() != null) {
+								return new ChatResponse(generations, from(chatCompletion2));
+							} else {
+								return new ChatResponse(generations);
+							}
+						} catch (Exception e) {
+							logger.error("Error processing chat completion", e);
+							return new ChatResponse(List.of());
+						}
+
+					}));
 
 			// @formatter:off
-						List<Generation> generations = chatCompletion2.output().choices().stream().map(choice -> {
-							if (choice.message().role() != null) {
-								roleMap.putIfAbsent(requestId, choice.message().role().name());
-							}
-							Map<String, Object> metadata = Map.of(
-									"id", chatCompletion2.requestId(),
-									"role", roleMap.getOrDefault(requestId, ""),
-									"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "");
-							return buildGeneration(choice, metadata);
-						}).toList();
-						// @formatter:on
+			Flux<ChatResponse> flux = chatResponse.flatMap(response -> {
 
-					if (chatCompletion2.usage() != null) {
-						return new ChatResponse(generations, from(chatCompletion2));
-					}
-					else {
-						return new ChatResponse(generations);
-					}
+				if (isToolCall(response,
+						Set.of(ChatCompletionFinishReason.TOOL_CALLS.name(), ChatCompletionFinishReason.STOP.name()))) {
+					var toolCallConversation = handleToolCalls(prompt, response);
+					// Recursively call the stream method with the tool call message
+					// conversation that contains the call responses.
+					return this.stream(new Prompt(toolCallConversation, prompt.getOptions()));
 				}
-				catch (Exception e) {
-					logger.error("Error processing chat completion", e);
-					return new ChatResponse(List.of());
+				else {
+					return Flux.just(response);
 				}
+			})
+			.doOnError(observation::error)
+			.doFinally(s -> observation.stop())
+			.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 
-			}));
-
-		return chatResponse.flatMap(response -> {
-
-			if (isToolCall(response,
-					Set.of(ChatCompletionFinishReason.TOOL_CALLS.name(), ChatCompletionFinishReason.STOP.name()))) {
-				var toolCallConversation = handleToolCalls(prompt, response);
-				// Recursively call the stream method with the tool call message
-				// conversation that contains the call responses.
-				return this.stream(new Prompt(toolCallConversation, prompt.getOptions()));
-			}
-			else {
-				return Flux.just(response);
-			}
+			return new MessageAggregator().aggregate(flux, observationContext::setResponse);
 		});
 	}
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -125,17 +125,30 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   @JsonIgnore
   private Map<String, Object> toolContext;
 
+  @Override
   public String getModel() {
     return model;
-  }@Override public Double getFrequencyPenalty() {
+  }
+
+  @Override
+  public Double getFrequencyPenalty() {
     return null;
-    }@Override public Integer getMaxTokens() {
+  }
+
+  @Override
+  public Integer getMaxTokens() {
     return null;
-    }@Override public Double getPresencePenalty() {
+  }
+
+  @Override
+  public Double getPresencePenalty() {
     return null;
-    }@Override public List<String> getStopSequences() {
+  }
+
+  @Override
+  public List<String> getStopSequences() {
     return null;
-    }
+  }
 
   public void setModel(String model) {
     this.model = model;
@@ -161,9 +174,12 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   @Override
   public Double getTopP() {
     return this.topP;
-  }@Override public ChatOptions copy() {
+  }
+
+  @Override
+  public ChatOptions copy() {
     return DashScopeChatOptions.fromOptions(this);
-    }
+  }
 
   public void setTopP(Double topP) {
     this.topP = topP;
@@ -264,7 +280,7 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
     this.incrementalOutput = incrementalOutput;
   }
 
-  public Boolean   getVlHighResolutionImages() {
+  public Boolean getVlHighResolutionImages() {
     return vlHighResolutionImages;
   }
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/observation/DashScopeChatModelObservationConvention.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/observation/DashScopeChatModelObservationConvention.java
@@ -51,13 +51,14 @@ public class DashScopeChatModelObservationConvention extends DefaultChatModelObs
 			if (CollectionUtils.isEmpty(stop)) {
 				return keyValues;
 			}
-			KeyValue.of(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES,
-					stop, Objects::nonNull);
+			KeyValue.of(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES, stop,
+					Objects::nonNull);
 
 			String stopSequences;
 			try {
 				stopSequences = JSON.toJSONString(stop);
-			} catch (Exception e) {
+			}
+			catch (Exception e) {
 				stopSequences = ILLEGAL_STOP_CONTENT;
 			}
 			return keyValues.and(

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/observation/DashScopeChatModelObservationConvention.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/observation/DashScopeChatModelObservationConvention.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dashscope.chat.observation;
+
+import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
+import com.alibaba.fastjson.JSON;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
+import org.springframework.util.CollectionUtils;
+
+import java.util.*;
+
+/**
+ * Dashscope conventions to populate observations for chat model operations.
+ *
+ * @author Lumian
+ * @since 1.0.0
+ */
+public class DashScopeChatModelObservationConvention extends DefaultChatModelObservationConvention {
+
+	public static final String DEFAULT_NAME = "gen_ai.client.operation";
+
+	private static final String ILLEGAL_STOP_CONTENT = "<illegal_stop_content>";
+
+	@Override
+	public String getName() {
+		return DEFAULT_NAME;
+	}
+
+	// Request
+
+	protected KeyValues requestStopSequences(KeyValues keyValues, ChatModelObservationContext context) {
+		if (context.getRequestOptions() instanceof DashScopeChatOptions) {
+			List<Object> stop = ((DashScopeChatOptions) context.getRequestOptions()).getStop();
+			if (CollectionUtils.isEmpty(stop)) {
+				return keyValues;
+			}
+			KeyValue.of(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES,
+					stop, Objects::nonNull);
+
+			String stopSequences;
+			try {
+				stopSequences = JSON.toJSONString(stop);
+			} catch (Exception e) {
+				stopSequences = ILLEGAL_STOP_CONTENT;
+			}
+			return keyValues.and(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
+					stopSequences);
+		}
+
+		return super.requestStopSequences(keyValues, context);
+	}
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/observation/package-info.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/observation/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+@NonNullFields
+package com.alibaba.cloud.ai.dashscope.chat.observation;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/observation/conventions/AiProvider.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/observation/conventions/AiProvider.java
@@ -1,0 +1,33 @@
+package com.alibaba.cloud.ai.observation.conventions;
+
+/**
+ * Extended collection of systems providing AI functionality. Based on the OpenTelemetry
+ * Semantic Conventions for AI Systems.
+ *
+ * @author Lumian
+ * @since 1.0.0
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai">OTel
+ * Semantic Conventions</a>.
+ * @see org.springframework.ai.observation.conventions.AiProvider
+ */
+public enum AiProvider {
+
+    // @formatter:off
+
+    // Please, keep the alphabetical sorting.
+    DASHSCOPE("dashscope");
+
+    private final String value;
+
+    AiProvider(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+
+    // @formatter:on
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/observation/conventions/AiProvider.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/observation/conventions/AiProvider.java
@@ -13,7 +13,7 @@ package com.alibaba.cloud.ai.observation.conventions;
  */
 public enum AiProvider {
 
-    // @formatter:off
+	// @formatter:off
 
     // Please, keep the alphabetical sorting.
     DASHSCOPE("dashscope");

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/DashscopeAiTestConfiguration.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/DashscopeAiTestConfiguration.java
@@ -16,8 +16,11 @@ import com.alibaba.cloud.ai.model.RerankModel;
 import com.alibaba.dashscope.audio.asr.transcription.Transcription;
 import com.alibaba.dashscope.audio.tts.SpeechSynthesizer;
 
+import io.micrometer.observation.tck.TestObservationRegistry;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.model.function.FunctionCallbackContext;
+import org.springframework.ai.retry.RetryUtils;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -84,9 +87,10 @@ public class DashscopeAiTestConfiguration {
 	}
 
 	@Bean
-	public ChatModel dashscopeChatModel(DashScopeApi dashscopeChatApi) {
+	public ChatModel dashscopeChatModel(DashScopeApi dashscopeChatApi, TestObservationRegistry observationRegistry) {
 		return new DashScopeChatModel(dashscopeChatApi,
-				DashScopeChatOptions.builder().withModel(DashScopeApi.DEFAULT_CHAT_MODEL).build());
+				DashScopeChatOptions.builder().withModel(DashScopeApi.DEFAULT_CHAT_MODEL).build(),
+				null, RetryUtils.DEFAULT_RETRY_TEMPLATE, observationRegistry);
 	}
 
 	@Bean
@@ -110,6 +114,11 @@ public class DashscopeAiTestConfiguration {
 	public DashScopeAudioTranscriptionModel dashScopeAudioTranscriptionModel(
 			DashScopeAudioTranscriptionApi dashScopeAudioTranscriptionApi) {
 		return new DashScopeAudioTranscriptionModel(dashScopeAudioTranscriptionApi);
+	}
+
+	@Bean
+	public TestObservationRegistry observationRegistry() {
+		return TestObservationRegistry.create();
 	}
 
 	@Bean

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/DashscopeAiTestConfiguration.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/DashscopeAiTestConfiguration.java
@@ -89,8 +89,8 @@ public class DashscopeAiTestConfiguration {
 	@Bean
 	public ChatModel dashscopeChatModel(DashScopeApi dashscopeChatApi, TestObservationRegistry observationRegistry) {
 		return new DashScopeChatModel(dashscopeChatApi,
-				DashScopeChatOptions.builder().withModel(DashScopeApi.DEFAULT_CHAT_MODEL).build(),
-				null, RetryUtils.DEFAULT_RETRY_TEMPLATE, observationRegistry);
+				DashScopeChatOptions.builder().withModel(DashScopeApi.DEFAULT_CHAT_MODEL).build(), null,
+				RetryUtils.DEFAULT_RETRY_TEMPLATE, observationRegistry);
 	}
 
 	@Bean

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelObservationIT.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelObservationIT.java
@@ -1,0 +1,139 @@
+package com.alibaba.cloud.ai.dashscope.chat;
+
+import com.alibaba.cloud.ai.dashscope.DashscopeAiTestConfiguration;
+import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+import com.alibaba.cloud.ai.observation.conventions.AiProvider;
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.observation.conventions.AiOperationType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for observation instrumentation in {@link DashScopeChatModel}
+ *
+ * @author Lumian
+ * */
+@SpringBootTest(classes = DashscopeAiTestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
+public class DashScopeChatModelObservationIT {
+
+    @Autowired
+    TestObservationRegistry observationRegistry;
+
+    @Autowired
+    ChatModel dashscopeChatModel;
+
+    @BeforeEach
+    void beforeEach() {
+        this.observationRegistry.clear();
+    }
+
+    @Test
+    void observationForChatOperation() {
+
+        var options = DashScopeChatOptions.builder()
+                .withModel(DashScopeApi.ChatModel.QWEN_MAX.getModel())
+                .withRepetitionPenalty(1.2)
+                .withStop(List.of("this-is-the-end"))
+                .withTemperature(0.75)
+                .withTopP(0.95)
+                .build();
+
+        Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
+
+        ChatResponse chatResponse = this.dashscopeChatModel.call(prompt);
+        assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+
+        ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
+        assertThat(responseMetadata).isNotNull();
+
+        validate(responseMetadata);
+    }
+
+    @Test
+    void observationForStreamingChatOperation() {
+        var options = DashScopeChatOptions.builder()
+                .withModel(DashScopeApi.ChatModel.QWEN_MAX.getModel())
+                .withRepetitionPenalty(1.2)
+                .withStop(List.of("this-is-the-end"))
+                .withTemperature(0.75)
+                .withTopP(0.95)
+                .withStream(true)
+                .build();
+
+        Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
+
+        Flux<ChatResponse> chatResponseFlux = this.dashscopeChatModel.stream(prompt);
+
+        List<ChatResponse> responses = chatResponseFlux.collectList().block();
+        assertThat(responses).isNotEmpty();
+        assertThat(responses).hasSizeGreaterThan(10);
+
+        String aggregatedResponse = responses.subList(0, responses.size() - 1)
+                .stream()
+                .map(r -> r.getResult().getOutput().getContent())
+                .collect(Collectors.joining());
+        assertThat(aggregatedResponse).isNotEmpty();
+
+        ChatResponse lastChatResponse = responses.get(responses.size() - 1);
+
+        ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
+        assertThat(responseMetadata).isNotNull();
+
+        validate(responseMetadata);
+    }
+
+    private void validate(ChatResponseMetadata responseMetadata) {
+        TestObservationRegistryAssert.assertThat(this.observationRegistry)
+                .doesNotHaveAnyRemainingCurrentObservation()
+                .hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
+                .that()
+                .hasContextualNameEqualTo("chat " + DashScopeApi.ChatModel.QWEN_MAX.getModel())
+                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
+                        AiOperationType.CHAT.value())
+                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.DASHSCOPE.value())
+                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL.asString(),
+                        DashScopeApi.ChatModel.QWEN_MAX.getModel())
+                // TODO cannot parse response model from chat response metadata
+                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.RESPONSE_MODEL.asString(), KeyValue.NONE_VALUE)
+                // TODO not support in dashscope yet
+                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString())
+                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString())
+                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString())
+                // FIXME stop sequences return null in options
+                // .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
+                //        "[\"this-is-the-end\"]")
+                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString())
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TEMPERATURE.asString(), "0.75")
+                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_K.asString())
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_P.asString(), "0.95")
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_ID.asString(), responseMetadata.getId())
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_FINISH_REASONS.asString(), "[\"STOP\"]")
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_INPUT_TOKENS.asString(),
+                        String.valueOf(responseMetadata.getUsage().getPromptTokens()))
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_OUTPUT_TOKENS.asString(),
+                        String.valueOf(responseMetadata.getUsage().getGenerationTokens()))
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_TOTAL_TOKENS.asString(),
+                        String.valueOf(responseMetadata.getUsage().getTotalTokens()))
+                .hasBeenStarted()
+                .hasBeenStopped();
+    }
+
+}

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelObservationIT.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelObservationIT.java
@@ -29,108 +29,127 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for observation instrumentation in {@link DashScopeChatModel}
  *
  * @author Lumian
- * */
+ */
 @SpringBootTest(classes = DashscopeAiTestConfiguration.class)
 @EnabledIfEnvironmentVariable(named = "DASHSCOPE_API_KEY", matches = ".+")
 public class DashScopeChatModelObservationIT {
 
-    @Autowired
-    TestObservationRegistry observationRegistry;
+	@Autowired
+	TestObservationRegistry observationRegistry;
 
-    @Autowired
-    ChatModel dashscopeChatModel;
+	@Autowired
+	ChatModel dashscopeChatModel;
 
-    @BeforeEach
-    void beforeEach() {
-        this.observationRegistry.clear();
-    }
+	@BeforeEach
+	void beforeEach() {
+		this.observationRegistry.clear();
+	}
 
-    @Test
-    void observationForChatOperation() {
+	@Test
+	void observationForChatOperation() {
 
-        var options = DashScopeChatOptions.builder()
-                .withModel(DashScopeApi.ChatModel.QWEN_MAX.getModel())
-                .withRepetitionPenalty(1.2)
-                .withStop(List.of("this-is-the-end"))
-                .withTemperature(0.75)
-                .withTopP(0.95)
-                .build();
+		var options = DashScopeChatOptions.builder()
+			.withModel(DashScopeApi.ChatModel.QWEN_MAX.getModel())
+			.withRepetitionPenalty(1.2)
+			.withStop(List.of("this-is-the-end"))
+			.withTemperature(0.75)
+			.withTopP(0.95)
+			.build();
 
-        Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
+		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
-        ChatResponse chatResponse = this.dashscopeChatModel.call(prompt);
-        assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		ChatResponse chatResponse = this.dashscopeChatModel.call(prompt);
+		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
 
-        ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
-        assertThat(responseMetadata).isNotNull();
+		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
+		assertThat(responseMetadata).isNotNull();
 
-        validate(responseMetadata);
-    }
+		validate(responseMetadata);
+	}
 
-    @Test
-    void observationForStreamingChatOperation() {
-        var options = DashScopeChatOptions.builder()
-                .withModel(DashScopeApi.ChatModel.QWEN_MAX.getModel())
-                .withRepetitionPenalty(1.2)
-                .withStop(List.of("this-is-the-end"))
-                .withTemperature(0.75)
-                .withTopP(0.95)
-                .withStream(true)
-                .build();
+	@Test
+	void observationForStreamingChatOperation() {
+		var options = DashScopeChatOptions.builder()
+			.withModel(DashScopeApi.ChatModel.QWEN_MAX.getModel())
+			.withRepetitionPenalty(1.2)
+			.withStop(List.of("this-is-the-end"))
+			.withTemperature(0.75)
+			.withTopP(0.95)
+			.withStream(true)
+			.build();
 
-        Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
+		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
-        Flux<ChatResponse> chatResponseFlux = this.dashscopeChatModel.stream(prompt);
+		Flux<ChatResponse> chatResponseFlux = this.dashscopeChatModel.stream(prompt);
 
-        List<ChatResponse> responses = chatResponseFlux.collectList().block();
-        assertThat(responses).isNotEmpty();
-        assertThat(responses).hasSizeGreaterThan(10);
+		List<ChatResponse> responses = chatResponseFlux.collectList().block();
+		assertThat(responses).isNotEmpty();
+		assertThat(responses).hasSizeGreaterThan(10);
 
-        String aggregatedResponse = responses.subList(0, responses.size() - 1)
-                .stream()
-                .map(r -> r.getResult().getOutput().getContent())
-                .collect(Collectors.joining());
-        assertThat(aggregatedResponse).isNotEmpty();
+		String aggregatedResponse = responses.subList(0, responses.size() - 1)
+			.stream()
+			.map(r -> r.getResult().getOutput().getContent())
+			.collect(Collectors.joining());
+		assertThat(aggregatedResponse).isNotEmpty();
 
-        ChatResponse lastChatResponse = responses.get(responses.size() - 1);
+		ChatResponse lastChatResponse = responses.get(responses.size() - 1);
 
-        ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
-        assertThat(responseMetadata).isNotNull();
+		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
+		assertThat(responseMetadata).isNotNull();
 
-        validate(responseMetadata);
-    }
+		validate(responseMetadata);
+	}
 
-    private void validate(ChatResponseMetadata responseMetadata) {
-        TestObservationRegistryAssert.assertThat(this.observationRegistry)
-                .doesNotHaveAnyRemainingCurrentObservation()
-                .hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
-                .that()
-                .hasContextualNameEqualTo("chat " + DashScopeApi.ChatModel.QWEN_MAX.getModel())
-                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
-                        AiOperationType.CHAT.value())
-                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.DASHSCOPE.value())
-                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL.asString(),
-                        DashScopeApi.ChatModel.QWEN_MAX.getModel())
-                // TODO Dashscope api is not supported currently
-                .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.RESPONSE_MODEL.asString(), KeyValue.NONE_VALUE)
-                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString())
-                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString())
-                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString())
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
-                        "[\"this-is-the-end\"]")
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TEMPERATURE.asString(), "0.75")
-                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_K.asString())
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_P.asString(), "0.95")
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_ID.asString(), responseMetadata.getId())
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_FINISH_REASONS.asString(), "[\"STOP\"]")
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_INPUT_TOKENS.asString(),
-                        String.valueOf(responseMetadata.getUsage().getPromptTokens()))
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_OUTPUT_TOKENS.asString(),
-                        String.valueOf(responseMetadata.getUsage().getGenerationTokens()))
-                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_TOTAL_TOKENS.asString(),
-                        String.valueOf(responseMetadata.getUsage().getTotalTokens()))
-                .hasBeenStarted()
-                .hasBeenStopped();
-    }
+	private void validate(ChatResponseMetadata responseMetadata) {
+		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+			.doesNotHaveAnyRemainingCurrentObservation()
+			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
+			.that()
+			.hasContextualNameEqualTo("chat " + DashScopeApi.ChatModel.QWEN_MAX.getModel())
+			.hasLowCardinalityKeyValue(
+					ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
+					AiOperationType.CHAT.value())
+			.hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(),
+					AiProvider.DASHSCOPE.value())
+			.hasLowCardinalityKeyValue(
+					ChatModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL.asString(),
+					DashScopeApi.ChatModel.QWEN_MAX.getModel())
+			// TODO Dashscope api is not supported currently
+			.hasLowCardinalityKeyValue(
+					ChatModelObservationDocumentation.LowCardinalityKeyNames.RESPONSE_MODEL.asString(),
+					KeyValue.NONE_VALUE)
+			.doesNotHaveHighCardinalityKeyValueWithKey(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString())
+			.doesNotHaveHighCardinalityKeyValueWithKey(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString())
+			.doesNotHaveHighCardinalityKeyValueWithKey(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString())
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
+					"[\"this-is-the-end\"]")
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TEMPERATURE.asString(), "0.75")
+			.doesNotHaveHighCardinalityKeyValueWithKey(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_K.asString())
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_P.asString(), "0.95")
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_ID.asString(),
+					responseMetadata.getId())
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_FINISH_REASONS.asString(),
+					"[\"STOP\"]")
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_INPUT_TOKENS.asString(),
+					String.valueOf(responseMetadata.getUsage().getPromptTokens()))
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_OUTPUT_TOKENS.asString(),
+					String.valueOf(responseMetadata.getUsage().getGenerationTokens()))
+			.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_TOTAL_TOKENS.asString(),
+					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
+			.hasBeenStarted()
+			.hasBeenStopped();
+	}
 
 }

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelObservationIT.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelObservationIT.java
@@ -111,16 +111,13 @@ public class DashScopeChatModelObservationIT {
                 .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.DASHSCOPE.value())
                 .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL.asString(),
                         DashScopeApi.ChatModel.QWEN_MAX.getModel())
-                // TODO cannot parse response model from chat response metadata
+                // TODO Dashscope api is not supported currently
                 .hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.RESPONSE_MODEL.asString(), KeyValue.NONE_VALUE)
-                // TODO not support in dashscope yet
                 .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString())
                 .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString())
                 .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString())
-                // FIXME stop sequences return null in options
-                // .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
-                //        "[\"this-is-the-end\"]")
-                .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString())
+                .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
+                        "[\"this-is-the-end\"]")
                 .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TEMPERATURE.asString(), "0.75")
                 .doesNotHaveHighCardinalityKeyValueWithKey(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_K.asString())
                 .hasHighCardinalityKeyValue(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_P.asString(), "0.95")


### PR DESCRIPTION
Add DashScopeChatModel call and stream observability so that we can trace and generate metrics for `DashScopeChatModel`.