### PR TITLE
rm AutoConfiguration in core

### DIFF
--- a/spring-ai-alibaba-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-alibaba-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,0 @@
-com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeAutoConfiguration
-com.alibaba.cloud.ai.autoconfigure.prompt.PromptTemplateAutoConfiguration


### PR DESCRIPTION
### Describe what this PR does / why we need it


### Does this pull request fix one issue?

fix bug in maven dependency. When the spring-ai-alibaba-core package is introduced separately and Dashscopechatmodel is manually initialized, the SPRINGBOOT project fails to start. Because of the autoconfiguration of spring-ai-alibaba-core. Imports declares objects that don't belong to this package. In fact, this declaration has been moved to spring-ai-alibaba-autofigure, and the declaration in the core should be removed.

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

rm AutoConfiguration.imports in spring-ai-alibaba-core

### Describe how to verify it


### Special notes for reviews
