### PR TITLE
feat:Optimized the query initialization method when DocumentRetrievalAdvisor calls the retrieve method, and adds context and message history

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
@@ -132,7 +132,7 @@ public class DocumentRetrievalAdvisor implements CallAroundAdvisor, StreamAround
 	private AdvisedRequest before(AdvisedRequest request) {
 
 		var context = new HashMap<>(request.adviseContext());
-		List<Document> documents = retriever.retrieve(new Query(request.userText()));
+		List<Document> documents = retriever.retrieve(new Query(request.userText(), request.messages(), request.adviseContext()));
 
 		context.put(RETRIEVED_DOCUMENTS, documents);
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
@@ -132,8 +132,7 @@ public class DocumentRetrievalAdvisor implements CallAroundAdvisor, StreamAround
 	private AdvisedRequest before(AdvisedRequest request) {
 
 		var context = new HashMap<>(request.adviseContext());
-		Query query = new Query(request.userText(), request.messages(), context);
-		List<Document> documents = retriever.retrieve(query);
+		List<Document> documents = retriever.retrieve(new Query(request.userText(), request.messages(), request.adviseContext()));
 
 		context.put(RETRIEVED_DOCUMENTS, documents);
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
@@ -132,7 +132,8 @@ public class DocumentRetrievalAdvisor implements CallAroundAdvisor, StreamAround
 	private AdvisedRequest before(AdvisedRequest request) {
 
 		var context = new HashMap<>(request.adviseContext());
-		List<Document> documents = retriever.retrieve(new Query(request.userText(), request.messages(), request.adviseContext()));
+		Query query = new Query(request.userText(), request.messages(), context);
+		List<Document> documents = retriever.retrieve(query);
 
 		context.put(RETRIEVED_DOCUMENTS, documents);
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
@@ -132,7 +132,8 @@ public class DocumentRetrievalAdvisor implements CallAroundAdvisor, StreamAround
 	private AdvisedRequest before(AdvisedRequest request) {
 
 		var context = new HashMap<>(request.adviseContext());
-		List<Document> documents = retriever.retrieve(new Query(request.userText()));
+		Query query = new Query(request.userText(), request.messages(), context);
+		List<Document> documents = retriever.retrieve(query);
 
 		context.put(RETRIEVED_DOCUMENTS, documents);
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/advisor/DocumentRetrievalAdvisor.java
@@ -132,7 +132,7 @@ public class DocumentRetrievalAdvisor implements CallAroundAdvisor, StreamAround
 	private AdvisedRequest before(AdvisedRequest request) {
 
 		var context = new HashMap<>(request.adviseContext());
-		List<Document> documents = retriever.retrieve(new Query(request.userText(), request.messages(), request.adviseContext()));
+		List<Document> documents = retriever.retrieve(new Query(request.userText()));
 
 		context.put(RETRIEVED_DOCUMENTS, documents);
 


### PR DESCRIPTION
Optimized the query initialization method when DocumentRetrievalAdvisor calls the retrieve method, and adds context and message history
在DocumentRetrievalAdvisor中调用retrieve方法时，调整Query初始化参数，
修改前：仅通过userText初始化Query；
修改后：除了userText，还将message list和adviseContext加入到query构造参数中；

Describe what this PR does / why we need it
简单召回使用userText就好，但是如果需要基于上下文做一些差异化的召回，则需要adviseContext参数作为判断依据。

Does this pull request fix one issue?
Describe how you did it
Describe how to verify it
在DocumentRetriever中可以通过query.context();获取到上下文信息。

Special notes for reviews