### PR TITLE
feat(front-end): Implement the feature of copy and paste of the menu

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/package.json
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/package.json
@@ -14,9 +14,11 @@
     "@ant-design/icons": "^5.0.1",
     "@ant-design/pro-components": "^2.4.4",
     "@szhsin/react-menu": "^4.2.3",
+    "@types/js-yaml": "^4.0.9",
     "@umijs/max": "^4.3.35",
     "@xyflow/react": "^12.3.5",
-    "antd": "^5.22.2"
+    "antd": "^5.22.2",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@iconify/react": "^5.0.2",

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/pnpm-lock.yaml
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/pnpm-lock.yaml
@@ -17,15 +17,21 @@ importers:
       '@szhsin/react-menu':
         specifier: ^4.2.3
         version: 4.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@umijs/max':
         specifier: ^4.3.35
-        version: 4.3.36(@babel/core@7.23.6)(@types/node@22.9.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1)
+        version: 4.3.36(@babel/core@7.26.0)(@types/node@22.9.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1)
       '@xyflow/react':
         specifier: ^12.3.5
         version: 12.3.5(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       antd:
         specifier: ^5.22.2
         version: 5.22.3(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       '@iconify/react':
         specifier: ^5.0.2
@@ -1327,6 +1333,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -6753,90 +6762,90 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.0
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.6)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.23.6)':
+  '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.23.6)
+      '@babel/core': 7.26.0
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-simple-access': 7.25.9
     transitivePeerDependencies:
@@ -7717,6 +7726,8 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/minimist@1.2.5': {}
@@ -8105,14 +8116,14 @@ snapshots:
       '@umijs/mako-win32-ia32-msvc': 0.9.8
       '@umijs/mako-win32-x64-msvc': 0.9.8
 
-  '@umijs/max@4.3.36(@babel/core@7.23.6)(@types/node@22.9.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1)':
+  '@umijs/max@4.3.36(@babel/core@7.26.0)(@types/node@22.9.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1)':
     dependencies:
       '@umijs/lint': 4.3.36(eslint@8.35.0)(stylelint@14.8.2)(typescript@5.6.3)
-      '@umijs/plugins': 4.3.36(@babel/core@7.23.6)(@types/react-dom@18.3.1)(@types/react@18.3.12)(antd@4.24.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@umijs/plugins': 4.3.36(@babel/core@7.26.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(antd@4.24.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       antd: 4.24.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       eslint: 8.35.0
       stylelint: 14.8.2
-      umi: 4.3.36(@babel/core@7.23.6)(@types/node@22.9.0)(@types/react@18.3.12)(eslint@8.35.0)(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(stylelint@14.8.2)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1)
+      umi: 4.3.36(@babel/core@7.26.0)(@types/node@22.9.0)(@types/react@18.3.12)(eslint@8.35.0)(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(stylelint@14.8.2)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
@@ -8163,7 +8174,7 @@ snapshots:
     dependencies:
       tsx: 3.12.2
 
-  '@umijs/plugins@4.3.36(@babel/core@7.23.6)(@types/react-dom@18.3.1)(@types/react@18.3.12)(antd@4.24.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@umijs/plugins@4.3.36(@babel/core@7.26.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(antd@4.24.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(rc-field-form@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ahooksjs/use-request': 2.8.15(react@18.3.1)
       '@ant-design/antd-theme-variable': 1.0.0
@@ -8178,7 +8189,7 @@ snapshots:
       antd-dayjs-webpack-plugin: 1.0.6(dayjs@1.11.13)
       axios: 0.27.2
       babel-plugin-import: 1.13.8
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.23.6)(styled-components@6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.26.0)(styled-components@6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       dayjs: 1.11.13
       dva-core: 2.0.4(redux@4.2.1)
       dva-immer: 1.0.2(dva@2.5.0-beta.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -8304,13 +8315,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/test@4.3.36(@babel/core@7.23.6)':
+  '@umijs/test@4.3.36(@babel/core@7.26.0)':
     dependencies:
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.6)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.26.0)
       '@jest/types': 27.5.1
       '@umijs/bundler-utils': 4.3.36
       '@umijs/utils': 4.3.36
-      babel-jest: 29.7.0(@babel/core@7.23.6)
+      babel-jest: 29.7.0(@babel/core@7.26.0)
       esbuild: 0.21.4
       identity-obj-proxy: 3.0.0
       isomorphic-unfetch: 4.0.2
@@ -8748,13 +8759,13 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-jest@29.7.0(@babel/core@7.23.6):
+  babel-jest@29.7.0(@babel/core@7.26.0):
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.23.6)
+      babel-preset-jest: 29.6.3(@babel/core@7.26.0)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -8798,11 +8809,11 @@ snapshots:
       zod: 3.23.8
       zod-validation-error: 2.1.0(zod@3.23.8)
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.23.6)(styled-components@6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.26.0)(styled-components@6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-module-imports': 7.25.9
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.23.6)
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
       lodash: 4.17.21
       picomatch: 2.3.1
       styled-components: 6.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8810,30 +8821,30 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@7.23.6):
