### PR TITLE
optimize serialize about mysql && redis

### DIFF
--- a/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/MysqlChatMemory.java
+++ b/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/MysqlChatMemory.java
@@ -15,13 +15,9 @@
  */
 package com.alibaba.cloud.ai.memory.mysql;
 
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.sql.Connection;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -109,7 +105,7 @@ public class MysqlChatMemory implements ChatMemory, AutoCloseable {
 		try (Statement stmt = connection.createStatement()) {
 			stmt.execute("USE spring_ai_alibaba_mysql");
 			stmt.execute(
-					"CREATE TABLE chat_memory( id BIGINT AUTO_INCREMENT PRIMARY KEY,conversation_id  VARBINARY(256)  NULL,messages VARBINARY(6144) NULL,UNIQUE (conversation_id));");
+					"CREATE TABLE chat_memory( id BIGINT AUTO_INCREMENT PRIMARY KEY,conversation_id  VARBINARY(256)  NULL,messages TEXT NULL,UNIQUE (conversation_id));");
 			logger.info("Table " + DEFAULT_TABLE_NAME + " created successfully.");
 		}
 		catch (Exception e) {
@@ -208,23 +204,27 @@ public class MysqlChatMemory implements ChatMemory, AutoCloseable {
 	}
 
 	public void updateMessageById(String conversationId, String messages) {
-		StringBuilder sql;
+		// Remove newlines and escape single quotes
+		messages = messages.replaceAll("[\\r\\n]", "").replace("'", "''");
+
+		String sql;
 		if (this.selectMessageById(conversationId).isEmpty()) {
-			sql = new StringBuilder("INSERT INTO " + DEFAULT_TABLE_NAME + " (conversation_id, messages) VALUES ('");
-			sql.append(conversationId);
-			sql.append("', '");
-			sql.append(messages);
-			sql.append("')");
+			sql = "INSERT INTO chat_memory (messages, conversation_id) VALUES (?, ?)";
 		}
 		else {
-			sql = new StringBuilder("UPDATE " + DEFAULT_TABLE_NAME + " SET messages = '");
-			sql.append(messages);
-			sql.append("' WHERE conversation_id = '");
-			sql.append(conversationId);
-			sql.append("'");
+			sql = "UPDATE chat_memory SET messages = ? WHERE conversation_id = ?";
 		}
-		try (Statement stmt = connection.createStatement()) {
-			stmt.executeUpdate(sql.toString());
+
+		try (PreparedStatement stmt = this.connection.prepareStatement(sql)) {
+			if (this.selectMessageById(conversationId).isEmpty()) {
+				stmt.setString(1, messages);
+				stmt.setString(2, conversationId);
+			}
+			else {
+				stmt.setString(1, messages);
+				stmt.setString(2, conversationId);
+			}
+			stmt.executeUpdate();
 		}
 		catch (SQLException e) {
 			logger.error("update message by mysql error，sql:{}", sql, e);

--- a/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/serializer/MessageDeserializer.java
+++ b/community/memories/spring-ai-alibaba-mysql-memory/src/main/java/com/alibaba/cloud/ai/memory/mysql/serializer/MessageDeserializer.java
@@ -35,35 +35,35 @@ import java.util.Map;
 
 public class MessageDeserializer extends JsonDeserializer<Message> {
 
-    private static final Logger logger = LoggerFactory.getLogger(MessageDeserializer.class);
+	private static final Logger logger = LoggerFactory.getLogger(MessageDeserializer.class);
 
-    public Message deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        JsonNode node = null;
-        Message message = null;
-        try {
-            node = mapper.readTree(p);
-            String messageType = node.get("messageType").asText();
-            switch (messageType) {
-                case "USER" -> message = new UserMessage(node.get("text").asText(),
-                        mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
-                        }), mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
-                }));
-                case "ASSISTANT" -> message = new AssistantMessage(node.get("text").asText(),
-                        mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
-                        }),
-                        (List<AssistantMessage.ToolCall>) mapper.convertValue(node.get("toolCalls"),
-                                new TypeReference<Collection<AssistantMessage.ToolCall>>() {
-                                }),
-                        (List<Media>) mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
-                        }));
-                default -> throw new IllegalArgumentException("Unknown message type: " + messageType);
-            }
-            ;
-        } catch (IOException e) {
-            logger.error("Error deserializing message", e);
-        }
-        return message;
-    }
+	public Message deserialize(JsonParser p, DeserializationContext ctxt) {
+		ObjectMapper mapper = (ObjectMapper) p.getCodec();
+		JsonNode node = null;
+		Message message = null;
+		try {
+			node = mapper.readTree(p);
+			String messageType = node.get("messageType").asText();
+			switch (messageType) {
+				case "USER" -> message = new UserMessage(node.get("text").asText(),
+						mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
+						}), mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
+						}));
+				case "ASSISTANT" -> message = new AssistantMessage(node.get("text").asText(),
+						mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
+						}), (List<AssistantMessage.ToolCall>) mapper.convertValue(node.get("toolCalls"),
+								new TypeReference<Collection<AssistantMessage.ToolCall>>() {
+								}),
+						(List<Media>) mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
+						}));
+				default -> throw new IllegalArgumentException("Unknown message type: " + messageType);
+			}
+			;
+		}
+		catch (IOException e) {
+			logger.error("Error deserializing message", e);
+		}
+		return message;
+	}
 
 }

