### PR TITLE
Feat: Add Google OneNote Document Reader Support

### DIFF
--- a/community/document-readers/onenote-document-reader/pom.xml
+++ b/community/document-readers/onenote-document-reader/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>onenote-document-reader</artifactId>
+    <name>onenote-document-reader</name>
+    <description>onenote reader for Spring AI Alibaba</description>
+    <packaging>jar</packaging>
+    <url>https://github.com/alibaba/spring-ai-alibaba</url>
+    <scm>
+        <url>https://github.com/alibaba/spring-ai-alibaba</url>
+        <connection>git://github.com/alibaba/spring-ai-alibaba.git</connection>
+        <developerConnection>git@github.com:alibaba/spring-ai-alibaba.git</developerConnection>
+    </scm>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <jsoup-version>1.18.1</jsoup-version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>document-parser-markdown</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup-version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+</project>

--- a/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
+++ b/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.cloud.api.reader.onenote;
 
 import com.google.gson.JsonArray;

--- a/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
+++ b/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
@@ -161,7 +161,7 @@ public class OneNoteDocumentReader implements DocumentReader {
         String text = parseDoc.text();
 
         // Return title and content in a readable format
-        return title + (title.isEmpty() ? "" : "\n") + text;
+        return title + (StringUtils.hasText(title) ? "" : "\n") + text;
     }
 
     /**

--- a/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
+++ b/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
@@ -1,0 +1,233 @@
+package com.alibaba.cloud.api.reader.onenote;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.jsoup.Jsoup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * @author sparkle6979l
+ */
+public class OneNoteDocumentReader implements DocumentReader {
+
+    public static final String MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
+
+    public static final String NOTEBOOK_ID_FILTER_PREFIX = "/me/onenote/pages/?$expand=parentNotebook&$filter=parentNotebook/id";
+
+    public static final String SECTION_ID_FILTER_PREFIX = "/me/onenote/pages/?$expand=parentSection&$filter=parentSection/id";
+
+    private static final Logger log = LoggerFactory.getLogger(OneNoteDocumentReader.class);
+
+    private final OneNoteResource oneNoteResource;
+
+    private final HttpClient client;
+
+    private final String accessToken;
+
+    public OneNoteDocumentReader(String accessToken, OneNoteResource oneNoteResource) {
+        this.accessToken = accessToken;
+        this.oneNoteResource = oneNoteResource;
+        this.client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_2).build();
+    }
+
+    /**
+     * Retrieves the content of a OneNote notebook by querying the Microsoft Graph API.
+     */
+    private List<String> getNoteBookContent(String accessToken, String notebookId) {
+        // Build the URI for fetching pages from the notebook
+        String uri = MICROSOFT_GRAPH_BASE_URL + NOTEBOOK_ID_FILTER_PREFIX
+                + "+eq+" + "'" + notebookId + "'";
+
+        // Get the page IDs from the notebook by querying the API
+        List<String> pageIdsFromNotebook = getOneNotePageIdsByURI(uri);
+
+        // Fetch the content for each page by its ID
+        return pageIdsFromNotebook.stream()
+                .map(id -> getPageContent(accessToken, id))
+                .toList();
+    }
+
+    /**
+     * Retrieves the content of a OneNote section by querying the Microsoft Graph API.
+     */
+    private List<String> getSectionContent(String accessToken, String sectionId) {
+        // Build the URI for fetching pages from the section
+        String uri = MICROSOFT_GRAPH_BASE_URL + SECTION_ID_FILTER_PREFIX
+                + "+eq+" + "'" + sectionId + "'";
+
+        // Get the page IDs from the notebook by querying the API
+        List<String> pageIdsBySection = getOneNotePageIdsByURI(uri);
+
+        // Fetch the content for each page by its ID
+        return pageIdsBySection.stream()
+                .map(id -> getPageContent(accessToken, id))
+                .toList();
+    }
+
+    private List<String> getOneNotePageIdsByURI(String uri) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .header("Authorization", accessToken)
+                .header("Content-Type", "application/json")
+                .uri(URI.create(uri))
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
+            Assert.isTrue(response.statusCode() == 200, "Failed to fetch pages information");
+            // Parse JSON response and extract page IDs
+            return parsePageIdsFromJson(response.body());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get pages id", e);
+        }
+    }
+
+    /**
+     * Parses the JSON response and extracts page IDs
+     */
+    private List<String> parsePageIdsFromJson(String jsonResponse) {
+        JsonObject rootObject = JsonParser.parseString(jsonResponse).getAsJsonObject();
+        JsonArray valueArray = rootObject.getAsJsonArray("value");
+
+        return valueArray.asList().stream()
+                .map(jsonElement -> jsonElement.getAsJsonObject().get("id").getAsString())
+                .toList();
+    }
+
+    /**
+     * Retrieves the content of a specific OneNote page by querying the Microsoft Graph API.
+     */
+    private String getPageContent(String accessToken, String pageId) {
+        URI uri = URI.create(MICROSOFT_GRAPH_BASE_URL + "/me/onenote/pages/" + pageId + "/content");
+        HttpRequest request = HttpRequest.newBuilder()
+                .header("Authorization", accessToken)
+                .uri(uri)
+                .GET()
+                .build();
+        try {
+            HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
+            Assert.isTrue(response.statusCode() == 200, "Failed to fetch page blocks");
+            return parseHtmlContent(response.body());
+        } catch (Exception e) {
+            log.warn("Failed to get page content with token: {}, pageId: {}, {}", accessToken, pageId, e.getMessage(), e);
+            throw new RuntimeException("Failed to get page content", e);
+        }
+    }
+
+    @Override
+    public List<Document> get() {
+        // Get the access token
+        String accessToken = this.accessToken;
+        // Get the resource type and resource ID for the OneNote resource
+        OneNoteResource.ResourceType resourceType = this.oneNoteResource.getResourceType();
+        String resourceId = this.oneNoteResource.getResourceId();
+
+        // Fetch content based on the resource type (Notebook, Section, or Page)
+        List<String> content = switch (resourceType) {
+            case NOTEBOOK -> getNoteBookContent(accessToken, resourceId);
+            case SECTION -> getSectionContent(accessToken, resourceId);
+            case PAGE -> Collections.singletonList(getPageContent(accessToken, resourceId));
+        };
+
+        // Build metadata for the resource
+        Map<String, Object> metaData = buildMetadata(accessToken);
+
+        // Construct a list of Document objects
+        return content.stream()
+                .map(c -> new Document(c, metaData))
+                .toList();
+    }
+
+    private String parseHtmlContent(String htmlContent) {
+        // Parse the HTML content
+        org.jsoup.nodes.Document parseDoc = Jsoup.parse(htmlContent);
+
+        // Get title and text content, ensuring title is not empty
+        String title = parseDoc.title();
+        String text = parseDoc.text();
+
+        // Return title and content in a readable format
+        return title + (title.isEmpty() ? "" : "\n") + text;
+    }
+
+    /**
+     * Builds metadata for a given OneNote resource (Notebook, Section, or Page) by querying the Microsoft Graph API.
+     */
+    private Map<String, Object> buildMetadata(String accessToken) {
+        Map<String, Object> metadata = new HashMap<>();
+
+        String resourceId = this.oneNoteResource.getResourceId();
+        OneNoteResource.ResourceType resourceType = this.oneNoteResource.getResourceType();
+        String endpoint = switch (resourceType) {
+            case NOTEBOOK -> "/notebooks/";
+            case SECTION -> "/sections/";
+            case PAGE -> "/pages/";
+        };
+        String uriPath = MICROSOFT_GRAPH_BASE_URL + "/me/onenote" + endpoint + resourceId;
+        URI uri = URI.create(uriPath);
+
+        // Add basic metadata to the map (resource URI, type, and ID)
+        metadata.put(OneNoteResource.SOURCE, uriPath);
+        metadata.put("resourceType", resourceType.name());
+        metadata.put("resourceId", resourceId);
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .header("Authorization", accessToken)
+                    .header("Content-Type", "application/json")
+                    .uri(uri)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
+            Assert.isTrue(response.statusCode() == 200, "Failed to fetch page blocks");
+
+            // Parse the JSON response to extract relevant metadata fields
+            JsonObject jsonMetaData = JsonParser.parseString(response.body()).getAsJsonObject();
+
+            // Extract creation date and add to metadata if available
+            String createDateTime = Optional.ofNullable(jsonMetaData.get("createdDateTime"))
+                    .map(JsonElement::getAsString)
+                    .orElse(null);
+            if (StringUtils.hasText(createDateTime)) {
+                metadata.put("createdTime", Instant.parse(createDateTime).toEpochMilli());
+            }
+
+            // Extract last modified date and add to metadata if available
+            String lastModifiedDateTime = Optional.ofNullable(jsonMetaData.get("lastModifiedDateTime"))
+                    .map(JsonElement::getAsString)
+                    .orElse(null);
+            if (StringUtils.hasText(lastModifiedDateTime)) {
+                metadata.put("lastModifiedTime", Instant.parse(lastModifiedDateTime).toEpochMilli());
+            }
+
+            // Extract content URL and add to metadata if available
+            String contentURL = Optional.ofNullable(jsonMetaData.get("contentUrl"))
+                    .map(JsonElement::getAsString)
+                    .orElse(null);
+            if (StringUtils.hasText(contentURL)) {
+                metadata.put("contentURL", contentURL);
+            }
+
+        } catch (Exception e) {
+            log.warn("Failed to get page content with token: {}, resourceId: {}, resourceType: {}, {}",
+                    accessToken, resourceId, resourceType, e.getMessage(), e);
+            throw new RuntimeException("Failed to get page content", e);
+        }
+        return metadata;
+    }
+}

