### PR TITLE
replacing getContent() API to getText()

### DIFF
--- a/community/document-parsers/document-parser-apache-pdfbox/src/main/java/com/alibaba/cloud/ai/parser/apache/pdfbox/ParagraphPdfDocumentParser.java
+++ b/community/document-parsers/document-parser-apache-pdfbox/src/main/java/com/alibaba/cloud/ai/parser/apache/pdfbox/ParagraphPdfDocumentParser.java
@@ -106,7 +106,7 @@ public class ParagraphPdfDocumentParser implements DocumentParser {
 					while (itr.hasNext()) {
 						var next = itr.next();
 						Document document = toDocument(current, next, pdDocument);
-						if (document != null && StringUtils.hasText(document.getContent())) {
+						if (document != null && StringUtils.hasText(document.getText())) {
 							documents.add(toDocument(current, next, pdDocument));
 						}
 						current = next;

--- a/community/document-parsers/document-parser-apache-pdfbox/src/test/java/com/alibaba/cloud/ai/parser/apache/pdfbox/PagePdfDocumentParserTests.java
+++ b/community/document-parsers/document-parser-apache-pdfbox/src/test/java/com/alibaba/cloud/ai/parser/apache/pdfbox/PagePdfDocumentParserTests.java
@@ -52,7 +52,7 @@ class PagePdfDocumentParserTests {
 
 		assertThat(docs).hasSize(4);
 
-		String allText = docs.stream().map(Document::getContent).collect(Collectors.joining(System.lineSeparator()));
+		String allText = docs.stream().map(Document::getText).collect(Collectors.joining(System.lineSeparator()));
 		System.out.println(allText);
 
 		// assertThat(allText).doesNotContain(

--- a/community/document-parsers/document-parser-apache-pdfbox/src/test/java/com/alibaba/cloud/ai/parser/apache/pdfbox/ParagraphPdfDocumentParserTests.java
+++ b/community/document-parsers/document-parser-apache-pdfbox/src/test/java/com/alibaba/cloud/ai/parser/apache/pdfbox/ParagraphPdfDocumentParserTests.java
@@ -44,7 +44,7 @@ public class ParagraphPdfDocumentParserTests {
 			.withPagesPerDocument(1)
 			.build()).parse(new DefaultResourceLoader().getResource("classpath:/sample1.pdf").getInputStream())
 			.get(0)
-			.getContent();
+			.getText();
 		System.out.println(content);
 	}
 

--- a/community/document-parsers/document-parser-markdown/src/test/java/com/alibaba/cloud/ai/parser/markdown/MarkdownDocumentParserTest.java
+++ b/community/document-parsers/document-parser-markdown/src/test/java/com/alibaba/cloud/ai/parser/markdown/MarkdownDocumentParserTest.java
@@ -41,7 +41,7 @@ class MarkdownDocumentParserTest {
 			.parse(new DefaultResourceLoader().getResource("classpath:/only-headers.md").getInputStream());
 
 		assertThat(documents).hasSize(4)
-			.extracting(Document::getMetadata, Document::getContent)
+			.extracting(Document::getMetadata, Document::getText)
 			.containsOnly(tuple(Map.of("category", "header_1", "title", "Header 1a"),
 					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
 					tuple(Map.of("category", "header_1", "title", "Header 1b"),
@@ -60,7 +60,7 @@ class MarkdownDocumentParserTest {
 			.parse(new DefaultResourceLoader().getResource("classpath:/with-formatting.md").getInputStream());
 
 		assertThat(documents).hasSize(2)
-			.extracting(Document::getMetadata, Document::getContent)
+			.extracting(Document::getMetadata, Document::getText)
 			.containsOnly(tuple(Map.of("category", "header_1", "title", "This is a fancy header name"),
 					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim."),
 					tuple(Map.of("category", "header_3", "title", "Header 3"),
@@ -79,7 +79,7 @@ class MarkdownDocumentParserTest {
 			.parse(new DefaultResourceLoader().getResource("classpath:/horizontal-rules.md").getInputStream());
 
 		assertThat(documents).hasSize(7)
-			.extracting(Document::getMetadata, Document::getContent)
+			.extracting(Document::getMetadata, Document::getText)
 			.containsOnly(tuple(Map.of(),
 					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida."),
 					tuple(Map.of(),
@@ -110,7 +110,7 @@ class MarkdownDocumentParserTest {
 
 		Document documentsFirst = documents.get(0);
 		assertThat(documentsFirst.getMetadata()).isEmpty();
-		assertThat(documentsFirst.getContent()).startsWith("Lorem ipsum dolor sit amet, consectetur adipiscing elit")
+		assertThat(documentsFirst.getText()).startsWith("Lorem ipsum dolor sit amet, consectetur adipiscing elit")
 			.endsWith("Phasellus eget tellus sed nibh ornare interdum eu eu mi.");
 	}
 
@@ -126,7 +126,7 @@ class MarkdownDocumentParserTest {
 
 		Document documentsFirst = documents.get(0);
 		assertThat(documentsFirst.getMetadata()).isEmpty();
-		assertThat(documentsFirst.getContent()).isEqualTo(
+		assertThat(documentsFirst.getText()).isEqualTo(
 				"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim.Nullam nisi dui, egestas nec sem nec, interdum lobortis enim. Pellentesque odio orci, faucibus eu luctus nec, venenatis et magna. Vestibulum nec eros non felis fermentum posuere eget ac risus.Aenean eu leo eu nibh tristique posuere quis quis massa. Nullam lacinia luctus sem ut vehicula.");
 	}
 
@@ -143,22 +143,22 @@ class MarkdownDocumentParserTest {
 
 		assertThat(documents).satisfiesExactly(document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of());
-			assertThat(document.getContent()).isEqualTo("This is a Java sample application:");
+			assertThat(document.getText()).isEqualTo("This is a Java sample application:");
 		}, document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "category", "code_block"));
-			assertThat(document.getContent()).startsWith("package com.example.demo;")
+			assertThat(document.getText()).startsWith("package com.example.demo;")
 				.contains("SpringApplication.run(DemoApplication.class, args);");
 		}, document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of("category", "code_inline"));
-			assertThat(document.getContent()).isEqualTo(
+			assertThat(document.getText()).isEqualTo(
 					"Markdown also provides the possibility to use inline code formatting throughout the entire sentence.");
 		}, document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of());
-			assertThat(document.getContent())
+			assertThat(document.getText())
 				.isEqualTo("Another possibility is to set block code without specific highlighting:");
 		}, document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "category", "code_block"));
-			assertThat(document.getContent()).isEqualTo("./mvnw spring-javaformat:apply\n");
+			assertThat(document.getText()).isEqualTo("./mvnw spring-javaformat:apply\n");
 		});
 	}
 
@@ -176,15 +176,15 @@ class MarkdownDocumentParserTest {
 
 		assertThat(documents).satisfiesExactly(document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "category", "code_block"));
-			assertThat(document.getContent()).startsWith("This is a Java sample application: package com.example.demo")
+			assertThat(document.getText()).startsWith("This is a Java sample application: package com.example.demo")
 				.contains("SpringApplication.run(DemoApplication.class, args);");
 		}, document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of("category", "code_inline"));
-			assertThat(document.getContent()).isEqualTo(
+			assertThat(document.getText()).isEqualTo(
 					"Markdown also provides the possibility to use inline code formatting throughout the entire sentence.");
 		}, document -> {
 			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "category", "code_block"));
-			assertThat(document.getContent()).isEqualTo(
+			assertThat(document.getText()).isEqualTo(
 					"Another possibility is to set block code without specific highlighting: ./mvnw spring-javaformat:apply\n");
 		});
 	}
