### PR TITLE
update mysql redis optional

### DIFF
--- a/community/memories/spring-ai-alibaba-mysql-memory/pom.xml
+++ b/community/memories/spring-ai-alibaba-mysql-memory/pom.xml
@@ -55,6 +55,7 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.32</version>
+            <optional>true</optional>
         </dependency>
 
         <!-- test dependencies -->

--- a/community/memories/spring-ai-alibaba-redis-memory/pom.xml
+++ b/community/memories/spring-ai-alibaba-redis-memory/pom.xml
@@ -54,7 +54,8 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>3.6.3</version>
+            <version>5.2.0</version>
+            <optional>true</optional>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
### Describe what this PR does / why we need it

Jedis 包编译时打入了，而且Jedis的版本较低，与程序中的jedis运行时冲突，spring boot 3+ 的Jedis默认版本已经是5+，现打包版本升级为5+ 与 optional 由外部程序指定。

MySQL连接池也改为 optional 由外部指定，因为有项目使用 5.7

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

<optional>true</optional>

### Describe how to verify it

程序引入启动验证

### Special notes for reviews