--- a/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
+++ b/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReader.java
@@ -39,215 +39,211 @@ import java.util.*;
  */
 public class OneNoteDocumentReader implements DocumentReader {
 
-    public static final String MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
+	public static final String MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
 
-    public static final String NOTEBOOK_ID_FILTER_PREFIX = "/me/onenote/pages/?$expand=parentNotebook&$filter=parentNotebook/id";
+	public static final String NOTEBOOK_ID_FILTER_PREFIX = "/me/onenote/pages/?$expand=parentNotebook&$filter=parentNotebook/id";
 
-    public static final String SECTION_ID_FILTER_PREFIX = "/me/onenote/pages/?$expand=parentSection&$filter=parentSection/id";
+	public static final String SECTION_ID_FILTER_PREFIX = "/me/onenote/pages/?$expand=parentSection&$filter=parentSection/id";
 
-    private static final Logger log = LoggerFactory.getLogger(OneNoteDocumentReader.class);
+	private static final Logger log = LoggerFactory.getLogger(OneNoteDocumentReader.class);
 
-    private final OneNoteResource oneNoteResource;
+	private final OneNoteResource oneNoteResource;
 
-    private final HttpClient client;
+	private final HttpClient client;
 
-    private final String accessToken;
+	private final String accessToken;
 
-    public OneNoteDocumentReader(String accessToken, OneNoteResource oneNoteResource) {
-        this.accessToken = accessToken;
-        this.oneNoteResource = oneNoteResource;
-        this.client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_2).build();
-    }
+	public OneNoteDocumentReader(String accessToken, OneNoteResource oneNoteResource) {
+		this.accessToken = accessToken;
+		this.oneNoteResource = oneNoteResource;
+		this.client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_2).build();
+	}
 
-    /**
-     * Retrieves the content of a OneNote notebook by querying the Microsoft Graph API.
-     */
-    private List<String> getNoteBookContent(String accessToken, String notebookId) {
-        // Build the URI for fetching pages from the notebook
-        String uri = MICROSOFT_GRAPH_BASE_URL + NOTEBOOK_ID_FILTER_PREFIX
-                + "+eq+" + "'" + notebookId + "'";
+	/**
+	 * Retrieves the content of a OneNote notebook by querying the Microsoft Graph API.
+	 */
+	private List<String> getNoteBookContent(String accessToken, String notebookId) {
+		// Build the URI for fetching pages from the notebook
+		String uri = MICROSOFT_GRAPH_BASE_URL + NOTEBOOK_ID_FILTER_PREFIX + "+eq+" + "'" + notebookId + "'";
 
-        // Get the page IDs from the notebook by querying the API
-        List<String> pageIdsFromNotebook = getOneNotePageIdsByURI(accessToken, uri);
+		// Get the page IDs from the notebook by querying the API
+		List<String> pageIdsFromNotebook = getOneNotePageIdsByURI(accessToken, uri);
 
-        // Fetch the content for each page by its ID
-        return pageIdsFromNotebook.stream()
-                .map(id -> getPageContent(accessToken, id))
-                .toList();
-    }
+		// Fetch the content for each page by its ID
+		return pageIdsFromNotebook.stream().map(id -> getPageContent(accessToken, id)).toList();
+	}
 
