### PR TITLE
[FIX]:Added SpringBoot auto-injection to modify the type of vector ID

### DIFF
--- a/community/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStore.java
+++ b/community/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/java/com/alibaba/cloud/ai/vectorstore/oceanbase/OceanBaseVectorStore.java
@@ -64,7 +64,8 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 	private static final Double DEFAULT_SIMILARITY_THRESHOLD = 0.0;
 
 	private static final String CREATE_TABLE_SQL_TEMPLATE = "CREATE TABLE IF NOT EXISTS %s ("
-			+ "id BIGINT PRIMARY KEY, " + "vector VECTOR(384) NOT NULL, " + "description text, " + "metadata text)";
+			+ "id varchar(100) PRIMARY KEY, " + "vector VECTOR(384) NOT NULL, " + "description text, "
+			+ "metadata text)";
 
 	private static final String INSERT_DOC_SQL_TEMPLATE = "INSERT INTO %s (id, vector, description, metadata) VALUES (?, ?, ?, ?)";
 
@@ -125,7 +126,7 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 				Document doc = documents.get(i);
 				Map<String, String> metadata = createMetadata(doc);
 				String vectorString = convertEmbeddingToString(embeddings.get(i));
-				pstmt.setLong(1, Long.parseLong(doc.getId()));
+				pstmt.setString(1, doc.getId());
 				pstmt.setString(2, vectorString);
 				pstmt.setString(3, doc.getText());
 				pstmt.setString(4, objectMapper.writeValueAsString(metadata));
@@ -201,7 +202,7 @@ public class OceanBaseVectorStore extends AbstractObservationVectorStore impleme
 	}
 
 	private Document extractDocumentFromResultSet(ResultSet rs) throws SQLException, JsonProcessingException {
-		long id = rs.getLong("id");
+		String id = rs.getString("id");
 		String vectorMetadata = rs.getString("metadata");
 		String distance = rs.getString("distance");
 		Map<String, String> metadata = extractMetadata(vectorMetadata);

--- a/community/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/community/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2024-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.alibaba.cloud.ai.vectorstore.oceanbase.OceanBaseVectorStoreAutoConfiguration


### PR DESCRIPTION
### Describe what this PR does / why we need it
Automatic injection of oceanbase is required to integrate the spring environment

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #722  Close #722 
### Describe how you did it
i add community/vector-stores/spring-ai-alibaba-starter-oceanbase-store/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports

### Describe how to verify it
The spring environment integrates it directly

### Special notes for reviews
no