### PR TITLE
feat(graph): add variableAggregatorNode and unit test

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/VariableAggregatorNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/VariableAggregatorNode.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class VariableAggregatorNode implements NodeAction {
+
+	private final List<List<String>> variables;
+
+	private final String outputKey;
+
+	private final String outputType;
+
+	private final AdvancedSettings advancedSettings;
+
+	public VariableAggregatorNode(List<List<String>> variables, String outputKey, String outputType,
+			AdvancedSettings advancedSettings) {
+		this.variables = variables;
+		this.outputKey = outputKey;
+		this.outputType = outputType;
+		this.advancedSettings = advancedSettings;
+	}
+
+	@Override
+	public Map<String, Object> apply(OverAllState state) throws Exception {
+		Map<String, Object> result = new HashMap<>();
+
+		if ("group".equals(outputType) && advancedSettings != null && advancedSettings.isGroupEnabled()) {
+			Map<String, Object> groupedResult = new HashMap<>();
+			for (Group group : advancedSettings.getGroups()) {
+				List<Object> values = new ArrayList<>();
+				for (List<String> path : group.getVariables()) {
+					Object value = getValueByPath(state, path);
+					if (value != null) {
+						values.add(value);
+					}
+				}
+				groupedResult.put(group.getGroupName(), convertOutput(values, group.getOutputType()));
+			}
+			result.put(outputKey, groupedResult);
+		}
+		else {
+			List<Object> allValues = new ArrayList<>();
+			for (List<String> path : variables) {
+				Object value = getValueByPath(state, path);
+				if (value != null) {
+					allValues.add(value);
+				}
+			}
+			result.put(outputKey, convertOutput(allValues, outputType));
+		}
+
+		return result;
+	}
+
+	private Object getValueByPath(OverAllState state, List<String> path) {
+		Object current = null;
+		for (String key : path) {
+			if (current == null) {
+				current = state.value(key).orElse(null);
+			}
+			else if (current instanceof Map) {
+				current = ((Map<?, ?>) current).get(key);
+			}
+			else {
+				return null;
+			}
+		}
+		return current;
+	}
+
+	private Object convertOutput(List<Object> values, String type) {
+		switch (type) {
+			case "list":
+				return new ArrayList<>(values);
+			case "string":
+				return String.join("\n", values.stream().map(Object::toString).collect(Collectors.toList()));
+			default:
+				return values;
+		}
+	}
+
+	public static class AdvancedSettings {
+
+		private boolean groupEnabled;
+
+		private List<Group> groups;
+
+		public boolean isGroupEnabled() {
+			return groupEnabled;
+		}
+
+		public AdvancedSettings setGroupEnabled(boolean groupEnabled) {
+			this.groupEnabled = groupEnabled;
+			return this;
+		}
+
+		public List<Group> getGroups() {
+			return groups;
+		}
+
+		public AdvancedSettings setGroups(List<Group> groups) {
+			this.groups = groups;
+			return this;
+		}
+
+	}
+
+	public static class Group {
+
+		private String outputType;
+
+		private List<List<String>> variables;
+
+		private String groupName;
+
+		private String groupId;
+
+		public String getOutputType() {
+			return outputType;
+		}
+
+		public void setOutputType(String outputType) {
+			this.outputType = outputType;
+		}
+
+		public List<List<String>> getVariables() {
+			return variables;
+		}
+
+		public void setVariables(List<List<String>> variables) {
+			this.variables = variables;
+		}
+
+		public String getGroupName() {
+			return groupName;
+		}
+
+		public void setGroupName(String groupName) {
+			this.groupName = groupName;
+		}
+
+		public String getGroupId() {
+			return groupId;
+		}
+
+		public void setGroupId(String groupId) {
+			this.groupId = groupId;
+		}
+
+	}
+
+	public static class Builder {
+
+		private List<List<String>> variables;
+
+		private String outputKey;
+
+		private String outputType = "list";
+
+		private AdvancedSettings advancedSettings;
+
+		public Builder variables(List<List<String>> variables) {
+			this.variables = variables;
+			return this;
+		}
+
+		public Builder outputKey(String outputKey) {
+			this.outputKey = outputKey;
+			return this;
+		}
+
+		public Builder outputType(String outputType) {
+			this.outputType = outputType;
+			return this;
+		}
+
+		public Builder advancedSettings(AdvancedSettings advancedSettings) {
+			this.advancedSettings = advancedSettings;
+			return this;
+		}
+
+		public VariableAggregatorNode build() {
+			return new VariableAggregatorNode(variables, outputKey, outputType, advancedSettings);
+		}
+
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/VariableAggregatorNodeTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/VariableAggregatorNodeTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import com.alibaba.cloud.ai.graph.node.VariableAggregatorNode;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class VariableAggregatorNodeTest {
+
+	private OverAllState mockState;
+
+	@BeforeEach
+	public void setUp() {
+		mockState = mock(OverAllState.class);
+	}
+
+	// Mock state
+	private Object getNestedValue(Map<String, Object> root, List<String> path) {
+		Object current = root;
+		for (String key : path) {
+			if (current instanceof Map) {
+				current = ((Map<?, ?>) current).get(key);
+			}
+			else {
+				return null;
+			}
+		}
+		return current;
+	}
+
+	@Test
+	public void testApply_withListOutputType() throws Exception {
+		List<List<String>> variables = Arrays.asList(Collections.singletonList("user"),
+				Collections.singletonList("age"));
+
+		when(mockState.value("user")).thenReturn(Optional.of("ricky"));
+		when(mockState.value("age")).thenReturn(Optional.of(20));
+
+		VariableAggregatorNode node = new VariableAggregatorNode(variables, "result", "list", null);
+
+		Map<String, Object> result = node.apply(mockState);
+
+		assertEquals(Arrays.asList("ricky", 20), result.get("result"));
+	}
+
+	@Test
+	public void testApply_withStringOutputType() throws Exception {
+		List<List<String>> variables = Arrays.asList(Collections.singletonList("product"),
+				Collections.singletonList("price"));
+
+		when(mockState.value("product")).thenReturn(Optional.of("Book"));
+		when(mockState.value("price")).thenReturn(Optional.of("19.9"));
+
+		VariableAggregatorNode node = new VariableAggregatorNode(variables, "result", "string", null);
+		Map<String, Object> result = node.apply(mockState);
+
+		assertEquals("Book\n19.9", result.get("result"));
+	}
+
+	@Test
+	public void testApply_withGroupedOutput() throws Exception {
+		VariableAggregatorNode.Group group1 = new VariableAggregatorNode.Group();
+		group1.setGroupName("UserInfo");
+		group1.setOutputType("list");
+		group1.setVariables(Arrays.asList(Arrays.asList("user", "name"), Arrays.asList("user", "age")));
+
+		VariableAggregatorNode.Group group2 = new VariableAggregatorNode.Group();
+		group2.setGroupName("ProductInfo");
+		group2.setOutputType("string");
+		group2.setVariables(Collections.singletonList(Collections.singletonList("product")));
+
+		VariableAggregatorNode.AdvancedSettings settings = new VariableAggregatorNode.AdvancedSettings();
+		settings.setGroupEnabled(true);
+		settings.setGroups(Arrays.asList(group1, group2));
+
+		List<List<String>> variables = Arrays.asList(Arrays.asList("user", "name"), Arrays.asList("user", "age"),
+				Collections.singletonList("product"));
+
+		Map<String, Object> userMap = new HashMap<>();
+		userMap.put("name", "Alice");
+		userMap.put("age", 30);
+
+		when(mockState.value("user")).thenReturn(Optional.of(userMap));
+		when(mockState.value("product")).thenReturn(Optional.of("Laptop"));
+
+		VariableAggregatorNode node = new VariableAggregatorNode(variables, "aggregatedData", "group", settings);
+		Map<String, Object> result = node.apply(mockState);
+
+		Map<String, Object> aggregated = (Map<String, Object>) result.get("aggregatedData");
+		assertEquals(Arrays.asList("Alice", 30), aggregated.get("UserInfo"));
+		assertEquals("Laptop", aggregated.get("ProductInfo"));
+	}
+
+	@Test
+	public void testApply_withMissingKey() throws Exception {
+		List<List<String>> variables = Collections.singletonList(Collections.singletonList("missing"));
+
+		when(mockState.value("missing")).thenReturn(Optional.empty());
+
+		VariableAggregatorNode node = new VariableAggregatorNode(variables, "result", "list", null);
+		Map<String, Object> result = node.apply(mockState);
+
+		assertEquals(Collections.emptyList(), result.get("result"));
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
A variable aggregation node has been added, which mainly aggregates the results of multiple branches into one node, simplifying the construction of workflows.

### Describe how you did it
Obtaining path information from overstate for the construction of variable aggregation information allows users to choose whether to enable grouping configuration and outputs results in String or list type.

### Describe how to verify it
Currently, unit tests have been added for validation, and in the future, this node will be used to refactor the existing examples of comment classification.

### Special notes for reviews
