### PR TITLE
feat: translate Chinese comments to English in DashScopeChatOptions class

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -44,43 +44,60 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   @JsonIgnore private Boolean stream;
 
   /**
-   * 用于控制随机性和多样性的程度。具体来说，temperature值控制了生成文本时对每个候选词的概率分布进行平滑的程度。较高的temperature值会降低概率分布的峰值，使得更多的低概率词被选择，生成结果更加多样化；而较低的temperature值则会增强概率分布的峰值，使得高概率词更容易被选择，生成结果更加确定。
-   * 取值范围：[0, 2)，系统默认值0.85。不建议取值为0，无意义。
+   * Used to control the degree of randomness and diversity.
+   * Specifically, the temperature value smooths the probability distribution
+   * of each candidate token during text generation. Higher temperature values
+   * lower the peak of the distribution—allowing more low-probability tokens
+   * to be selected and producing more diverse outputs—while lower temperature
+   * values increase the peak—making high-probability tokens more likely and
+   * resulting in more deterministic outputs.
+   * Range: [0, 2), system default: 0.85. Setting to 0 is not recommended.
    */
   private @JsonProperty("temperature") Double temperature;
 
   /**
-   * 生成时使用的随机数种子，用户控制模型生成内容的随机性。seed支持无符号64位整数。在使用seed时，模型将尽可能生成相同或相似的结果，但目前不保证每次生成的结果完全相同。
+   * Random seed for generation, controlled by the user to affect reproducibility.
+   * Seed supports unsigned 64‑bit integers. When a seed is provided, the model
+   * will attempt to generate identical or similar results, though exact
+   * reproducibility is not guaranteed.
    */
   private @JsonProperty("seed") Integer seed;
 
   /**
-   * 生成时，核采样方法的概率阈值。例如，取值为0.8时，仅保留累计概率之和大于等于0.8的概率分布中的token，作为随机采样的候选集。取值范围为（0,1.0)，取值越大，生成的随机性越高；取值越低，生成的随机性越低。默认值为0.8。注意，取值不要大于等于1
+   * Nucleus (top-p) sampling threshold during generation. For example, with
+   * top_p = 0.8, only tokens whose cumulative probability mass reaches at least
+   * 0.8 are retained as candidates for sampling. Range: (0, 1.0), default: 0.8.
+   * Higher values increase randomness; lower values increase determinism.
+   * Note: do not set >= 1.0.
    */
   private @JsonProperty("top_p") Double topP;
 
   /**
-   * 生成时，采样候选集的大小。例如，取值为50时，仅将单次生成中得分最高的50个token组成随机采样的候选集。取值越大，生成的随机性越高；取值越小，生成的确定性越高。注意：如果top_k参数为空或者top_k的值大于100，表示不启用top_k策略，此时仅有top_p策略生效，默认是空。
+   * Size of the sampling candidate pool (top-k). For example, top_k = 50 means
+   * only the 50 highest-scoring tokens are considered for random sampling.
+   * Larger values increase randomness; smaller values increase determinism.
+   * Note: if top_k is null or > 100, top-k is disabled and only top-p applies.
+   * Default is null (i.e., disabled).
    */
   private @JsonProperty("top_k") Integer topK;
 
   /**
    * <ul>
-   *   <li>stop参数用于实现内容生成过程的精确控制，在生成内容即将包含指定的字符串或token_ids时自动停止，生成内容不包含指定的内容。
-   *       <p>例如，如果指定stop为"你好"，表示将要生成"你好"时停止；如果指定stop为[37763, 367]，表示将要生成"Observation"时停止。
-   *   <li>stop参数支持以list方式传入字符串数组或者token_ids数组，支持使用多个stop的场景。
+   *   <li>The stop parameter is used to precisely control the content generation process. It automatically stops the generation when the content is about to include the specified string or token_ids, and the generated content does not include the specified content.
+   *       <p>For example, if stop is set to "Hello", the generation will stop when "Hello" is about to be generated; if stop is set to [37763, 367], the generation will stop when "Observation" is about to be generated.
+   *   <li>The stop parameter supports passing in an array of strings or an array of token_ids in list mode, and it supports scenarios where multiple stop conditions are used.
    * </ul>
    *
-   * <q>说明 list模式下不支持字符串和token_ids混用，list模式下元素类型要相同。</q>
+   * <q>Note: In list mode, strings and token_ids cannot be mixed. The element types in list mode must be the same.</q>
    */
   private @JsonProperty("stop") List<Object> stop;
 
   /**
-   * 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。取值如下：
+   * The model has a built - in internet search service. This parameter controls whether the model refers to and uses internet search results when generating text. The possible values are as follows:
    *
    * <ul>
-   *   <li>true：启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑"自行判断"是否使用互联网搜索结果。
-   *   <li>false（默认）：关闭互联网搜索。
+   *   <li>true: Enable internet search. The model will use the search results as reference information during the text generation process. However, the model will "decide on its own" whether to use the internet search results based on its internal logic.
+   *   <li>false (default): Disable internet search.
    * </ul>
    */
   private @JsonProperty("enable_search") Boolean enableSearch = false;
