### PR TITLE
feat: Initialize Spring AI Alibaba project with DotPrompt support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+tab_width = 4
+max_line_length = 120
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = tab
+ij_java_continuation_indent_size = 8
+ij_java_keep_control_statement_in_one_line = false
+ij_java_for_brace_force = always
+ij_java_if_brace_force = always
+ij_java_keep_first_column_comment = false
+ij_java_keep_line_breaks = false
+ij_java_keep_simple_blocks_in_one_line = true
+ij_java_keep_simple_classes_in_one_line = true
+ij_java_keep_simple_lambdas_in_one_line = true
+ij_java_keep_simple_methods_in_one_line = true
+ij_java_keep_blank_lines_in_code = 1
+ij_java_keep_blank_lines_in_declarations = 1
+ij_java_blank_lines_after_class_header = 1
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999
+ij_java_imports_layout = javax.**, |, java.**, |, *, |, $*
+ij_java_insert_inner_class_imports = true
+ij_java_space_before_array_initializer_left_brace = true
+ij_java_method_parameters_new_line_after_left_paren = true
+ij_java_wrap_comments = false
+ij_java_wrap_long_lines = false
+ij_java_enum_constants_wrap = split_into_lines
+ij_java_method_call_chain_wrap = on_every_item
+ij_java_method_parameters_wrap = on_every_item
+ij_java_extends_list_wrap = normal
+ij_java_extends_keyword_wrap = normal
+ij_java_binary_operation_wrap = normal
+ij_java_binary_operation_sign_on_next_line = true
+ij_java_generate_final_locals = false
+ij_java_generate_final_parameters = false
+
+[*.json]
+tab_width = 2
+indent_size = 2
+
+[*.{yml,yaml}]
+tab_width = 2
+indent_size = 2
+
+[*.xml]
+ij_xml_attribute_wrap = off
+ij_xml_text_wrap = off
+ij_xml_keep_blank_lines = 1

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <spring-ai.version>1.0.0-M3</spring-ai.version>
         <dashscope-sdk-java.version>2.15.1</dashscope-sdk-java.version>
 
+        <handlebars.version>4.3.1</handlebars.version>
+
         <!-- plugin versions -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
