### PR TITLE
tools 百度搜索 自动配置bug 修复 prefix

### DIFF
--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchAutoConfiguration.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchAutoConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Description;
 
 @Configuration
 @ConditionalOnClass(BaiduSearchService.class)
-@ConditionalOnProperty(value = "spring.ai.alibaba.toolcalling.baidusearch", name = "enabled", havingValue = "true")
+@ConditionalOnProperty(prefix = "spring.ai.alibaba.toolcalling.baidusearch", name = "enabled", havingValue = "true")
 public class BaiduSearchAutoConfiguration {
 
 	@Bean


### PR DESCRIPTION
###  BaiduSearchAutoConfiguration， ConditionalOnProperty 属性配置错误

ConditionalOnProperty 属性 prefix 写成了了value，导致启动报错

