### PR TITLE
feat(document-readers): add mbox implements  ( License cannot be added to an mbox file.)

### DIFF
--- a/community/document-parsers/document-parser-bshtml/pom.xml
+++ b/community/document-parsers/document-parser-bshtml/pom.xml
@@ -81,6 +81,7 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/community/document-readers/mbox-document-reader/README.md
+++ b/community/document-readers/mbox-document-reader/README.md
@@ -1,0 +1,144 @@
+<!--
+  Copyright 2024-2025 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Spring AI Mbox Document Reader
+
+A Spring AI document reader implementation for reading and parsing Mbox format email files. Mbox is a common format for storing collections of email messages.
+
+Spring AI 的 Mbox 文档读取器实现，用于读取和解析 Mbox 格式的邮件文件。Mbox 是一种用于存储电子邮件集合的常用格式。
+
+## Features / 功能特点
+
+- Supports standard Mbox format files / 支持标准 Mbox 格式文件
+- Handles various email content types / 处理多种邮件内容类型：
+  - Plain text emails / 纯文本邮件
+  - HTML formatted emails / HTML 格式邮件
+  - Multipart emails (text/html) / 多部分邮件（文本/HTML）
+  - Emails with attachments (attachments are ignored) / 带附件的邮件（附件会被忽略）
+- Extracts email metadata / 提取邮件元数据：
+  - Subject / 主题
+  - From address / 发件人地址
+  - To address / 收件人地址
+  - Date / 日期
+  - Message ID / 消息ID
+- Configurable message formatting / 可配置的消息格式化
+- HTML content parsing with JSoup / 使用 JSoup 解析 HTML 内容
+- Robust error handling / 健壮的错误处理
+
+## Installation / 安装
+
+Add the following dependency to your project / 在项目中添加以下依赖：
+
+```xml
+<dependency>
+    <groupId>com.alibaba.cloud.ai</groupId>
+    <artifactId>spring-ai-mbox-document-reader</artifactId>
+    <version>${version}</version>
+</dependency>
+```
+
+## Usage / 使用方法
+
+### Basic Usage / 基本用法
+
+```java
+// Create a reader instance with default settings
+// 使用默认设置创建阅读器实例
+MboxDocumentReader reader = new MboxDocumentReader("/path/to/your.mbox");
+
+// Read all emails
+// 读取所有邮件
+List<Document> documents = reader.get();
+
+// Process each email
+// 处理每封邮件
+for (Document doc : documents) {
+    // Get formatted content
+    // 获取格式化的内容
+    String content = doc.getContent();
+    
+    // Access metadata
+    // 访问元数据
+    Map<String, Object> metadata = doc.getMetadata();
+    String subject = (String) metadata.get("subject");
+    String from = (String) metadata.get("from");
+    String to = (String) metadata.get("to");
+    Date date = (Date) metadata.get("date");
+}
+```
+
+### Advanced Usage / 高级用法
+
+```java
+// Custom message limit and format
+// 自定义消息限制和格式
+String customFormat = "Email Details:\nSubject: %4$s\nFrom: %2$s\nTo: %3$s\nDate: %1$s\n\nContent:\n%5$s";
+MboxDocumentReader reader = new MboxDocumentReader(
+    "/path/to/your.mbox",  // Mbox file path / Mbox文件路径
+    10,                    // Maximum number of emails to read (0 for unlimited) / 最大读取邮件数（0表示无限制）
+    customFormat          // Custom format string / 自定义格式字符串
+);
+
+List<Document> documents = reader.get();
+```
+
+## Message Format / 消息格式
+
+The default message format is / 默认消息格式为：
+```
+Date: %s
+From: %s
+To: %s
+Subject: %s
+Content: %s
+```
+
+Format parameters / 格式参数：
+1. `%1$s` - Date / 日期
+2. `%2$s` - From address / 发件人地址
+3. `%3$s` - To address / 收件人地址
+4. `%4$s` - Subject / 主题
+5. `%5$s` - Message content / 消息内容
+
+## Error Handling / 错误处理
+
+The reader uses runtime exceptions for error handling / 读取器使用运行时异常进行错误处理：
+- Invalid file path or format / 无效的文件路径或格式
+- Empty or malformed content / 空或格式错误的内容
+- HTML parsing errors / HTML解析错误
+- Date parsing errors / 日期解析错误
+
+Example / 示例：
+```java
+try {
+    List<Document> documents = reader.get();
+} catch (RuntimeException e) {
+    // Handle errors / 处理错误
+    System.err.println("Failed to read mbox file: " + e.getMessage());
+}
+```
+
+## Limitations / 限制
+
+- Only supports UTF-8 encoding / 仅支持 UTF-8 编码
+- Attachments are ignored / 附件会被忽略
+- Only text and HTML content types are processed / 仅处理文本和 HTML 内容类型
+- HTML content is converted to plain text / HTML 内容会被转换为纯文本
+- Requires valid Mbox format with "From " line separators / 需要带有 "From " 行分隔符的有效 Mbox 格式
+
+## License / 许可证
+
+Licensed under the Apache License, Version 2.0 / 基于 Apache License 2.0 许可证 

