### PR TITLE
:wrench: use Maven Central Portal

### DIFF
--- a/spring-ai-alibaba-bom/pom.xml
+++ b/spring-ai-alibaba-bom/pom.xml
@@ -82,6 +82,9 @@
         <maven-project-info-reports-plugin.version>3.4.5</maven-project-info-reports-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <spring-javaformat-maven-plugin.version>0.0.39</spring-javaformat-maven-plugin.version>
+
+        <!-- Maven Central Portal -->
+        <central.publishing.maven.version>0.7.0</central.publishing.maven.version>
     </properties>
 
     <dependencyManagement>
@@ -959,19 +962,23 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central.publishing.maven.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
             <distributionManagement>
+                <!-- After using org.sonatype.central:central-publishing-maven-plugin, it can be ignored. This is only a prompt -->
                 <snapshotRepository>
-                    <id>sonatype-nexus-snapshots</id>
-                    <name>Sonatype Nexus Snapshots</name>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <id>central</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots</url>
                 </snapshotRepository>
-                <repository>
-                    <id>sonatype-nexus-staging</id>
-                    <name>Nexus Release Repository</name>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
             </distributionManagement>
         </profile>
     </profiles>


### PR DESCRIPTION
https://github.com/alibaba/nacos/issues/13358

settings.xml servers use:

```
<server>
  <id>central</id>
  <username>${CENTRAL_USERNAME}</username>
  <password>${CENTRAL_PASSWORD}</password>
</server>
```


### Describe what this PR does / why we need it

Announcement of the End-of-Life Sunset Date for Maven OSSRH
宣布 Maven OSSRH 的生命周期终止日期 ︎

https://central.sonatype.org/news/20250326_ossrh_sunset/#announcement-of-the-end-of-life-sunset-date-for-ossrh

Maven Central Portal Publish Example：https://central.sonatype.com/artifact/cn.ac.xxw/xxw-rsa
Publish command：`mvn -V clean -U package source:jar javadoc:jar deploy -Prelease -DskipTests`

使用与 https://oss.sonatype.org 相同的账户有效在 https://central.sonatype.com/ 登录，即可一键将域名迁移到新平台。

两者密码相同（如果无法登录，可以在 https://central.sonatype.com/ 平台重置密码）

快照功能需要在 https://central.sonatype.com/ 平台的命名空间下手动开启

![Image](https://github.com/user-attachments/assets/fff81c21-c8fe-453f-b67e-c56236eff7b2)


```
NOTE: If you have already migrated your namespace(s) to Maven Central this email does not apply to you and thank you for your initiative.

Greetings OSSRH Publisher,

As you may have heard, OSSRH is reaching end of life on June 30, 2025. OSSRH users need to migrate their namespaces to the Central Portal as soon as possible.

Instructions for self migration are located here: https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration

To make the transition smoother we will be automatically migrating publishers that have not used oss.sonatype.org or s01.sonatype.org to publish artifacts in some time starting with the oldest and working our way forward. To avoid disruption to your publishing processes we strongly encourage migrating before the June 30, 2025 deadline.

Thank you for your assistance,

The Central Team
```

```
注意：如果您已将命名空间迁移到 Maven Central，则此电子邮件不适用于您，感谢您的主动性。

问候 OSSRH 发布者，

如您所知，OSSRH将于2025年6月30日终止。OSSRH用户需要尽快将命名空间迁移到中央门户。

自迁移说明位于此处：https://central.sonatype.com/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration

为了使过渡更加顺畅，我们将自动迁移在一段时间内未使用 oss.sonatype.org 或 s01.sonatype.org 发布软件包的发布者，从最旧的开始，然后逐步进行。为了避免对您的发布过程造成干扰，我们强烈建议在2025年6月30日截止日期之前进行迁移。

感谢您的帮助，

中央团队
```


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
