### PR TITLE
fix: gson missing

### DIFF
--- a/spring-ai-alibaba-deepresearch/pom.xml
+++ b/spring-ai-alibaba-deepresearch/pom.xml
@@ -69,7 +69,12 @@
             <artifactId>guava</artifactId>
             <version>33.4.0-jre</version>
         </dependency>
-        
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.11.0</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
### Describe what this PR does / why we need it

示例项目DeepResearch
无法找到 com.google.gson.GsonBuilder 类，导致 NoClassDefFoundError 异常，pom缺少 Gson 依赖

### Does this pull request fix one issue?

Fixes #1036 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