--- a/community/memories/spring-ai-alibaba-redis-memory/src/main/java/com/alibaba/cloud/ai/memory/redis/serializer/MessageDeserializer.java
+++ b/community/memories/spring-ai-alibaba-redis-memory/src/main/java/com/alibaba/cloud/ai/memory/redis/serializer/MessageDeserializer.java
@@ -35,34 +35,35 @@ import java.util.Map;
 
 public class MessageDeserializer extends JsonDeserializer<Message> {
 
-    private static final Logger logger = LoggerFactory.getLogger(MessageDeserializer.class);
+	private static final Logger logger = LoggerFactory.getLogger(MessageDeserializer.class);
 
-    public Message deserialize(JsonParser p, DeserializationContext ctxt) {
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        JsonNode node = null;
-        Message message = null;
-        try {
-            node = mapper.readTree(p);
-            String messageType = node.get("messageType").asText();
-            switch (messageType) {
-                case "USER" -> message = new UserMessage(node.get("text").asText(),
-                        mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
-                        }), mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
-                }));
-                case "ASSISTANT" -> message = new AssistantMessage(node.get("text").asText(),
-                        mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
-                        }), (List<AssistantMessage.ToolCall>) mapper.convertValue(node.get("toolCalls"),
-                        new TypeReference<Collection<AssistantMessage.ToolCall>>() {
-                        }),
-                        (List<Media>) mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
-                        }));
-                default -> throw new IllegalArgumentException("Unknown message type: " + messageType);
-            }
-            ;
-        } catch (IOException e) {
-            logger.error("Error deserializing message", e);
-        }
-        return message;
-    }
+	public Message deserialize(JsonParser p, DeserializationContext ctxt) {
+		ObjectMapper mapper = (ObjectMapper) p.getCodec();
+		JsonNode node = null;
+		Message message = null;
+		try {
+			node = mapper.readTree(p);
+			String messageType = node.get("messageType").asText();
+			switch (messageType) {
+				case "USER" -> message = new UserMessage(node.get("text").asText(),
+						mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
+						}), mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
+						}));
+				case "ASSISTANT" -> message = new AssistantMessage(node.get("text").asText(),
+						mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
+						}), (List<AssistantMessage.ToolCall>) mapper.convertValue(node.get("toolCalls"),
+								new TypeReference<Collection<AssistantMessage.ToolCall>>() {
+								}),
+						(List<Media>) mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
+						}));
+				default -> throw new IllegalArgumentException("Unknown message type: " + messageType);
+			}
+			;
+		}
+		catch (IOException e) {
+			logger.error("Error deserializing message", e);
+		}
+		return message;
+	}
 
 }

--- a/community/memories/spring-ai-alibaba-redis-memory/src/main/java/com/alibaba/cloud/ai/memory/redis/serializer/MessageDeserializer.java
+++ b/community/memories/spring-ai-alibaba-redis-memory/src/main/java/com/alibaba/cloud/ai/memory/redis/serializer/MessageDeserializer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.cloud.ai.memory.mysql.serializer;
+package com.alibaba.cloud.ai.memory.redis.serializer;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -51,10 +51,9 @@ public class MessageDeserializer extends JsonDeserializer<Message> {
                 }));
                 case "ASSISTANT" -> message = new AssistantMessage(node.get("text").asText(),
                         mapper.convertValue(node.get("metadata"), new TypeReference<Map<String, Object>>() {
+                        }), (List<AssistantMessage.ToolCall>) mapper.convertValue(node.get("toolCalls"),
+                        new TypeReference<Collection<AssistantMessage.ToolCall>>() {
                         }),
-                        (List<AssistantMessage.ToolCall>) mapper.convertValue(node.get("toolCalls"),
-                                new TypeReference<Collection<AssistantMessage.ToolCall>>() {
-                                }),
                         (List<Media>) mapper.convertValue(node.get("media"), new TypeReference<Collection<Media>>() {
                         }));
                 default -> throw new IllegalArgumentException("Unknown message type: " + messageType);


### PR DESCRIPTION
### Describe what this PR does / why we need it
1. Redis的反序列化问题，保证RedisChatMemory类的get方法能正常获取
2. Redis提供updateMessageById方法用于更新messages
3. Mysql插入messages时需要处理下换行符，否则反序列时回解析失败
4. 建表chart_memory时，messages字段修改为text格式
5. MessageDeserializer类补充了ASSISTANT类的信息
<img width="1554" alt="image" src="https://github.com/user-attachments/assets/71f8ad79-f4a5-4323-a26c-ee514c16d701" />


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. 确保Redis反序列化成功，提供MessageDeserializer类，
2. 参照mysql版的updateMessageById，Redis版需要先对键删除，再添加
3. 往mysql表插入messages字段时，需要特别处理换行符，不然json解析有问题（经测试，Redis无该问题）
4. 原varchar不够用，我在使用时，messages溢出了，替换为text
5. 补充MessageDeserializer的ASSISTANT类的信息

### Describe how to verify it
实现Mysql、Redis版的增删改查接口，确保功能符合预期，后续会提供到spring-ai-alibaba-examples项目中去

### Special notes for reviews
