### PR TITLE
fit GraphAPIController.java

### DIFF
--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/GraphAPIController.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/controller/GraphAPIController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @CrossOrigin
 @RestController
-@RequestMapping("studio/api/graph")
+@RequestMapping("studio/api/graphs")
 public class GraphAPIController implements GraphAPI {
 
 	private final GraphService graphService;


### PR DESCRIPTION
修复接口地址错误，页面请求是复数形式，接口是单数形式导致页面报错



![iwEeAqNwbmcDAQTRBBUF0QFjBrBwVJEqN4fyagfp-7g_AL4AB9IdeNNyCAAJomltCgAL0gAA3m8 png_720x720q90](https://github.com/user-attachments/assets/e41a1ee6-53ec-4dad-8b64-79724f6d26ee)

![iwEcAqNwbmcDAQTRAzIF0QHTBrBaR6wtHjIEhwfp-7g_AL4BB9IdeNNyCAAJomltCgAL0W3A png_720x720q90](https://github.com/user-attachments/assets/f9b7f8ed-4b39-4ac7-aa1e-de7f2f8d2721)
