### PR TITLE
feat: change dashscope option interface

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/metadata/DashScopeAiUsage.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/metadata/DashScopeAiUsage.java
@@ -53,7 +53,7 @@ public class DashScopeAiUsage implements Usage {
 
 	@Override
 	public Integer getCompletionTokens() {
-		return 0;
+		return getUsage().outputTokens();
 	}
 
 	@Override
@@ -63,7 +63,7 @@ public class DashScopeAiUsage implements Usage {
 			return totalTokens;
 		}
 		else {
-			return getPromptTokens() + getGenerationTokens().intValue();
+			return getPromptTokens() + getCompletionTokens();
 		}
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
1. Change dashscope option interface to ToolCallingChatOptions as FunctionCallingOptions is deprecated.
2. Fix issue that dashscope usage completion tokens return 0.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