@@ -198,7 +198,7 @@ class MarkdownDocumentParserTest {
 			.parse(new DefaultResourceLoader().getResource("classpath:/blockquote.md").getInputStream());
 
 		assertThat(documents).hasSize(2)
-			.extracting(Document::getMetadata, Document::getContent)
+			.extracting(Document::getMetadata, Document::getText)
 			.containsOnly(tuple(Map.of(),
 					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
 					tuple(Map.of("category", "blockquote"),
@@ -220,7 +220,7 @@ class MarkdownDocumentParserTest {
 
 		Document documentsFirst = documents.get(0);
 		assertThat(documentsFirst.getMetadata()).isEqualTo(Map.of("category", "blockquote"));
-		assertThat(documentsFirst.getContent()).isEqualTo(
+		assertThat(documentsFirst.getText()).isEqualTo(
 				"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue. Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit.");
 	}
 
@@ -233,7 +233,7 @@ class MarkdownDocumentParserTest {
 			.parse(new DefaultResourceLoader().getResource("classpath:/lists.md").getInputStream());
 
 		assertThat(documents).hasSize(2)
-			.extracting(Document::getMetadata, Document::getContent)
+			.extracting(Document::getMetadata, Document::getText)
 			.containsOnly(tuple(Map.of("category", "header_2", "title", "Ordered list"),
 					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue. Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor."),
 					tuple(Map.of("category", "header_2", "title", "Unordered list"),
@@ -256,7 +256,7 @@ class MarkdownDocumentParserTest {
 
 		Document documentsFirst = documents.get(0);
 		assertThat(documentsFirst.getMetadata()).isEqualTo(Map.of("service", "some-service-name", "env", "prod"));
-		assertThat(documentsFirst.getContent()).startsWith("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
+		assertThat(documentsFirst.getText()).startsWith("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
 	}
 
 }

--- a/community/document-parsers/document-parser-multi-modality/src/main/java/com/alibaba/cloud/ai/parser/multi/ImageDashScopeParser.java
+++ b/community/document-parsers/document-parser-multi-modality/src/main/java/com/alibaba/cloud/ai/parser/multi/ImageDashScopeParser.java
@@ -96,7 +96,7 @@ public class ImageDashScopeParser implements DocumentParser {
 				.build();
 			MultiModalConversationResult result = conversation.call(param);
 			return List.of(new Document(
-					result.getOutput().getChoices().get(0).getMessage().getContent().get(0).get("text").toString()));
+					result.getOutput().getChoices().get(0).getMessage().getText().get(0).get("text").toString()));
 
 		}
 		catch (ApiException | NoApiKeyException | UploadFileException e) {

--- a/community/document-parsers/document-parser-multi-modality/src/main/java/com/alibaba/cloud/ai/parser/multi/SttDashScopeParser.java
+++ b/community/document-parsers/document-parser-multi-modality/src/main/java/com/alibaba/cloud/ai/parser/multi/SttDashScopeParser.java
@@ -94,7 +94,7 @@ public class SttDashScopeParser implements DocumentParser {
 				.build();
 			MultiModalConversationResult result = conversation.call(param);
 			return List.of(new Document(
-					result.getOutput().getChoices().get(0).getMessage().getContent().get(0).get("text").toString()));
+					result.getOutput().getChoices().get(0).getMessage().getText().get(0).get("text").toString()));
 
 		}
 		catch (ApiException | NoApiKeyException | UploadFileException e) {

--- a/community/document-parsers/document-parser-tika/src/test/java/com/alibaba/cloud/ai/parser/tika/ApacheTikaDocumentParserTest.java
+++ b/community/document-parsers/document-parser-tika/src/test/java/com/alibaba/cloud/ai/parser/tika/ApacheTikaDocumentParserTest.java
@@ -39,7 +39,7 @@ class ApacheTikaDocumentParserTest {
 
 		Document document = parser.parse(inputStream).get(0);
 
-		assertThat(document.getContent()).isEqualToIgnoringWhitespace("test content");
+		assertThat(document.getText()).isEqualToIgnoringWhitespace("test content");
 		assertThat(document.getMetadata()).isEmpty();
 	}
 
@@ -52,7 +52,7 @@ class ApacheTikaDocumentParserTest {
 
 		Document document = parser.parse(inputStream).get(0);
 
-		assertThat(document.getContent()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
+		assertThat(document.getText()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
 		assertThat(document.getMetadata()).isEmpty();
 	}
 
@@ -66,8 +66,8 @@ class ApacheTikaDocumentParserTest {
 		Document document1 = parser.parse(inputStream1).get(0);
 		Document document2 = parser.parse(inputStream2).get(0);
 
-		assertThat(document1.getContent()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
-		assertThat(document2.getContent()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
+		assertThat(document1.getText()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
+		assertThat(document2.getText()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
 		assertThat(document1.getMetadata()).isEmpty();
 		assertThat(document2.getMetadata()).isEmpty();
 	}

--- a/community/document-readers/arxiv-document-reader/src/main/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReader.java
+++ b/community/document-readers/arxiv-document-reader/src/main/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReader.java
@@ -185,7 +185,7 @@ public class ArxivDocumentReader implements DocumentReader {
 						metadata.putAll(createMetadata(result));
 
 						// Create new Document instance with complete metadata
-						documents.add(new Document(doc.getContent(), metadata));
+						documents.add(new Document(doc.getText(), metadata));
 					}
 				}
 				catch (IOException e) {

--- a/community/document-readers/arxiv-document-reader/src/main/java/com/alibaba/cloud/ai/reader/arxiv/client/ArxivResult.java
+++ b/community/document-readers/arxiv-document-reader/src/main/java/com/alibaba/cloud/ai/reader/arxiv/client/ArxivResult.java
@@ -281,7 +281,7 @@ public class ArxivResult {
 			this.rel = rel;
 		}
 
-		public String getContentType() {
+		public String getTextType() {
 			return contentType;
 		}
 

--- a/community/document-readers/arxiv-document-reader/src/test/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReaderTest.java
+++ b/community/document-readers/arxiv-document-reader/src/test/java/com/alibaba/cloud/ai/reader/arxiv/ArxivDocumentReaderTest.java
@@ -46,7 +46,7 @@ public class ArxivDocumentReaderTest {
 
 		// 验证第一个文档的元数据
 		Document firstDoc = documents.get(0);
-		assertNotNull(firstDoc.getContent(), "文档内容不应为空");
+		assertNotNull(firstDoc.getText(), "文档内容不应为空");
 
 		// 验证元数据
 		var metadata = firstDoc.getMetadata();
@@ -79,8 +79,8 @@ public class ArxivDocumentReaderTest {
 		Document firstDoc = documents.get(0);
 
 		// 验证内容（摘要）
-		assertNotNull(firstDoc.getContent(), "文档内容（摘要）不应为空");
-		assertFalse(firstDoc.getContent().trim().isEmpty(), "文档内容（摘要）不应为空字符串");
+		assertNotNull(firstDoc.getText(), "文档内容（摘要）不应为空");
+		assertFalse(firstDoc.getText().trim().isEmpty(), "文档内容（摘要）不应为空字符串");
 
 		// 验证元数据
 		var metadata = firstDoc.getMetadata();
@@ -93,7 +93,7 @@ public class ArxivDocumentReaderTest {
 		assertNotNull(metadata.get(ArxivResource.PDF_URL), "应包含PDF URL");
 
 		// 验证摘要内容与元数据中的摘要一致
-		assertEquals(firstDoc.getContent(), metadata.get(ArxivResource.SUMMARY), "文档内容应该与元数据中的摘要一致");
+		assertEquals(firstDoc.getText(), metadata.get(ArxivResource.SUMMARY), "文档内容应该与元数据中的摘要一致");
 	}
 
 }

--- a/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/eml/EmailParser.java
+++ b/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/eml/EmailParser.java
@@ -252,10 +252,10 @@ public class EmailParser {
 		String htmlContent = null;
 		String textContent = null;
 
-		Object content = part.getContent();
+		Object content = part.getText();
 		if (content instanceof String) {
 			// Check if content is HTML
-			String contentType = part.getContentType().toLowerCase();
+			String contentType = part.getTextType().toLowerCase();
 			if (contentType.contains("text/html")) {
 				htmlContent = (String) content;
 			}
@@ -267,7 +267,7 @@ public class EmailParser {
 			Multipart multipart = (Multipart) content;
 			for (int i = 0; i < multipart.getCount(); i++) {
 				Part bodyPart = multipart.getBodyPart(i);
-				String contentType = bodyPart.getContentType().toLowerCase();
+				String contentType = bodyPart.getTextType().toLowerCase();
 
 				if (contentType.contains("text/html")) {
 					htmlContent = new String(bodyPart.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
@@ -310,7 +310,7 @@ public class EmailParser {
 		try (InputStream is = new ByteArrayInputStream(htmlContent.getBytes(StandardCharsets.UTF_8))) {
 			List<Document> docs = htmlParser.parse(is);
 			if (!docs.isEmpty()) {
-				return docs.get(0).getContent();
+				return docs.get(0).getText();
 			}
 		}
 		return htmlContent;

--- a/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/eml/EmlEmailDocumentReader.java
+++ b/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/eml/EmlEmailDocumentReader.java
@@ -170,7 +170,7 @@ public class EmlEmailDocumentReader implements DocumentReader {
 	 */
 	private void processMessageContent(Part part, Map<String, Object> metadata, List<Document> documents)
 			throws Exception {
-		Object content = part.getContent();
+		Object content = part.getText();
 
 		if (content instanceof Multipart) {
 			// Handle multipart content
@@ -179,11 +179,11 @@ public class EmlEmailDocumentReader implements DocumentReader {
 			for (int i = 0; i < multipart.getCount(); i++) {
 				Part bodyPart = multipart.getBodyPart(i);
 				String disposition = bodyPart.getDisposition();
-				String contentType = bodyPart.getContentType().toLowerCase();
+				String contentType = bodyPart.getTextType().toLowerCase();
 
 				if (disposition == null) {
 					// This could be main content or nested multipart
-					if (bodyPart.getContent() instanceof Multipart) {
+					if (bodyPart.getText() instanceof Multipart) {
 						processMessageContent(bodyPart, metadata, documents);
 					}
 					else if (contentType.contains("text/plain") || contentType.contains("text/html")) {
@@ -204,7 +204,7 @@ public class EmlEmailDocumentReader implements DocumentReader {
 			// Handle simple text/html content
 			String mainContent = emailParser.getEmailContent(part, preferHtml);
 			Map<String, Object> mainMetadata = new HashMap<>(metadata);
-			mainMetadata.put("content_type", part.getContentType().toLowerCase());
+			mainMetadata.put("content_type", part.getTextType().toLowerCase());
 			documents.add(new Document(mainContent, mainMetadata));
 		}
 	}
@@ -224,12 +224,12 @@ public class EmlEmailDocumentReader implements DocumentReader {
 		// Create attachment metadata
 		Map<String, Object> attachmentMetadata = new HashMap<>(metadata);
 		attachmentMetadata.put("filename", filename);
-		attachmentMetadata.put("content_type", part.getContentType());
+		attachmentMetadata.put("content_type", part.getTextType());
 		attachmentMetadata.put("size", part.getSize());
 
 		// Choose appropriate parser based on content type
 		try (InputStream is = part.getInputStream()) {
-			String contentType = part.getContentType().toLowerCase();
+			String contentType = part.getTextType().toLowerCase();
 			List<Document> parsedDocuments;
 
 			if (contentType.contains("text/html") || contentType.contains("application/html")) {

--- a/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/msg/MsgEmailElement.java
+++ b/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/msg/MsgEmailElement.java
@@ -97,7 +97,7 @@ public class MsgEmailElement {
 		this.date = date;
 	}
 
-	public String getContentType() {
+	public String getTextType() {
 		return contentType;
 	}
 
@@ -105,7 +105,7 @@ public class MsgEmailElement {
 		this.contentType = contentType;
 	}
 
-	public String getContent() {
+	public String getText() {
 		return content;
 	}
 

--- a/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/msg/MsgEmailParser.java
+++ b/community/document-readers/email-document-reader/src/main/java/com/alibaba/cloud/ai/reader/email/msg/MsgEmailParser.java
@@ -79,12 +79,12 @@ public class MsgEmailParser {
 			metadata.put("date", element.getDate());
 		}
 
-		if (StringUtils.hasText(element.getContentType())) {
-			metadata.put("content_type", element.getContentType());
+		if (StringUtils.hasText(element.getTextType())) {
+			metadata.put("content_type", element.getTextType());
 		}
 
 		// Create Document object with content null check
-		String content = StringUtils.hasText(element.getContent()) ? element.getContent() : "";
+		String content = StringUtils.hasText(element.getText()) ? element.getText() : "";
 		return new Document(content, metadata);
 	}
 

--- a/community/document-readers/gitbook-document-reader/README.md
+++ b/community/document-readers/gitbook-document-reader/README.md
@@ -99,7 +99,7 @@ public class GitbookReaderExample {
         // Process document content and metadata
         for (Document doc : documents) {
             System.out.println("Document ID: " + doc.getId());
-            System.out.println("Content: " + doc.getContent());
+            System.out.println("Content: " + doc.getText());
             System.out.println("Metadata: " + doc.getMetadata());
         }
     }

--- a/community/document-readers/github-document-reader/src/main/java/com/alibaba/cloud/ai/reader/github/GitHubDocumentReader.java
+++ b/community/document-readers/github-document-reader/src/main/java/com/alibaba/cloud/ai/reader/github/GitHubDocumentReader.java
@@ -73,7 +73,7 @@ public class GitHubDocumentReader implements DocumentReader {
 		try {
 			List<Document> documentList = parser.parse(gitHubResource.getInputStream());
 			for (Document document : documentList) {
-				GHContent ghContent = gitHubResource.getContent();
+				GHContent ghContent = gitHubResource.getText();
 				Map<String, Object> metadata = document.getMetadata();
 				metadata.put("github_git_url", ghContent.getGitUrl());
 				metadata.put("github_download_url", ghContent.getDownloadUrl());

--- a/community/document-readers/github-document-reader/src/main/java/com/alibaba/cloud/ai/reader/github/GitHubResource.java
+++ b/community/document-readers/github-document-reader/src/main/java/com/alibaba/cloud/ai/reader/github/GitHubResource.java
@@ -72,7 +72,7 @@ public class GitHubResource implements Resource {
 		return new GitHubResource(content);
 	}
 
-	public GHContent getContent() {
+	public GHContent getText() {
 		return content;
 	}
 

--- a/community/document-readers/github-document-reader/src/test/java/com/alibaba/cloud/ai/reader/github/GitHubDocumentLoaderIT.java
+++ b/community/document-readers/github-document-reader/src/test/java/com/alibaba/cloud/ai/reader/github/GitHubDocumentLoaderIT.java
@@ -50,7 +50,7 @@ class GitHubDocumentLoaderIT {
 	@Test
 	public void should_load_file() {
 		List<Document> document = reader.get();
-		String content = document.get(0).getContent();
+		String content = document.get(0).getText();
 		System.out.println(System.getenv("GITHUB_TOKEN"));
 		System.out.println(content);
 		// assertThat(content).contains("<groupId>com.alibaba.cloud</groupId>");

--- a/community/document-readers/gitlab-document-reader/src/test/java/com/alibaba/cloud/ai/reader/gitlab/GitLabRepositoryReaderTest.java
+++ b/community/document-readers/gitlab-document-reader/src/test/java/com/alibaba/cloud/ai/reader/gitlab/GitLabRepositoryReaderTest.java
@@ -59,7 +59,7 @@ class GitLabRepositoryReaderTest {
 		assertThat(documents).hasSize(1);
 		Document doc = documents.get(0);
 		assertThat(doc.getId()).isNotNull();
-		assertThat(doc.getContent()).isNotBlank();
+		assertThat(doc.getText()).isNotBlank();
 		assertThat(doc.getMetadata()).containsKey("file_path")
 			.containsKey("file_name")
 			.containsKey("url")

--- a/community/document-readers/gpt-repo-document-reader/src/test/java/com/alibaba/cloud/ai/reader/gptrepo/GptRepoDocumentReaderTest.java
+++ b/community/document-readers/gpt-repo-document-reader/src/test/java/com/alibaba/cloud/ai/reader/gptrepo/GptRepoDocumentReaderTest.java
@@ -77,7 +77,7 @@ class GptRepoDocumentReaderTest {
 		boolean foundPythonFile = false;
 
 		for (Document doc : documents) {
-			String content = doc.getContent();
+			String content = doc.getText();
 			if (content.contains("TestFile.java")) {
 				foundJavaFile = true;
 				assertTrue(content.contains(TEST_FILE_CONTENT));
@@ -106,7 +106,7 @@ class GptRepoDocumentReaderTest {
 		Document doc = documents.get(0);
 
 		// Verify concatenated document contains all file contents
-		String content = doc.getContent();
+		String content = doc.getText();
 		assertTrue(content.contains(TEST_FILE_CONTENT));
 		assertTrue(content.contains(TEST_PYTHON_CONTENT));
 		assertTrue(content.contains("----")); // Verify separator exists
@@ -127,8 +127,8 @@ class GptRepoDocumentReaderTest {
 		assertEquals(1, documents.size(), "Should only find one Java file");
 
 		Document doc = documents.get(0);
-		assertTrue(doc.getContent().contains("TestFile.java"));
-		assertFalse(doc.getContent().contains("test.py"));
+		assertTrue(doc.getText().contains("TestFile.java"));
+		assertFalse(doc.getText().contains("test.py"));
 	}
 
 	/**
@@ -144,7 +144,7 @@ class GptRepoDocumentReaderTest {
 
 		// Verify .log file is ignored
 		for (Document doc : documents) {
-			assertFalse(doc.getContent().contains("test.log"), "Should not contain ignored .log file");
+			assertFalse(doc.getText().contains("test.log"), "Should not contain ignored .log file");
 		}
 	}
 
@@ -196,7 +196,7 @@ class GptRepoDocumentReaderTest {
 		List<Document> documents = reader.get();
 		assertFalse(documents.isEmpty());
 		Document doc = documents.get(0);
-		assertTrue(doc.getContent().startsWith(customPreamble));
+		assertTrue(doc.getText().startsWith(customPreamble));
 	}
 
 	/**
@@ -211,7 +211,7 @@ class GptRepoDocumentReaderTest {
 
 		// Find Java file document
 		Optional<Document> javaDoc = documents.stream()
-			.filter(doc -> doc.getContent().contains("TestFile.java"))
+			.filter(doc -> doc.getText().contains("TestFile.java"))
 			.findFirst();
 
 		assertTrue(javaDoc.isPresent());
@@ -235,7 +235,7 @@ class GptRepoDocumentReaderTest {
 		List<Document> documents = reader.get();
 		assertFalse(documents.isEmpty());
 		Document doc = documents.get(0);
-		assertTrue(doc.getContent().startsWith(customPreamble));
+		assertTrue(doc.getText().startsWith(customPreamble));
 
 		// Print document count and first document metadata
 		System.out.println("Total documents: " + documents.size());
@@ -263,12 +263,12 @@ class GptRepoDocumentReaderTest {
 
 		// Find Chinese file document
 		Optional<Document> chineseDoc = documents.stream()
-			.filter(doc -> doc.getContent().contains("chinese.txt"))
+			.filter(doc -> doc.getText().contains("chinese.txt"))
 			.findFirst();
 
 		assertTrue(chineseDoc.isPresent());
 		Document doc = chineseDoc.get();
-		assertTrue(doc.getContent().contains(chineseContent));
+		assertTrue(doc.getText().contains(chineseContent));
 
 		// Read with wrong encoding (should throw exception)
 		reader = new GptRepoDocumentReader(repoPath.toString(), false, Collections.singletonList("txt"), "UTF-8");

--- a/community/document-readers/huggingface-fs-document-reader/README.md
+++ b/community/document-readers/huggingface-fs-document-reader/README.md
@@ -34,7 +34,7 @@ List<Document> documents = reader.get();
 // 处理文档
 for (Document doc : documents) {
     // 获取文档内容
-    String content = doc.getContent();
+    String content = doc.getText();
     
     // 获取源文件路径（元数据）
     String source = doc.getMetadata().get(HuggingFaceFSDocumentReader.SOURCE);

--- a/community/document-readers/huggingface-fs-document-reader/src/test/java/com/alibaba/cloud/ai/reader/huggingface/fs/HuggingFaceFSDocumentReaderTests.java
+++ b/community/document-readers/huggingface-fs-document-reader/src/test/java/com/alibaba/cloud/ai/reader/huggingface/fs/HuggingFaceFSDocumentReaderTests.java
@@ -61,7 +61,7 @@ class HuggingFaceFSDocumentReaderTests {
 		Document firstDoc = documents.get(0);
 		assertNotNull(firstDoc);
 		assertEquals(testFile.toString(), firstDoc.getMetadata().get(HuggingFaceFSDocumentReader.SOURCE));
-		assertTrue(firstDoc.getContent().contains("Hello world"));
+		assertTrue(firstDoc.getText().contains("Hello world"));
 	}
 
 	@Test
@@ -84,7 +84,7 @@ class HuggingFaceFSDocumentReaderTests {
 		Document doc = documents.get(0);
 		assertNotNull(doc);
 		assertEquals(testFile.toString(), doc.getMetadata().get(HuggingFaceFSDocumentReader.SOURCE));
-		assertTrue(doc.getContent().contains("Compressed content"));
+		assertTrue(doc.getText().contains("Compressed content"));
 	}
 
 	private byte[] createGzippedContent(String content) throws Exception {

--- a/community/document-readers/mbox-document-reader/README.md
+++ b/community/document-readers/mbox-document-reader/README.md
@@ -68,7 +68,7 @@ List<Document> documents = reader.get();
 for (Document doc : documents) {
     // Get formatted content
     // 获取格式化的内容
-    String content = doc.getContent();
+    String content = doc.getText();
     
     // Access metadata
     // 访问元数据

--- a/community/document-readers/mbox-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReaderTest.java
+++ b/community/document-readers/mbox-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mbox/MboxDocumentReaderTest.java
@@ -96,7 +96,7 @@ public class MboxDocumentReaderTest {
 		assertEquals("<test123@example.com>", doc.getId());
 
 		// Verify plain text message content
-		String content = doc.getContent();
+		String content = doc.getText();
 		assertTrue(content.contains("This is a plain text email message"));
 		assertTrue(content.contains("Best regards"));
 	}
@@ -125,7 +125,7 @@ public class MboxDocumentReaderTest {
 		assertEquals("<test124@example.com>", doc.getId());
 
 		// Verify HTML content was correctly parsed to text
-		String content = doc.getContent();
+		String content = doc.getText();
 
 		// Verify heading was correctly extracted
 		assertTrue(content.contains("HTML Email Test"), "Should contain the h1 heading text");
@@ -171,7 +171,7 @@ public class MboxDocumentReaderTest {
 		assertEquals("<test125@example.com>", doc.getId());
 
 		// Verify content - should prefer HTML part
-		String content = doc.getContent();
+		String content = doc.getText();
 		assertTrue(content.contains("Multipart Email Test"));
 		assertTrue(content.contains("This is the HTML version"));
 		// Should not contain plain text part
@@ -209,7 +209,7 @@ public class MboxDocumentReaderTest {
 
 		// Read first email
 		Document doc = reader.get().get(0);
-		String content = doc.getContent();
+		String content = doc.getText();
 
 		// Verify custom format
 		assertTrue(content.startsWith("Email Details:"));

--- a/community/document-readers/mongodb-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mongodb/MongodbDocumentReaderIT.java
+++ b/community/document-readers/mongodb-document-reader/src/test/java/com/alibaba/cloud/ai/reader/mongodb/MongodbDocumentReaderIT.java
@@ -78,7 +78,7 @@ public class MongodbDocumentReaderIT {
 
 		System.out.println("Found " + documents.size() + " documents:");
 		for (Document doc : documents) {
-			System.out.println("- " + doc.getContent());
+			System.out.println("- " + doc.getText());
 			System.out.println("  Metadata: " + doc.getMetadata());
 		}
 	}

--- a/community/document-readers/mysql-document-reader/src/main/java/com/alibaba/cloud/ai/reader/mysql/MySQLDocumentReader.java
+++ b/community/document-readers/mysql-document-reader/src/main/java/com/alibaba/cloud/ai/reader/mysql/MySQLDocumentReader.java
@@ -115,7 +115,7 @@ public class MySQLDocumentReader implements DocumentReader {
 	 */
 	private String buildContent(Map<String, Object> rowData) {
 		StringBuilder contentBuilder = new StringBuilder();
-		List<String> contentColumns = mysqlResource.getContentColumns();
+		List<String> contentColumns = mysqlResource.getTextColumns();
 
 		if (contentColumns == null || contentColumns.isEmpty()) {
 			// If no content columns specified, use all columns

--- a/community/document-readers/mysql-document-reader/src/main/java/com/alibaba/cloud/ai/reader/mysql/MySQLResource.java
+++ b/community/document-readers/mysql-document-reader/src/main/java/com/alibaba/cloud/ai/reader/mysql/MySQLResource.java
@@ -117,7 +117,7 @@ public class MySQLResource {
 		return query;
 	}
 
-	public List<String> getContentColumns() {
+	public List<String> getTextColumns() {
 		return contentColumns;
 	}
 

--- a/community/document-readers/notion-document-reader/src/test/java/com/alibaba/cloud/ai/reader/notion/NotionDocumentReaderIT.java
+++ b/community/document-readers/notion-document-reader/src/test/java/com/alibaba/cloud/ai/reader/notion/NotionDocumentReaderIT.java
@@ -79,7 +79,7 @@ class NotionDocumentReaderIT {
 		assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_PAGE_ID);
 
 		// Verify content
-		String content = document.getContent();
+		String content = document.getText();
 		assertThat(content).isNotEmpty();
 		System.out.println("Page content: " + content);
 	}
@@ -101,7 +101,7 @@ class NotionDocumentReaderIT {
 		assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_DATABASE_ID);
 
 		// Verify content
-		String content = document.getContent();
+		String content = document.getText();
 		assertThat(content).isNotEmpty();
 		System.out.println("Database content: " + content);
 	}

--- a/community/document-readers/obsidian-document-reader/src/test/java/com/alibaba/cloud/ai/reader/obsidian/ObsidianDocumentReaderIT.java
+++ b/community/document-readers/obsidian-document-reader/src/test/java/com/alibaba/cloud/ai/reader/obsidian/ObsidianDocumentReaderIT.java
@@ -59,14 +59,14 @@ class ObsidianDocumentReaderIT {
 			assertThat(source).isNotEmpty().endsWith(ObsidianResource.MARKDOWN_EXTENSION);
 
 			// Verify content
-			assertThat(doc.getContent()).isNotEmpty();
+			assertThat(doc.getText()).isNotEmpty();
 
 			// Print for debugging
 			System.out.println("Document source: " + source);
 			if (doc.getMetadata().containsKey("category")) {
 				System.out.println("Document category: " + doc.getMetadata().get("category"));
 			}
-			System.out.println("Document content: " + doc.getContent());
+			System.out.println("Document content: " + doc.getText());
 			System.out.println("---");
 		}
 	}

--- a/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
+++ b/community/document-readers/onenote-document-reader/src/test/java/com/alibaba/cloud/api/reader/onenote/OneNoteDocumentReaderTest.java
@@ -61,7 +61,7 @@ public class OneNoteDocumentReaderTest {
 		assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_PAGE_ID);
 
 		// Verify content
-		String content = document.getContent();
+		String content = document.getText();
 		assertThat(content).isNotEmpty();
 	}
 
@@ -86,7 +86,7 @@ public class OneNoteDocumentReaderTest {
 		assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_SECTION_ID);
 
 		// Verify content
-		String content = document.getContent();
+		String content = document.getText();
 		assertThat(content).isNotEmpty();
 	}
 
@@ -111,7 +111,7 @@ public class OneNoteDocumentReaderTest {
 		assertThat(document.getMetadata().get("resourceId")).isEqualTo(TEST_NOTEBOOK_ID);
 
 		// Verify content
-		String content = document.getContent();
+		String content = document.getText();
 		assertThat(content).isNotEmpty();
 	}
 

--- a/community/document-readers/poi-document-reader/src/test/java/com/alibaba/cloud/ai/reader/poi/ApachePoiDocumentParserTest.java
+++ b/community/document-readers/poi-document-reader/src/test/java/com/alibaba/cloud/ai/reader/poi/ApachePoiDocumentParserTest.java
@@ -32,7 +32,7 @@ public class ApachePoiDocumentParserTest {
 		DocumentReader reader = new PoiDocumentReader(fileName);
 		List<Document> documents = reader.get();
 		Document document = documents.get(0);
-		assertThat(document.getContent()).isEqualToIgnoringWhitespace("test content");
+		assertThat(document.getText()).isEqualToIgnoringWhitespace("test content");
 		System.out.println(document.getMetadata());
 	}
 
@@ -44,7 +44,7 @@ public class ApachePoiDocumentParserTest {
 		List<Document> documents = reader.get();
 		Document document = documents.get(0);
 
-		assertThat(document.getContent()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
+		assertThat(document.getText()).isEqualToIgnoringWhitespace("Sheet1\ntest content\nSheet2\ntest content");
 		System.out.println(document.getMetadata());
 	}
 

--- a/community/document-readers/tencent-cos-document-reader/src/test/java/com/alibaba/cloud/ai/reader/tencent/cos/TencentCosDocumentLoaderIT.java
+++ b/community/document-readers/tencent-cos-document-reader/src/test/java/com/alibaba/cloud/ai/reader/tencent/cos/TencentCosDocumentLoaderIT.java
@@ -95,7 +95,7 @@ class TencentCosDocumentLoaderIT {
 		Document document = loader.get().get(0);
 
 		// then
-		assertThat(document.getContent()).isEqualTo(TEST_CONTENT);
+		assertThat(document.getText()).isEqualTo(TEST_CONTENT);
 		assertThat(document.getMetadata()).hasSize(1);
 		assertThat(document.getMetadata().get("source")).isEqualTo(String.format("cos://%s/%s", TEST_BUCKET, TEST_KEY));
 	}
@@ -127,12 +127,12 @@ class TencentCosDocumentLoaderIT {
 		// then
 		assertThat(documents).hasSize(2);
 
-		assertThat(documents.get(0).getContent()).isEqualTo(TEST_CONTENT_2);
+		assertThat(documents.get(0).getText()).isEqualTo(TEST_CONTENT_2);
 		assertThat(documents.get(0).getMetadata()).hasSize(1);
 		assertThat(documents.get(0).getMetadata().get("source"))
 			.isEqualTo(String.format("cos://%s/%s", TEST_BUCKET, TEST_KEY_2));
 
-		assertThat(documents.get(1).getContent()).isEqualTo(TEST_CONTENT);
+		assertThat(documents.get(1).getText()).isEqualTo(TEST_CONTENT);
 		assertThat(documents.get(1).getMetadata()).hasSize(1);
 		assertThat(documents.get(1).getMetadata().get("source"))
 			.isEqualTo(String.format("cos://%s/%s", TEST_BUCKET, TEST_KEY));
@@ -169,8 +169,8 @@ class TencentCosDocumentLoaderIT {
 
 		// then
 		assertThat(documents).hasSize(2);
-		assertThat(documents.get(0).getContent()).isEqualTo(TEST_CONTENT_2);
-		assertThat(documents.get(1).getContent()).isEqualTo(TEST_CONTENT);
+		assertThat(documents.get(0).getText()).isEqualTo(TEST_CONTENT_2);
+		assertThat(documents.get(1).getText()).isEqualTo(TEST_CONTENT);
 	}
 
 }

--- a/community/document-readers/yuque-document-reader/src/test/java/com/alibaba/cloud/ai/reader/yuque/YuQueDocumentLoaderIT.java
+++ b/community/document-readers/yuque-document-reader/src/test/java/com/alibaba/cloud/ai/reader/yuque/YuQueDocumentLoaderIT.java
@@ -40,7 +40,7 @@ class YuQueDocumentLoaderIT {
 	@Test
 	public void should_load_file() {
 		List<Document> document = reader.get();
-		String content = document.get(0).getContent();
+		String content = document.get(0).getText();
 
 		System.out.println(content);
 	}

--- a/spring-ai-alibaba-autoconfigure/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAutoConfigurationIT.java
+++ b/spring-ai-alibaba-autoconfigure/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAutoConfigurationIT.java
@@ -115,7 +115,7 @@ public class DashScopeAutoConfigurationIT {
 			Flux<ChatResponse> responseFlux = chatModel.stream(new Prompt(new UserMessage("Hello")));
 			String response = Objects.requireNonNull(responseFlux.collectList().block())
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();
@@ -133,7 +133,7 @@ public class DashScopeAutoConfigurationIT {
 			Usage[] streamingTokenUsage = new Usage[1];
 			String response = Objects.requireNonNull(responseFlux.collectList().block()).stream().map(chatResponse -> {
 				streamingTokenUsage[0] = chatResponse.getMetadata().getUsage();
-				return (chatResponse.getResult() != null) ? chatResponse.getResult().getOutput().getContent() : "";
+				return (chatResponse.getResult() != null) ? chatResponse.getResult().getOutput().getText() : "";
 			}).collect(Collectors.joining());
 
 			assertThat(streamingTokenUsage[0].getPromptTokens()).isGreaterThan(0);

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -378,7 +378,7 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 						return new ToolCall(toolCall.id(), toolCall.type(), function);
 					}).toList();
 				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getContent(),
+				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
 						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
@@ -413,7 +413,7 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 
 		List<MediaContent> contentList = new ArrayList<>();
 		if (format == MessageFormat.VIDEO) {
-			MediaContent mediaContent = new MediaContent(message.getContent());
+			MediaContent mediaContent = new MediaContent(message.getText());
 			contentList.add(mediaContent);
 
 			List<String> mediaList = message.getMedia()
@@ -424,7 +424,7 @@ public class DashScopeChatModel extends AbstractToolCallSupport implements ChatM
 			contentList.add(new MediaContent("video", null, null, mediaList));
 		}
 		else {
-			MediaContent mediaContent = new MediaContent(message.getContent());
+			MediaContent mediaContent = new MediaContent(message.getText());
 			contentList.add(mediaContent);
 
 			contentList.addAll(message.getMedia()

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/rag/DashScopeDocumentRetrievalAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/rag/DashScopeDocumentRetrievalAdvisor.java
@@ -201,14 +201,14 @@ public class DashScopeDocumentRetrievalAdvisor implements CallAroundAdvisor, Str
 			.valueOf(response.getResult().getMetadata().getFinishReason());
 		if (finishReason == ChatCompletionFinishReason.NULL) {
 			String fullContent = context.getOrDefault("full_content", "").toString()
-					+ response.getResult().getOutput().getContent();
+					+ response.getResult().getOutput().getText();
 			context.put("full_content", fullContent);
 			return advisedResponse;
 		}
 
 		String content = context.getOrDefault("full_content", "").toString();
 		if ("".equalsIgnoreCase(content)) {
-			content = response.getResult().getOutput().getContent();
+			content = response.getResult().getOutput().getText();
 		}
 
 		Map<String, Document> documentMap = (Map<String, Document>) context.get(RETRIEVED_DOCUMENTS);


### PR DESCRIPTION
### Describe what this PR does / why we need it
After upgrading spring-ai-alibaba, some old APIs of Document Reader API cannot be used and need to be replaced with new APIs.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
