### PR TITLE
[HotFix]: remove DashScopeImageModel Observation

### DIFF
--- a/spring-ai-alibaba-autoconfigure/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAutoConfiguration.java
+++ b/spring-ai-alibaba-autoconfigure/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAutoConfiguration.java
@@ -209,9 +209,7 @@ public class DashScopeAutoConfiguration {
 				RestClient.Builder restClientBuilder,
 				WebClient.Builder webClientBuilder,
 				RetryTemplate retryTemplate,
-				ResponseErrorHandler responseErrorHandler,
-				ObjectProvider<ObservationRegistry> observationRegistry,
-				ObjectProvider<ImageModelObservationConvention> observationConvention
+				ResponseErrorHandler responseErrorHandler
 		) {
 
 			ResolvedConnectionProperties resolved = resolveConnectionProperties(
@@ -232,11 +230,8 @@ public class DashScopeAutoConfiguration {
 			DashScopeImageModel dashScopeImageModel = new DashScopeImageModel(
 					dashScopeImageApi,
 					imageProperties.getOptions(),
-					retryTemplate,
-					observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP
-			));
-
-			observationConvention.ifAvailable(dashScopeImageModel::setObservationConvention);
+					retryTemplate
+			);
 
 			return dashScopeImageModel;
 		}


### PR DESCRIPTION
### Describe what this PR does / why we need it
1. current DashScopeImageModel due to the adoption of the retry. It could not work well. So, remove it and have a discussion with @chickenlj.


