### PR TITLE
fix(spring-ai-alibaba-deepresearch): fix about chatclient builder

### DIFF
--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationToolCallsNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationToolCallsNode.java
@@ -68,10 +68,19 @@ public class BackgroundInvestigationToolCallsNode implements BackgroundInvestiga
 			.call()
 			.content();
 
+		// 使用标准的返回格式
+		// [{ "title": "背景调查结果", "content": "..." }]
+		// 否则会反序列化失败：com/alibaba/cloud/ai/example/deepresearch/serializer/DeepResearchDeserializer.java:49
+		Map<String, String> result = new HashMap<>();
+		result.put("title", "背景调查结果");
+		result.put("content", completion);
+
+		List<Map<String, String>> results = Lists.newArrayList(result);
+
 		logger.info("✅ 调查结果: {}", completion);
 
 		Map<String, Object> resultMap = new HashMap<>();
-		resultMap.put("background_investigation_results", Lists.newArrayList(completion));
+		resultMap.put("background_investigation_results", results);
 		return resultMap;
 	}
 

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/CoordinatorNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/CoordinatorNode.java
@@ -45,13 +45,11 @@ public class CoordinatorNode implements NodeAction {
 
 	private final ChatClient chatClient;
 
+	private final PlannerTool plannerTool;
+
 	public CoordinatorNode(ChatClient.Builder chatClientBuilder) {
-		this.chatClient = chatClientBuilder
-			.defaultOptions(ToolCallingChatOptions.builder()
-				.internalToolExecutionEnabled(false) // 禁用内部工具执行
-				.build())
-			.defaultTools(new PlannerTool())
-			.build();
+		this.chatClient = chatClientBuilder.build();
+		this.plannerTool = new PlannerTool();
 	}
 
 	@Override
@@ -61,7 +59,12 @@ public class CoordinatorNode implements NodeAction {
 		logger.debug("Current Coordinator messages: {}", messages);
 
 		// 发起调用并获取完整响应
-		ChatResponse response = chatClient.prompt().messages(messages).call().chatResponse();
+		ChatResponse response = chatClient.prompt()
+			.options(ToolCallingChatOptions.builder().internalToolExecutionEnabled(false).build())
+			.tools(plannerTool)
+			.messages(messages)
+			.call()
+			.chatResponse();
 
 		String nextStep = END;
 		Map<String, Object> updated = new HashMap<>();

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/PlannerNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/PlannerNode.java
@@ -70,7 +70,7 @@ public class PlannerNode implements NodeAction {
 		.build();
 
 	public PlannerNode(ChatClient.Builder chatClientBuilder, ToolCallback[] toolCallbacks) {
-		this.chatClient = chatClientBuilder
+		this.chatClient = chatClientBuilder.clone()
 			.defaultAdvisors(MessageChatMemoryAdvisor.builder(messageWindowChatMemory).build())
 			.build();
 		this.toolCallbacks = toolCallbacks;


### PR DESCRIPTION
1、`BackgroundInvestigationToolCallsNode` 的返回结果兼容 DeepResearchDeserializer 反序列化；
2、`PlannerNode` 设置了全局 `MessageChatMemoryAdvisor`，当第2次及后续再调用 `/chat` 时，会导致`CoordinatorNode`去查询内存关联的历史`Message`，从而发生 `An assistant message with \"tool_calls\" must be followed by tool messages responding to each \"tool_call_id\".` 异常；
3、`CoordinatorNode` 设置的全局 internalToolExecutionEnabled = false，会出现因加载顺序导致影响其他 Node 的工具调用的方式。