### PR TITLE
fix:add dashscope-sdk-java dependency in document-parser-multi-modality module pom file

### DIFF
--- a/community/document-parsers/document-parser-multi-modality/pom.xml
+++ b/community/document-parsers/document-parser-multi-modality/pom.xml
@@ -34,6 +34,11 @@
             <version>${project.parent.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>dashscope-sdk-java</artifactId>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>org.springframework.ai</groupId>


### PR DESCRIPTION
fix:add dashscope-sdk-java dependency in document-parser-multi-modality module pom file

### Describe what this PR does / why we need it
when I run "mvn clean install", it cannot find  dashscope-sdk-java dependency in document-parser-multi-modality module

