### PR TITLE
feat(日志打印调整): ExecutionPlan打印对象地址改为打印具体字段信息，字符串拼接打印改为占位符打印

### DIFF
--- a/community/openmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/creator/PlanCreator.java
+++ b/community/openmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/creator/PlanCreator.java
@@ -87,7 +87,7 @@ public class PlanCreator {
 			// 检查计划是否创建成功
 			if (planId.equals(planningTool.getCurrentPlanId())) {
 				currentPlan = planningTool.getCurrentPlan();
-				log.info("Plan created successfully: " + currentPlan);
+				log.info("Plan created successfully: {}", currentPlan);
 				currentPlan.setPlanningThinking(outputText);
 			}
 			context.setPlan(currentPlan);

--- a/community/openmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/model/vo/ExecutionPlan.java
+++ b/community/openmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/model/vo/ExecutionPlan.java
@@ -95,6 +95,12 @@ public class ExecutionPlan {
 		this.executionParams = executionParams;
 	}
 
+	@Override
+	public String toString() {
+		return "ExecutionPlan{" + "planId='" + planId + '\'' + ", title='" + title + '\'' + ", stepsCount="
+				+ (steps != null ? steps.size() : 0) + '}';
+	}
+
 	public String getPlanExecutionStateStringFormat() {
 		StringBuilder state = new StringBuilder();
 		state.append("Plan: ").append(title).append(" (ID: ").append(planId).append(")\n");


### PR DESCRIPTION
### Describe what this PR does / why we need it
ExecutionPlan打印对象地址改为打印具体字段信息，字符串拼接打印改为占位符打印

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
override toString方法

### Describe how to verify it
打印ExecutionPlan对象

### Special notes for reviews
只打印了关键字段：planId、title、steps的大小