### PR TITLE
reduce redundant getProperty calls to improve performance

### DIFF
--- a/community/document-parsers/document-parser-multi-modality/src/main/java/com/alibaba/cloud/ai/parser/multi/ImageDashScopeParser.java
+++ b/community/document-parsers/document-parser-multi-modality/src/main/java/com/alibaba/cloud/ai/parser/multi/ImageDashScopeParser.java
@@ -41,6 +41,8 @@ import org.springframework.ai.document.Document;
 
 public class ImageDashScopeParser implements DocumentParser {
 
+	private static final String OS = System.getProperty("os.name").toLowerCase();
+
 	private final String model;
 
 	private final String maxPixels;
@@ -72,12 +74,11 @@ public class ImageDashScopeParser implements DocumentParser {
 				filePath = path;
 			}
 			else {
-				String os = System.getProperty("os.name").toLowerCase();
 
-				if (os.contains("win")) {
+				if (OS.contains("win")) {
 					filePath = "file:///" + path;
 				}
-				else if (os.contains("nix") || os.contains("nux") || os.contains("mac")) {
+				else if (OS.contains("nix") || OS.contains("nux") || OS.contains("mac")) {
 					filePath = "file://" + path;
 				}
 			}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/ApiUtils.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/ApiUtils.java
@@ -30,6 +30,8 @@ import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.*;
  */
 public class ApiUtils {
 
+	private static final String USER_AGENT = userAgent();
+
 	public static Consumer<HttpHeaders> getJsonContentHeaders(String apiKey) {
 		return getJsonContentHeaders(apiKey, null);
 	}
@@ -43,7 +45,7 @@ public class ApiUtils {
 			headers.setBearerAuth(apiKey);
 			headers.set(HEADER_OPENAPI_SOURCE, SOURCE_FLAG);
 
-			headers.set("user-agent", userAgent());
+			headers.set("user-agent", USER_AGENT);
 			if (workspaceId != null) {
 				headers.set(HEADER_WORK_SPACE_ID, workspaceId);
 			}
@@ -58,7 +60,7 @@ public class ApiUtils {
 			Map<String, String> customHeaders) {
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Authorization", "bearer " + apiKey);
-		headers.put("user-agent", userAgent());
+		headers.put("user-agent", USER_AGENT);
 		if (workspace != null && !workspace.isEmpty()) {
 			headers.put("X-DashScope-WorkSpace", workspace);
 		}
@@ -75,7 +77,7 @@ public class ApiUtils {
 			Boolean isAsyncTask, Boolean isSecurityCheck, Boolean isSSE) {
 		return (headers) -> {
 			headers.setBearerAuth(apiKey);
-			headers.set("user-agent", userAgent());
+			headers.set("user-agent", USER_AGENT);
 			if (isSecurityCheck) {
 				headers.set("X-DashScope-DataInspection", "enable");
 			}


### PR DESCRIPTION
From the JMH test results, getProperty usually incurs some overhead.