@@ -98,21 +115,25 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   private @JsonProperty("max_tokens") Integer maxTokens;
 
   /**
-   * 控制在流式输出模式下是否开启增量输出，即后续输出内容是否包含已输出的内容。设置为True时，将开启增量输出模式，后面输出不会包含已经输出的内容，您需要自行拼接整体输出；设置为False则会包含已输出的内容。
+   * Controls whether to enable incremental output in streaming output mode, that is, whether the subsequent output content includes the previously output content. When set to true, the incremental output mode will be enabled, and the subsequent output will not include the previously output content. You need to concatenate the overall output yourself. When set to false, the subsequent output will include the previously output content.
    */
   private @JsonProperty("incremental_output") Boolean incrementalOutput = true;
 
-  /** 用于控制模型生成时的重复度。提高repetition_penalty时可以降低模型生成的重复度。1.0表示不做惩罚。默认为1.1。 */
+  /**
+   * Used to control the repetition degree during model generation. Increasing the repetition_penalty can reduce the repetition degree of the model generation. A value of 1.0 means no penalty. The default value is 1.1.
+   */
   private @JsonProperty("repetition_penalty") Double repetitionPenalty;
 
-  /** 模型可选调用的工具列表。目前仅支持function，并且即使输入多个function，模型仅会选择其中一个生成结果。模型根据tools参数内容可以生产函数调用的参数 */
+  /**
+   * A list of optional tools that the model can call. Currently, only functions are supported. Even if multiple functions are input, the model will only select one of them to generate results. The model can generate function call parameters based on the content of the tools parameter.
+   */
   private @JsonProperty("tools") List<DashScopeApi.FunctionTool> tools;
 
   /**
-   * 在使用tools参数时，用于控制模型调用指定工具。有三种取值：
-   * "none"表示不调用工具。tools参数为空时，默认值为"none"。
-   * "auto"表示模型判断是否调用工具，可能调用也可能不调用。tools参数不为空时，默认值为"auto"。
-   * object结构可以指定模型调用指定工具。例如tool_choice={"type": "function", "function": {"name": "user_function"}}
+   * When using the tools parameter, it is used to control the model to call a specified tool. There are three possible values:
+   * "none" indicates not to call any tool. When the tools parameter is empty, the default value is "none".
+   * "auto" indicates that the model decides whether to call a tool, which may or may not happen. When the tools parameter is not empty, the default value is "auto".
+   * An object structure can specify the model to call a specific tool. For example, tool_choice={"type": "function", "function": {"name": "user_function"}}.
    */
   @JsonProperty("tool_choice")
   private Object toolChoice;
@@ -147,7 +168,7 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   @JsonIgnore private Set<String> functions = new HashSet<>();
 
   /**
-   * Indicate if the request is multi model
+   * Indicates whether the request involves multiple models
    */
   private @JsonProperty("multi_model") Boolean multiModel = false;
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR translates the Chinese comments in the `DashScopeChatOptions` class to English. It helps international developers better understand the code, promoting cross - cultural collaboration in the project.

### Does this pull request fix one issue?
Fixes #667.

### Describe how you did it
I first used online translation tools to translate the comments, and then manually adjusted the translations to fit the code context and ensure technical terms were accurate.

### Describe how to verify it
Reviewers can compare the translated comments with the original Chinese ones to check for accuracy. They should also ensure the translated terms are appropriate in the code context.

### Special notes for reviews
Some technical terms may have multiple translations. If there are any concerns about the translation accuracy or suitability in the code, please feel free to point them out. 