-    /**
-     * Retrieves the content of a OneNote section by querying the Microsoft Graph API.
-     */
-    private List<String> getSectionContent(String accessToken, String sectionId) {
-        // Build the URI for fetching pages from the section
-        String uri = MICROSOFT_GRAPH_BASE_URL + SECTION_ID_FILTER_PREFIX
-                + "+eq+" + "'" + sectionId + "'";
+	/**
+	 * Retrieves the content of a OneNote section by querying the Microsoft Graph API.
+	 */
+	private List<String> getSectionContent(String accessToken, String sectionId) {
+		// Build the URI for fetching pages from the section
+		String uri = MICROSOFT_GRAPH_BASE_URL + SECTION_ID_FILTER_PREFIX + "+eq+" + "'" + sectionId + "'";
 
-        // Get the page IDs from the notebook by querying the API
-        List<String> pageIdsBySection = getOneNotePageIdsByURI(accessToken, uri);
+		// Get the page IDs from the notebook by querying the API
+		List<String> pageIdsBySection = getOneNotePageIdsByURI(accessToken, uri);
 
-        // Fetch the content for each page by its ID
-        return pageIdsBySection.stream()
-                .map(id -> getPageContent(accessToken, id))
-                .toList();
-    }
+		// Fetch the content for each page by its ID
+		return pageIdsBySection.stream().map(id -> getPageContent(accessToken, id)).toList();
+	}
 
-    private List<String> getOneNotePageIdsByURI(String accessToken, String uri) {
-        HttpRequest request = HttpRequest.newBuilder()
-                .header("Authorization", accessToken)
-                .header("Content-Type", "application/json")
-                .uri(URI.create(uri))
-                .GET()
-                .build();
+	private List<String> getOneNotePageIdsByURI(String accessToken, String uri) {
+		HttpRequest request = HttpRequest.newBuilder()
+			.header("Authorization", accessToken)
+			.header("Content-Type", "application/json")
+			.uri(URI.create(uri))
+			.GET()
+			.build();
 
-        try {
-            HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
-            Assert.isTrue(response.statusCode() == 200, "Failed to fetch pages information");
-            // Parse JSON response and extract page IDs
-            return parsePageIdsFromJson(response.body());
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to get pages id", e);
-        }
-    }
+		try {
+			HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
+			Assert.isTrue(response.statusCode() == 200, "Failed to fetch pages information");
+			// Parse JSON response and extract page IDs
+			return parsePageIdsFromJson(response.body());
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to get pages id", e);
+		}
+	}
 
-    /**
-     * Parses the JSON response and extracts page IDs
-     */
-    private List<String> parsePageIdsFromJson(String jsonResponse) {
-        JsonObject rootObject = JsonParser.parseString(jsonResponse).getAsJsonObject();
-        JsonArray valueArray = rootObject.getAsJsonArray("value");
+	/**
+	 * Parses the JSON response and extracts page IDs
+	 */
+	private List<String> parsePageIdsFromJson(String jsonResponse) {
+		JsonObject rootObject = JsonParser.parseString(jsonResponse).getAsJsonObject();
+		JsonArray valueArray = rootObject.getAsJsonArray("value");
 
-        return valueArray.asList().stream()
-                .map(jsonElement -> jsonElement.getAsJsonObject().get("id").getAsString())
-                .toList();
-    }
+		return valueArray.asList()
+			.stream()
+			.map(jsonElement -> jsonElement.getAsJsonObject().get("id").getAsString())
+			.toList();
+	}
 
-    /**
-     * Retrieves the content of a specific OneNote page by querying the Microsoft Graph API.
-     */
-    private String getPageContent(String accessToken, String pageId) {
-        URI uri = URI.create(MICROSOFT_GRAPH_BASE_URL + "/me/onenote/pages/" + pageId + "/content");
-        HttpRequest request = HttpRequest.newBuilder()
-                .header("Authorization", accessToken)
-                .uri(uri)
-                .GET()
-                .build();
-        try {
-            HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
-            Assert.isTrue(response.statusCode() == 200, "Failed to fetch page blocks");
-            return parseHtmlContent(response.body());
-        } catch (Exception e) {
-            log.warn("Failed to get page content with token: {}, pageId: {}, {}", accessToken, pageId, e.getMessage(), e);
-            throw new RuntimeException("Failed to get page content", e);
-        }
-    }
+	/**
+	 * Retrieves the content of a specific OneNote page by querying the Microsoft Graph
+	 * API.
+	 */
+	private String getPageContent(String accessToken, String pageId) {
+		URI uri = URI.create(MICROSOFT_GRAPH_BASE_URL + "/me/onenote/pages/" + pageId + "/content");
+		HttpRequest request = HttpRequest.newBuilder().header("Authorization", accessToken).uri(uri).GET().build();
+		try {
+			HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
+			Assert.isTrue(response.statusCode() == 200, "Failed to fetch page blocks");
+			return parseHtmlContent(response.body());
+		}
+		catch (Exception e) {
+			log.warn("Failed to get page content with token: {}, pageId: {}, {}", accessToken, pageId, e.getMessage(),
+					e);
+			throw new RuntimeException("Failed to get page content", e);
+		}
+	}
 
-    @Override
-    public List<Document> get() {
-        // Get the access token
-        String accessToken = this.accessToken;
-        // Get the resource type and resource ID for the OneNote resource
-        OneNoteResource.ResourceType resourceType = this.oneNoteResource.getResourceType();
-        String resourceId = this.oneNoteResource.getResourceId();
+	@Override
+	public List<Document> get() {
+		// Get the access token
+		String accessToken = this.accessToken;
+		// Get the resource type and resource ID for the OneNote resource
+		OneNoteResource.ResourceType resourceType = this.oneNoteResource.getResourceType();
+		String resourceId = this.oneNoteResource.getResourceId();
 
-        // Parameters check
-        Assert.notNull(accessToken, "token must not be null");
-        Assert.notNull(resourceType, "resource type must not be null");
-        Assert.notNull(resourceId, "resource id must not be null");
+		// Parameters check
+		Assert.notNull(accessToken, "token must not be null");
+		Assert.notNull(resourceType, "resource type must not be null");
+		Assert.notNull(resourceId, "resource id must not be null");
 
-        // Fetch content based on the resource type (Notebook, Section, or Page)
-        List<String> content = switch (resourceType) {
-            case NOTEBOOK -> getNoteBookContent(accessToken, resourceId);
-            case SECTION -> getSectionContent(accessToken, resourceId);
-            case PAGE -> Collections.singletonList(getPageContent(accessToken, resourceId));
-        };
+		// Fetch content based on the resource type (Notebook, Section, or Page)
+		List<String> content = switch (resourceType) {
+			case NOTEBOOK -> getNoteBookContent(accessToken, resourceId);
+			case SECTION -> getSectionContent(accessToken, resourceId);
+			case PAGE -> Collections.singletonList(getPageContent(accessToken, resourceId));
+		};
 
-        // Build metadata for the resource
-        Map<String, Object> metaData = buildMetadata();
+		// Build metadata for the resource
+		Map<String, Object> metaData = buildMetadata();
 
-        // Construct a list of Document objects
-        return content.stream()
-                .map(c -> new Document(c, metaData))
-                .toList();
-    }
+		// Construct a list of Document objects
+		return content.stream().map(c -> new Document(c, metaData)).toList();
+	}
 