+  babel-preset-current-node-syntax@1.1.0(@babel/core@7.26.0):
     dependencies:
-      '@babel/core': 7.23.6
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.6)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.6)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.23.6)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.6)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.6)
+      '@babel/core': 7.26.0
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
 
-  babel-preset-jest@29.6.3(@babel/core@7.23.6):
+  babel-preset-jest@29.6.3(@babel/core@7.26.0):
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.26.0
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.23.6)
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.0)
 
   balanced-match@1.0.2: {}
 
@@ -13371,7 +13382,7 @@ snapshots:
 
   typescript@5.6.3: {}
 
-  umi@4.3.36(@babel/core@7.23.6)(@types/node@22.9.0)(@types/react@18.3.12)(eslint@8.35.0)(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(stylelint@14.8.2)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1):
+  umi@4.3.36(@babel/core@7.26.0)(@types/node@22.9.0)(@types/react@18.3.12)(eslint@8.35.0)(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(stylelint@14.8.2)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1):
     dependencies:
       '@babel/runtime': 7.23.6
       '@umijs/bundler-utils': 4.3.36
@@ -13381,7 +13392,7 @@ snapshots:
       '@umijs/preset-umi': 4.3.36(@types/node@22.9.0)(@types/react@18.3.12)(lightningcss@1.22.1)(rollup@3.29.5)(terser@5.36.0)(type-fest@1.4.0)(typescript@5.6.3)(webpack@5.96.1)
       '@umijs/renderer-react': 4.3.36(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@umijs/server': 4.3.36
-      '@umijs/test': 4.3.36(@babel/core@7.23.6)
+      '@umijs/test': 4.3.36(@babel/core@7.26.0)
       '@umijs/utils': 4.3.36
       prettier-plugin-organize-imports: 3.2.4(prettier@2.8.8)(typescript@5.6.3)
       prettier-plugin-packagejson: 2.4.3(prettier@2.8.8)

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/Common/manageNodes.tsx
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/Common/manageNodes.tsx
@@ -1,19 +1,34 @@
+import { IEdge, INode } from '@/pages/Graph/Design/types';
+import { message } from 'antd';
+import { dump as yamlDump, load as yamlLoad } from 'js-yaml';
+import LLMNode from '../LLMNode';
 import StartNode from '../StartNode';
+
+// TODO: The type `any` will be replaced when the type of node is defined in some future version...
 
 export enum NODE_TYPE {
   START = 'start',
   LLM = 'llm',
 }
 
+export const NODE_TITLE = {
+  [NODE_TYPE.START]: 'Start',
+  [NODE_TYPE.LLM]: 'LLM',
+};
+
 const getNodeElement = (key: NODE_TYPE) => {
   switch (key) {
     case NODE_TYPE.START:
       return <StartNode />;
     case NODE_TYPE.LLM:
-      return null;
+      return <LLMNode />;
     default:
       return null;
   }
+};
+
+const getUniqueId = () => {
+  return `key-${Date.now()}`;
 };
 
 // TODO: const getNodeFormProps = (key: NODE_TYPE) => {};
@@ -21,13 +36,12 @@ export const generateNodeFromKey = (
   key: NODE_TYPE,
   position?: { x: number; y: number },
 ) => {
+  console.log('key', key);
   const { x = 0, y = 0 } = position || {};
   const nodeElement = getNodeElement(key);
 
-  console.log('generate', x, y);
-
   return {
-    id: `key-${Date.now()}`,
+    id: getUniqueId(),
     type: key,
     sourcePosition: 'right',
     targetPosition: 'left',
@@ -37,8 +51,117 @@ export const generateNodeFromKey = (
         // TODO: name: 1,
       },
     },
-    // position: { x: x - 600, y: y - 450 },
     position: { x, y },
   } as any;
-  // TODO: The type `any` will be replaced when the type of node is defined in some future version...
 };