@@ -115,6 +117,11 @@
                 <version>${spring-ai.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jknack</groupId>
+                <artifactId>handlebars</artifactId>
+                <version>${handlebars.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/spring-ai-alibaba-autoconfigure/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/DotPromptAutoConfiguration.java
+++ b/spring-ai-alibaba-autoconfigure/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/DotPromptAutoConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.autoconfigure.prompt;
+
+import com.alibaba.cloud.ai.dotprompt.*;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@EnableConfigurationProperties(DotPromptProperties.class)
+@ConditionalOnProperty(prefix = DotPromptProperties.PREFIX, name = "enabled", matchIfMissing = true)
+public class DotPromptAutoConfiguration {
+
+	@Bean
+	public DotPromptLoader dotPromptLoader(DotPromptProperties properties) {
+		return new ClassPathDotPromptLoader(properties);
+	}
+
+	@Bean
+	public DotPromptRenderer dotPromptRenderer(DotPromptProperties properties) {
+		return new DotPromptRenderer(properties);
+	}
+
+	@Bean
+	public DotPromptTemplate dotPromptTemplate(DotPromptLoader loader, DotPromptRenderer renderer) {
+		return new DotPromptTemplate(loader, renderer);
+	}
+
+	@Bean
+	public DotPromptService dotPromptService(DotPromptLoader loader) {
+		return new DefaultDotPromptService(loader);
+	}
+
+}

--- a/spring-ai-alibaba-core/pom.xml
+++ b/spring-ai-alibaba-core/pom.xml
@@ -49,6 +49,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-retry</artifactId>
         </dependency>

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/ClassPathDotPromptLoader.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/ClassPathDotPromptLoader.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Implementation of DotPromptLoader that loads prompts from the classpath.
+ */
+public class ClassPathDotPromptLoader implements DotPromptLoader {
+
+	private final PathMatchingResourcePatternResolver resourceResolver;
+
+	private final Map<String, DotPrompt> promptCache;
+
+	private final DotPromptProperties properties;
+
+	private final Yaml yaml;
+
+	private static final Pattern FRONT_MATTER_PATTERN = Pattern.compile("^---\\s*$(.+?)^---\\s*$(.+)$",
+			Pattern.MULTILINE | Pattern.DOTALL);
+
+	public ClassPathDotPromptLoader(DotPromptProperties properties) {
+		Assert.notNull(properties, "properties must not be null");
+		this.resourceResolver = new PathMatchingResourcePatternResolver();
+		this.promptCache = new HashMap<>();
+		this.properties = properties;
+		this.yaml = new Yaml();
+	}
+
+	@Override
+	public List<String> getPromptNames() throws IOException {
+		List<String> promptNames = new ArrayList<>();
+		String promptLocation = properties.getBasePath();
+
+		Assert.hasText(promptLocation, "Prompt location must not be empty");
+
+		// Ensure the location ends with /
+		if (!promptLocation.endsWith("/")) {
+			promptLocation += "/";
+		}
+
+		// Search for all .prompt files in the configured location
+		String locationPattern = "classpath*:" + promptLocation + "**/*" + properties.getFileExtension();
+		Resource[] resources = resourceResolver.getResources(locationPattern);
+
+		for (Resource resource : resources) {
+			String filename = resource.getFilename();
+			if (filename != null) {
+				// Remove the file extension
+				String promptName = StringUtils.stripFilenameExtension(filename);
+				promptNames.add(promptName);
+			}
+		}
+
+		return promptNames;
+	}
+
+	@Override
+	public DotPrompt load(String promptName) throws IOException {
+		Assert.hasText(promptName, "promptName must not be empty");
+
+		// Check cache first
+		DotPrompt cachedPrompt = promptCache.get(promptName);
+		if (cachedPrompt != null) {
+			return cachedPrompt;
+		}
+
+		String promptLocation = properties.getBasePath();
+		if (!promptLocation.endsWith("/")) {
+			promptLocation += "/";
+		}
+
+		String resourcePath = promptLocation + promptName + properties.getFileExtension();
+		Resource resource = resourceResolver.getResource("classpath:" + resourcePath);
+
+		if (!resource.exists()) {
+			throw new IOException("Prompt file not found: " + resourcePath);
+		}
+
+		try (Reader reader = new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8)) {
+			StringBuilder content = new StringBuilder();
+			char[] buffer = new char[1024];
+			int read;
+			while ((read = reader.read(buffer)) != -1) {
+				content.append(buffer, 0, read);
+			}
+
+			Matcher matcher = FRONT_MATTER_PATTERN.matcher(content.toString());
+			if (!matcher.find()) {
+				throw new IOException("Invalid prompt file format. Expected front matter and template sections.");
+			}
+
+			String frontMatter = matcher.group(1).trim();
+			String template = matcher.group(2).trim();
+
+			Map<String, Object> metadata = yaml.load(frontMatter);
+
+			DotPrompt prompt = new DotPrompt();
+			prompt.setModel((String) metadata.get("model"));
+			prompt.setConfig((Map<String, Object>) metadata.get("config"));
+			prompt.setInput(parseInputSchema((Map<String, Object>) metadata.get("input")));
+			prompt.setTemplate(template);
+
+			// Cache the prompt
+			promptCache.put(promptName, prompt);
+
+			return prompt;
+		}
+	}
+
+	private DotPrompt.InputSchema parseInputSchema(Map<String, Object> input) {
+		if (input == null) {
+			return null;
+		}
+
+		DotPrompt.InputSchema schema = new DotPrompt.InputSchema();
+		schema.setSchema((Map<String, String>) input.get("schema"));
+		schema.setDefaultValues((Map<String, Object>) input.get("default"));
+		return schema;
+	}
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DefaultDotPromptService.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DefaultDotPromptService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Default implementation of DotPromptService.
+ */
+public class DefaultDotPromptService implements DotPromptService {
+
+	private final DotPromptLoader promptLoader;
+
+	public DefaultDotPromptService(DotPromptLoader promptLoader) {
+		Assert.notNull(promptLoader, "promptLoader must not be null");
+		this.promptLoader = promptLoader;
+	}
+
+	@Override
+	public List<String> getPromptNames() throws IOException {
+		return promptLoader.getPromptNames();
+	}
+
+	@Override
+	public DotPrompt getPrompt(String promptName) throws IOException {
+		Assert.hasText(promptName, "promptName must not be empty");
+		return promptLoader.load(promptName);
+	}
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPrompt.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPrompt.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class DotPrompt {
+
+	private String model;
+
+	private Map<String, Object> config;
+
+	private InputSchema input;
+
+	private String template;
+
+	@Data
+	public static class InputSchema {
+
+		private Map<String, String> schema;
+
+		private Map<String, Object> defaultValues;
+
+	}
+
+	public DotPrompt withModel(String model) {
+		if (model != null) {
+			this.model = model;
+		}
+		return this;
+	}
+
+	public DotPrompt withConfig(Map<String, Object> config) {
+		if (config != null) {
+			if (this.config == null) {
+				this.config = config;
+			}
+			else {
+				this.config.putAll(config);
+			}
+		}
+		return this;
+	}
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptLoader.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Interface for loading dot prompt templates from a source.
+ */
+public interface DotPromptLoader {
+
+	/**
+	 * Get a list of all available prompt names.
+	 * @return List of prompt names
+	 * @throws IOException if there's an error accessing the prompts
+	 */
+	List<String> getPromptNames() throws IOException;
+
+	/**
+	 * Load a prompt by its name.
+	 * @param promptName the name of the prompt to load
+	 * @return the loaded DotPrompt
+	 * @throws IOException if there's an error loading the prompt
+	 */
+	DotPrompt load(String promptName) throws IOException;
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptProperties.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = DotPromptProperties.PREFIX)
+public class DotPromptProperties {
+
+	public static final String PREFIX = "spring.ai.alibaba.dotprompt";
+
+	/**
+	 * Base path for prompt files, defaults to "classpath:prompts/"
+	 */
+	private String basePath = "classpath:prompts/";
+
+	/**
+	 * File extension for prompt files, defaults to ".prompt"
+	 */
+	private String fileExtension = ".prompt";
+
+	/**
+	 * Enable caching of parsed prompts
+	 */
+	private boolean cacheEnabled = true;
+
+	/**
+	 * Cache size, defaults to 100
+	 */
+	private int cacheSize = 100;
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptRenderer.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptRenderer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DotPromptRenderer {
+
+	private final Handlebars handlebars;
+
+	public DotPromptRenderer(DotPromptProperties properties) {
+		this.handlebars = new Handlebars();
+		if (properties.isCacheEnabled()) {
+			this.handlebars.with(new LRUTemplateCache(properties.getCacheSize()));
+		}
+	}
+
+	public String render(DotPrompt prompt, Map<String, Object> variables) {
+		Map<String, Object> context = new HashMap<>();
+
+		// Merge default values with provided variables
+		if (prompt.getInput() != null && prompt.getInput().getDefaultValues() != null) {
+			context.putAll(prompt.getInput().getDefaultValues());
+		}
+		if (variables != null) {
+			context.putAll(variables);
+		}
+
+		// Validate required variables
+		if (prompt.getInput() != null && prompt.getInput().getSchema() != null) {
+			for (Map.Entry<String, String> entry : prompt.getInput().getSchema().entrySet()) {
+				String key = entry.getKey();
+				if (!key.endsWith("?") && !context.containsKey(key)) {
+					throw new IllegalArgumentException("Missing required variable: " + key);
+				}
+			}
+		}
+
+		try {
+			Template template = handlebars.compileInline(prompt.getTemplate());
+			return template.apply(context);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to render template", e);
+		}
+	}
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptService.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Service interface for managing DotPrompt templates.
+ */
+public interface DotPromptService {
+
+	/**
+	 * Get a list of all available DotPrompt names.
+	 * @return List of DotPrompt names
+	 * @throws IOException if there's an error accessing the prompt files
+	 */
+	List<String> getPromptNames() throws IOException;
+
+	/**
+	 * Get the DotPrompt details for a specific prompt name.
+	 * @param promptName the name of the prompt to retrieve
+	 * @return the DotPrompt object containing the prompt details
+	 * @throws IOException if there's an error loading the prompt
+	 */
+	DotPrompt getPrompt(String promptName) throws IOException;
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptTemplate.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/DotPromptTemplate.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplateActions;
+import org.springframework.ai.chat.prompt.PromptTemplateMessageActions;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.model.Media;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class DotPromptTemplate implements PromptTemplateActions, PromptTemplateMessageActions {
+
+	private final DotPromptLoader loader;
+
+	private final DotPromptRenderer renderer;
+
+	private final String promptName;
+
+	private DotPrompt dotPrompt;
+
+	private String model;
+
+	private Map<String, Object> config;
+
+	public DotPromptTemplate(DotPromptLoader loader, DotPromptRenderer renderer) {
+		this.loader = loader;
+		this.renderer = renderer;
+		this.promptName = null;
+	}
+
+	public DotPromptTemplate(String promptName, DotPromptLoader loader, DotPromptRenderer renderer) {
+		Assert.hasText(promptName, "promptName must not be empty");
+		this.promptName = promptName;
+		this.loader = loader;
+		this.renderer = renderer;
+	}
+
+	@Override
+	public Prompt create() {
+		return create(Map.of());
+	}
+
+	@Override
+	public Prompt create(ChatOptions modelOptions) {
+		return null;
+	}
+
+	@Override
+	public Prompt create(Map<String, Object> model) {
+		return new Prompt(renderTemplate(model));
+	}
+
+	private String renderTemplate(Map<String, Object> model) {
+		try {
+			if (dotPrompt == null) {
+				Assert.hasText(promptName,
+						"promptName must be set either via constructor or by loading the prompt first");
+				dotPrompt = loader.load(promptName);
+			}
+
+			if (this.model != null) {
+				dotPrompt.withModel(this.model);
+			}
+			if (config != null) {
+				dotPrompt.withConfig(config);
+			}
+
+			return renderer.render(dotPrompt, model);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to load or render prompt: " + promptName, e);
+		}
+	}
+
+	@Override
+	public Prompt create(Map<String, Object> model, ChatOptions modelOptions) {
+		return null;
+	}
+
+	@Override
+	public Message createMessage() {
+		return createMessage(Map.of());
+	}
+
+	@Override
+	public Message createMessage(List<Media> mediaList) {
+		return null;
+	}
+
+	@Override
+	public Message createMessage(Map<String, Object> model) {
+		return new UserMessage(renderTemplate(model));
+	}
+
+	public DotPromptTemplate withPrompt(String promptName) {
+		return new DotPromptTemplate(promptName, this.loader, this.renderer);
+	}
+
+	public DotPromptTemplate withModel(String model) {
+		this.model = model;
+		return this;
+	}
+
+	public DotPromptTemplate withConfig(Map<String, Object> config) {
+		this.config = config;
+		return this;
+	}
+
+	public String getModel() {
+		return dotPrompt != null ? (model != null ? model : dotPrompt.getModel()) : null;
+	}
+
+	public Map<String, Object> getConfig() {
+		if (dotPrompt == null) {
+			return config;
+		}
+		Map<String, Object> baseConfig = dotPrompt.getConfig();
+		if (config != null && baseConfig != null) {
+			baseConfig.putAll(config);
+		}
+		return baseConfig;
+	}
+
+	@Override
+	public String render() {
+		return "";
+	}
+
+	@Override
+	public String render(Map<String, Object> model) {
+		return "";
+	}
+
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/LRUTemplateCache.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dotprompt/LRUTemplateCache.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.dotprompt;
+
+import com.github.jknack.handlebars.Parser;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.cache.TemplateCache;
+import com.github.jknack.handlebars.io.TemplateSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class LRUTemplateCache implements TemplateCache {
+
+	private final Map<String, Template> cache;
+
+	public LRUTemplateCache(int maxSize) {
+		this.cache = new LinkedHashMap<>(maxSize, 0.75f, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Template> eldest) {
+				return size() > maxSize;
+			}
+		};
+	}
+
+	@Override
+	public void clear() {
+		synchronized (cache) {
+			cache.clear();
+		}
+	}
+
+	@Override
+	public void evict(TemplateSource templateSource) {
+		synchronized (cache) {
+			try {
+				cache.remove(templateSource.content(StandardCharsets.UTF_8));
+			}
+			catch (IOException ignored) {
+			}
+		}
+	}
+
+	@Override
+	public Template get(TemplateSource templateSource, Parser parser) throws IOException {
+		synchronized (cache) {
+			String content = templateSource.content(StandardCharsets.UTF_8);
+			Template template = cache.get(content);
+			if (template == null) {
+				template = parser.parse(templateSource);
+				cache.put(content, template);
+			}
+			return template;
+		}
+	}
+
+	@Override
+	public TemplateCache setReload(boolean b) {
+		return null;
+	}
+
+}

--- a/spring-ai-alibaba-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-alibaba-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeAutoConfiguration
 com.alibaba.cloud.ai.autoconfigure.prompt.PromptTemplateAutoConfiguration
+com.alibaba.cloud.ai.autoconfigure.prompt.DotPromptAutoConfiguration

--- a/spring-ai-alibaba-examples/dotprompt-example/pom.xml
+++ b/spring-ai-alibaba-examples/dotprompt-example/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2023-2024 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.alibaba.cloud.ai</groupId>
+    <artifactId>dotprompt-example</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>dotprompt-example</name>
+    <description>Demo project for Spring AI Alibaba</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <spring-javaformat-maven-plugin.version>0.0.39</spring-javaformat-maven-plugin.version>
+        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+
+        <!-- Spring AI -->
+        <spring-ai-alibaba.version>1.0.0-M3.workflow-SNAPSHOT</spring-ai-alibaba.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-starter</artifactId>
+			<version>${spring-ai-alibaba.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.spring.javaformat</groupId>
+                <artifactId>spring-javaformat-maven-plugin</artifactId>
+                <version>${spring-javaformat-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>${maven-deploy-plugin.version}</version>
+                <configuration>
+					<skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+</project>

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/DotPromptExampleApplication.java
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/DotPromptExampleApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.dotprompt;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DotPromptExampleApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DotPromptExampleApplication.class, args);
+	}
+
+}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/config/ChatClientConfig.java
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/config/ChatClientConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.dotprompt.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatClientConfig {
+
+	@Bean
+	public ChatClient chatClient(ChatClient.Builder builder) {
+		return builder.build();
+	}
+
+}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/controller/TextProcessingController.java
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/controller/TextProcessingController.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.dotprompt.controller;
+
+import com.alibaba.cloud.ai.example.dotprompt.model.TextRequest;
+import com.alibaba.cloud.ai.example.dotprompt.model.TextResponse;
+import com.alibaba.cloud.ai.example.dotprompt.service.TextProcessingService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/text")
+public class TextProcessingController {
+
+	private final TextProcessingService textProcessingService;
+
+	public TextProcessingController(TextProcessingService textProcessingService) {
+		this.textProcessingService = textProcessingService;
+	}
+
+	@PostMapping("/translate")
+	public TextResponse translate(@RequestBody TextRequest request) {
+		return textProcessingService.translate(request);
+	}
+
+	@PostMapping("/summarize")
+	public TextResponse summarize(@RequestBody TextRequest request) {
+		return textProcessingService.summarize(request);
+	}
+
+	@PostMapping("/analyze")
+	public TextResponse analyze(@RequestBody TextRequest request) {
+		return textProcessingService.analyze(request);
+	}
+
+}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/model/TextRequest.java
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/model/TextRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.dotprompt.model;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class TextRequest {
+
+	@NotBlank(message = "Text cannot be empty")
+	private String text;
+
+	private String from;
+
+	private String to;
+
+	private String length;
+
+	private String format;
+
+	private List<String> aspects;
+
+	// Optional model override
+	private String model;
+
+	private Map<String, Object> modelConfig;
+
+}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/model/TextResponse.java
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/model/TextResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.dotprompt.model;
+
+import lombok.Data;
+
+@Data
+public class TextResponse {
+
+	private String result;
+
+	private String model;
+
+	private String prompt;
+
+	public static TextResponse of(String result, String model, String prompt) {
+		TextResponse response = new TextResponse();
+		response.setResult(result);
+		response.setModel(model);
+		response.setPrompt(prompt);
+		return response;
+	}
+
+}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/service/TextProcessingService.java
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/java/com/alibaba/cloud/ai/example/dotprompt/service/TextProcessingService.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.dotprompt.service;
+
+import com.alibaba.cloud.ai.dotprompt.DotPromptTemplate;
+import com.alibaba.cloud.ai.example.dotprompt.model.TextRequest;
+import com.alibaba.cloud.ai.example.dotprompt.model.TextResponse;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class TextProcessingService {
+
+	private final DotPromptTemplate promptTemplate;
+
+	private final ChatClient chatClient;
+
+	public TextProcessingService(DotPromptTemplate promptTemplate, ChatClient chatClient) {
+		this.promptTemplate = promptTemplate;
+		this.chatClient = chatClient;
+	}
+
+	public TextResponse translate(TextRequest request) {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("text", request.getText());
+		variables.put("to", request.getTo());
+		if (request.getFrom() != null) {
+			variables.put("from", request.getFrom());
+		}
+
+		return processText("translate", variables, request);
+	}
+
+	public TextResponse summarize(TextRequest request) {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("text", request.getText());
+		if (request.getLength() != null) {
+			variables.put("length", request.getLength());
+		}
+		if (request.getFormat() != null) {
+			variables.put("format", request.getFormat());
+		}
+
+		return processText("summarize", variables, request);
+	}
+
+	public TextResponse analyze(TextRequest request) {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("text", request.getText());
+		if (request.getAspects() != null && !request.getAspects().isEmpty()) {
+			variables.put("aspects", request.getAspects());
+		}
+
+		return processText("analyze", variables, request);
+	}
+
+	private TextResponse processText(String promptName, Map<String, Object> variables, TextRequest request) {
+		DotPromptTemplate template = promptTemplate.withPrompt(promptName);
+
+		// Apply model and config overrides if present
+		if (request.getModel() != null) {
+			template.withModel(request.getModel());
+		}
+		if (request.getModelConfig() != null) {
+			template.withConfig(request.getModelConfig());
+		}
+
+		Prompt prompt = template.create(variables);
+
+		AssistantMessage response = chatClient.prompt(prompt).call().chatResponse().getResult().getOutput();
+
+		return TextResponse.of(response.getContent(), template.getModel(),
+				prompt.getInstructions().get(0).getContent());
+	}
+
+}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/application.yml
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  ai:
+    alibaba:
+      dotprompt:
+        enabled: true
+        base-path: prompts/
+        file-extension: .prompt
+        cache-enabled: true
+    dashscope:
+      api-key: ${DASHSCOPE_API_KEY}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/prompts/analyze.prompt
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/prompts/analyze.prompt
@@ -1,0 +1,17 @@
+---
+config:
+  temperature: 0.1
+  top_p: 0.95
+input:
+  schema:
+    text: string
+    aspects: string[]
+  default:
+    aspects: ["sentiment", "key_points", "tone"]
+---
+Analyze the following text focusing on these aspects: {{#each aspects}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}.
+
+Text to analyze:
+{{text}}
+
+Please provide a structured analysis with clear headings for each aspect.

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/prompts/summarize.prompt
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/prompts/summarize.prompt
@@ -1,0 +1,16 @@
+---
+config:
+  temperature: 0.3
+  top_p: 0.9
+input:
+  schema:
+    text: string
+    length?: string
+    format?: string
+  default:
+    length: short
+    format: paragraph
+---
+Summarize the following text{{#if length}} in {{length}} form{{/if}}{{#if format}} as a {{format}}{{/if}}:
+
+{{text}}

--- a/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/prompts/translate.prompt
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/main/resources/prompts/translate.prompt
@@ -1,0 +1,17 @@
+---
+config:
+  temperature: 0.7
+  top_p: 1.0
+input:
+  schema:
+    text: string
+    from?: string
+    to: string
+  default:
+    from: English
+---
+Translate the following text from {{from}} to {{to}}:
+
+{{text}}
+
+Please provide only the translation without any additional explanation or notes.

--- a/spring-ai-alibaba-examples/dotprompt-example/src/test/java/com/alibaba/cloud/ai/example/dotprompt/TextProcessingTests.java
+++ b/spring-ai-alibaba-examples/dotprompt-example/src/test/java/com/alibaba/cloud/ai/example/dotprompt/TextProcessingTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.dotprompt;
+
+import com.alibaba.cloud.ai.example.dotprompt.model.TextRequest;
+import com.alibaba.cloud.ai.example.dotprompt.model.TextResponse;
+import com.alibaba.cloud.ai.example.dotprompt.service.TextProcessingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClient.CallResponseSpec;
+import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+class TextProcessingTests {
+
+	@Autowired
+	private TextProcessingService textProcessingService;
+
+	@MockBean
+	private ChatClient chatClient;
+
+	@Test
+	void translateText() {
+		// Mock ChatClient response
+		mockChatClientResponse("Hola, mundo!");
+
+		TextRequest request = new TextRequest();
+		request.setModel("googleai/gemini-1.5-flash");
+		request.setText("Hello, world!");
+		request.setFrom("English");
+		request.setTo("Spanish");
+
+		TextResponse response = textProcessingService.translate(request);
+
+		assertThat(response.getModel()).isEqualTo("googleai/gemini-1.5-flash");
+		assertThat(response.getPrompt()).contains("Translate the following text");
+		assertThat(response.getResult()).isEqualTo("Hola, mundo!");
+	}
+
+	@Test
+	void summarizeText() {
+		// Mock ChatClient response
+		mockChatClientResponse("Brief summary: Important points discussed.");
+
+		TextRequest request = new TextRequest();
+		request.setModel("googleai/gemini-1.5-flash");
+		request.setText("This is a long text that needs to be summarized...");
+		request.setLength("brief");
+		request.setFormat("bullet points");
+
+		TextResponse response = textProcessingService.summarize(request);
+
+		assertThat(response.getModel()).isEqualTo("googleai/gemini-1.5-flash");
+		assertThat(response.getPrompt()).contains("Summarize the following text");
+		assertThat(response.getResult()).contains("Brief summary");
+	}
+
+	@Test
+	void analyzeText() {
+		// Mock ChatClient response
+		mockChatClientResponse("Analysis: Positive sentiment, formal style, high clarity");
+
+		TextRequest request = new TextRequest();
+		request.setModel("googleai/gemini-1.5-flash");
+		request.setText("This is a sample text for analysis.");
+		request.setAspects(Arrays.asList("emotion", "style", "clarity"));
+
+		TextResponse response = textProcessingService.analyze(request);
+
+		assertThat(response.getModel()).isEqualTo("googleai/gemini-1.5-flash");
+		assertThat(response.getPrompt()).contains("Analyze the following text");
+		assertThat(response.getResult()).contains("Analysis:");
+	}
+
+	private void mockChatClientResponse(String content) {
+		ChatClientRequestSpec promptResponse = mock(ChatClientRequestSpec.class);
+		CallResponseSpec callResponse = mock(CallResponseSpec.class);
+		ChatResponse chatResponse = mock(ChatResponse.class);
+		Generation chatResult = mock(Generation.class);
+		AssistantMessage assistantMessage = new AssistantMessage(content);
+
+		when(chatClient.prompt(any(Prompt.class))).thenReturn(promptResponse);
+		when(promptResponse.call()).thenReturn(callResponse);
+		when(callResponse.chatResponse()).thenReturn(chatResponse);
+		when(chatResponse.getResult()).thenReturn(chatResult);
+		when(chatResult.getOutput()).thenReturn(assistantMessage);
+	}
+
+}

--- a/spring-ai-alibaba-examples/pom.xml
+++ b/spring-ai-alibaba-examples/pom.xml
@@ -37,6 +37,7 @@
 		<module>multi-model-example</module>
 		<module>audio-example</module>
 		<module>prompt-example</module>
+		<module>dotprompt-example</module>
 		<module>function-calling-example</module>
 		<module>rag-example</module>
 		<module>output-parser-example</module>

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/DotPromptAPIController.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/DotPromptAPIController.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.controller;
+
+import com.alibaba.cloud.ai.dotprompt.DotPrompt;
+import com.alibaba.cloud.ai.dotprompt.DotPromptService;
+import com.alibaba.cloud.ai.dotprompt.DotPromptTemplate;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * REST API controller for managing DotPrompt templates.
+ */
+@CrossOrigin
+@RestController
+@RequestMapping("studio/api/dotprompt")
+public class DotPromptAPIController {
+
+	private final DotPromptService dotPromptService;
+
+	private final DotPromptTemplate dotPromptTemplate;
+
+	private final ChatClient chatClient;
+
+	public DotPromptAPIController(DotPromptService dotPromptService, DotPromptTemplate dotPromptTemplate,
+								  ChatClient.Builder builder) {
+		this.dotPromptService = dotPromptService;
+		this.dotPromptTemplate = dotPromptTemplate;
+		this.chatClient = builder.build();
+	}
+
+	/**
+	 * Get a list of all available prompt names.
+	 * @return List of prompt names
+	 */
+	@GetMapping("/list")
+	public ResponseEntity<List<String>> listPrompts() throws IOException {
+		return ResponseEntity.ok(dotPromptService.getPromptNames());
+	}
+
+	/**
+	 * Get details of a specific prompt by name.
+	 * @param promptName Name of the prompt to retrieve
+	 * @return The prompt details
+	 */
+	@GetMapping("/{promptName}")
+	public ResponseEntity<DotPrompt> getPrompt(@PathVariable String promptName) throws IOException {
+		return ResponseEntity.ok(dotPromptService.getPrompt(promptName));
+	}
+
+	/**
+	 * Chat using a specific prompt template.
+	 * @param request The chat request containing prompt name and variables
+	 * @return The chat response
+	 */
+	@PostMapping("/chat")
+	public ResponseEntity<ChatResponse> chat(@RequestBody DotPromptChatRequest request) throws IOException {
+		Assert.hasText(request.getPromptName(), "promptName must not be empty");
+
+		DotPromptTemplate template = dotPromptTemplate.withPrompt(request.getPromptName());
+
+		// Override model if specified
+		if (request.getModel() != null) {
+			template = template.withModel(request.getModel());
+		}
+
+		// Override config if specified
+		if (request.getConfig() != null) {
+			template = template.withConfig(request.getConfig());
+		}
+
+		// Create message with variables
+		return ResponseEntity.ok(chatClient.prompt(template.create(request.getVariables())).call().chatResponse());
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/DotPromptChatRequest.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/DotPromptChatRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.controller;
+
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * Request object for DotPrompt chat API.
+ */
+@Data
+public class DotPromptChatRequest {
+
+	private String promptName;
+
+	private Map<String, Object> variables;
+
+	private String model;
+
+	private Map<String, Object> config;
+
+}


### PR DESCRIPTION
Core features:
- Implement DotPrompt template system with Handlebars support
- Add ClassPath-based prompt loader and renderer
- Implement LRU caching for template compilation
- Add Spring Boot auto-configuration

Examples:
- Add text processing example with analyze/summarize/translate capabilities
- Include API controller for DotPrompt operations
- Add comprehensive test cases

The project provides a Spring Boot starter for AI prompt template management, with built-in caching and flexible template loading mechanisms.


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