-    private String parseHtmlContent(String htmlContent) {
-        // Parse the HTML content
-        org.jsoup.nodes.Document parseDoc = Jsoup.parse(htmlContent);
+	private String parseHtmlContent(String htmlContent) {
+		// Parse the HTML content
+		org.jsoup.nodes.Document parseDoc = Jsoup.parse(htmlContent);
 
-        // Get title and text content, ensuring title is not empty
-        String title = parseDoc.title();
-        String text = parseDoc.text();
+		// Get title and text content, ensuring title is not empty
+		String title = parseDoc.title();
+		String text = parseDoc.text();
 
-        // Return title and content in a readable format
-        return (StringUtils.hasText(title) ? title : "") + "\n" + text;
-    }
+		// Return title and content in a readable format
+		return (StringUtils.hasText(title) ? title : "") + "\n" + text;
+	}
 
-    /**
-     * Builds metadata for a given OneNote resource (Notebook, Section, or Page) by querying the Microsoft Graph API.
-     */
-    private Map<String, Object> buildMetadata() {
-        Map<String, Object> metadata = new HashMap<>();
-        String accessToken = this.accessToken;
-        String resourceId = this.oneNoteResource.getResourceId();
-        OneNoteResource.ResourceType resourceType = this.oneNoteResource.getResourceType();
-        String endpoint = switch (resourceType) {
-            case NOTEBOOK -> "/notebooks/";
-            case SECTION -> "/sections/";
-            case PAGE -> "/pages/";
-        };
-        String uriPath = MICROSOFT_GRAPH_BASE_URL + "/me/onenote" + endpoint + resourceId;
-        URI uri = URI.create(uriPath);
+	/**
+	 * Builds metadata for a given OneNote resource (Notebook, Section, or Page) by
+	 * querying the Microsoft Graph API.
+	 */
+	private Map<String, Object> buildMetadata() {
+		Map<String, Object> metadata = new HashMap<>();
+		String accessToken = this.accessToken;
+		String resourceId = this.oneNoteResource.getResourceId();
+		OneNoteResource.ResourceType resourceType = this.oneNoteResource.getResourceType();
+		String endpoint = switch (resourceType) {
+			case NOTEBOOK -> "/notebooks/";
+			case SECTION -> "/sections/";
+			case PAGE -> "/pages/";
+		};
+		String uriPath = MICROSOFT_GRAPH_BASE_URL + "/me/onenote" + endpoint + resourceId;
+		URI uri = URI.create(uriPath);
 
-        // Add basic metadata to the map (resource URI, type, and ID)
-        metadata.put(OneNoteResource.SOURCE, uriPath);
-        metadata.put("resourceType", resourceType.name());
-        metadata.put("resourceId", resourceId);
+		// Add basic metadata to the map (resource URI, type, and ID)
+		metadata.put(OneNoteResource.SOURCE, uriPath);
+		metadata.put("resourceType", resourceType.name());
+		metadata.put("resourceId", resourceId);
 
-        try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .header("Authorization", accessToken)
-                    .header("Content-Type", "application/json")
-                    .uri(uri)
-                    .GET()
-                    .build();
+		try {
+			HttpRequest request = HttpRequest.newBuilder()
+				.header("Authorization", accessToken)
+				.header("Content-Type", "application/json")
+				.uri(uri)
+				.GET()
+				.build();
 
-            HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
-            Assert.isTrue(response.statusCode() == 200, "Failed to fetch page blocks");
+			HttpResponse<String> response = this.client.send(request, HttpResponse.BodyHandlers.ofString());
+			Assert.isTrue(response.statusCode() == 200, "Failed to fetch page blocks");
 
-            // Parse the JSON response to extract relevant metadata fields
-            JsonObject jsonMetaData = JsonParser.parseString(response.body()).getAsJsonObject();
+			// Parse the JSON response to extract relevant metadata fields
+			JsonObject jsonMetaData = JsonParser.parseString(response.body()).getAsJsonObject();
 
-            // Extract creation date and add to metadata if available
-            String createDateTime = Optional.ofNullable(jsonMetaData.get("createdDateTime"))
-                    .map(JsonElement::getAsString)
-                    .orElse(null);
-            if (StringUtils.hasText(createDateTime)) {
-                metadata.put("createdTime", Instant.parse(createDateTime).toEpochMilli());
-            }
+			// Extract creation date and add to metadata if available
+			String createDateTime = Optional.ofNullable(jsonMetaData.get("createdDateTime"))
+				.map(JsonElement::getAsString)
+				.orElse(null);
+			if (StringUtils.hasText(createDateTime)) {
+				metadata.put("createdTime", Instant.parse(createDateTime).toEpochMilli());
+			}
 
-            // Extract last modified date and add to metadata if available
-            String lastModifiedDateTime = Optional.ofNullable(jsonMetaData.get("lastModifiedDateTime"))
-                    .map(JsonElement::getAsString)
-                    .orElse(null);
-            if (StringUtils.hasText(lastModifiedDateTime)) {
-                metadata.put("lastModifiedTime", Instant.parse(lastModifiedDateTime).toEpochMilli());
-            }
+			// Extract last modified date and add to metadata if available
+			String lastModifiedDateTime = Optional.ofNullable(jsonMetaData.get("lastModifiedDateTime"))
+				.map(JsonElement::getAsString)
+				.orElse(null);
+			if (StringUtils.hasText(lastModifiedDateTime)) {
+				metadata.put("lastModifiedTime", Instant.parse(lastModifiedDateTime).toEpochMilli());
+			}
 
-            // Extract content URL and add to metadata if available
-            String contentURL = Optional.ofNullable(jsonMetaData.get("contentUrl"))
-                    .map(JsonElement::getAsString)
-                    .orElse(null);
-            if (StringUtils.hasText(contentURL)) {
-                metadata.put("contentURL", contentURL);
-            }
+			// Extract content URL and add to metadata if available
+			String contentURL = Optional.ofNullable(jsonMetaData.get("contentUrl"))
+				.map(JsonElement::getAsString)
+				.orElse(null);
+			if (StringUtils.hasText(contentURL)) {
+				metadata.put("contentURL", contentURL);
+			}
 
-        } catch (Exception e) {
-            log.warn("Failed to get page content with token: {}, resourceId: {}, resourceType: {}, {}",
-                    accessToken, resourceId, resourceType, e.getMessage(), e);
-            throw new RuntimeException("Failed to get page content", e);
-        }
-        return metadata;
-    }
+		}
+		catch (Exception e) {
+			log.warn("Failed to get page content with token: {}, resourceId: {}, resourceType: {}, {}", accessToken,
+					resourceId, resourceType, e.getMessage(), e);
+			throw new RuntimeException("Failed to get page content", e);
+		}
+		return metadata;
+	}
+
 }

