### PR TITLE
add interruptible streaming support

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions {
 
-    // @formatter:off
+	// @formatter:off
   /** ID of the model to use. */
   @JsonProperty("model")
   private String model;

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatOptions.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions {
 
-	// @formatter:off
+    // @formatter:off
   /** ID of the model to use. */
   @JsonProperty("model")
   private String model;
@@ -380,6 +380,16 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
   public static DashscopeChatOptionsBuilder builder() {
     return new DashscopeChatOptionsBuilder();
   }
+  @JsonIgnore
+  private Boolean interruptible = false;
+
+  public Boolean getInterruptible() {
+    return interruptible;
+  }
+
+  public void setInterruptible(Boolean interruptible) {
+    this.interruptible = interruptible;
+  }
 
   public static class DashscopeChatOptionsBuilder {
     private DashScopeChatOptions options;
@@ -500,6 +510,12 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
       this.options.multiModel = multiModel;
       return this;
     }
+    private Boolean interruptible;
+
+    public DashscopeChatOptionsBuilder withInterruptible(Boolean interruptible) {
+      this.options.interruptible = interruptible;
+      return this;
+    }
 
     public DashScopeChatOptions build() {
       return this.options;
@@ -508,26 +524,27 @@ public class DashScopeChatOptions implements FunctionCallingOptions, ChatOptions
 
   public static DashScopeChatOptions fromOptions(DashScopeChatOptions fromOptions){
     return DashScopeChatOptions.builder()
-        .withModel(fromOptions.getModel())
-        .withTemperature(fromOptions.getTemperature())
-        .withMaxToken(fromOptions.getMaxTokens())
-        .withTopP(fromOptions.getTopP())
-        .withTopK(fromOptions.getTopK())
-        .withSeed(fromOptions.getSeed())
-        .withStop(fromOptions.getStop())
-        .withResponseFormat(fromOptions.getResponseFormat())
-        .withStream(fromOptions.getStream())
-        .withEnableSearch(fromOptions.enableSearch)
-        .withIncrementalOutput(fromOptions.getIncrementalOutput())
-        .withFunctionCallbacks(fromOptions.getFunctionCallbacks())
-        .withFunctions(fromOptions.getFunctions())
-        .withRepetitionPenalty(fromOptions.getRepetitionPenalty())
-        .withTools(fromOptions.getTools())
-        .withToolContext(fromOptions.getToolContext())
-        .withMultiModel(fromOptions.getMultiModel())
-        .withProxyToolCalls(fromOptions.getProxyToolCalls())
-        .withVlHighResolutionImages(fromOptions.getVlHighResolutionImages())
-        .build();
+            .withModel(fromOptions.getModel())
+            .withTemperature(fromOptions.getTemperature())
+            .withMaxToken(fromOptions.getMaxTokens())
+            .withTopP(fromOptions.getTopP())
+            .withTopK(fromOptions.getTopK())
+            .withSeed(fromOptions.getSeed())
+            .withStop(fromOptions.getStop())
+            .withResponseFormat(fromOptions.getResponseFormat())
+            .withStream(fromOptions.getStream())
+            .withEnableSearch(fromOptions.enableSearch)
+            .withIncrementalOutput(fromOptions.getIncrementalOutput())
+            .withFunctionCallbacks(fromOptions.getFunctionCallbacks())
+            .withFunctions(fromOptions.getFunctions())
+            .withRepetitionPenalty(fromOptions.getRepetitionPenalty())
+            .withTools(fromOptions.getTools())
+            .withToolContext(fromOptions.getToolContext())
+            .withMultiModel(fromOptions.getMultiModel())
+            .withProxyToolCalls(fromOptions.getProxyToolCalls())
+            .withVlHighResolutionImages(fromOptions.getVlHighResolutionImages())
+            .withInterruptible(fromOptions.getInterruptible())
+            .build();
   }
 
   @Override

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/StreamInterruptManager.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/StreamInterruptManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.cloud.ai.dashscope.common;
 
 import reactor.core.publisher.Flux;

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/StreamInterruptManager.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/StreamInterruptManager.java
@@ -1,0 +1,39 @@
+package com.alibaba.cloud.ai.dashscope.common;
+
+import reactor.core.publisher.Flux;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author logic.wu
+ */
+public class StreamInterruptManager {
+    private static final ConcurrentHashMap<String, AtomicBoolean> stopFlags = new ConcurrentHashMap<>();
+
+    public static void register(String requestId) {
+        stopFlags.put(requestId, new AtomicBoolean(false));
+    }
+
+    public static void stop(String requestId) {
+        AtomicBoolean flag = stopFlags.get(requestId);
+        if (flag != null) {
+            flag.set(true);
+        }
+    }
+
+    public static <T> Flux<T> wrapFluxWithInterrupt(Flux<T> flux, String requestId) {
+        AtomicBoolean flag = stopFlags.getOrDefault(requestId, new AtomicBoolean(false));
+        return flux.takeUntilOther(Flux.create(sink -> {
+            new Thread(() -> {
+                while (!flag.get()) {
+                    try {
+                        Thread.sleep(50);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+                sink.complete();
+            }).start();
+        }));
+    }
+}

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/StreamInterruptManager.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/common/StreamInterruptManager.java
@@ -24,31 +24,34 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author logic.wu
  */
 public class StreamInterruptManager {
-    private static final ConcurrentHashMap<String, AtomicBoolean> stopFlags = new ConcurrentHashMap<>();
 
-    public static void register(String requestId) {
-        stopFlags.put(requestId, new AtomicBoolean(false));
-    }
+	private static final ConcurrentHashMap<String, AtomicBoolean> stopFlags = new ConcurrentHashMap<>();
 
-    public static void stop(String requestId) {
-        AtomicBoolean flag = stopFlags.get(requestId);
-        if (flag != null) {
-            flag.set(true);
-        }
-    }
+	public static void register(String requestId) {
+		stopFlags.put(requestId, new AtomicBoolean(false));
+	}
 
-    public static <T> Flux<T> wrapFluxWithInterrupt(Flux<T> flux, String requestId) {
-        AtomicBoolean flag = stopFlags.getOrDefault(requestId, new AtomicBoolean(false));
-        return flux.takeUntilOther(Flux.create(sink -> {
-            new Thread(() -> {
-                while (!flag.get()) {
-                    try {
-                        Thread.sleep(50);
-                    } catch (InterruptedException ignored) {
-                    }
-                }
-                sink.complete();
-            }).start();
-        }));
-    }
+	public static void stop(String requestId) {
+		AtomicBoolean flag = stopFlags.get(requestId);
+		if (flag != null) {
+			flag.set(true);
+		}
+	}
+
+	public static <T> Flux<T> wrapFluxWithInterrupt(Flux<T> flux, String requestId) {
+		AtomicBoolean flag = stopFlags.getOrDefault(requestId, new AtomicBoolean(false));
+		return flux.takeUntilOther(Flux.create(sink -> {
+			new Thread(() -> {
+				while (!flag.get()) {
+					try {
+						Thread.sleep(50);
+					}
+					catch (InterruptedException ignored) {
+					}
+				}
+				sink.complete();
+			}).start();
+		}));
+	}
+
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
新增了“可中断”流式输出功能，允许客户端在任意时刻（例如用户点击“停止”按钮或后端发生异常时）立即取消正在进行的 SSE/Flux 流，而无需等待模型生成全部内容返回。这样可以提升交互体验并避免不必要的计算和网络开销。

### Does this pull request fix one issue?
https://github.com/alibaba/spring-ai-alibaba/issues/632

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
	1. 新增 StreamInterruptManager，内部维护 ConcurrentHashMap<requestId, AtomicBoolean>：
	2. register(requestId) 用于注册一个新的流中断标识；
	3. stop(requestId) 将对应标识置为 true；
	4. wrapFluxWithInterrupt(flux, requestId) 利用 Flux.takeUntilOther(...) 在标识为 true 时优雅完成流。

### Describe how to verify it


### Special notes for reviews
