### PR TITLE
Merge graph-run module into studio

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/pom.xml
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/pom.xml
@@ -68,7 +68,7 @@
 
         <dependency>
             <groupId>com.alibaba.cloud.ai</groupId>
-            <artifactId>spring-ai-alibaba-starter</artifactId>
+            <artifactId>spring-ai-alibaba-core</artifactId>
             <version>${parent.version}</version>
             <scope>test</scope>
         </dependency>

--- a/spring-ai-alibaba-studio/pom.xml
+++ b/spring-ai-alibaba-studio/pom.xml
@@ -33,6 +33,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-graph-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/api/GraphAPI.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/api/GraphAPI.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.api;
+
+import com.alibaba.cloud.ai.common.R;
+import com.alibaba.cloud.ai.param.GraphStreamParam;
+import com.alibaba.cloud.ai.service.GraphService;
+import com.alibaba.cloud.ai.graph.InitData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+
+@Tag(name = "Graph", description = "the graph API")
+public interface GraphAPI {
+
+    GraphService graphService();
+
+    @Operation(
+            summary = "init graph",
+            description = "",
+            tags = {"Graph"})
+    @GetMapping(value = "init", produces = MediaType.APPLICATION_JSON_VALUE)
+    default R<InitData> init() {
+        return R.success(graphService().init());
+    }
+
+    @Operation(
+            summary = "stream",
+            description = "",
+            tags = {"Graph"})
+    @PostMapping(value = "stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    default Flux<ServerSentEvent<String>> stream(HttpServletRequest request, GraphStreamParam param) throws Exception {
+        param.setSessionId(request.getSession().getId());
+        return graphService().stream(param, request.getInputStream());
+    }
+
+    @Operation(
+            summary = "user input",
+            description = "",
+            tags = {"Graph"})
+    @PostMapping(value = "/user/input", produces = MediaType.APPLICATION_JSON_VALUE)
+    default R<Void> userInput(@RequestBody Map<String, Object> dataMap) {
+        graphService().userInput(dataMap);
+        return R.success(null);
+    }
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/config/GraphAutoConfiguration.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/config/GraphAutoConfiguration.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.config;
+
+import com.alibaba.cloud.ai.graph.AiInsurance;
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.GraphRepresentation;
+import com.alibaba.cloud.ai.graph.GraphStateException;
+import com.alibaba.cloud.ai.graph.HumanNode;
+import com.alibaba.cloud.ai.graph.InitData;
+import com.alibaba.cloud.ai.graph.InitDataSerializer;
+import com.alibaba.cloud.ai.graph.IsAgentService;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.NodeOutputSerializer;
+import com.alibaba.cloud.ai.graph.PromptNode;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.ToolService;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.constant.SaverConstant;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
+import com.alibaba.cloud.ai.graph.serializer.agent.JSONStateSerializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncEdgeAction.edge_async;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+
+@Configuration
+public class GraphAutoConfiguration {
+
+    @Bean
+    public InitData initData(StateGraph stateGraph) {
+        String title = "AGENT EXECUTOR";
+        Map<String, InitData.ArgumentMetadata> inputArgs = new HashMap<>();
+        inputArgs.put("input", new InitData.ArgumentMetadata("string", true));
+        var graph = stateGraph.getGraph(GraphRepresentation.Type.MERMAID, title, false);
+        return new InitData(title, graph.getContent(), inputArgs);
+    }
+
+    @Bean
+    public StateGraph stateGraph(StateSerializer stateSerializer, AiInsurance aiInsurance) throws GraphStateException {
+        MemorySaver saver = new MemorySaver();
+        SaverConfig saverConfig = SaverConfig.builder()
+                .type(SaverConstant.MEMORY)
+                .register(SaverConstant.MEMORY, saver)
+                .build();
+        CompileConfig compileConfig =
+                CompileConfig.builder().saverConfig(saverConfig).build();
+        var subGraph = new StateGraph(stateSerializer)
+                .addEdge(START, "select_prompt")
+                .addNode("select_prompt", node_async(new PromptNode("请选择：1-人寿保险：100元/年，2-健康险：200元/年")))
+                .addEdge("select_prompt", "user_select")
+                .addNode("user_select", node_async(new HumanNode()))
+                .addConditionalEdges( // 条件边，在agent节点之后
+                        "user_select",
+                        edge_async(aiInsurance::generateBills),
+                        Map.of("continue", "do_purchase", "error", "error_prompt"))
+                .addNode("do_purchase", node_async(new PromptNode("请使用付款链接#{url}付款，成功后确认", input -> {
+                    var url = "www.bill.com?money=" + Integer.parseInt(input) * 100;
+                    return Map.of("url", url);
+                })))
+                .addNode("error_prompt", node_async(new PromptNode("输入错误，请重新选择")))
+                .addEdge("error_prompt", "select_prompt")
+                .addEdge("do_purchase", "user_confirm")
+                .addNode("user_confirm", node_async(new HumanNode()))
+                .addConditionalEdges( // 条件边，在agent节点之后
+                        "user_confirm",
+                        edge_async(aiInsurance::payFinish),
+                        Map.of("continue", "pay_success", "error", END, "prompt", "error_prompt1"))
+                .addNode("error_prompt1", node_async(new PromptNode("参数错误，请选择确认或者取消")))
+                .addEdge("error_prompt1", "user_confirm")
+                .addNode("pay_success", node_async(new PromptNode("付款成功")))
+                .addEdge("pay_success", END)
+                .compile(compileConfig);
+
+        return new StateGraph(stateSerializer)
+                .addEdge(START, "welcome")
+                .addNode(
+                        "welcome",
+                        node_async(new PromptNode(
+                                "您好！我是您的保险助手popo。无论您是在寻找保障、规划未来，还是需要专业的保险建议，我都在这里为您提供帮助。请告诉我您的保险需求，让我们开始吧！"))) // 调用llm
+                .addEdge("welcome", "input_customer_wish") // 下一个节点
+                .addNode("input_customer_wish", node_async(new HumanNode()))
+                .addConditionalEdges( // 条件边，在agent节点之后
+                        "input_customer_wish",
+                        edge_async(aiInsurance::questionEnough),
+                        Map.of("input_enough", "llm_answer", "input_not_enough", "prompt"))
+                .addNode("prompt", node_async(new PromptNode("请填写年龄、性别、学历等完整信息")))
+                .addEdge("prompt", "llm_answer") // 下一个节点
+                // .addEdge("human", "agent")// 下一个节点
+                .addNode("llm_answer", node_async(aiInsurance::callAgent)) // 调用llm
+                .addNode("input_customer_purchase_intention", node_async(new HumanNode()))
+                .addEdge("llm_answer", "input_customer_purchase_intention") // 下一个节点
+                .addConditionalEdges( // 条件边，在agent节点之后
+                        "input_customer_purchase_intention",
+                        edge_async(aiInsurance::purchaseIntention),
+                        Map.of("want_purchase", "purchaseGraph", "not_want_purchase", "want_feedback"))
+                .addNode("want_feedback", node_async(new PromptNode("感谢您的咨询，欢迎向我们反馈任何建议")))
+                .addEdge("want_feedback", END)
+                .addSubgraph("purchaseGraph", subGraph)
+                .addEdge("purchaseGraph", END);
+    }
+
+    @Bean
+    public StateSerializer stateSerializer() {
+        return new JSONStateSerializer();
+    }
+
+    @Bean
+    public AiInsurance aiInsurance(IsAgentService agentService) {
+        return new AiInsurance(agentService);
+    }
+
+    @Bean
+    public IsAgentService agentService(ChatClient.Builder chatClientBuilder, ToolService toolService) {
+        return new IsAgentService(chatClientBuilder, toolService);
+    }
+
+    @Bean
+    public ToolService toolService(ApplicationContext applicationContext) {
+        return new ToolService(applicationContext);
+    }
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer customJackson() {
+        return jackson2ObjectMapperBuilder -> jackson2ObjectMapperBuilder.modules(new SimpleModule()
+                .addSerializer(InitData.class, new InitDataSerializer(InitData.class))
+                .addSerializer(NodeOutput.class, new NodeOutputSerializer()));
+    }
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/GraphAPIController.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/GraphAPIController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.controller;
+
+import com.alibaba.cloud.ai.api.GraphAPI;
+import com.alibaba.cloud.ai.service.GraphService;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin
+@RestController
+@RequestMapping("studio/api/graph")
+public class GraphAPIController implements GraphAPI {
+
+    private final GraphService graphService;
+
+    public GraphAPIController(GraphService graphService) {
+        this.graphService = graphService;
+    }
+
+    @Override
+    public GraphService graphService() {
+        return graphService;
+    }
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/function/AgentFunctionCallbackWrapper.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/function/AgentFunctionCallbackWrapper.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.function;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.model.function.FunctionCallbackContext;
+import org.springframework.ai.model.function.TypeResolverHelper;
+import org.springframework.util.Assert;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+@EqualsAndHashCode
+public class AgentFunctionCallbackWrapper<I, O> implements BiFunction<I, ToolContext, O>, FunctionCallback {
+
+	@Getter
+	private final String name;
+
+	@Getter
+	private final String description;
+
+	@Getter
+	private final String inputTypeSchema;
+
+	private final Class<I> inputType;
+
+	private final ObjectMapper objectMapper;
+
+	private final Function<O, String> responseConverter;
+
+	private final BiFunction<I, ToolContext, O> biFunction;
+
+	protected AgentFunctionCallbackWrapper(String name, String description, String inputTypeSchema, Class<I> inputType,
+                                           Function<O, String> responseConverter, ObjectMapper objectMapper, BiFunction<I, ToolContext, O> function) {
+		Assert.notNull(name, "Name must not be null");
+		Assert.notNull(description, "Description must not be null");
+		Assert.notNull(inputType, "InputType must not be null");
+		Assert.notNull(inputTypeSchema, "InputTypeSchema must not be null");
+		Assert.notNull(responseConverter, "ResponseConverter must not be null");
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		Assert.notNull(function, "Function must not be null");
+		this.name = name;
+		this.description = description;
+		this.inputType = inputType;
+		this.inputTypeSchema = inputTypeSchema;
+		this.responseConverter = responseConverter;
+		this.objectMapper = objectMapper;
+		this.biFunction = function;
+	}
+
+	public O convertResponse(ToolResponseMessage.ToolResponse toolResponse) {
+		try {
+			Class<O> targetClass = resolveOutputType(biFunction);
+			return objectMapper.readValue(toolResponse.responseData(), targetClass);
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public String call(String functionInput, ToolContext toolContext) {
+		I request = fromJson(functionInput, inputType);
+		O response = apply(request, toolContext);
+		return this.responseConverter.apply(response);
+	}
+
+	public String call(String functionArguments) {
+		I request = fromJson(functionArguments, inputType);
+		return andThen(responseConverter).apply(request, null);
+	}
+
+	private <T> T fromJson(String json, Class<T> targetClass) {
+		try {
+			return objectMapper.readValue(json, targetClass);
+		}
+		catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public O apply(I input, ToolContext context) {
+		return biFunction.apply(input, context);
+	}
+
+	private static <I, O> Class<O> resolveOutputType(BiFunction<I, ToolContext, O> biFunction) {
+		return (Class<O>) TypeResolverHelper
+			.getBiFunctionArgumentClass((Class<? extends BiFunction<?, ?, ?>>) biFunction.getClass(), 2);
+	}
+
+	public static <I, O> Builder<I, O> builder(BiFunction<I, ToolContext, O> biFunction) {
+		return new Builder<>(biFunction);
+	}
+
+	public static <I, O> Builder<I, O> builder(Function<I, O> function) {
+		return new Builder<>(function);
+	}
+
+	public static class Builder<I, O> {
+
+		private String name;
+
+		private String description;
+
+		private Class<I> inputType;
+
+		private final BiFunction<I, ToolContext, O> biFunction;
+
+		private final Function<I, O> function;
+
+		private FunctionCallbackContext.SchemaType schemaType;
+
+		private Function<O, String> responseConverter;
+
+		private String inputTypeSchema;
+
+		private ObjectMapper objectMapper;
+
+		public Builder(BiFunction<I, ToolContext, O> biFunction) {
+			this.schemaType = FunctionCallbackContext.SchemaType.JSON_SCHEMA;
+			this.responseConverter = ModelOptionsUtils::toJsonString;
+			this.objectMapper = (new ObjectMapper()).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+				.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+				.registerModule(new JavaTimeModule());
+			Assert.notNull(biFunction, "Function must not be null");
+			this.biFunction = biFunction;
+			this.function = null;
+		}
+
+		public Builder(Function<I, O> function) {
+			this.schemaType = FunctionCallbackContext.SchemaType.JSON_SCHEMA;
+			this.responseConverter = ModelOptionsUtils::toJsonString;
+			this.objectMapper = (new ObjectMapper()).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+				.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+				.registerModule(new JavaTimeModule());
+			Assert.notNull(function, "Function must not be null");
+			this.biFunction = null;
+			this.function = function;
+		}
+
+		public Builder<I, O> withName(String name) {
+			Assert.hasText(name, "Name must not be empty");
+			this.name = name;
+			return this;
+		}
+
+		public Builder<I, O> withDescription(String description) {
+			Assert.hasText(description, "Description must not be empty");
+			this.description = description;
+			return this;
+		}
+
+		public Builder<I, O> withInputType(Class<I> inputType) {
+			this.inputType = inputType;
+			return this;
+		}
+
+		public Builder<I, O> withResponseConverter(Function<O, String> responseConverter) {
+			Assert.notNull(responseConverter, "ResponseConverter must not be null");
+			this.responseConverter = responseConverter;
+			return this;
+		}
+
+		public Builder<I, O> withInputTypeSchema(String inputTypeSchema) {
+			Assert.hasText(inputTypeSchema, "InputTypeSchema must not be empty");
+			this.inputTypeSchema = inputTypeSchema;
+			return this;
+		}
+
+		public Builder<I, O> withObjectMapper(ObjectMapper objectMapper) {
+			Assert.notNull(objectMapper, "ObjectMapper must not be null");
+			this.objectMapper = objectMapper;
+			return this;
+		}
+
+		public Builder<I, O> withSchemaType(FunctionCallbackContext.SchemaType schemaType) {
+			Assert.notNull(schemaType, "SchemaType must not be null");
+			this.schemaType = schemaType;
+			return this;
+		}
+
+		public AgentFunctionCallbackWrapper<I, O> build() {
+			Assert.hasText(name, "Name must not be empty");
+			Assert.hasText(description, "Description must not be empty");
+			Assert.notNull(responseConverter, "ResponseConverter must not be null");
+			Assert.notNull(objectMapper, "ObjectMapper must not be null");
+			if (inputType == null) {
+				if (function != null) {
+					inputType = resolveInputType(function);
+				}
+				else {
+					inputType = resolveInputType(biFunction);
+				}
+			}
+
+			if (inputTypeSchema == null) {
+				boolean upperCaseTypeValues = schemaType == FunctionCallbackContext.SchemaType.OPEN_API_SCHEMA;
+				inputTypeSchema = ModelOptionsUtils.getJsonSchema(inputType, upperCaseTypeValues);
+			}
+
+			BiFunction<I, ToolContext, O> finalBiFunction = biFunction != null ? biFunction
+					: (request, context) -> function.apply(request);
+
+			return new AgentFunctionCallbackWrapper<>(name, description, inputTypeSchema, inputType, responseConverter,
+					objectMapper, finalBiFunction);
+		}
+
+		private static <I, O> Class<I> resolveInputType(BiFunction<I, ToolContext, O> biFunction) {
+			return (Class<I>) TypeResolverHelper
+				.getBiFunctionInputClass((Class<? extends BiFunction<?, ?, ?>>) biFunction.getClass());
+		}
+
+		private static <I, O> Class<I> resolveInputType(Function<I, O> function) {
+			return (Class<I>) TypeResolverHelper
+				.getFunctionInputClass((Class<? extends Function<?, ?>>) function.getClass());
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/AiInsurance.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/AiInsurance.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.serializer.agent.AgentAction;
+import com.alibaba.cloud.ai.graph.serializer.agent.AgentFinish;
+import com.alibaba.cloud.ai.graph.serializer.agent.AgentOutcome;
+import com.alibaba.cloud.ai.graph.state.NodeState;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+import java.util.Random;
+
+@Slf4j
+public class AiInsurance {
+
+    private final IsAgentService agentService;
+
+    public AiInsurance(IsAgentService agentService) {
+        this.agentService = agentService;
+    }
+
+    public Map<String, Object> callAgent(NodeState state) {
+        log.info("callAgent");
+
+        var input = state.input()
+                .filter(StringUtils::hasText)
+                .orElseThrow(() -> new IllegalArgumentException("no input provided!"));
+
+        var response = agentService.execute(input);
+
+        var output = response.getResult().getOutput();
+
+        if (output.hasToolCalls()) {
+            var action = new AgentAction(output.getToolCalls().get(0), "");
+            return Map.of(NodeState.OUTPUT, new AgentOutcome(action, null));
+
+        } else {
+            var finish = new AgentFinish(Map.of("returnValues", output.getContent()), output.getContent());
+
+            return Map.of(NodeState.OUTPUT, new AgentOutcome(null, finish));
+        }
+    }
+
+    public String questionEnough(NodeState state) {
+
+        Map<String, Object> returnValues = state.data();
+        if (!returnValues.containsKey("input")) {
+            return "return";
+        }
+        String input = (String) returnValues.get("input");
+        // 判断用户输入内容是否包括全部所需要信息（年龄、性别、学历……）
+        if (input.contains("年龄") && input.contains("性别") && input.contains("学历")) {
+            return "input_enough";
+        } else {
+            return "input_not_enough";
+        }
+    }
+
+    public String purchaseIntention(NodeState state) {
+
+        var input = state.input()
+                .filter(StringUtils::hasText)
+                .orElseThrow(() -> new IllegalArgumentException("no input provided!"));
+
+        var response = agentService.executeByPrompt(
+                "判断用户是否有购买保险意愿，只返回是或者否。比如用户输入我要买，返回是" + input, "判断用户是否有购买保险意愿，只返回是或者否。比如用户输入我要买，返回是");
+
+        var output = response.getResult().getOutput();
+        log.info("agent:{}", output.getContent());
+        // 判断用户输入内容是否包括全部所需要信息（年龄、性别、学历……）
+        if (output.getContent().equals("是")) {
+            return "want_purchase";
+        } else {
+            return "not_want_purchase";
+        }
+    }
+
+    public String generateBills(NodeState state) {
+
+        var input = state.input()
+                .filter(StringUtils::hasText)
+                .orElseThrow(() -> new IllegalArgumentException("no input provided!"));
+
+        if ("1".equals(input) || "2".equals(input)) {
+            return "continue";
+        } else {
+            return "error";
+        }
+    }
+
+    public String payFinish(NodeState state) {
+
+        var input = state.input()
+                .filter(StringUtils::hasText)
+                .orElseThrow(() -> new IllegalArgumentException("no input provided!"));
+
+        // 1 确认 0 取消
+        if ("1".equals(input)) {
+            // 查询是否付款，假设已付款
+            if (new Random().nextInt(100) < 50) {
+                return "continue";
+            } else {
+                return "error";
+            }
+        } else if ("0".equals(input)) {
+            return "error";
+        } else {
+            return "prompt";
+        }
+    }
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/HumanNode.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/HumanNode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import com.alibaba.cloud.ai.graph.state.NodeState;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.service.impl.GraphServiceImpl.USER_INPUT;
+
+public class HumanNode implements NodeAction {
+
+	@Override
+	public Map<String, Object> apply(NodeState state) {
+		USER_INPUT.clear();
+		synchronized (USER_INPUT) {
+			try {
+				USER_INPUT.wait();
+			}
+			catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+
+		}
+		USER_INPUT.remove(NodeState.OUTPUT);
+		return new HashMap<>(USER_INPUT);
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/InitData.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/InitData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import java.util.List;
+import java.util.Map;
+
+public record InitData(String title, String graph, Map<String, ArgumentMetadata> args, List<ThreadEntry> threads) {
+
+    public InitData(String title, String graph, Map<String, ArgumentMetadata> args) {
+        this(title, graph, args, List.of(new ThreadEntry("default", List.of())));
+    }
+
+    public record ArgumentMetadata(String type, boolean required) {
+    }
+
+    public record ThreadEntry(String id, List<? extends NodeOutput> entries) {
+
+    }
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/InitDataSerializer.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/InitDataSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class InitDataSerializer extends StdSerializer<InitData> {
+
+    public InitDataSerializer(Class<InitData> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(InitData initData, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+
+        jsonGenerator.writeStringField("graph", initData.graph());
+        jsonGenerator.writeStringField("title", initData.title());
+        jsonGenerator.writeObjectField("args", initData.args());
+
+        // jsonGenerator.writeArrayFieldStart("nodes" );
+        // for( var node : initData.nodes() ) {
+        // jsonGenerator.writeString(node);
+        // }
+        // jsonGenerator.writeEndArray();
+
+        jsonGenerator.writeArrayFieldStart("threads");
+        for (var thread : initData.threads()) {
+            jsonGenerator.writeStartArray();
+            jsonGenerator.writeString(thread.id());
+            jsonGenerator.writeStartArray(thread.entries());
+            jsonGenerator.writeEndArray();
+            jsonGenerator.writeEndArray();
+        }
+        jsonGenerator.writeEndArray();
+
+        jsonGenerator.writeEndObject();
+    }
+
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/IsAgentService.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/IsAgentService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.model.function.FunctionCallback;
+
+public class IsAgentService {
+
+	public final ToolService toolService;
+
+	private final ChatClient chatClient;
+
+	public IsAgentService(ChatClient.Builder chatClientBuilder, ToolService toolService) {
+		var functions = toolService.agentFunctionsCallback().toArray(FunctionCallback[]::new);
+
+		this.chatClient = chatClientBuilder.defaultSystem("You are a helpful AI Assistant answering questions.")
+			.defaultFunctions(functions)
+			.build();
+		this.toolService = toolService;
+	}
+
+	public ChatResponse execute(String input) {
+		return chatClient.prompt().user(input).call().chatResponse();
+	}
+
+	public ChatResponse executeByPrompt(String input, String prompt) {
+		return chatClient.prompt(prompt).user(input).call().chatResponse();
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/NodeOutputSerializer.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/NodeOutputSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.state.StateSnapshot;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class NodeOutputSerializer extends StdSerializer<NodeOutput> {
+
+    public NodeOutputSerializer() {
+        super(NodeOutput.class);
+    }
+
+    @Override
+    public void serialize(NodeOutput nodeOutput, JsonGenerator gen, SerializerProvider serializerProvider)
+            throws IOException {
+        log.trace("NodeOutputSerializer start! {}", nodeOutput.getClass());
+        gen.writeStartObject();
+        if (nodeOutput instanceof StateSnapshot snapshot) {
+            var checkpoint = snapshot.config().checkPointId();
+            log.trace("checkpoint: {}", checkpoint);
+            if (checkpoint.isPresent()) {
+                gen.writeStringField("checkpoint", checkpoint.get());
+            }
+        }
+        gen.writeStringField("node", nodeOutput.node());
+        gen.writeObjectField("state", nodeOutput.state().data());
+        gen.writeEndObject();
+    }
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/PersistentConfig.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/PersistentConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import java.util.Objects;
+
+public record PersistentConfig(String sessionId, String threadId) {
+    public PersistentConfig {
+        Objects.requireNonNull(sessionId);
+    }
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/PromptNode.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/PromptNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import com.alibaba.cloud.ai.graph.state.NodeState;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PromptNode implements NodeAction {
+
+	private Function<String, Map<String, String>> inputMapFunc;
+
+	public PromptNode(String template) {
+		this.template = template;
+	}
+
+	public PromptNode(String template, Function<String, Map<String, String>> function) {
+		this.template = template;
+		this.inputMapFunc = function;
+	}
+
+	// 可以通过前端映射
+	private final String template;
+
+	@Override
+	public Map<String, Object> apply(NodeState agentState) {
+		Pattern pattern = Pattern.compile("#\\{(.*?)\\}");
+		Matcher matcher = pattern.matcher(template);
+		StringBuilder sb = new StringBuilder();
+		boolean anyFind = false;
+		while (matcher.find()) {
+			anyFind = true;
+			String key = matcher.group(1);
+			if (inputMapFunc != null) {
+				var input = agentState.input()
+					.filter(StringUtils::hasText)
+					.orElseThrow(() -> new IllegalArgumentException("no input provided!"));
+				Map<String, String> mapV = inputMapFunc.apply(input);
+				if (mapV.containsKey(key)) {
+					String replacement = mapV.get(key);
+					matcher.appendReplacement(sb, replacement != null ? replacement : "");
+				}
+
+			}
+			else if (agentState.data().containsKey(key)) {
+				String replacement = agentState.data().get(key).toString();
+				matcher.appendReplacement(sb, replacement != null ? replacement : "");
+			}
+		}
+		matcher.appendTail(sb);
+		String content = anyFind ? sb.toString() : template;
+
+		return Map.of(NodeState.OUTPUT, content);
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/ToolService.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/graph/ToolService.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.function.AgentFunctionCallbackWrapper;
+import lombok.NonNull;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.context.ApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class ToolService {
+
+	private final List<FunctionCallback> agentFunctionCallbackWrappers;
+
+	private final ApplicationContext applicationContext;
+
+	public ToolService(ApplicationContext applicationContext) {
+
+		this.applicationContext = applicationContext;
+		var AgentFunctionCallbackMap = applicationContext.getBeansOfType(AgentFunctionCallbackWrapper.class);
+
+		agentFunctionCallbackWrappers = AgentFunctionCallbackMap.values()
+			.stream()
+			.map(FunctionCallback.class::cast)
+			.toList();
+	}
+
+	public List<FunctionCallback> agentFunctionsCallback() {
+		return agentFunctionCallbackWrappers;
+	}
+
+	public <I, O> Optional<AgentFunctionCallbackWrapper<I, O>> agentFunction(@NonNull String name) {
+		return (applicationContext.containsBean(name))
+				? Optional.of(applicationContext.getBean(name, AgentFunctionCallbackWrapper.class)) : Optional.empty();
+	}
+
+	public <O> Optional<O> getFunctionResult(@NonNull ToolResponseMessage.ToolResponse response) {
+		return agentFunction(response.name()).map(functionCallback -> (O) functionCallback.convertResponse(response));
+	}
+
+	public ToolResponseMessage buildToolResponseMessage(@NonNull ToolResponseMessage.ToolResponse response) {
+		return new ToolResponseMessage(List.of(response), Map.of());
+	}
+
+	public CompletableFuture<ToolResponseMessage.ToolResponse> executeFunction(AssistantMessage.ToolCall toolCall,
+			Map<String, Object> toolContextMap) {
+		CompletableFuture<ToolResponseMessage.ToolResponse> result = new CompletableFuture<>();
+
+		String functionName = toolCall.name();
+		String functionArguments = toolCall.arguments();
+
+		var functionCallback = agentFunction(functionName);
+
+		if (functionCallback.isPresent()) {
+			var functionResponse = functionCallback.get().call(functionArguments, new ToolContext(toolContextMap));
+
+			result.complete(new ToolResponseMessage.ToolResponse(toolCall.id(), functionName, functionResponse));
+		}
+		else {
+
+			result.completeExceptionally(
+					new IllegalStateException("No function callback found for function name: " + functionName));
+		}
+
+		return result;
+
+	}
+
+	public CompletableFuture<ToolResponseMessage.ToolResponse> executeFunction(AssistantMessage.ToolCall toolCall) {
+		return executeFunction(toolCall, Map.of());
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/param/GraphStreamParam.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/param/GraphStreamParam.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.param;
+
+import lombok.Data;
+
+@Data
+public class GraphStreamParam {
+
+    private String sessionId;
+
+    private String thread;
+
+    private boolean resume;
+
+    private String checkpoint;
+
+    private String node;
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/service/GraphService.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/service/GraphService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.service;
+
+import com.alibaba.cloud.ai.graph.InitData;
+import com.alibaba.cloud.ai.param.GraphStreamParam;
+import org.springframework.http.codec.ServerSentEvent;
+import reactor.core.publisher.Flux;
+
+import java.io.InputStream;
+import java.util.Map;
+
+public interface GraphService {
+
+    InitData init();
+
+    Flux<ServerSentEvent<String>> stream(GraphStreamParam param, InputStream inputStream) throws Exception;
+
+    void userInput(Map<String, Object> dataMap);
+}

--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/service/impl/GraphServiceImpl.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/service/impl/GraphServiceImpl.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.service.impl;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.PersistentConfig;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.constant.SaverConstant;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.serializer.plain_text.PlainTextStateSerializer;
+import com.alibaba.cloud.ai.graph.state.NodeState;
+import com.alibaba.cloud.ai.param.GraphStreamParam;
+import com.alibaba.cloud.ai.service.GraphService;
+import com.alibaba.cloud.ai.graph.InitData;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.bsc.async.AsyncGenerator;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@Slf4j
+public class GraphServiceImpl implements GraphService {
+
+    private final ObjectMapper objectMapper;
+
+    private final StateGraph stateGraph;
+
+    private InitData initData;
+
+    private final Map<PersistentConfig, CompiledGraph> graphCache = new ConcurrentHashMap<>();
+
+    public static final Map<String, Object> USER_INPUT = new HashMap<>();
+
+    public GraphServiceImpl(ObjectMapper objectMapper, InitData initData, StateGraph stateGraph) {
+        this.objectMapper = objectMapper;
+        this.initData = initData;
+        this.stateGraph = stateGraph;
+    }
+
+    @Override
+    public InitData init() {
+        return initData;
+    }
+
+    @Override
+    public Flux<ServerSentEvent<String>> stream(GraphStreamParam param, InputStream inputStream) throws Exception {
+        var threadId = param.getThread();
+        var resume = param.isResume();
+        var persistentConfig = new PersistentConfig(param.getSessionId(), threadId);
+        var compiledGraph = graphCache.get(persistentConfig);
+
+        final Map<String, Object> dataMap;
+        if (resume && stateGraph.getStateSerializer() instanceof PlainTextStateSerializer textSerializer) {
+            dataMap = textSerializer.read(new InputStreamReader(inputStream)).data();
+        } else {
+            dataMap = objectMapper.readValue(inputStream, new TypeReference<>() {});
+        }
+
+        AsyncGenerator<? extends NodeOutput> generator;
+        if (resume) {
+            log.trace("RESUME REQUEST PREPARE");
+
+            if (compiledGraph == null) {
+                throw new IllegalStateException("Missing CompiledGraph in session!");
+            }
+
+            var checkpointId = param.getCheckpoint();
+            var node = param.getNode();
+            var config = RunnableConfig.builder()
+                    .threadId(threadId)
+                    .checkPointId(checkpointId)
+                    .build();
+            var stateSnapshot = compiledGraph.getState(config);
+
+            config = stateSnapshot.config();
+            log.trace("RESUME UPDATE STATE FORM {} USING CONFIG {}\n{}", node, config, dataMap);
+            config = compiledGraph.updateState(config, dataMap, node);
+            log.trace("RESUME REQUEST STREAM {}", config);
+
+            generator = compiledGraph.streamSnapshots(null, config);
+        } else {
+            log.trace("dataMap: {}", dataMap);
+            if (compiledGraph == null) {
+                compiledGraph = stateGraph.compile(compileConfig(persistentConfig));
+                graphCache.put(persistentConfig, compiledGraph);
+            }
+            generator = compiledGraph.streamSnapshots(dataMap, runnableConfig(persistentConfig));
+        }
+
+        Sinks.Many<ServerSentEvent<String>> sink = Sinks.many().unicast().onBackpressureBuffer();
+        Flux<ServerSentEvent<String>> flux = sink.asFlux();
+        generator
+                .forEachAsync(s -> {
+                    try {
+                        if (s.state().data().containsKey(NodeState.SUB_GRAPH)) {
+                            CompiledGraph.AsyncNodeGenerator<NodeOutput> subGenerator =
+                                    (CompiledGraph.AsyncNodeGenerator)
+                                            s.state().data().get(NodeState.SUB_GRAPH);
+                            subGenerator.forEach(subS -> {
+                                try {
+                                    NodeOutput output = subGenerator.buildNodeOutput(subGenerator.getCurrentNodeId());
+                                    sink.tryEmitNext(ServerSentEvent.<String>builder()
+                                            .id(threadId)
+                                            .data(objectMapper.writeValueAsString(output))
+                                            .build());
+                                } catch (IOException e) {
+                                    log.warn("error serializing state", e);
+                                } catch (Exception e) {
+                                    log.warn("error state", e);
+                                    sink.tryEmitError(e);
+                                }
+                            });
+                        } else {
+                            sink.tryEmitNext(ServerSentEvent.<String>builder()
+                                    .id(threadId)
+                                    .data(objectMapper.writeValueAsString(s))
+                                    .build());
+                        }
+                    } catch (IOException e) {
+                        log.warn("error state", e);
+                        sink.tryEmitError(e);
+                    }
+                })
+                .whenComplete((unused, throwable) -> {
+                    if (throwable != null) {
+                        log.error("Error streaming", throwable);
+                        sink.tryEmitError(throwable);
+                    } else {
+                        sink.tryEmitComplete();
+                    }
+                });
+
+        return flux;
+    }
+
+    @Override
+    public void userInput(Map<String, Object> dataMap) {
+        USER_INPUT.putAll(dataMap);
+        synchronized (USER_INPUT) {
+            USER_INPUT.notify();
+        }
+    }
+
+    private CompileConfig compileConfig(PersistentConfig config) {
+        return CompileConfig.builder()
+                .saverConfig(SaverConfig.builder()
+                        .register(SaverConstant.MEMORY, new MemorySaver())
+                        .build()) // .stateSerializer(stateSerializer)
+                .build();
+    }
+
+    RunnableConfig runnableConfig(PersistentConfig config) {
+        return RunnableConfig.builder().threadId(config.threadId()).build();
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Merge graph-run module into studio

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it
1. startup CliDebugExampleApplication
2. execute in your terminal: 
  > curl 'http://localhost:8080/studio/api/graph/stream?thread=default' \
  -H 'Accept: */*' \
  -H 'Accept-Language: zh-CN,zh;q=0.9' \
  -H 'Cache-Control: no-cache' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  -H 'Cookie: JSESSIONID=node01fouu9prlcx8u1xfmam4zzynpy0.node0' \
  --data-raw '{"input":""}' -v
3. execute in your another terminal in order: 
> curl -X POST 'http://localhost:8080/studio/api/graph/user/input' -H 'Content-Type: application/json' --data '{"input":"年龄21 性别男 学历本科"}'

> curl -X POST 'http://localhost:8080/studio/api/graph/user/input' -H 'Content-Type: application/json' --data '{"input":"我要买保险"}'

> curl -X POST 'http://localhost:8080/studio/api/graph/user/input' -H 'Content-Type: application/json' --data '{"input":"1"}'

> curl -X POST 'http://localhost:8080/studio/api/graph/user/input' -H 'Content-Type: application/json' --data '{"input":"1"}'

4. Result:
![image](https://github.com/user-attachments/assets/3288e94e-1e32-48ac-bf3d-ff15191b0f6a)

### Special notes for reviews