--- a/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteResource.java
+++ b/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteResource.java
@@ -28,106 +28,111 @@ import java.net.URL;
  * @author sparkle6979l
  */
 public class OneNoteResource implements Resource {
-    public static final String SOURCE = "source";
 
-    public enum ResourceType {
-        NOTEBOOK, SECTION, PAGE
+	public static final String SOURCE = "source";
 
-    }
-    private final ResourceType resourceType;
-    private final String resourceId;
+	public enum ResourceType {
 
-    public ResourceType getResourceType() {
-        return resourceType;
-    }
+		NOTEBOOK, SECTION, PAGE
 
-    public String getResourceId() {
-        return resourceId;
-    }
+	}
 
-    public OneNoteResource(String resourceId, ResourceType resourceType) {
-        Assert.hasText(resourceId, "ResourceId must not be empty");
-        Assert.notNull(resourceType, "ResourceType must not be null");
+	private final ResourceType resourceType;
 
-        this.resourceId = resourceId;
-        this.resourceType = resourceType;
-    }
+	private final String resourceId;
 
-    public static Builder builder() {
-        return new Builder();
-    }
+	public ResourceType getResourceType() {
+		return resourceType;
+	}
 
-    public static class Builder {
+	public String getResourceId() {
+		return resourceId;
+	}
 
-        private ResourceType resourceType;
+	public OneNoteResource(String resourceId, ResourceType resourceType) {
+		Assert.hasText(resourceId, "ResourceId must not be empty");
+		Assert.notNull(resourceType, "ResourceType must not be null");
 
-        private String resourceId;
+		this.resourceId = resourceId;
+		this.resourceType = resourceType;
+	}
 
-        public Builder resourceType(ResourceType resourceType) {
-            this.resourceType = resourceType;
-            return this;
-        }
+	public static Builder builder() {
+		return new Builder();
+	}
 
-        public Builder resourceId(String resourceId) {
-            this.resourceId = resourceId;
-            return this;
-        }
+	public static class Builder {
 
-        public OneNoteResource build() {
-            Assert.hasText(resourceId, "ResourceId must not be empty");
-            Assert.notNull(resourceType, "ResourceType must not be null");
-            return new OneNoteResource(resourceId, resourceType);
-        }
+		private ResourceType resourceType;
 
-    }
+		private String resourceId;
 
-    @Override
-    public boolean exists() {
-        return false;
-    }
+		public Builder resourceType(ResourceType resourceType) {
+			this.resourceType = resourceType;
+			return this;
+		}
 
-    @Override
-    public URL getURL() throws IOException {
-        return null;
-    }
+		public Builder resourceId(String resourceId) {
+			this.resourceId = resourceId;
+			return this;
+		}
 
-    @Override
-    public URI getURI() throws IOException {
-        return null;
-    }
+		public OneNoteResource build() {
+			Assert.hasText(resourceId, "ResourceId must not be empty");
+			Assert.notNull(resourceType, "ResourceType must not be null");
+			return new OneNoteResource(resourceId, resourceType);
+		}
 
-    @Override
-    public File getFile() throws IOException {
-        return null;
-    }
+	}
 
-    @Override
-    public long contentLength() throws IOException {
-        return 0;
-    }
+	@Override
+	public boolean exists() {
+		return false;
+	}
 
-    @Override
-    public long lastModified() throws IOException {
-        return 0;
-    }
+	@Override
+	public URL getURL() throws IOException {
+		return null;
+	}
 
-    @Override
-    public Resource createRelative(String relativePath) throws IOException {
-        return null;
-    }
+	@Override
+	public URI getURI() throws IOException {
+		return null;
+	}
 
-    @Override
-    public String getFilename() {
-        return null;
-    }
+	@Override
+	public File getFile() throws IOException {
+		return null;
+	}
 
-    @Override
-    public String getDescription() {
-        return null;
-    }
+	@Override
+	public long contentLength() throws IOException {
+		return 0;
+	}
 
-    @Override
-    public InputStream getInputStream() throws IOException {
-        return null;
-    }
+	@Override
+	public long lastModified() throws IOException {
+		return 0;
+	}
+
+	@Override
+	public Resource createRelative(String relativePath) throws IOException {
+		return null;
+	}
+
+	@Override
+	public String getFilename() {
+		return null;
+	}
+
+	@Override
+	public String getDescription() {
+		return null;
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return null;
+	}
+
 }

--- a/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteResource.java
+++ b/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteResource.java
@@ -1,0 +1,118 @@
+package com.alibaba.cloud.api.reader.onenote;
+
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * @author sparkle6979l
+ */
+public class OneNoteResource implements Resource {
+    public static final String SOURCE = "source";
+
+    public enum ResourceType {
+        NOTEBOOK, SECTION, PAGE
+
+    }
+    private final ResourceType resourceType;
+    private final String resourceId;
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public OneNoteResource(String resourceId, ResourceType resourceType) {
+        Assert.hasText(resourceId, "ResourceId must not be empty");
+        Assert.notNull(resourceType, "ResourceType must not be null");
+
+        this.resourceId = resourceId;
+        this.resourceType = resourceType;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ResourceType resourceType;
+
+        private String resourceId;
+
+        public Builder resourceType(ResourceType resourceType) {
+            this.resourceType = resourceType;
+            return this;
+        }
+
+        public Builder resourceId(String resourceId) {
+            this.resourceId = resourceId;
+            return this;
+        }
+
+        public OneNoteResource build() {
+            Assert.hasText(resourceId, "ResourceId must not be empty");
+            Assert.notNull(resourceType, "ResourceType must not be null");
+            return new OneNoteResource(resourceId, resourceType);
+        }
+
+    }
+
+    @Override
+    public boolean exists() {
+        return false;
+    }
+
+    @Override
+    public URL getURL() throws IOException {
+        return null;
+    }
+
+    @Override
+    public URI getURI() throws IOException {
+        return null;
+    }
+
+    @Override
+    public File getFile() throws IOException {
+        return null;
+    }
+
+    @Override
+    public long contentLength() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public long lastModified() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public Resource createRelative(String relativePath) throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getFilename() {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return null;
+    }
+}

