### PR TITLE
fix AsyncServerImpl为McpAsyncServer子类，构造方法传入的为父类而非子类

### DIFF
--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/NacosMcpRegister.java
@@ -92,20 +92,18 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 		this.nacosMcpProperties = nacosMcpProperties;
 
 		try {
-			Class clazz = McpAsyncServer.class;
+			Class<?> clazz = Class.forName("io.modelcontextprotocol.server.McpAsyncServer$AsyncServerImpl");
+			Field delegateField = McpAsyncServer.class.getDeclaredField("delegate");
+			delegateField.setAccessible(true);
+			Object delegateInstance = delegateField.get(mcpAsyncServer);
 
-			Field serverInfoField = clazz.getDeclaredField("serverInfo");
-			serverInfoField.setAccessible(true);
-			this.serverInfo = (McpSchema.Implementation) serverInfoField.get(mcpAsyncServer);
-
-			Field serverCapabilitiesField = clazz.getDeclaredField("serverCapabilities");
-			serverCapabilitiesField.setAccessible(true);
-			this.serverCapabilities = (McpSchema.ServerCapabilities) serverCapabilitiesField.get(mcpAsyncServer);
+			this.serverInfo = mcpAsyncServer.getServerInfo();
+			this.serverCapabilities = mcpAsyncServer.getServerCapabilities();
 
 			Field toolsField = clazz.getDeclaredField("tools");
 			toolsField.setAccessible(true);
 			this.tools = (CopyOnWriteArrayList<McpServerFeatures.AsyncToolSpecification>) toolsField
-				.get(mcpAsyncServer);
+				.get(delegateInstance);
 
 			this.toolsMeta = new HashMap<>();
 			this.tools.forEach(toolRegistration -> {
@@ -119,7 +117,7 @@ public class NacosMcpRegister implements ApplicationListener<WebServerInitialize
 			if (this.serverCapabilities.tools() != null) {
 				Field mcpSessionField = clazz.getDeclaredField("mcpSession");
 				mcpSessionField.setAccessible(true);
-				McpClientSession mcpSession = (McpClientSession) mcpSessionField.get(mcpAsyncServer);
+				McpClientSession mcpSession = (McpClientSession) mcpSessionField.get(delegateInstance);
 				Field requestHandlersField = McpClientSession.class.getDeclaredField("requestHandlers");
 				requestHandlersField.setAccessible(true);
 				ConcurrentHashMap<String, McpClientSession.RequestHandler<?>> requestHandlers = (ConcurrentHashMap<String, McpClientSession.RequestHandler<?>>) requestHandlersField


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix: AsyncServerImpl为McpAsyncServer子类，构造方法传入的为父类而非子类

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
改为从实际的AsyncServerImpl中获取字段属性

### Describe how to verify it


### Special notes for reviews
