### PR TITLE
Refactor NacosMcpRegister: Replace reflection with getters, externalize hardcoded values, and ensure thread pool shutdown

### DIFF
--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
@@ -100,15 +100,9 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 		});
 
 		try {
-			Class clazz = McpAsyncServer.class;
-
-			Field serverInfoField = clazz.getDeclaredField("serverInfo");
-			serverInfoField.setAccessible(true);
-			this.serverInfo = (McpSchema.Implementation) serverInfoField.get(mcpAsyncServer);
-
-			Field serverCapabilitiesField = clazz.getDeclaredField("serverCapabilities");
-			serverCapabilitiesField.setAccessible(true);
-			this.serverCapabilities = (McpSchema.ServerCapabilities) serverCapabilitiesField.get(mcpAsyncServer);
+			Class<McpAsyncServer> clazz = McpAsyncServer.class;
+            this.serverInfo = mcpAsyncServer.getServerInfo();
+            this.serverCapabilities = mcpAsyncServer.getServerCapabilities();
 
 			Field toolsField = clazz.getDeclaredField("tools");
 			toolsField.setAccessible(true);
@@ -129,6 +123,7 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 				DefaultMcpSession mcpSession = (DefaultMcpSession) mcpSessionField.get(mcpAsyncServer);
 				Field requestHandlersField = DefaultMcpSession.class.getDeclaredField("requestHandlers");
 				requestHandlersField.setAccessible(true);
+                @SuppressWarnings("unchecked")
 				ConcurrentHashMap<String, DefaultMcpSession.RequestHandler<?>> requestHandlers = (ConcurrentHashMap<String, DefaultMcpSession.RequestHandler<?>>) requestHandlersField
 					.get(mcpSession);
 				requestHandlers.put(McpSchema.METHOD_TOOLS_LIST, toolsListRequestHandler());

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
@@ -94,8 +94,8 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 
 		try {
 			Class<McpAsyncServer> clazz = McpAsyncServer.class;
-            this.serverInfo = mcpAsyncServer.getServerInfo();
-            this.serverCapabilities = mcpAsyncServer.getServerCapabilities();
+			this.serverInfo = mcpAsyncServer.getServerInfo();
+			this.serverCapabilities = mcpAsyncServer.getServerCapabilities();
 
 			Field toolsField = clazz.getDeclaredField("tools");
 			toolsField.setAccessible(true);
@@ -116,12 +116,13 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 				DefaultMcpSession mcpSession = (DefaultMcpSession) mcpSessionField.get(mcpAsyncServer);
 				Field requestHandlersField = DefaultMcpSession.class.getDeclaredField("requestHandlers");
 				requestHandlersField.setAccessible(true);
-                @SuppressWarnings("unchecked")
+				@SuppressWarnings("unchecked")
 				ConcurrentHashMap<String, DefaultMcpSession.RequestHandler<?>> requestHandlers = (ConcurrentHashMap<String, DefaultMcpSession.RequestHandler<?>>) requestHandlersField
 					.get(mcpSession);
 				requestHandlers.put(McpSchema.METHOD_TOOLS_LIST, toolsListRequestHandler());
 
-				String toolsInNacosContent = this.configService.getConfig(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
+				String toolsInNacosContent = this.configService.getConfig(
+						this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
 						nacosMcpProperties.getToolsGroup(), 3000);
 				if (toolsInNacosContent != null) {
 					updateToolsDescription(toolsInNacosContent);
@@ -133,23 +134,25 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 				mcpToolsInfo.setTools(toolsNeedtoRegister);
 				mcpToolsInfo.setToolsMeta(this.toolsMeta);
 				String toolsConfigContent = JsonUtils.serialize(mcpToolsInfo);
-				boolean isPublishSuccess = this.configService.publishConfig(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
-                        nacosMcpProperties.getToolsGroup(), toolsConfigContent);
+				boolean isPublishSuccess = this.configService.publishConfig(
+						this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
+						nacosMcpProperties.getToolsGroup(), toolsConfigContent);
 				if (!isPublishSuccess) {
 					log.error("Publish tools config to nacos failed.");
 					throw new Exception("Publish tools config to nacos failed.");
 				}
-				this.configService.addListener(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(), nacosMcpProperties.getToolsGroup(), new Listener() {
-					@Override
-					public void receiveConfigInfo(String configInfo) {
-						updateToolsDescription(configInfo);
-					}
+				this.configService.addListener(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
+						nacosMcpProperties.getToolsGroup(), new Listener() {
+							@Override
+							public void receiveConfigInfo(String configInfo) {
+								updateToolsDescription(configInfo);
+							}
 
-					@Override
-					public Executor getExecutor() {
-						return null;
-					}
-				});
+							@Override
+							public Executor getExecutor() {
+								return null;
+							}
+						});
 			}
 
 			McpServerInfo mcpServerInfo = new McpServerInfo();
@@ -175,7 +178,8 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 				mcpServerInfo.setProtocol("mcp-sse");
 			}
 			if (this.serverCapabilities.tools() != null) {
-				mcpServerInfo.setToolsDescriptionRef(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix());
+				mcpServerInfo
+					.setToolsDescriptionRef(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix());
 			}
 			boolean isPublishSuccess = this.configService.publishConfig(this.serverInfo.name() + "-mcp-server.json",
 					nacosMcpProperties.getServerGroup(), JsonUtils.serialize(mcpServerInfo));
@@ -191,7 +195,8 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 
 		executorService.scheduleWithFixedDelay(() -> {
 			try {
-				String toolsInNacosContent = this.configService.getConfig(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
+				String toolsInNacosContent = this.configService.getConfig(
+						this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
 						nacosMcpProperties.getToolsGroup(), 3000);
 				updateToolsDescription(toolsInNacosContent);
 				McpToolsInfo mcpToolsInfo = JsonUtils.deserialize(toolsInNacosContent, McpToolsInfo.class);
@@ -204,8 +209,8 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 				if (!StringUtils.equals(toolsContentInLocal, toolsContentInNacos)) {
 					mcpToolsInfo.setTools(toolsInLocal);
 					String mcpToolsInfoString = JsonUtils.serialize(mcpToolsInfo);
-					this.configService.publishConfig(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(), nacosMcpProperties.getToolsGroup(),
-							mcpToolsInfoString);
+					this.configService.publishConfig(this.serverInfo.name() + nacosMcpProperties.getToolsConfigSuffix(),
+							nacosMcpProperties.getToolsGroup(), mcpToolsInfoString);
 				}
 			}
 			catch (Exception e) {
@@ -295,23 +300,24 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 		};
 	}
 
-    /**
-     * 释放线程池资源
-     */
-    @PreDestroy
-    public void shutdown() {
-        log.info("Shutting down executorService in NacosMcpRegister...");
-        if (executorService != null && !executorService.isShutdown()) {
-            executorService.shutdown();
-            try {
-                if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
-                    executorService.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                executorService.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
-        }
-    }
+	/**
+	 * 释放线程池资源
+	 */
+	@PreDestroy
+	public void shutdown() {
+		log.info("Shutting down executorService in NacosMcpRegister...");
+		if (executorService != null && !executorService.isShutdown()) {
+			executorService.shutdown();
+			try {
+				if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+					executorService.shutdownNow();
+				}
+			}
+			catch (InterruptedException e) {
+				executorService.shutdownNow();
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
 
 }

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
@@ -34,6 +34,7 @@ import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.DefaultMcpSession;
 import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.web.context.WebServerInitializedEvent;
@@ -293,5 +294,24 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 			return Mono.just(new McpSchema.ListToolsResult(toolsEnable, null));
 		};
 	}
+
+    /**
+     * 释放线程池资源
+     */
+    @PreDestroy
+    public void shutdown() {
+        log.info("Shutting down executorService in NacosMcpRegister...");
+        if (executorService != null && !executorService.isShutdown()) {
+            executorService.shutdown();
+            try {
+                if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                    executorService.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
 
 }

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegistryProperties.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegistryProperties.java
@@ -85,13 +85,14 @@ public class NacosMcpRegistryProperties {
 	String sseExportContextPath;
 
 	boolean serviceRegister = true;
-    String toolsGroup = "mcp-tools";
 
-    String toolsConfigSuffix = "-mcp-tools.json";
+	String toolsGroup = "mcp-tools";
 
-    String configNamespace = "nacos-default-mcp";
+	String toolsConfigSuffix = "-mcp-tools.json";
 
-    String serverGroup = "mcp-server";
+	String configNamespace = "nacos-default-mcp";
+
+	String serverGroup = "mcp-server";
 
 	@Autowired
 	@JsonIgnore
@@ -185,37 +186,37 @@ public class NacosMcpRegistryProperties {
 		this.serviceNamespace = serviceNamespace;
 	}
 
-    public String getToolsGroup() {
-        return toolsGroup;
-    }
+	public String getToolsGroup() {
+		return toolsGroup;
+	}
 
-    public void setToolsGroup(String toolsGroup) {
-        this.toolsGroup = toolsGroup;
-    }
+	public void setToolsGroup(String toolsGroup) {
+		this.toolsGroup = toolsGroup;
+	}
 
-    public String getToolsConfigSuffix() {
-        return toolsConfigSuffix;
-    }
+	public String getToolsConfigSuffix() {
+		return toolsConfigSuffix;
+	}
 
-    public void setToolsConfigSuffix(String toolsConfigSuffix) {
-        this.toolsConfigSuffix = toolsConfigSuffix;
-    }
+	public void setToolsConfigSuffix(String toolsConfigSuffix) {
+		this.toolsConfigSuffix = toolsConfigSuffix;
+	}
 
-    public String getConfigNamespace() {
-        return configNamespace;
-    }
+	public String getConfigNamespace() {
+		return configNamespace;
+	}
 
-    public void setConfigNamespace(String configNamespace) {
-        this.configNamespace = configNamespace;
-    }
+	public void setConfigNamespace(String configNamespace) {
+		this.configNamespace = configNamespace;
+	}
 
-    public String getServerGroup() {
-        return serverGroup;
-    }
+	public String getServerGroup() {
+		return serverGroup;
+	}
 
-    public void setServerGroup(String serverGroup) {
-        this.serverGroup = serverGroup;
-    }
+	public void setServerGroup(String serverGroup) {
+		this.serverGroup = serverGroup;
+	}
 
 	@PostConstruct
 	public void init() throws Exception {

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegistryProperties.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegistryProperties.java
@@ -85,6 +85,13 @@ public class NacosMcpRegistryProperties {
 	String sseExportContextPath;
 
 	boolean serviceRegister = true;
+    String toolsGroup = "mcp-tools";
+
+    String toolsConfigSuffix = "-mcp-tools.json";
+
+    String configNamespace = "nacos-default-mcp";
+
+    String serverGroup = "mcp-server";
 
 	@Autowired
 	@JsonIgnore
@@ -177,6 +184,38 @@ public class NacosMcpRegistryProperties {
 	void setServiceNamespace(String serviceNamespace) {
 		this.serviceNamespace = serviceNamespace;
 	}
+
+    public String getToolsGroup() {
+        return toolsGroup;
+    }
+
+    public void setToolsGroup(String toolsGroup) {
+        this.toolsGroup = toolsGroup;
+    }
+
+    public String getToolsConfigSuffix() {
+        return toolsConfigSuffix;
+    }
+
+    public void setToolsConfigSuffix(String toolsConfigSuffix) {
+        this.toolsConfigSuffix = toolsConfigSuffix;
+    }
+
+    public String getConfigNamespace() {
+        return configNamespace;
+    }
+
+    public void setConfigNamespace(String configNamespace) {
+        this.configNamespace = configNamespace;
+    }
+
+    public String getServerGroup() {
+        return serverGroup;
+    }
+
+    public void setServerGroup(String serverGroup) {
+        this.serverGroup = serverGroup;
+    }
 
 	@PostConstruct
 	public void init() throws Exception {


### PR DESCRIPTION
This PR refactors the NacosMcpRegister class to improve code maintainability and resource management:

- 使用 Getter 方法替代反射： 在 NacosMcpRegister 类中，将原先通过反射获取属性的方式替换为直接调用 Getter 方法，提高了代码的可读性和性能。

- 移除硬编码配置： 将硬编码的配置项（如服务地址、命名空间等）提取到配置文件中，并通过 NacosMcpRegistryProperties 类进行管理，增强了系统的灵活性和可维护性。

- 关闭线程池： 在服务停止时，确保线程池资源被正确释放，防止潜在的内存泄漏问题。

已经完成单元测试， 上述更改未引入新的问题