--- a/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteResource.java
+++ b/community/document-readers/onenote-document-reader/src/main/java/com/alibaba/cloud/api/reader/onenote/OneNoteResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.cloud.api.reader.onenote;
 
 import org.springframework.core.io.Resource;

--- a/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
+++ b/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
@@ -52,11 +52,10 @@ public class OneNoteDocumentReaderTest {
 
     @Test
     public void test_load_section(){
-        String testSectionId = "0-4F3ACAF53591DCC0!2862";
 
         // Create page reader
         OneNoteResource oneNoteResource = OneNoteResource.builder()
-                .resourceId(testSectionId)
+                .resourceId(TEST_SECTION_ID)
                 .resourceType(OneNoteResource.ResourceType.SECTION)
                 .build();
         OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
@@ -79,11 +78,10 @@ public class OneNoteDocumentReaderTest {
 
     @Test
     public void test_load_notebook(){
-        String testNoteBookId = "0-4F3ACAF53591DCC0!2860";
 
         // Create page reader
         OneNoteResource oneNoteResource = OneNoteResource.builder()
-                .resourceId(testNoteBookId)
+                .resourceId(TEST_NOTEBOOK_ID)
                 .resourceType(OneNoteResource.ResourceType.NOTEBOOK)
                 .build();
         OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);

--- a/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
+++ b/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
@@ -29,92 +29,89 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class OneNoteDocumentReaderTest {
 
-    private static final String TEST_ACCESS_TOKEN = System.getenv("ONENOTE_ACCESS_TOKEN");
+	private static final String TEST_ACCESS_TOKEN = System.getenv("ONENOTE_ACCESS_TOKEN");
 
-    private static final String TEST_NOTEBOOK_ID = "${notebookId}";
+	private static final String TEST_NOTEBOOK_ID = "${notebookId}";
 
-    private static final String TEST_SECTION_ID = "${sectionId}";
+	private static final String TEST_SECTION_ID = "${sectionId}";
 
-    private static final String TEST_PAGE_ID = "${pageId}";
+	private static final String TEST_PAGE_ID = "${pageId}";
 
-    private OneNoteDocumentReader oneNoteDocumentReader;
+	private OneNoteDocumentReader oneNoteDocumentReader;
 
-    @Test
-    public void test_load_page(){
+	@Test
+	public void test_load_page() {
 
-        // Create page reader
-        OneNoteResource oneNoteResource = OneNoteResource.builder()
-                .resourceId(TEST_PAGE_ID)
-                .resourceType(OneNoteResource.ResourceType.PAGE)
-                .build();
-        OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
+		// Create page reader
+		OneNoteResource oneNoteResource = OneNoteResource.builder()
+			.resourceId(TEST_PAGE_ID)
+			.resourceType(OneNoteResource.ResourceType.PAGE)
+			.build();
+		OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
 
-        List<Document> documents = oneNoteDocumentReader.get();
-        // then
-        assertThat(documents).isNotEmpty();
-        Document document = documents.get(0);
+		List<Document> documents = oneNoteDocumentReader.get();
+		// then
+		assertThat(documents).isNotEmpty();
+		Document document = documents.get(0);
 
-        // Verify metadata
-        assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
-        assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.PAGE.name());
-        assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_PAGE_ID);
+		// Verify metadata
+		assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
+		assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.PAGE.name());
+		assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_PAGE_ID);
 
-        // Verify content
-        String content = document.getContent();
-        assertThat(content).isNotEmpty();
-    }
+		// Verify content
+		String content = document.getContent();
+		assertThat(content).isNotEmpty();
+	}
 
+	@Test
+	public void test_load_section() {
 
-    @Test
-    public void test_load_section(){
+		// Create page reader
+		OneNoteResource oneNoteResource = OneNoteResource.builder()
+			.resourceId(TEST_SECTION_ID)
+			.resourceType(OneNoteResource.ResourceType.SECTION)
+			.build();
+		OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
 
-        // Create page reader
-        OneNoteResource oneNoteResource = OneNoteResource.builder()
-                .resourceId(TEST_SECTION_ID)
-                .resourceType(OneNoteResource.ResourceType.SECTION)
-                .build();
-        OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
+		List<Document> documents = oneNoteDocumentReader.get();
+		// then
+		assertThat(documents).isNotEmpty();
+		Document document = documents.get(0);
 
-        List<Document> documents = oneNoteDocumentReader.get();
-        // then
-        assertThat(documents).isNotEmpty();
-        Document document = documents.get(0);
+		// Verify metadata
+		assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
+		assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.SECTION.name());
+		assertThat(document.getMetadata().get("resourceId")).isEqualTo(testSectionId);
 
-        // Verify metadata
-        assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
-        assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.SECTION.name());
-        assertThat(document.getMetadata().get("resourceId")).isEqualTo(testSectionId);
+		// Verify content
+		String content = document.getContent();
+		assertThat(content).isNotEmpty();
+	}
 
-        // Verify content
-        String content = document.getContent();
-        assertThat(content).isNotEmpty();
-    }
+	@Test
+	public void test_load_notebook() {
 
+		// Create page reader
+		OneNoteResource oneNoteResource = OneNoteResource.builder()
+			.resourceId(TEST_NOTEBOOK_ID)
+			.resourceType(OneNoteResource.ResourceType.NOTEBOOK)
+			.build();
+		OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
 
-    @Test
-    public void test_load_notebook(){
+		List<Document> documents = oneNoteDocumentReader.get();
+		// then
+		assertThat(documents).isNotEmpty();
+		Document document = documents.get(0);
 
-        // Create page reader
-        OneNoteResource oneNoteResource = OneNoteResource.builder()
-                .resourceId(TEST_NOTEBOOK_ID)
-                .resourceType(OneNoteResource.ResourceType.NOTEBOOK)
-                .build();
-        OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
+		// Verify metadata
+		assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
+		assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.NOTEBOOK.name());
+		assertThat(document.getMetadata().get("resourceId")).isEqualTo(testNoteBookId);
 
-        List<Document> documents = oneNoteDocumentReader.get();
-        // then
-        assertThat(documents).isNotEmpty();
-        Document document = documents.get(0);
-
-        // Verify metadata
-        assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
-        assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.NOTEBOOK.name());
-        assertThat(document.getMetadata().get("resourceId")).isEqualTo(testNoteBookId);
-
-        // Verify content
-        String content = document.getContent();
-        assertThat(content).isNotEmpty();
-    }
-
+		// Verify content
+		String content = document.getContent();
+		assertThat(content).isNotEmpty();
+	}
 
 }