--- a/community/document-readers/mbox-document-reader/pom.xml
+++ b/community/document-readers/mbox-document-reader/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2024-2025 the original author or authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-ai-mbox-document-reader</artifactId>
+    <name>Spring AI Document Reader - Mbox</name>
+    <description>Spring AI Document Reader implementation for Mbox format emails</description>
+
+    <dependencies>
+        <!-- Spring AI Core -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-core</artifactId>
+        </dependency>
+
+        <!-- HTML Parser -->
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>document-parser-bshtml</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Apache Commons IO -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.15.1</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project> 

--- a/community/document-readers/mbox-document-reader/src/main/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReader.java
+++ b/community/document-readers/mbox-document-reader/src/main/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReader.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.reader.mbox;
+
+import com.alibaba.cloud.ai.parser.bshtml.BsHtmlDocumentParser;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.LineIterator;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.util.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A DocumentReader implementation that reads emails from Mbox format files. Mbox is a
+ * common format for storing collections of email messages.
+ *
+ * @author brianxiadong
+ */
+public class MboxDocumentReader implements DocumentReader {
+
+	private static final Logger logger = LoggerFactory.getLogger(MboxDocumentReader.class);
+
+	public static final String DEFAULT_MESSAGE_FORMAT = "Date: %s\nFrom: %s\nTo: %s\nSubject: %s\nContent: %s";
+
+	private static final Pattern FROM_LINE_PATTERN = Pattern.compile("^From .*\\d{4}$");
+	private static final Pattern HEADER_PATTERN = Pattern.compile("^([^:]+):\\s*(.*)$");
+	private static final Pattern BOUNDARY_PATTERN = Pattern.compile("boundary=\"?([^\"]+)\"?");
+
+	private final File mboxFile;
+	private final int maxCount;
+	private final String messageFormat;
+	private final BsHtmlDocumentParser htmlParser;
+	private final SimpleDateFormat dateFormat;
+
+	/**
+	 * Creates a new MboxDocumentReader instance with default settings.
+	 * @param mboxPath the absolute path to the mbox file
+	 */
+	public MboxDocumentReader(String mboxPath) {
+		this(new File(mboxPath), 0, DEFAULT_MESSAGE_FORMAT);
+	}
+
+	/**
+	 * Creates a new MboxDocumentReader instance with custom settings.
+	 * @param mboxPath the absolute path to the mbox file
+	 * @param maxCount maximum number of messages to read (0 for unlimited)
+	 * @param messageFormat custom format for message content
+	 */
+	public MboxDocumentReader(String mboxPath, int maxCount, String messageFormat) {
+		this(new File(mboxPath), maxCount, messageFormat);
+	}
+
+	/**
+	 * Creates a new MboxDocumentReader instance with custom settings.
+	 * @param mboxFile the mbox file
+	 * @param maxCount maximum number of messages to read (0 for unlimited)
+	 * @param messageFormat custom format for message content
+	 */
+	public MboxDocumentReader(File mboxFile, int maxCount, String messageFormat) {
+		Assert.notNull(mboxFile, "Mbox file must not be null");
+		Assert.isTrue(mboxFile.exists(), "Mbox file does not exist: " + mboxFile.getAbsolutePath());
+		Assert.isTrue(mboxFile.isFile(), "Mbox path is not a file: " + mboxFile.getAbsolutePath());
+		
+		this.mboxFile = mboxFile;
+		this.maxCount = maxCount;
+		this.messageFormat = messageFormat;
+		this.htmlParser = new BsHtmlDocumentParser();
+		this.dateFormat = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.US);
+	}
+
+	@Override
+	public List<Document> get() {
+		try {
+			return readMboxFile();
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to read mbox file: " + mboxFile.getAbsolutePath(), e);
+		}
+	}
+
+	private List<Document> readMboxFile() throws IOException {
+		List<Document> documents = new ArrayList<>();
+		int count = 0;
+		StringBuilder currentMessage = new StringBuilder();
+		boolean isFirstMessage = true;
+
+		try (LineIterator it = FileUtils.lineIterator(mboxFile, StandardCharsets.UTF_8.name())) {
+			while (it.hasNext()) {
+				String line = it.nextLine();
+				
+				// Check if this is a new message
+				if (FROM_LINE_PATTERN.matcher(line).matches()) {
+					// Process previous message if exists
+					if (!isFirstMessage && !currentMessage.isEmpty()) {
+						Document doc = parseMessage(currentMessage.toString());
+						if (doc != null) {
+							documents.add(doc);
+							count++;
+							
+							if (maxCount > 0 && count >= maxCount) {
+								break;
+							}
+						}
+						currentMessage.setLength(0);
+					}
+					isFirstMessage = false;
+					// Start new message with the From line
+					currentMessage.append(line).append("\n");
+				}
+				else {
+					// Append line to current message
+					currentMessage.append(line).append("\n");
+				}
+			}
+			
+			// Process the last message
+			if (!currentMessage.isEmpty()) {
+				Document doc = parseMessage(currentMessage.toString());
+				if (doc != null && (maxCount == 0 || count < maxCount)) {
+					documents.add(doc);
+				}
+			}
+		}
+
+		return documents;
+	}
+
+	private Document parseMessage(String messageContent) {
+		Map<String, Object> metadata = new HashMap<>();
+		Map<String, String> headers = new HashMap<>();
+		StringBuilder content = new StringBuilder();
+		String[] lines = messageContent.split("\n");
+		
+		boolean inHeaders = true;
+		String boundary = null;
+		boolean inHtmlPart = false;
+		boolean skipCurrentPart = false;
+		StringBuilder currentPart = new StringBuilder();
+		
+		for (int i = 0; i < lines.length; i++) {
+			String line = lines[i];
+			
+			if (inHeaders) {
+				if (line.trim().isEmpty()) {
+					inHeaders = false;
+					// Check if this is a multipart message
+					String contentType = headers.get("Content-Type");
+					if (contentType != null && contentType.contains("multipart")) {
+						Matcher m = BOUNDARY_PATTERN.matcher(contentType);
+						if (m.find()) {
+							boundary = m.group(1);
+						}
+					}
+					continue;
+				}
+				
+				Matcher m = HEADER_PATTERN.matcher(line);
+				if (m.matches()) {
+					String name = m.group(1).trim();
+					String value = m.group(2).trim();
+					headers.put(name, value);
+				}
+				continue;
+			}
+			
+			// Process message body
+			if (boundary != null) {
+				if (line.contains("--" + boundary)) {
+					// Process the previous part if it exists
+					if (!currentPart.isEmpty()) {
+						if (inHtmlPart && !skipCurrentPart) {
+							// Parse HTML content and set as current content
+							String parsedHtml = parseHtmlContent(currentPart.toString());
+							if (!parsedHtml.isEmpty()) {
+								content = new StringBuilder(parsedHtml);
+							}
+						} else if (content.isEmpty() && !skipCurrentPart) {
+							content = currentPart;
+						}
+					}
+					currentPart.setLength(0);
+					inHtmlPart = false;
+					skipCurrentPart = false;
+					continue;
+				}
+				
+				// Check content type of the part
+				if (line.startsWith("Content-Type:")) {
+					if (line.contains("text/html")) {
+						inHtmlPart = true;
+						skipCurrentPart = false;
+					} else if (!line.contains("text/plain")) {
+						// Skip non-text parts
+						skipCurrentPart = true;
+					}
+					continue;
+				}
+				
+				if (!skipCurrentPart) {
+					currentPart.append(line).append("\n");
+				}
+			} else {
+				// For non-multipart messages
+				String contentType = headers.get("Content-Type");
+				if (contentType != null && contentType.contains("text/html")) {
+					// If it's an HTML message, collect all lines for parsing
+					content.append(line).append("\n");
+					if (i == lines.length - 1) {
+						// Parse the complete HTML content at the end
+						String parsedHtml = parseHtmlContent(content.toString());
+						if (!parsedHtml.isEmpty()) {
+							content = new StringBuilder(parsedHtml);
+						}
+					}
+				} else {
+					content.append(line).append("\n");
+				}
+			}
+		}
+		
+		// Extract metadata
+		metadata.put("subject", headers.getOrDefault("Subject", ""));
+		metadata.put("from", headers.getOrDefault("From", ""));
+		metadata.put("to", headers.getOrDefault("To", ""));
+		try {
+			String dateStr = headers.get("Date");
+			if (dateStr != null) {
+				metadata.put("date", dateFormat.parse(dateStr));
+			}
+		} catch (ParseException e) {
+			throw new RuntimeException("Failed to parse date: " + e.getMessage(), e);
+		}
+		
+		// Check if content is empty
+		String contentStr = content.toString().trim();
+		if (contentStr.isEmpty()) {
+			throw new RuntimeException("Empty content found for message: " + headers.getOrDefault("Message-ID", "unknown"));
+		}
+		
+		// Format the content
+		String formattedContent = String.format(messageFormat,
+				metadata.getOrDefault("date", ""),
+				metadata.get("from"),
+				metadata.get("to"),
+				metadata.get("subject"),
+				contentStr);
+		
+		// Check if formatted content is empty
+		if (formattedContent.trim().isEmpty()) {
+			throw new RuntimeException("Empty formatted content for message: " + headers.getOrDefault("Message-ID", "unknown"));
+		}
+		
+		// Use Message-ID as document ID
+		String id = headers.getOrDefault("Message-ID", "msg-" + System.currentTimeMillis());
+		
+		return new Document(id, formattedContent, metadata);
+	}
+
+	private String parseHtmlContent(String html) {
+		if (html == null || html.trim().isEmpty()) {
+			throw new RuntimeException("HTML content is null or empty");
+		}
+		
+		try (InputStream is = new ByteArrayInputStream(html.getBytes(StandardCharsets.UTF_8))) {
+			List<Document> docs = htmlParser.parse(is);
+			if (!docs.isEmpty()) {
+				// Get parsed text content
+				String text = docs.get(0).getText();
+				if (text == null || text.trim().isEmpty()) {
+					throw new RuntimeException("Parsed HTML content is empty");
+				}
+				// Remove extra whitespace characters
+				return text.replaceAll("\\s+", " ").trim();
+			}
+			throw new RuntimeException("No documents returned from HTML parser");
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to parse HTML content: " + e.getMessage(), e);
+		}
+	}
+}

