### PR TITLE
feat(front-end): Add basic structure for right-click menu and new node creation

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/Common/manageNodes.tsx
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/Common/manageNodes.tsx
@@ -1,0 +1,44 @@
+import StartNode from '../StartNode';
+
+export enum NODE_TYPE {
+  START = 'start',
+  LLM = 'llm',
+}
+
+const getNodeElement = (key: NODE_TYPE) => {
+  switch (key) {
+    case NODE_TYPE.START:
+      return <StartNode />;
+    case NODE_TYPE.LLM:
+      return null;
+    default:
+      return null;
+  }
+};
+
+// TODO: const getNodeFormProps = (key: NODE_TYPE) => {};
+export const generateNodeFromKey = (
+  key: NODE_TYPE,
+  position?: { x: number; y: number },
+) => {
+  const { x = 0, y = 0 } = position || {};
+  const nodeElement = getNodeElement(key);
+
+  console.log('generate', x, y);
+
+  return {
+    id: `key-${Date.now()}`,
+    type: key,
+    sourcePosition: 'right',
+    targetPosition: 'left',
+    data: {
+      label: nodeElement,
+      form: {
+        // TODO: name: 1,
+      },
+    },
+    // position: { x: x - 600, y: y - 450 },
+    position: { x, y },
+  } as any;
+  // TODO: The type `any` will be replaced when the type of node is defined in some future version...
+};

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/StartNode/index.tsx
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/StartNode/index.tsx
@@ -1,0 +1,5 @@
+const StartNode = () => {
+  return <div>StartNode</div>;
+};
+
+export default StartNode;


### PR DESCRIPTION
#  Basic structure for right-click menu and new node creation

- Implements the foundational layout for a context menu.
- Adds functionality to create a new node via the right-click menu.


### Describe what this PR does / why we need it

🛠️ Implement the ability to create a new node on the workflow graph.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it

⭐️ The code commited is brief, so just check it directly.

### Describe how to verify it

🎥 The video below shows how it works: 

https://github.com/user-attachments/assets/e9bb53f4-6e7a-4731-b221-8295635bc48f



### Special notes for reviews