--- a/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
+++ b/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
@@ -1,0 +1,103 @@
+package com.alibaba.cloud.api.reader.onenote;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author sparkle6979l
+ * @version 1.0
+ * @data 2025/1/27 19:59
+ */
+public class OneNoteDocumentReaderTest {
+
+    private static final String ONENOTE_ACCESS_TOKEN = System.getenv("ONENOTE_ACCESS_TOKEN");
+
+    private static final String TEST_ACCESS_TOKEN = "EwB4A8l6BAAUBKgm8k1UswUNwklmy2v7U/S+1fEAAba2iydLSDlzJFhBCED/MW+mm4ImR6QHSsyiFeXYWJmTP69wZWHUBDR4XEWV9QMV6CPiperBohvrg5Yeek2Xd8llq9QylEcZruZG4sYuLAs4v0xupNgSas1htKO6Ii+7o3YvhX7XFVbdXE024NXCGvvUssXsUwK684DAfG2ZOoO1hMzsWJlfULR8Sz94F02kORdP2UqtCTMiSmGQgZrcTh4aro3VO0M84lDXqQf1GywIGTI2NFQ8FjLegQ2sn5zYiEARlAsik7LSCuMwWvWzZdtz0sxoSxHczIQJi7qjvXfSL5T+4kqERhuOJEp2/JNcA9g33aXhk/3TNuHC7ZQVn5EQZgAAEHpM1GKBHyQf0Kvwxy9sEwpAAo4InGesijwB4BV/NmKuhNKlk6Ef0oslNtt/QS22ZF+yZb6VAkQK2JGzIRBmHncGRmikhchhqftrqo0sE+bCkAgRXa8S73cF00dqah0Va3T+aI/ep3gDNfovc8q3KrIZBGhFM0cme5/bMToyzvKTBBnooaKYXwvSU5gH/WnhbOQoQ+5B55wjlxXSG87FdTEQUoer60InA0wE1yQECukhIlWotKB3gCUzMpf3lZby3DX7eYASBdXz1r+3vuWGbD09Kg+e8KjR0xFrl2W9T9y9abzGMFvDRnZa/w6n4aR7anTqj1OX3VYvIx7PX6sZ0PgKW06dJyBDejHKhyUhBvMlRXIVWjkCqnQeIGghzUkvnxSYIpG5I44wUtSYvLCWRmGKe7g7ylMV+BGm6eabvwXpESWfPQiUCh2M1nQNLxwv5chCdi4zHdFIE4mq1l5G5d7HPCDxxQoJlSOBGcshYkqfMm9y4BSbTz50as0LWxOo+tPw5ko4I39DtTrTqarLpxEyq94cem6r1mRUB5DTQ6ITeYXeZnzHkCsTdFEgUxMnPqGrpz+WuuuBdxeabttup2dlVLuv8istKddcoCd71xyV02r7iMWi0wz1+Xr3VBUhMln7E3dRUOoSlaVI1lMxHdaqbIIkdYEfPR/N7tJcawShp6wwZHE5XyoZ6D2NRQ5auih/bnVd/u6ACpWwPyDTSO1VumgQyzCYHJkwF6d+gEoE3y3QF32VDN0srw2q2r6jiwaT+vi/jPklXGxh9aG0OqAQLX4C";
+    private OneNoteDocumentReader oneNoteDocumentReader;
+
+    @Test
+    public void test_load_page(){
+        String TEST_PAGE_ID = "0-03ec86ad7070ce4193ecc4dbd76e4e41!1-4F3ACAF53591DCC0!2997";
+
+        // Create page reader
+        OneNoteResource oneNoteResource = OneNoteResource.builder()
+                .resourceId(TEST_PAGE_ID)
+                .resourceType(OneNoteResource.ResourceType.PAGE)
+                .build();
+        OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
+
+        List<Document> documents = oneNoteDocumentReader.get();
+        // then
+        assertThat(documents).isNotEmpty();
+        Document document = documents.get(0);
+
+        // Verify metadata
+        assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
+        assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.PAGE.name());
+        assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_PAGE_ID);
+
+        // Verify content
+        String content = document.getContent();
+        assertThat(content).isNotEmpty();
+    }
+
+
+    @Test
+    public void test_load_section(){
+        String testSectionId = "0-4F3ACAF53591DCC0!2862";
+
+        // Create page reader
+        OneNoteResource oneNoteResource = OneNoteResource.builder()
+                .resourceId(testSectionId)
+                .resourceType(OneNoteResource.ResourceType.SECTION)
+                .build();
+        OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
+
+        List<Document> documents = oneNoteDocumentReader.get();
+        // then
+        assertThat(documents).isNotEmpty();
+        Document document = documents.get(0);
+
+        // Verify metadata
+        assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
+        assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.SECTION.name());
+        assertThat(document.getMetadata().get("resourceId")).isEqualTo(testSectionId);
+
+        // Verify content
+        String content = document.getContent();
+        assertThat(content).isNotEmpty();
+    }
+
+
+    @Test
+    public void test_load_notebook(){
+        String testNoteBookId = "0-4F3ACAF53591DCC0!2860";
+
+        // Create page reader
+        OneNoteResource oneNoteResource = OneNoteResource.builder()
+                .resourceId(testNoteBookId)
+                .resourceType(OneNoteResource.ResourceType.NOTEBOOK)
+                .build();
+        OneNoteDocumentReader oneNoteDocumentReader = new OneNoteDocumentReader(TEST_ACCESS_TOKEN, oneNoteResource);
+
+        List<Document> documents = oneNoteDocumentReader.get();
+        // then
+        assertThat(documents).isNotEmpty();
+        Document document = documents.get(0);
+
+        // Verify metadata
+        assertThat(document.getMetadata()).containsKey(OneNoteResource.SOURCE);
+        assertThat(document.getMetadata().get("resourceType")).isEqualTo(OneNoteResource.ResourceType.NOTEBOOK.name());
+        assertThat(document.getMetadata().get("resourceId")).isEqualTo(testNoteBookId);
+
+        // Verify content
+        String content = document.getContent();
+        assertThat(content).isNotEmpty();
+    }
+
+
+}

