### PR TITLE
feat: mysql序列化

### DIFF
--- a/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/MysqlChatMemory.java
+++ b/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/MysqlChatMemory.java
@@ -26,11 +26,14 @@ import java.sql.Connection;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.Message;
+
+import com.alibaba.cloud.ai.memory.mysql.serializer.MessageDeserializer;
 
 public class MysqlChatMemory implements ChatMemory, AutoCloseable {
 
@@ -56,6 +59,10 @@ public class MysqlChatMemory implements ChatMemory, AutoCloseable {
 	}
 
 	public MysqlChatMemory(String username, String password, String url) {
+		// 配置ObjectMapper以支持接口反序列化
+		SimpleModule module = new SimpleModule();
+		module.addDeserializer(Message.class, new MessageDeserializer());
+		this.objectMapper.registerModule(module);
 
 		try {
 			this.connection = DriverManager.getConnection(
@@ -68,6 +75,10 @@ public class MysqlChatMemory implements ChatMemory, AutoCloseable {
 	}
 
 	public MysqlChatMemory(Connection connection) {
+		// 配置ObjectMapper以支持接口反序列化
+		SimpleModule module = new SimpleModule();
+		module.addDeserializer(Message.class, new MessageDeserializer());
+		this.objectMapper.registerModule(module);
 
 		this.connection = connection;
 

--- a/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/MysqlChatMemory.java
+++ b/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/MysqlChatMemory.java
@@ -59,7 +59,7 @@ public class MysqlChatMemory implements ChatMemory, AutoCloseable {
 	}
 
 	public MysqlChatMemory(String username, String password, String url) {
-		// 配置ObjectMapper以支持接口反序列化
+		// Configure ObjectMapper to support interface deserialization
 		SimpleModule module = new SimpleModule();
 		module.addDeserializer(Message.class, new MessageDeserializer());
 		this.objectMapper.registerModule(module);
@@ -75,7 +75,7 @@ public class MysqlChatMemory implements ChatMemory, AutoCloseable {
 	}
 
 	public MysqlChatMemory(Connection connection) {
-		// 配置ObjectMapper以支持接口反序列化
+		// Configure ObjectMapper to support interface deserialization
 		SimpleModule module = new SimpleModule();
 		module.addDeserializer(Message.class, new MessageDeserializer());
 		this.objectMapper.registerModule(module);

--- a/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/serializer/MessageDeserializer.java
+++ b/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/serializer/MessageDeserializer.java
@@ -1,0 +1,51 @@
+package com.alibaba.cloud.ai.memory.mysql.serializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.model.Media;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * @author yingzi
+ * @date 2025/3/23:15:12
+ */
+public class MessageDeserializer extends JsonDeserializer<Message> {
+
+	private static final Logger logger = LoggerFactory.getLogger(MessageDeserializer.class);
+
+	public Message deserialize(JsonParser p, DeserializationContext ctxt) {
+		ObjectMapper mapper = (ObjectMapper) p.getCodec();
+		JsonNode node = null;
+		Message message = null;
+		try {
+			node = mapper.readTree(p);
+			String messageType = node.get("messageType").asText();
+			switch (messageType) {
+				case "USER" -> message = new UserMessage(node.get("text").asText(),
+						mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
+						}), mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
+						}));
+				case "ASSISTANT" -> message = new AssistantMessage(node.get("text").asText());
+				default -> throw new IllegalArgumentException("Unknown message type: " + messageType);
+			}
+			;
+		}
+		catch (IOException e) {
+			logger.error("Error deserializing message", e);
+		}
+		return message;
+	}
+
+}

--- a/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/serializer/MessageDeserializer.java
+++ b/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/serializer/MessageDeserializer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.cloud.ai.memory.mysql.serializer;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -17,10 +32,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
-/**
- * @author yingzi
- * @date 2025/3/23:15:12
- */
 public class MessageDeserializer extends JsonDeserializer<Message> {
 
 	private static final Logger logger = LoggerFactory.getLogger(MessageDeserializer.class);


### PR DESCRIPTION
### Describe what this PR does / why we need it
解决Mysql查询序列化Message的问题，具体解决在selectMessageById方法正常
![image](https://github.com/user-attachments/assets/0ed5957b-6245-4f2e-b4f1-58cc19be0157)


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
增加一个反序列化器，识别Message的类别，是UserMessage、AssistantMessage中的哪类

### Describe how to verify it
调用/advisor/mysql示例接口，此时Debug能发现selectMessageById正常返回，以前会在改行序列化失败
 List<Message> all = (List)this.objectMapper.readValue(oldMessage, new TypeReference<List<Message>>() {
                        });


### Special notes for reviews
