### PR TITLE
Improve parameter naming in EdgeValue and Node for enhanced readability

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/edge/EdgeValue.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/edge/EdgeValue.java
@@ -33,13 +33,13 @@ public record EdgeValue(String id, EdgeCondition value) {
 		this(null, value);
 	}
 
-	EdgeValue withTargetIdsUpdated(Function<String, EdgeValue> target) {
+	EdgeValue withTargetIdsUpdated(Function<String, EdgeValue> idMapper) {
 		if (id != null) {
-			return target.apply(id);
+			return idMapper.apply(id);
 		}
 
 		var newMappings = value.mappings().entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> {
-			var v = target.apply(e.getValue());
+			var v = idMapper.apply(e.getValue());
 			return (v.id() != null) ? v.id() : e.getValue();
 		}));
 

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/Node.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/Node.java
@@ -81,8 +81,8 @@ public class Node {
 		return false;
 	}
 
-	public Node withIdUpdated(Function<String, String> newId) {
-		return new Node(newId.apply(id), actionFactory);
+	public Node withIdUpdated(Function<String, String> idMapper) {
+		return new Node(idMapper.apply(id), actionFactory);
 	}
 
 	/**


### PR DESCRIPTION
Description:
This PR sharpens the semantic clarity of two internal mapping methods by renaming their function parameters:

1、EdgeValue.withTargetIdsUpdated
- Before: Function<String, EdgeValue> target
- After: Function<String, EdgeValue> idMapper
- Why: Makes it explicit that this function maps an old node ID to a new EdgeValue.

2、Node.withIdUpdated
- Before: Function<String, String> newId
- After: Function<String, String> idMapper
- Why: Clearly indicates that this function transforms an old node ID into a new node ID.