--- a/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
+++ b/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
@@ -14,14 +14,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class OneNoteDocumentReaderTest {
 
-    private static final String ONENOTE_ACCESS_TOKEN = System.getenv("ONENOTE_ACCESS_TOKEN");
+    private static final String TEST_ACCESS_TOKEN = System.getenv("ONENOTE_ACCESS_TOKEN");
 
-    private static final String TEST_ACCESS_TOKEN = "EwB4A8l6BAAUBKgm8k1UswUNwklmy2v7U/S+1fEAAba2iydLSDlzJFhBCED/MW+mm4ImR6QHSsyiFeXYWJmTP69wZWHUBDR4XEWV9QMV6CPiperBohvrg5Yeek2Xd8llq9QylEcZruZG4sYuLAs4v0xupNgSas1htKO6Ii+7o3YvhX7XFVbdXE024NXCGvvUssXsUwK684DAfG2ZOoO1hMzsWJlfULR8Sz94F02kORdP2UqtCTMiSmGQgZrcTh4aro3VO0M84lDXqQf1GywIGTI2NFQ8FjLegQ2sn5zYiEARlAsik7LSCuMwWvWzZdtz0sxoSxHczIQJi7qjvXfSL5T+4kqERhuOJEp2/JNcA9g33aXhk/3TNuHC7ZQVn5EQZgAAEHpM1GKBHyQf0Kvwxy9sEwpAAo4InGesijwB4BV/NmKuhNKlk6Ef0oslNtt/QS22ZF+yZb6VAkQK2JGzIRBmHncGRmikhchhqftrqo0sE+bCkAgRXa8S73cF00dqah0Va3T+aI/ep3gDNfovc8q3KrIZBGhFM0cme5/bMToyzvKTBBnooaKYXwvSU5gH/WnhbOQoQ+5B55wjlxXSG87FdTEQUoer60InA0wE1yQECukhIlWotKB3gCUzMpf3lZby3DX7eYASBdXz1r+3vuWGbD09Kg+e8KjR0xFrl2W9T9y9abzGMFvDRnZa/w6n4aR7anTqj1OX3VYvIx7PX6sZ0PgKW06dJyBDejHKhyUhBvMlRXIVWjkCqnQeIGghzUkvnxSYIpG5I44wUtSYvLCWRmGKe7g7ylMV+BGm6eabvwXpESWfPQiUCh2M1nQNLxwv5chCdi4zHdFIE4mq1l5G5d7HPCDxxQoJlSOBGcshYkqfMm9y4BSbTz50as0LWxOo+tPw5ko4I39DtTrTqarLpxEyq94cem6r1mRUB5DTQ6ITeYXeZnzHkCsTdFEgUxMnPqGrpz+WuuuBdxeabttup2dlVLuv8istKddcoCd71xyV02r7iMWi0wz1+Xr3VBUhMln7E3dRUOoSlaVI1lMxHdaqbIIkdYEfPR/N7tJcawShp6wwZHE5XyoZ6D2NRQ5auih/bnVd/u6ACpWwPyDTSO1VumgQyzCYHJkwF6d+gEoE3y3QF32VDN0srw2q2r6jiwaT+vi/jPklXGxh9aG0OqAQLX4C";
+    private static final String TEST_NOTEBOOK_ID = "${notebookId}";
+
+    private static final String TEST_SECTION_ID = "${sectionId}";
+
+    private static final String TEST_PAGE_ID = "${pageId}";
+
     private OneNoteDocumentReader oneNoteDocumentReader;
 
     @Test
     public void test_load_page(){
-        String TEST_PAGE_ID = "0-03ec86ad7070ce4193ecc4dbd76e4e41!1-4F3ACAF53591DCC0!2997";
 
         // Create page reader
         OneNoteResource oneNoteResource = OneNoteResource.builder()

--- a/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
+++ b/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.cloud.api.reader.onenote;
 
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,6 @@
 
     <packaging>pom</packaging>
     <url>https://github.com/alibaba/spring-ai-alibaba</url>
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-core</artifactId>
-        </dependency>
-    </dependencies>
 
     <name>Spring AI Alibaba</name>
     <description>Building AI applications with Spring Boot</description>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
 
     <packaging>pom</packaging>
     <url>https://github.com/alibaba/spring-ai-alibaba</url>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-core</artifactId>
+        </dependency>
+    </dependencies>
 
     <name>Spring AI Alibaba</name>
     <description>Building AI applications with Spring Boot</description>
@@ -63,6 +69,7 @@
         <module>community/document-readers/feishu-document-reader</module>
         <module>community/document-readers/yuque-document-reader</module>
         <module>community/document-readers/obsidian-document-reader</module>
+        <module>community/document-readers/onenote-document-reader</module>
         <module>community/document-readers/notion-document-reader</module>
         <module>community/document-readers/arxiv-document-reader</module>
         <module>community/document-readers/chatgpt-data-document-reader</module>


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR introduces the OneNote Document Reader component, which supports fetching content from OneNote resources of three types: Notebook, Section, and individual Page. The component integrates with the Microsoft Graph API to retrieve relevant metadata and page content for each resource type.

该PR引入了OneNote文档读取组件，支持从三种类型的OneNote资源中获取内容：Notebook（笔记本），Section（分区）和单个Page（页面）。该组件与Microsoft Graph API集成，用于获取每种资源类型的相关元数据和页面内容。



### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
https://github.com/alibaba/spring-ai-alibaba/issues/98
### Describe how you did it

#### OneNoteDocumentReader
- Implement Spring AI's DocumentReader interface
- 实现 Spring AI 的 DocumentReader 接口
- Convert Notion content to Document format
- 将 Notion 内容转换为 Document 格式
- Handle metadata safely with null checks
- 安全处理元数据，包含空值检查
Integration Tests
- Test both page and database reading
- 测试页面和数据库的读取功能
- Verify metadata extraction
- 验证元数据提取
- Use environment variables for credentials
- 使用环境变量存储凭证
### Describe how to verify it
- Ensure that the OneNote Document Reader can successfully fetch content from a notebook, section, and page.
- 确保OneNote Document Reader能够成功从笔记本、分区和页面中获取内容。
- Validate that the metadata for each resource type is correctly populated, including resource ID, creation time, last modified time, and content URL.
- 验证每种资源类型的元数据是否正确填充，包括资源ID、创建时间、最后修改时间和内容URL。
- Review the logging and error messages to ensure they provide useful information for debugging.
- 审查日志和错误信息，确保它们提供有用的调试信息。
- Run unit tests to ensure the component works as expected for all resource types.
- 运行单元测试和集成测试，确保功能预期工作。