--- a/community/document-readers/mbox-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReaderTest.java
+++ b/community/document-readers/mbox-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReaderTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test cases for MboxDocumentReader functionality
- * 
+ *
  * @author brianxiadong
  */
 public class MboxDocumentReaderTest {
@@ -44,9 +44,13 @@ public class MboxDocumentReaderTest {
 	Path tempDir;
 
 	private static final String SAMPLE_MBOX = "sample.mbox";
+
 	private static final String INVALID_MBOX = "invalid.mbox";
+
 	private File sampleMboxFile;
+
 	private File invalidMboxFile;
+
 	private SimpleDateFormat dateFormat;
 
 	@BeforeEach
@@ -54,18 +58,14 @@ public class MboxDocumentReaderTest {
 		// Create temporary test files
 		sampleMboxFile = tempDir.resolve(SAMPLE_MBOX).toFile();
 		invalidMboxFile = tempDir.resolve(INVALID_MBOX).toFile();
-		
+
 		// Copy test resource files from classpath to temporary directory
-		FileCopyUtils.copy(
-			new ClassPathResource(SAMPLE_MBOX).getInputStream(),
-			Files.newOutputStream(sampleMboxFile.toPath())
-		);
-		
-		FileCopyUtils.copy(
-			new ClassPathResource(INVALID_MBOX).getInputStream(),
-			Files.newOutputStream(invalidMboxFile.toPath())
-		);
-		
+		FileCopyUtils.copy(new ClassPathResource(SAMPLE_MBOX).getInputStream(),
+				Files.newOutputStream(sampleMboxFile.toPath()));
+
+		FileCopyUtils.copy(new ClassPathResource(INVALID_MBOX).getInputStream(),
+				Files.newOutputStream(invalidMboxFile.toPath()));
+
 		// Initialize date formatter
 		dateFormat = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.US);
 	}
@@ -76,24 +76,25 @@ public class MboxDocumentReaderTest {
 	@Test
 	void testPlainTextEmail() {
 		// Create reader instance
-		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 1, MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
-		
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 1,
+				MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
+
 		// Get document list
 		List<Document> documents = reader.get();
-		
+
 		// Verify only one email was read
 		assertEquals(1, documents.size(), "Should only read one email");
-		
+
 		// Get the first email
 		Document doc = documents.get(0);
 		Map<String, Object> metadata = doc.getMetadata();
-		
+
 		// Verify metadata
 		assertEquals("Plain Text Email", metadata.get("subject"));
 		assertEquals("Test Sender <test@example.com>", metadata.get("from"));
 		assertEquals("recipient@example.com", metadata.get("to"));
 		assertEquals("<test123@example.com>", doc.getId());
-		
+
 		// Verify plain text message content
 		String content = doc.getContent();
 		assertTrue(content.contains("This is a plain text email message"));
@@ -106,32 +107,35 @@ public class MboxDocumentReaderTest {
 	@Test
 	void testHtmlEmail() {
 		// Create reader instance and set to read first two emails
-		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 2, MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 2,
+				MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
 		List<Document> documents = reader.get();
-		
+
 		// Verify two emails were read
 		assertEquals(2, documents.size(), "Should read two emails");
-		
+
 		// Get the second HTML email
 		Document doc = documents.get(1);
 		Map<String, Object> metadata = doc.getMetadata();
-		
+
 		// Verify metadata
 		assertEquals("HTML Email", metadata.get("subject"));
 		assertEquals("Test Sender <test@example.com>", metadata.get("from"));
 		assertEquals("recipient@example.com", metadata.get("to"));
 		assertEquals("<test124@example.com>", doc.getId());
-		
+
 		// Verify HTML content was correctly parsed to text
 		String content = doc.getContent();
-		
+
 		// Verify heading was correctly extracted
 		assertTrue(content.contains("HTML Email Test"), "Should contain the h1 heading text");
-		
+
 		// Verify paragraph content was correctly extracted
-		assertTrue(content.contains("This is a HTML formatted email message"), "Should contain the first paragraph text");
-		assertTrue(content.contains("It contains styled text and multiple paragraphs"), "Should contain the second paragraph text");
-		
+		assertTrue(content.contains("This is a HTML formatted email message"),
+				"Should contain the first paragraph text");
+		assertTrue(content.contains("It contains styled text and multiple paragraphs"),
+				"Should contain the second paragraph text");
+
 		// Verify HTML tags were correctly removed
 		assertFalse(content.contains("<html>"), "Should not contain html tag");
 		assertFalse(content.contains("<head>"), "Should not contain head tag");
@@ -140,14 +144,12 @@ public class MboxDocumentReaderTest {
 		assertFalse(content.contains("<p>"), "Should not contain p tag");
 		assertFalse(content.contains("<b>"), "Should not contain b tag");
 		assertFalse(content.contains("<i>"), "Should not contain i tag");
-		
+
 		// Verify formatted content structure
-		String expectedFormat = String.format(MboxDocumentReader.DEFAULT_MESSAGE_FORMAT,
-				metadata.get("date"),
-				metadata.get("from"),
-				metadata.get("to"),
-				metadata.get("subject"),
-				"HTML Email Test This is a HTML formatted email message It contains styled text and multiple paragraphs".trim());
+		String expectedFormat = String.format(MboxDocumentReader.DEFAULT_MESSAGE_FORMAT, metadata.get("date"),
+				metadata.get("from"), metadata.get("to"), metadata.get("subject"),
+				"HTML Email Test This is a HTML formatted email message It contains styled text and multiple paragraphs"
+					.trim());
 	}
 
 	/**
@@ -156,7 +158,8 @@ public class MboxDocumentReaderTest {
 	@Test
 	void testMultipartEmail() {
 		// Create reader instance and set to read third email
-		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 3, MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 3,
+				MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
 		List<Document> documents = reader.get();
 
 		// Get multipart email
@@ -182,13 +185,13 @@ public class MboxDocumentReaderTest {
 	void testReadAllEmails() {
 		// Create reader instance with no limit
 		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath());
-		
+
 		// Get all emails
 		List<Document> documents = reader.get();
-		
+
 		// Verify total count
 		assertEquals(3, documents.size(), "Should read all four emails");
-		
+
 		// Verify email IDs in order
 		assertEquals("<test123@example.com>", documents.get(0).getId());
 		assertEquals("<test124@example.com>", documents.get(1).getId());
@@ -203,11 +206,11 @@ public class MboxDocumentReaderTest {
 		// Create reader with custom format
 		String customFormat = "Email Details:\nSubject: %4$s\nSender: %2$s\nReceiver: %3$s\nDate: %1$s\n\nMessage:\n%5$s";
 		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 1, customFormat);
-		
+
 		// Read first email
 		Document doc = reader.get().get(0);
 		String content = doc.getContent();
-		
+
 		// Verify custom format
 		assertTrue(content.startsWith("Email Details:"));
 		assertTrue(content.contains("Subject: Plain Text Email"));
@@ -239,4 +242,5 @@ public class MboxDocumentReaderTest {
 			new MboxDocumentReader("non_existent.mbox");
 		});
 	}
+
 }

--- a/community/document-readers/mbox-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReaderTest.java
+++ b/community/document-readers/mbox-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReaderTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.reader.mbox;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.document.Document;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test cases for MboxDocumentReader functionality
+ * 
+ * @author brianxiadong
+ */
+public class MboxDocumentReaderTest {
+
+	@TempDir
+	Path tempDir;
+
+	private static final String SAMPLE_MBOX = "sample.mbox";
+	private static final String INVALID_MBOX = "invalid.mbox";
+	private File sampleMboxFile;
+	private File invalidMboxFile;
+	private SimpleDateFormat dateFormat;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		// Create temporary test files
+		sampleMboxFile = tempDir.resolve(SAMPLE_MBOX).toFile();
+		invalidMboxFile = tempDir.resolve(INVALID_MBOX).toFile();
+		
+		// Copy test resource files from classpath to temporary directory
+		FileCopyUtils.copy(
+			new ClassPathResource(SAMPLE_MBOX).getInputStream(),
+			Files.newOutputStream(sampleMboxFile.toPath())
+		);
+		
+		FileCopyUtils.copy(
+			new ClassPathResource(INVALID_MBOX).getInputStream(),
+			Files.newOutputStream(invalidMboxFile.toPath())
+		);
+		
+		// Initialize date formatter
+		dateFormat = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z", Locale.US);
+	}
+
+	/**
+	 * Test reading plain text email
+	 */
+	@Test
+	void testPlainTextEmail() {
+		// Create reader instance
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 1, MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
+		
+		// Get document list
+		List<Document> documents = reader.get();
+		
+		// Verify only one email was read
+		assertEquals(1, documents.size(), "Should only read one email");
+		
+		// Get the first email
+		Document doc = documents.get(0);
+		Map<String, Object> metadata = doc.getMetadata();
+		
+		// Verify metadata
+		assertEquals("Plain Text Email", metadata.get("subject"));
+		assertEquals("Test Sender <test@example.com>", metadata.get("from"));
+		assertEquals("recipient@example.com", metadata.get("to"));
+		assertEquals("<test123@example.com>", doc.getId());
+		
+		// Verify plain text message content
+		String content = doc.getContent();
+		assertTrue(content.contains("This is a plain text email message"));
+		assertTrue(content.contains("Best regards"));
+	}
+
+	/**
+	 * Test reading HTML format email
+	 */
+	@Test
+	void testHtmlEmail() {
+		// Create reader instance and set to read first two emails
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 2, MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
+		List<Document> documents = reader.get();
+		
+		// Verify two emails were read
+		assertEquals(2, documents.size(), "Should read two emails");
+		
+		// Get the second HTML email
+		Document doc = documents.get(1);
+		Map<String, Object> metadata = doc.getMetadata();
+		
+		// Verify metadata
+		assertEquals("HTML Email", metadata.get("subject"));
+		assertEquals("Test Sender <test@example.com>", metadata.get("from"));
+		assertEquals("recipient@example.com", metadata.get("to"));
+		assertEquals("<test124@example.com>", doc.getId());
+		
+		// Verify HTML content was correctly parsed to text
+		String content = doc.getContent();
+		
+		// Verify heading was correctly extracted
+		assertTrue(content.contains("HTML Email Test"), "Should contain the h1 heading text");
+		
+		// Verify paragraph content was correctly extracted
+		assertTrue(content.contains("This is a HTML formatted email message"), "Should contain the first paragraph text");
+		assertTrue(content.contains("It contains styled text and multiple paragraphs"), "Should contain the second paragraph text");
+		
+		// Verify HTML tags were correctly removed
+		assertFalse(content.contains("<html>"), "Should not contain html tag");
+		assertFalse(content.contains("<head>"), "Should not contain head tag");
+		assertFalse(content.contains("<body>"), "Should not contain body tag");
+		assertFalse(content.contains("<h1>"), "Should not contain h1 tag");
+		assertFalse(content.contains("<p>"), "Should not contain p tag");
+		assertFalse(content.contains("<b>"), "Should not contain b tag");
+		assertFalse(content.contains("<i>"), "Should not contain i tag");
+		
+		// Verify formatted content structure
+		String expectedFormat = String.format(MboxDocumentReader.DEFAULT_MESSAGE_FORMAT,
+				metadata.get("date"),
+				metadata.get("from"),
+				metadata.get("to"),
+				metadata.get("subject"),
+				"HTML Email Test This is a HTML formatted email message It contains styled text and multiple paragraphs".trim());
+	}
+
+	/**
+	 * Test reading multipart email (multipart/alternative)
+	 */
+	@Test
+	void testMultipartEmail() {
+		// Create reader instance and set to read third email
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 3, MboxDocumentReader.DEFAULT_MESSAGE_FORMAT);
+		List<Document> documents = reader.get();
+
+		// Get multipart email
+		Document doc = documents.get(2);
+		Map<String, Object> metadata = doc.getMetadata();
+
+		// Verify metadata
+		assertEquals("Multipart Email", metadata.get("subject"));
+		assertEquals("<test125@example.com>", doc.getId());
+
+		// Verify content - should prefer HTML part
+		String content = doc.getContent();
+		assertTrue(content.contains("Multipart Email Test"));
+		assertTrue(content.contains("This is the HTML version"));
+		// Should not contain plain text part
+		assertFalse(content.contains("This is the plain text version"));
+	}
+
+	/**
+	 * Test reading all emails
+	 */
+	@Test
+	void testReadAllEmails() {
+		// Create reader instance with no limit
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath());
+		
+		// Get all emails
+		List<Document> documents = reader.get();
+		
+		// Verify total count
+		assertEquals(3, documents.size(), "Should read all four emails");
+		
+		// Verify email IDs in order
+		assertEquals("<test123@example.com>", documents.get(0).getId());
+		assertEquals("<test124@example.com>", documents.get(1).getId());
+		assertEquals("<test125@example.com>", documents.get(2).getId());
+	}
+
+	/**
+	 * Test custom message format
+	 */
+	@Test
+	void testCustomMessageFormat() {
+		// Create reader with custom format
+		String customFormat = "Email Details:\nSubject: %4$s\nSender: %2$s\nReceiver: %3$s\nDate: %1$s\n\nMessage:\n%5$s";
+		MboxDocumentReader reader = new MboxDocumentReader(sampleMboxFile.getAbsolutePath(), 1, customFormat);
+		
+		// Read first email
+		Document doc = reader.get().get(0);
+		String content = doc.getContent();
+		
+		// Verify custom format
+		assertTrue(content.startsWith("Email Details:"));
+		assertTrue(content.contains("Subject: Plain Text Email"));
+		assertTrue(content.contains("Sender: Test Sender <test@example.com>"));
+	}
+
+	/**
+	 * Test invalid mbox file
+	 */
+	@Test
+	void testInvalidMboxFile() {
+		// Create reader instance
+		MboxDocumentReader reader = new MboxDocumentReader(invalidMboxFile.getAbsolutePath());
+
+		// Read file
+		List<Document> documents = reader.get();
+
+		// Verify result is empty list
+		assertTrue(documents.isEmpty(), "Should return empty list for invalid mbox file");
+	}
+
+	/**
+	 * Test non-existent file
+	 */
+	@Test
+	void testNonExistentFile() {
+		// Verify constructor throws exception
+		assertThrows(IllegalArgumentException.class, () -> {
+			new MboxDocumentReader("non_existent.mbox");
+		});
+	}
+}

--- a/community/document-readers/mbox-document-reader/src/test/resources/invalid.mbox
+++ b/community/document-readers/mbox-document-reader/src/test/resources/invalid.mbox
@@ -1,0 +1,3 @@
+This is not a valid mbox file.
+It does not follow the mbox format specification.
+Missing required headers and structure. 

--- a/community/document-readers/mbox-document-reader/src/test/resources/sample.mbox
+++ b/community/document-readers/mbox-document-reader/src/test/resources/sample.mbox
@@ -1,0 +1,82 @@
+From test@example.com Thu Jan 1 00:00:00 2024
+From: Test Sender <test@example.com>
+Date: Thu, 1 Jan 2024 00:00:00 +0000
+Message-ID: <test123@example.com>
+Subject: Plain Text Email
+To: recipient@example.com
+Content-Type: text/plain; charset=UTF-8
+
+This is a plain text email message.
+It contains multiple lines of text
+for testing the MboxDocumentReader implementation.
+
+Best regards,
+Test Sender
+
+From test@example.com Thu Jan 1 00:00:01 2024
+From: Test Sender <test@example.com>
+Date: Thu, 1 Jan 2024 00:00:01 +0000
+Message-ID: <test124@example.com>
+Subject: HTML Email
+To: recipient@example.com
+Content-Type: text/html; charset=UTF-8
+
+<html>
+<head><title>Test HTML Email</title></head>
+<body>
+<h1>HTML Email Test</h1>
+<p>This is a <b>HTML</b> formatted email message.</p>
+<p>It contains <i>styled</i> text and multiple paragraphs.</p>
+</body>
+</html>
+
+From test@example.com Thu Jan 1 00:00:02 2024
+From: Test Sender <test@example.com>
+Date: Thu, 1 Jan 2024 00:00:02 +0000
+Message-ID: <test125@example.com>
+Subject: Multipart Email
+To: recipient@example.com
+Content-Type: multipart/alternative; boundary="boundary123"
+
+--boundary123
+Content-Type: text/plain; charset=UTF-8
+
+This is the plain text version of the email.
+For email clients that don't support HTML.
+
+--boundary123
+Content-Type: text/html; charset=UTF-8
+
+<html>
+<head><title>Multipart Email</title></head>
+<body>
+<h1>Multipart Email Test</h1>
+<p>This is the <b>HTML version</b> of the email.</p>
+<p>For modern email clients that support HTML.</p>
+</body>
+</html>
+--boundary123--
+
+From test@example.com Thu Jan 1 00:00:03 2024
+From: Test Sender <test@example.com>
+Date: Thu, 1 Jan 2024 00:00:03 +0000
+Message-ID: <test126@example.com>
+Subject: Email with Attachment
+To: recipient@example.com
+Content-Type: multipart/mixed; boundary="boundary456"
+
+--boundary456
+Content-Type: text/plain; charset=UTF-8
+
+This is the main email content.
+The attachment should be ignored by the reader.
+
+--boundary456
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="test.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjMKJcTl8uXrp/Og0MTGCjQgMCBvYmoKPDwgL0xlbmd0aCA1IDAgUiAvRmls
+dGVyIC9GbGF0ZURlY29kZSA+PgpzdHJlYW0KeAEtjTELwjAUhPd
+
+--boundary456-- 

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,15 @@
         <module>community/document-readers/gitlab-document-reader</module>
         <module>community/document-readers/gitbook-document-reader</module>
         <module>community/document-readers/huggingface-fs-document-reader</module>
+        <module>community/document-readers/mbox-document-reader</module>
 
 
         <module>community/document-parsers/document-parser-apache-pdfbox</module>
         <module>community/document-parsers/document-parser-markdown</module>
         <module>community/document-parsers/document-parser-tika</module>
         <module>community/document-parsers/document-parser-pdf-tables</module>
+        <module>community/document-parsers/document-parser-bshtml</module>
+        <module>community/document-parsers/document-parser-bibtex</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### Describe what this PR does / why we need it / 描述此 PR 的作用及必要性

This PR adds a new document reader implementation for Mbox format emails, which enables Spring AI to process email data from Mbox files. This is useful for scenarios where we need to analyze or process email content in batch.

此 PR 添加了一个新的 Mbox 格式邮件文档读取器实现，使 Spring AI 能够处理 Mbox 文件中的邮件数据。这对于需要批量分析或处理邮件内容的场景非常有用。

### Does this pull request fix one issue? / 此 PR 是否解决某个问题？

NONE

### Describe how you did it / 描述实现方式

- Implemented MboxDocumentReader using Apache Commons IO for file reading
- Used JSoup for HTML content parsing
- Added support for different email formats (plain text, HTML, multipart)
- Implemented robust error handling with runtime exceptions
- Added comprehensive test cases with sample mbox files
- Created bilingual documentation

- 使用 Apache Commons IO 实现 MboxDocumentReader 的文件读取
- 使用 JSoup 进行 HTML 内容解析
- 添加对不同邮件格式的支持（纯文本、HTML、多部分）
- 实现使用运行时异常的健壮错误处理
- 使用示例 mbox 文件添加全面的测试用例
- 创建中英文双语文档

### Describe how to verify it / 描述验证方式

1. Run the test cases:
   ```bash
   mvn test -Dtest=MboxDocumentReaderTest
   ```
2. Check the test coverage report
3. Verify the sample code in README.md works as expected

1. 运行测试用例：
   ```bash
   mvn test -Dtest=MboxDocumentReaderTest
   ```
2. 检查测试覆盖率报告
3. 验证 README.md 中的示例代码按预期工作

### Special notes for reviews / 审阅特别说明

- The implementation follows Spring AI's document reader pattern
- Error handling uses runtime exceptions as per project convention
- HTML parsing is done using JSoup to ensure clean text extraction
- The reader ignores email attachments by design
- Documentation is provided in both English and Chinese

- 实现遵循 Spring AI 的文档读取器模式
- 按照项目惯例使用运行时异常进行错误处理
- 使用 JSoup 进行 HTML 解析以确保干净的文本提取
- 读取器设计上忽略邮件附件
- 文档提供英文和中文双语版本

close #292 