### PR TITLE
feat: add ListOperatorNode to graph module

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/ListOperatorNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/ListOperatorNode.java
@@ -104,6 +104,47 @@ public class ListOperatorNode<T extends ListOperatorNode.ListElement> implements
 			return value.toString();
 		}
 
+		// 一些预定义的Predicate和Comparator，可以供用户直接使用
+		public boolean isInteger() {
+			return value instanceof Integer;
+		}
+
+		public boolean isDouble() {
+			return value instanceof Double;
+		}
+
+		public boolean greater(Number val) {
+			return Double.compare(value.doubleValue(), val.doubleValue()) > 0;
+		}
+
+		public boolean less(Number val) {
+			return Double.compare(value.doubleValue(), val.doubleValue()) < 0;
+		}
+
+		public boolean noGreater(Number val) {
+			return Double.compare(value.doubleValue(), val.doubleValue()) <= 0;
+		}
+
+		public boolean noLess(Number val) {
+			return Double.compare(value.doubleValue(), val.doubleValue()) >= 0;
+		}
+
+		public boolean equal(Number val) {
+			return Double.compare(value.doubleValue(), val.doubleValue()) == 0;
+		}
+
+		public boolean noEqual(Number val) {
+			return Double.compare(value.doubleValue(), val.doubleValue()) != 0;
+		}
+
+		public int compareTo(NumberElement other) {
+			return Double.compare(this.value.doubleValue(), other.value.doubleValue());
+		}
+
+		public int compareToReverse(NumberElement other) {
+			return Double.compare(other.value.doubleValue(), this.value.doubleValue());
+		}
+
 	}
 
 	public static class StringElement implements ListElement {
@@ -200,112 +241,93 @@ public class ListOperatorNode<T extends ListOperatorNode.ListElement> implements
 					+ ", transferMethod='" + transferMethod + '\'' + '}';
 		}
 
