### PR TITLE
fix: update method name for tool callbacks in PlanCreator, using old api of "tools" will not exec the tool

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/LlmNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/LlmNode.java
@@ -118,7 +118,7 @@ public class LlmNode implements NodeAction {
 				.user(userPrompt)
 				.messages(messages)
 				.advisors(advisors)
-				.tools(toolCallbacks)
+				.toolCallbacks(toolCallbacks)
 				.stream()
 				.chatResponse();
 		}
@@ -128,7 +128,7 @@ public class LlmNode implements NodeAction {
 					.system(systemPrompt)
 					.messages(messages)
 					.advisors(advisors)
-					.tools(toolCallbacks)
+					.toolCallbacks(toolCallbacks)
 					.stream()
 					.chatResponse();
 			}
@@ -137,7 +137,7 @@ public class LlmNode implements NodeAction {
 					.user(userPrompt)
 					.messages(messages)
 					.advisors(advisors)
-					.tools(toolCallbacks)
+					.toolCallbacks(toolCallbacks)
 					.stream()
 					.chatResponse();
 			}
@@ -145,7 +145,7 @@ public class LlmNode implements NodeAction {
 				return chatClient.prompt()
 					.messages(messages)
 					.advisors(advisors)
-					.tools(toolCallbacks)
+					.toolCallbacks(toolCallbacks)
 					.stream()
 					.chatResponse();
 			}
@@ -160,7 +160,7 @@ public class LlmNode implements NodeAction {
 				.user(userPrompt)
 				.messages(messages)
 				.advisors(advisors)
-				.tools(toolCallbacks)
+				.toolCallbacks(toolCallbacks)
 				.call()
 				.chatResponse();
 		}
@@ -170,7 +170,7 @@ public class LlmNode implements NodeAction {
 					.system(systemPrompt)
 					.messages(messages)
 					.advisors(advisors)
-					.tools(toolCallbacks)
+					.toolCallbacks(toolCallbacks)
 					.call()
 					.chatResponse();
 			}
@@ -179,7 +179,7 @@ public class LlmNode implements NodeAction {
 					.user(userPrompt)
 					.messages(messages)
 					.advisors(advisors)
-					.tools(toolCallbacks)
+					.toolCallbacks(toolCallbacks)
 					.call()
 					.chatResponse();
 			}
@@ -187,7 +187,7 @@ public class LlmNode implements NodeAction {
 				return chatClient.prompt()
 					.messages(messages)
 					.advisors(advisors)
-					.tools(toolCallbacks)
+					.toolCallbacks(toolCallbacks)
 					.call()
 					.chatResponse();
 			}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-example/src/main/java/com/alibaba/cloud/ai/example/graph/bigtool/agent/CalculateAgent.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-example/src/main/java/com/alibaba/cloud/ai/example/graph/bigtool/agent/CalculateAgent.java
@@ -81,7 +81,7 @@ public class CalculateAgent implements NodeAction {
 		ChatResponse response = chatClient.prompt()
 			.system(CLASSIFIER_PROMPT_TEMPLATE)
 			.user(inputText)
-			.tools(toolCallbacks)
+			.toolCallbacks(toolCallbacks)
 			.call()
 			.chatResponse();
 

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/DynamicAgent.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/DynamicAgent.java
@@ -113,7 +113,7 @@ public class DynamicAgent extends ReActAgent {
 				.prompt(userPrompt)
 				.advisors(memoryAdvisor -> memoryAdvisor.param(CHAT_MEMORY_CONVERSATION_ID_KEY, getPlanId())
 					.param(CHAT_MEMORY_RETRIEVE_SIZE_KEY, 100))
-				.tools(getToolCallList())
+				.toolCallbacks(getToolCallList())
 				.call()
 				.chatResponse();
 

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/creator/PlanCreator.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/creator/PlanCreator.java
@@ -77,7 +77,7 @@ public class PlanCreator {
 
 			ChatClient.CallResponseSpec response = llmService.getPlanningChatClient()
 				.prompt(prompt)
-				.tools(List.of(planningTool.getFunctionToolCallback()))
+				.toolCallbacks(List.of(planningTool.getFunctionToolCallback()))
 				.advisors(memoryAdvisor -> memoryAdvisor.param("chat_memory_conversation_id", planId)
 					.param("chat_memory_retrieve_size", 100))
 				.call();


### PR DESCRIPTION
### Describe what this PR does / why we need it

in spring ai 1.0.0-M8，tools register method is "ChatClientRequestSpec toolCallbacks(List<ToolCallback> toolCallbacks)", using the old method of "tools"，the tool will not exec, and the code will occur npe.

java.lang.NullPointerException: Cannot invoke "com.alibaba.cloud.ai.example.manus.planning.model.vo.ExecutionPlan.getPlanId()" because the return value of "com.alibaba.cloud.ai.example.manus.planning.model.vo.ExecutionContext.getPlan()" is null
	at com.alibaba.cloud.ai.example.manus.planning.executor.PlanExecutor.recordPlanExecutionStart(PlanExecutor.java:157)
	at com.alibaba.cloud.ai.example.manus.planning.executor.PlanExecutor.executeAllSteps(PlanExecutor.java:69)
	at com.alibaba.cloud.ai.example.manus.planning.coordinator.PlanningCoordinator.executePlan(PlanningCoordinator.java:61)
	at com.alibaba.cloud.ai.example.manus.controller.ManusController.lambda$executeQuery$0(ManusController.java:75)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run$$$capture(CompletableFuture.java:1768)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #820 

### Describe how you did it

using the new method of "ChatClientRequestSpec toolCallbacks(List<ToolCallback> toolCallbacks)"

### Describe how to verify it

in the webui, it runs correctly.

### Special notes for reviews
none