+
+export const yaml2Json = (yaml: string) => {
+  try {
+    return yamlLoad(yaml) as Record<string, any>;
+  } catch (error) {
+    console.error('Error parsing YAML:', error);
+    throw new Error('Invalid YAML format');
+  }
+};
+
+export const json2Yaml = (json: any) => {
+  try {
+    return yamlDump(json, {
+      indent: 2,
+      lineWidth: -1,
+      noRefs: true,
+      quotingType: '"',
+    });
+  } catch (error) {
+    console.error('Error converting to YAML:', error);
+    throw new Error('Failed to convert JSON to YAML');
+  }
+};
+// export const getEdgeDataFromDSL = () => {};
+
+// export const getEdgeDSLFromData = (edge: IEdge) => {
+//   return '';
+// };
+
+export const getNodeDataFromDSL = (jsonDSL: any) => {
+  console.log('jsonDSL', jsonDSL);
+  return {
+    id: jsonDSL.id || getUniqueId(),
+    sourcePosition: jsonDSL.sourcePosition || 'right',
+    targetPosition: jsonDSL.targetPosition || 'left',
+    type: jsonDSL.type || 'start',
+    data: {
+      label: jsonDSL.data?.title || 'node',
+      form: {
+        // TODO: This part will be implemented when the form is implemented
+      },
+    },
+    position: {
+      x: jsonDSL.position?.x || 0,
+      y: jsonDSL.position?.y || 100,
+    },
+    measured: {
+      width: jsonDSL.measured?.width || 150,
+      height: jsonDSL.measured?.height || 36,
+    },
+  };
+};
+
+export const getNodeDSLFromData = (node: INode<any>) => {
+  return {
+    data: {
+      desc: '',
+      selected: false,
+      title: NODE_TITLE[node.type as NODE_TYPE] ?? 'node',
+      type: node.type,
+      variables: [],
+    },
+    height: node.measured?.height || 54,
+    id: node.id,
+    position: {
+      x: node.position.x,
+      y: node.position.y,
+    },
+    positionAbsolute: {
+      x: node.position.x,
+      y: node.position.y,
+    },
+    selected: false,
+  };
+};
+
+type CopyFunction = {
+  (data: INode<any>, type: 'node'): void;
+  (data: IEdge, type: 'edge'): void;
+};
+export const copy: CopyFunction = async (data, type) => {
+  try {
+    let res = '';
+    if (type === 'node') {
+      res = JSON.stringify(getNodeDSLFromData(data as INode<any>));
+    }
+    // else {
+    //   res = JSON.stringify(getEdgeDSLFromData(data as IEdge));
+    // }
+    await navigator.clipboard.writeText(res);
+  } catch (error) {
+    console.error('Error copying data:', error);
+    message.error('Error copying data');
+  }
+};
+
+export const paste = async (position: { x: number; y: number }) => {
+  try {
+    const jsonData = await navigator.clipboard.readText();
+    const dsl = JSON.parse(jsonData);
+    const nodeData = getNodeDataFromDSL(dsl);
+    nodeData.id = getUniqueId();
+    nodeData.position = position;
+    return nodeData;
+  } catch (error) {
+    console.error('Error parsing JSON:', error);
+    message.error('Error parsing JSON');
+  }
+};
+
+export const importDataFromDSL = () => {};

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/LLMNode/index.tsx
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/LLMNode/index.tsx
@@ -1,0 +1,7 @@
+import { NODE_TITLE, NODE_TYPE } from '../Common/manageNodes';
+
+const LLMNode = () => {
+  return <div>{NODE_TITLE[NODE_TYPE.LLM]}</div>;
+};
+
+export default LLMNode;

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/StartNode/index.tsx
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/components/Nodes/StartNode/index.tsx
@@ -1,5 +1,7 @@
+import { NODE_TITLE, NODE_TYPE } from '../Common/manageNodes';
+
 const StartNode = () => {
-  return <div>StartNode</div>;
+  return <div>{NODE_TITLE[NODE_TYPE.START]}</div>;
 };
 
 export default StartNode;

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/pages/Graph/Design/types.ts
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/graph-ui/src/pages/Graph/Design/types.ts
@@ -1,0 +1,41 @@
+import { MenuProps } from 'antd';
+
+export type TODO = any;
+
+export type IEdge = {
+  animated: boolean;
+  id: string;
+  selected: boolean;
+  source: string;
+  target: string;
+  type: string;
+};
+
+export type INode<T> = {
+  data: {
+    form: T;
+    label: string | symbol;
+  };
+  id: string;
+  measured: { width: number; height: number };
+  position: { x: number; y: number };
+  sourcePosition: string;
+  targetPosition: string;
+  type: string;
+};
+
+export type ISelections = {
+  nodes: Array<INode<TODO>>;
+  edges: Array<IEdge>;
+};
+
+export type ContextMenuType = {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+} | null;
+
+export type MenuItem = Required<MenuProps>['items'][number];
+
+export type IGraphMenuItems = Array<MenuItem & { onClick: (e: TODO) => void }>;


### PR DESCRIPTION
### Describe what this PR does / why we need it

Implement copy and paste functionality for nodes with using the right-click menu.

![image](https://github.com/user-attachments/assets/8d618653-41ae-4be5-b206-0de04ee05007)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it

**Copy**

- Convert the node's data structure to a standardized DSL schema.
- Store the DSL schema in the clipboard.

**Paste**

- Retrieve the DSL schema from the clipboard.
- Convert the DSL schema back into the original data structure.

### Describe how to verify it

1. Select a node within the graph.
2. Right-click on the selected node to open the context menu.
3. Choose the "Copy" option from the menu.
4. Right-click again in an empty area of the graph and select "Paste" from the context menu.

### Special notes for reviews