-	}
-
-	public interface ListElementFilterEnum<T extends ListElement> {
-
-		Predicate<T> getFilter();
-
-	}
-
-	public interface ListElementComparatorEnum<T extends ListElement> {
-
-		Comparator<T> getComparator();
-
-	}
-
-	public enum StringElementFilterEnum implements ListElementFilterEnum<StringElement> {
-
-		;
-		private final Predicate<StringElement> filter;
-
-		StringElementFilterEnum(Predicate<StringElement> filter) {
-			this.filter = filter;
+		// 一些预定义的Predicate和Comparator，可以供用户直接使用
+		public boolean includeExtension(String... extensions) {
+			for (String extension : extensions) {
+				if (this.extension.equals(extension)) {
+					return true;
+				}
+			}
+			return false;
 		}
 
-		@Override
-		public Predicate<StringElement> getFilter() {
-			return this.filter;
+		public boolean excludeExtension(String... extensions) {
+			for (String extension : extensions) {
+				if (this.extension.equals(extension)) {
+					return false;
+				}
+			}
+			return true;
 		}
 
-	}
-
-	public enum NumberElementFilterEnum implements ListElementFilterEnum<NumberElement> {
-
-		;
-		private final Predicate<NumberElement> filter;
-
-		NumberElementFilterEnum(Predicate<NumberElement> filter) {
-			this.filter = filter;
+		public boolean includeType(String... types) {
+			for (String type : types) {
+				if (this.type.equals(type)) {
+					return true;
+				}
+			}
+			return false;
 		}
 
-		@Override
-		public Predicate<NumberElement> getFilter() {
-			return this.filter;
+		public boolean excludeType(String... types) {
+			for (String type : types) {
+				if (this.type.equals(type)) {
+					return false;
+				}
+			}
+			return true;
 		}
 
-	}
-
-	public enum FileElementFilterEnum implements ListElementFilterEnum<FileElement> {
-
-		;
-		private final Predicate<FileElement> filter;
-
-		FileElementFilterEnum(Predicate<FileElement> filter) {
-			this.filter = filter;
+		public boolean sizeNoBiggerThan(Integer sizeLimit) {
+			return this.size.compareTo(sizeLimit) <= 0;
 		}
 
-		@Override
-		public Predicate<FileElement> getFilter() {
-			return this.filter;
+		public boolean sizeNoLessThan(Integer sizeLimit) {
+			return this.size.compareTo(sizeLimit) >= 0;
 		}
 
-	}
-
-	public enum StringElementComparatorEnum implements ListElementComparatorEnum<StringElement> {
-
-		;
-		private final Comparator<StringElement> comparator;
-
-		StringElementComparatorEnum(Comparator<StringElement> comparator) {
-			this.comparator = comparator;
+		public boolean nameStartWith(String prefix) {
+			return this.name.startsWith(prefix);
 		}
 
-		@Override
-		public Comparator<StringElement> getComparator() {
-			return this.comparator;
+		public boolean nameEndWith(String suffix) {
+			return this.name.endsWith(suffix);
 		}
 
-	}
-
-	public enum NumberElementComparatorEnum implements ListElementComparatorEnum<NumberElement> {
-
-		;
-		private final Comparator<NumberElement> comparator;
-
-		NumberElementComparatorEnum(Comparator<NumberElement> comparator) {
-			this.comparator = comparator;
+		public boolean nameContains(String sub) {
+			return this.name.contains(sub);
 		}
 
-		@Override
-		public Comparator<NumberElement> getComparator() {
-			return this.comparator;
+		public int compareType(FileElement other) {
+			return this.type.compareTo(other.type);
 		}
 
-	}
-
-	public enum FileElementComparatorEnum implements ListElementComparatorEnum<FileElement> {
-
-		;
-		private final Comparator<FileElement> comparator;
-
-		FileElementComparatorEnum(Comparator<FileElement> comparator) {
-			this.comparator = comparator;
+		public int compareTypeReverse(FileElement other) {
+			return other.type.compareTo(this.type);
 		}
 
-		@Override
-		public Comparator<FileElement> getComparator() {
-			return this.comparator;
+		public int compareSize(FileElement other) {
+			return this.size.compareTo(other.size);
+		}
+
+		public int compareSizeReverse(FileElement other) {
+			return other.type.compareTo(this.type);
+		}
+
+		public int compareName(FileElement other) {
+			return this.name.compareTo(other.name);
+		}
+
+		public int compareNameReverse(FileElement other) {
+			return other.name.compareTo(this.name);
+		}
+
+		public int compareExtension(FileElement other) {
+			return this.extension.compareTo(other.extension);
+		}
+
+		public int compareExtensionReverse(FileElement other) {
+			return other.extension.compareTo(this.extension);
 		}
 
 	}
@@ -345,18 +367,8 @@ public class ListOperatorNode<T extends ListOperatorNode.ListElement> implements
 			return this;
 		}
 
-		public Builder<T> filter(ListElementFilterEnum<T> filterEnum) {
-			filters.add(filterEnum.getFilter());
-			return this;
-		}
-
 		public Builder<T> comparator(Comparator<T> comparator) {
 			comparators.add(comparator);
-			return this;
-		}
-
-		public Builder<T> comparator(ListElementComparatorEnum<T> comparatorEnum) {
-			comparators.add(comparatorEnum.getComparator());
 			return this;
 		}
 

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/ListOperatorNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/ListOperatorNode.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class ListOperatorNode<T extends ListOperatorNode.ListElement> implements NodeAction {
+
+	private static final Logger log = LoggerFactory.getLogger(ListOperatorNode.class);
+
+	private final String inputTextKey; // 默认“input”
+
+	private final String outputTextKey; // 默认“output”
+
+	// 过滤条件
+	private final Predicate<T> filterChain;
+
+	// 排序条件
+	private final Comparator<T> comparatorChain;
+
+	// 取前几个值
+	private final Long limitNumber;
+
+	private ListOperatorNode(String inputTextKey, String outputTextKey, Predicate<T> filterChain,
+			Comparator<T> comparatorChain, Long limitNumber) {
+		this.inputTextKey = inputTextKey;
+		this.outputTextKey = outputTextKey;
+		this.filterChain = filterChain;
+		this.comparatorChain = comparatorChain;
+		this.limitNumber = limitNumber;
+	}
+
+	@Override
+	public Map<String, Object> apply(OverAllState t) throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
+			String inputJsonString = (String) t.value(inputTextKey).orElse(null);
+			if (inputJsonString == null) {
+				throw new RuntimeException("inputJsonString is null");
+			}
+			List<T> listElements = objectMapper.readValue(inputJsonString, new TypeReference<List<T>>() {
+			})
+				.stream()
+				.filter(filterChain)
+				.sorted(comparatorChain)
+				.limit(limitNumber != null && limitNumber > 0 ? limitNumber : Long.MAX_VALUE)
+				.toList();
+			return Map.of(outputTextKey, objectMapper.writeValueAsString(listElements));
+		}
+		catch (Exception e) {
+			log.error("ListOperatorNode apply failed, message: {}", e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	public interface ListElement {
+
+	}
+
+	public static class NumberElement implements ListElement {
+
+		Number value;
+
+		@JsonCreator
+		public NumberElement(Number value) {
+			this.value = value;
+		}
+
+		@JsonValue
+		public Number getValue() {
+			return value;
+		}
+
+		@Override
+		public String toString() {
+			return value.toString();
+		}
+
+	}
+
+	public static class StringElement implements ListElement {
+
+		String value;
+
+		@JsonCreator
+		public StringElement(String value) {
+			this.value = value;
+		}
+
+		@JsonValue
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public String toString() {
+			return value;
+		}
+
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class FileElement implements ListElement {
+
+		String type;
+
+		Integer size;
+
+		String name;
+
+		String url;
+
+		String extension;
+
+		String mimeType;
+
+		String transferMethod;
+
+		@JsonCreator
+		public FileElement(@JsonProperty("type") String type, @JsonProperty("size") Integer size,
+				@JsonProperty("name") String name, @JsonProperty("url") String url,
+				@JsonProperty("extension") String extension, @JsonProperty("mime_type") String mimeType,
+				@JsonProperty("transfer_method") String transferMethod) {
+			this.type = type;
+			this.size = size;
+			this.name = name;
+			this.url = url;
+			this.extension = extension;
+			this.mimeType = mimeType;
+			this.transferMethod = transferMethod;
+		}
+
+		@JsonProperty("type")
+		public String getType() {
+			return type;
+		}
+
+		@JsonProperty("size")
+		public Integer getSize() {
+			return size;
+		}
+
+		@JsonProperty("name")
+		public String getName() {
+			return name;
+		}
+
+		@JsonProperty("url")
+		public String getUrl() {
+			return url;
+		}
+
+		@JsonProperty("extension")
+		public String getExtension() {
+			return extension;
+		}
+
+		@JsonProperty("mime_type")
+		public String getMimeType() {
+			return mimeType;
+		}
+
+		@JsonProperty("transfer_method")
+		public String getTransferMethod() {
+			return transferMethod;
+		}
+
+		@Override
+		public String toString() {
+			return "FileElement{" + "type='" + type + '\'' + ", size=" + size + ", name='" + name + '\'' + ", url='"
+					+ url + '\'' + ", extension='" + extension + '\'' + ", mimeType='" + mimeType + '\''
+					+ ", transferMethod='" + transferMethod + '\'' + '}';
+		}
+
+	}
+
+	public interface ListElementFilterEnum<T extends ListElement> {
+
+		Predicate<T> getFilter();
+
+	}
+
+	public interface ListElementComparatorEnum<T extends ListElement> {
+
+		Comparator<T> getComparator();
+
+	}
+
+	public enum StringElementFilterEnum implements ListElementFilterEnum<StringElement> {
+
+		;
+		private final Predicate<StringElement> filter;
+
+		StringElementFilterEnum(Predicate<StringElement> filter) {
+			this.filter = filter;
+		}
+
+		@Override
+		public Predicate<StringElement> getFilter() {
+			return this.filter;
+		}
+
+	}
+
+	public enum NumberElementFilterEnum implements ListElementFilterEnum<NumberElement> {
+
+		;
+		private final Predicate<NumberElement> filter;
+
+		NumberElementFilterEnum(Predicate<NumberElement> filter) {
+			this.filter = filter;
+		}
+
+		@Override
+		public Predicate<NumberElement> getFilter() {
+			return this.filter;
+		}
+
+	}
+
+	public enum FileElementFilterEnum implements ListElementFilterEnum<FileElement> {
+
+		;
+		private final Predicate<FileElement> filter;
+
+		FileElementFilterEnum(Predicate<FileElement> filter) {
+			this.filter = filter;
+		}
+
+		@Override
+		public Predicate<FileElement> getFilter() {
+			return this.filter;
+		}
+
+	}
+
+	public enum StringElementComparatorEnum implements ListElementComparatorEnum<StringElement> {
+
+		;
+		private final Comparator<StringElement> comparator;
+
+		StringElementComparatorEnum(Comparator<StringElement> comparator) {
+			this.comparator = comparator;
+		}
+
+		@Override
+		public Comparator<StringElement> getComparator() {
+			return this.comparator;
+		}
+
+	}
+
+	public enum NumberElementComparatorEnum implements ListElementComparatorEnum<NumberElement> {
+
+		;
+		private final Comparator<NumberElement> comparator;
+
+		NumberElementComparatorEnum(Comparator<NumberElement> comparator) {
+			this.comparator = comparator;
+		}
+
+		@Override
+		public Comparator<NumberElement> getComparator() {
+			return this.comparator;
+		}
+
+	}
+
+	public enum FileElementComparatorEnum implements ListElementComparatorEnum<FileElement> {
+
+		;
+		private final Comparator<FileElement> comparator;
+
+		FileElementComparatorEnum(Comparator<FileElement> comparator) {
+			this.comparator = comparator;
+		}
+
+		@Override
+		public Comparator<FileElement> getComparator() {
+			return this.comparator;
+		}
+
+	}
+
+	public static class Builder<T extends ListElement> {
+
+		private String inputTextKey;
+
+		private String outputTextKey;
+
+		private final List<Predicate<T>> filters;
+
+		private final List<Comparator<T>> comparators;
+
+		private Long limitNumber;
+
+		private Builder() {
+			inputTextKey = "input";
+			outputTextKey = "output";
+			filters = new ArrayList<>();
+			comparators = new ArrayList<>();
+			limitNumber = null;
+		}
+
+		public Builder<T> inputTextKey(String inputTextKey) {
+			this.inputTextKey = inputTextKey;
+			return this;
+		}
+
+		public Builder<T> outputTextKey(String outputTextKey) {
+			this.outputTextKey = outputTextKey;
+			return this;
+		}
+
+		public Builder<T> filter(Predicate<T> filter) {
+			filters.add(filter);
+			return this;
+		}
+
+		public Builder<T> filter(ListElementFilterEnum<T> filterEnum) {
+			filters.add(filterEnum.getFilter());
+			return this;
+		}
+
+		public Builder<T> comparator(Comparator<T> comparator) {
+			comparators.add(comparator);
+			return this;
+		}
+
+		public Builder<T> comparator(ListElementComparatorEnum<T> comparatorEnum) {
+			comparators.add(comparatorEnum.getComparator());
+			return this;
+		}
+
+		public Builder<T> limitNumber(Long limitNumber) {
+			this.limitNumber = limitNumber;
+			return this;
+		}
+
+		public ListOperatorNode<T> build() {
+			return new ListOperatorNode<T>(inputTextKey, outputTextKey,
+					filters.stream().reduce(Predicate::and).orElse(t -> true),
+					comparators.stream().reduce(Comparator::thenComparing).orElse((a, b) -> 0), limitNumber);
+		}
+
+	}
+
+	public static <T extends ListElement> Builder<T> builder() {
+		return new Builder<T>();
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/ListOperatorNodeTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/ListOperatorNodeTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.state.AgentStateFactory;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ListOperatorNodeTest {
+
+	@Test
+	public void testNumberListOperatorNode() throws Exception {
+		OverAllState t = new OverAllState();
+		t.input(Map.of("input", "[1,3,4,5.6,2,3.5,1,2,0.3,4,5,0.6,7,8,9,23]"));
+		// Define a list operation where the elements are nodes of numbers (integers or
+		// floating-point numbers).
+		ListOperatorNode<ListOperatorNode.NumberElement> node = ListOperatorNode.<ListOperatorNode.NumberElement>builder()
+			.elementClassType(ListOperatorNode.NumberElement.class)
+			.inputTextKey("input")
+			.outputTextKey("output")
+			// Filter the elements to retain only the integer parts of the list.
+			.filter(ListOperatorNode.NumberElement::isInteger)
+			// Sort in descending order.
+			.comparator(ListOperatorNode.NumberElement::compareToReverse)
+			.limitNumber(10)
+			.build();
+		assertEquals("[23,9,8,7,5,4,4,3,2,2]", node.apply(t).get("output").toString());
+	}
+
+	@Test
+	public void testStringListOperatorNode() throws Exception {
+		OverAllState t = new OverAllState();
+		t.input(Map.of("input", "[\"123456\", \"12345678\", \"1234\", \"234567\", \"abcdefg\"]"));
+		// Define a list operation where the elements are nodes of strings.
+		ListOperatorNode<ListOperatorNode.StringElement> node = ListOperatorNode.<ListOperatorNode.StringElement>builder()
+			.elementClassType(ListOperatorNode.StringElement.class)
+			.inputTextKey("input")
+			.outputTextKey("output")
+			// Retain strings with the prefix '1234'.
+			.filter(x -> x.getValue().startsWith("1234"))
+			// Retain strings with a length greater than 4.
+			.filter(x -> x.getValue().length() > 4)
+			// Sort in lexicographical ascending order.
+			.comparator(ListOperatorNode.StringElement::compareTo)
+			.limitNumber(10)
+			.build();
+		assertEquals("[\"123456\",\"12345678\"]", node.apply(t).get("output").toString());
+	}
+
+	@Test
+	public void testFileListOperatorNode() throws Exception {
+		OverAllState t = new OverAllState();
+		// Simulate JSON file objects.
+		String jsonList = "["
+				+ "{\"type\":\"image\",\"size\":2048000,\"name\":\"sunset.jpg\",\"url\":\"https://example.com/files/sunset.jpg\",\"extension\":\"jpg\",\"mime_type\":\"image/jpeg\",\"transfer_method\":\"http\"},"
+				+ "{\"type\":\"document\",\"size\":512000,\"name\":\"report_2023.pdf\",\"url\":\"https://example.com/docs/report.pdf\",\"extension\":\"pdf\",\"mime_type\":\"application/pdf\",\"transfer_method\":\"s3\"},"
+				+ "{\"type\":\"video\",\"size\":52428800,\"name\":\"demo-video.mp4\",\"url\":\"https://example.com/videos/demo.mp4\",\"extension\":\"mp4\",\"mime_type\":\"video/mp4\",\"transfer_method\":\"ftp\"},"
+				+ "{\"type\":\"text\",\"size\":0,\"name\":\"empty-file.txt\",\"url\":\"https://example.com/files/empty.txt\",\"extension\":\"txt\",\"mime_type\":\"text/plain\",\"transfer_method\":\"local\"},"
+				+ "{\"type\":\"archive\",\"size\":102400,\"name\":\"data_2023-10.zip\",\"url\":\"https://example.com/archives/data.zip\",\"extension\":\"zip\",\"mime_type\":\"application/zip\",\"transfer_method\":\"sftp\"}"
+				+ "]";
+		t.input(Map.of("input", jsonList));
+		// Define a list operation where the elements are nodes of file objects.
+		ListOperatorNode<ListOperatorNode.FileElement> node = ListOperatorNode.<ListOperatorNode.FileElement>builder()
+			.elementClassType(ListOperatorNode.FileElement.class)
+			// Exclude file objects with certain extensions.
+			.filter(x -> x.excludeExtension("jpg", "pdf"))
+			// Define the minimum file size.
+			.filter(x -> x.sizeNoLessThan(1))
+			// Sort files by size first.
+			.comparator(ListOperatorNode.FileElement::compareSize)
+			// Then sort by filename.
+			.comparator(ListOperatorNode.FileElement::compareName)
+			.build();
+		assertEquals(
+				"[{\"type\":\"archive\",\"size\":102400,\"name\":\"data_2023-10.zip\",\"url\":\"https://example.com/archives/data.zip\",\"extension\":\"zip\",\"mime_type\":\"application/zip\",\"transfer_method\":\"sftp\"},{\"type\":\"video\",\"size\":52428800,\"name\":\"demo-video.mp4\",\"url\":\"https://example.com/videos/demo.mp4\",\"extension\":\"mp4\",\"mime_type\":\"video/mp4\",\"transfer_method\":\"ftp\"}]",
+				node.apply(t).get("output").toString());
+	}
+
+	@Test
+	public void testNodeInGraph() throws Exception {
+		// Take NumberElement as an example.
+		ListOperatorNode<ListOperatorNode.NumberElement> node = ListOperatorNode.<ListOperatorNode.NumberElement>builder()
+			.elementClassType(ListOperatorNode.NumberElement.class)
+			.inputTextKey("input")
+			.outputTextKey("output")
+			.filter(ListOperatorNode.NumberElement::isInteger)
+			.comparator(ListOperatorNode.NumberElement::compareToReverse)
+			.limitNumber(10)
+			.build();
+		AgentStateFactory<OverAllState> stateFactory = (inputs) -> {
+			OverAllState state = new OverAllState();
+			state.registerKeyAndStrategy("input", new ReplaceStrategy());
+			state.registerKeyAndStrategy("output", new ReplaceStrategy());
+			state.input(inputs);
+			return state;
+		};
+		CompiledGraph compiledGraph = new StateGraph("ListOperatorNode Workflow Demo", stateFactory)
+			.addNode("number_list_operator", node_async(node))
+			.addEdge(START, "number_list_operator")
+			.addEdge("number_list_operator", END)
+			.compile();
+		assertEquals("[23,9,8,7,5,4,4,3,2,2]",
+				compiledGraph.invoke(Map.of("input", "[1,3,4,5.6,2,3.5,1,2,0.3,4,5,0.6,7,8,9,23]"))
+					.orElseThrow()
+					.value("output")
+					.orElseThrow()
+					.toString());
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

The model, when accepting elements of a list such as numbers, strings, or file objects, may need to filter based on specific conditions or sort the list to pass the data to the next Node for processing, thus requiring a ListOperatorNode.

### Does this pull request fix one issue?

NONE

### Describe how you did it

A generic class `ListOperatorNode` is defined to generate node objects capable of handling different list elements. For consistency, it is specified that `T` must be a subclass of the `ListOperatorNode.ListElement` interface. Predefined classes `NumberElement`, `StringElement`, and `FileElement` are provided to handle lists containing numeric values (a mix of Integer and Double), strings, and file objects respectively. The `FileElement` corresponds to a JSON-formatted file object. These three classes include predefined methods that can be instantiated as Predicate and Comparator, such as checking if a numeric element is an integer, excluding files with specific extensions, sorting by file size, etc.

The apply method of the Node retrieves a list JSON string from the `OverAllState` object (either from the previous node or user input), then performs filtering, sorting, and element count limitation based on the Predicate and Comparator combinations passed during the instantiation of the `ListOperatorNode`. Finally, the processed list is converted back into a JSON string for output.

### Describe how to verify it

A sample project was written to verify that the node's output meets expectations.

### Special notes for reviews
