### PR TITLE
[hotfix]: fix the prefix of the DashScopeApiConstants.DASHSCOPE_API_KEY

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/DashScopeApiConstants.java
@@ -35,7 +35,7 @@ public final class DashScopeApiConstants {
 
 	public static final String DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com";
 
-	public static final String DASHSCOPE_API_KEY = "AI_DASHSCOPE_API_KEY";
+	public static final String DASHSCOPE_API_KEY = "DASHSCOPE_API_KEY";
 
 	public static final String DEFAULT_WEBSOCKET_URL = "wss://dashscope.aliyuncs.com/api-ws/v1/inference/";
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

1. The current version of DASHSCOPE_API_KEY prefix Slightly different from the URL(https://help.aliyun.com/zh/model-studio/developer-reference/configure-api-key-through-environment-variables)

<img width="1375" alt="image" src="https://github.com/user-attachments/assets/21a910f5-977c-4984-bd50-e6428899c62a" />

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

change com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DASHSCOPE_API_KEY form "AI_DASHSCOPE_API_KEY" to "DASHSCOPE_API_KEY";

### Describe how to verify it
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/1120534b-101a-4734-af57-83853fb643e8" />