### PR TITLE
feat(deepresearch): (WIP) Enable researchTeamNode parallel

### DIFF
--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/agents/AgentsConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/agents/AgentsConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.io.Resource;
 
 import java.nio.charset.Charset;
@@ -44,6 +45,7 @@ public class AgentsConfiguration {
 	 */
 	@SneakyThrows
 	@Bean
+	@Scope("prototype")
 	public ChatClient researchAgent(ChatClient.Builder chatClientBuilder) {
 		return chatClientBuilder.defaultSystem(researcherPrompt.getContentAsString(Charset.defaultCharset()))
 			.defaultToolNames("tavilySearch")
@@ -59,6 +61,7 @@ public class AgentsConfiguration {
 	 */
 	@SneakyThrows
 	@Bean
+	@Scope("prototype")
 	public ChatClient coderAgent(ChatClient.Builder chatClientBuilder, PythonCoderProperties coderProperties) {
 		return chatClientBuilder.defaultSystem(coderPrompt.getContentAsString(Charset.defaultCharset()))
 			.defaultTools(new PythonReplTool(coderProperties))

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
@@ -25,8 +25,6 @@ import com.alibaba.cloud.ai.example.deepresearch.node.BackgroundInvestigationNod
 import com.alibaba.cloud.ai.example.deepresearch.node.PlannerNode;
 import com.alibaba.cloud.ai.example.deepresearch.node.HumanFeedbackNode;
 import com.alibaba.cloud.ai.example.deepresearch.node.ResearchTeamNode;
-import com.alibaba.cloud.ai.example.deepresearch.node.CoderNode;
-import com.alibaba.cloud.ai.example.deepresearch.node.ResearcherNode;
 import com.alibaba.cloud.ai.example.deepresearch.node.ReporterNode;
 import com.alibaba.cloud.ai.example.deepresearch.serializer.DeepResearchStateSerializer;
 import com.alibaba.cloud.ai.graph.GraphRepresentation;
@@ -44,6 +42,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.Map;
 
@@ -73,6 +72,9 @@ public class DeepResearchConfiguration {
 
 	@Autowired
 	private ApplicationContext applicationContext;
+
+	@Autowired
+	private ThreadPoolTaskExecutor executorNodeTaskExecutor;
 
 	@Bean
 	public StateGraph deepResearch(ChatClient.Builder chatClientBuilder) throws GraphStateException {
@@ -110,7 +112,7 @@ public class DeepResearchConfiguration {
 			.addNode("background_investigator", node_async(new BackgroundInvestigationNode(tavilySearchService)))
 			.addNode("planner", node_async((new PlannerNode(chatClientBuilder))))
 			.addNode("human_feedback", node_async(new HumanFeedbackNode()))
-			.addNode("research_team", node_async(new ResearchTeamNode(applicationContext)))
+			.addNode("research_team", node_async(new ResearchTeamNode(applicationContext, executorNodeTaskExecutor)))
 			.addNode("reporter", node_async((new ReporterNode(chatClientBuilder))))
 
 			.addEdge(START, "coordinator")

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/ThreadPoolTaskConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/ThreadPoolTaskConfiguration.java
@@ -1,0 +1,36 @@
+package com.alibaba.cloud.ai.example.deepresearch.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+public class ThreadPoolTaskConfiguration {
+    private static final int CORE_POOL_SIZE = 5;
+
+    private static final int MAX_POOL_SIZE = 10;
+
+    private static final int KEEP_ALIVE_TIME = 10;
+
+    private static final int QUEUE_CAPACITY = 200;
+
+    private static final String THREAD_NAME_PREFIX = "ExecutorNodeThread-";
+
+    @Bean
+    public ThreadPoolTaskExecutor executorNodeTaskExecutor()
+    {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setKeepAliveSeconds(KEEP_ALIVE_TIME);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(THREAD_NAME_PREFIX);
+
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/dto/Plan.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/dto/Plan.java
@@ -52,6 +52,8 @@ public class Plan {
 
 		private String executionRes;
 
+		private String executionStatus;
+
 	}
 
 	public enum StepType {

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ReporterNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ReporterNode.java
@@ -37,7 +37,8 @@ import java.util.*;
  * @since 2025/5/18 15:58
  */
 
-public class ReporterNode implements NodeAction {
+public class
+ReporterNode implements NodeAction {
 
 	private static final Logger logger = LoggerFactory.getLogger(ReporterNode.class);
 

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ResearchTeamNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ResearchTeamNode.java
@@ -24,53 +24,95 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.ApplicationContext;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * @author yingzi
  * @since 2025/5/18 16:59
+ * @author sixiyida
+ * @since 2025/6/11 15:15
+ *
  */
-
 public class ResearchTeamNode implements NodeAction {
 
 	private static final Logger logger = LoggerFactory.getLogger(ResearchTeamNode.class);
 
+	private final ApplicationContext applicationContext;
+
+	private final ExecutorService executorService;
+
+	public ResearchTeamNode(ApplicationContext applicationContext) {
+		this.applicationContext = applicationContext;
+		this.executorService = Executors.newFixedThreadPool(10);
+	}
+
 	@Override
 	public Map<String, Object> apply(OverAllState state) throws Exception {
 		logger.info("research_team node is running.");
-		String nextStep = "reporter";
 		Map<String, Object> updated = new HashMap<>();
 
 		Plan curPlan = StateUtil.getPlan(state);
-		// 判断steps里的每个step都有执行结果
-		if (areAllExecutionResultsPresent(curPlan)) {
-			updated.put("research_team_next_node", nextStep);
-			logger.info("research_team node -> {} node", nextStep);
-			return updated;
+
+		// 收集所有步骤
+		List<Plan.Step> steps = curPlan.getSteps();
+
+		// 为每个步骤创建异步任务
+		for (int i = 0; i < steps.size(); i++) {
+			final int stepIndex = i;
+			Plan.Step step = steps.get(stepIndex);
+
+			// 检查步骤是否未完成且未分配
+			if (!StringUtils.hasText(step.getExecutionRes()) && !StringUtils.hasText(step.getExecutionStatus())) {
+				// 为步骤分配一个研究者节点，使用step的索引作为节点ID
+				String executorNodeId = String.valueOf(stepIndex);
+				String assignedStatus = StateUtil.EXECUTION_STATUS_ASSIGNED_PREFIX + executorNodeId;
+				step.setExecutionStatus(assignedStatus);
+				CompletableFuture.runAsync(() -> {
+					try {
+						if (step.getStepType() == Plan.StepType.RESEARCH) {
+							logger.info("Executing research step {}: {}", stepIndex, step.getTitle());
+							// 为每个研究步骤创建新的Agent
+							ChatClient researchAgent = applicationContext.getBean("researchAgent", ChatClient.class);
+							ResearcherNode researcherNode = new ResearcherNode(researchAgent, executorNodeId);
+							researcherNode.apply(state);
+						}
+						else {
+							logger.info("Executing processing step {}: {}", stepIndex, step.getTitle());
+							// 为每个处理步骤创建新的Agent
+							ChatClient coderAgent = applicationContext.getBean("coderAgent", ChatClient.class);
+							CoderNode coderNode = new CoderNode(coderAgent, executorNodeId);
+							coderNode.apply(state);
+						}
+					}
+					catch (Exception e) {
+						logger.error("Error executing step {}: {}", stepIndex, step.getTitle(), e);
+					}
+				}, executorService);
+			}
 		}
 
-		// todo 异步 + 并行执行Step
-		for (Plan.Step step : curPlan.getSteps()) {
-			if (StringUtils.hasText(step.getExecutionRes())) {
-				continue;
+		// 检查是否所有步骤都已完成
+		if (areAllExecutionResultsPresent(curPlan)) {
+			updated.put("research_team_next_node", "reporter");
+			logger.info("All steps completed, moving to reporter node");
+		}
+		else {
+			// 如果还有未完成的步骤，继续执行
+			updated.put("research_team_next_node", "research_team");
+			logger.info("Some steps are still pending, continuing execution");
+			// 在TeamNode这里自旋等待
+			try {
+				Thread.sleep(20000);
 			}
-			if (step.getStepType() == Plan.StepType.RESEARCH) {
-				nextStep = "researcher";
-				updated.put("research_team_next_node", nextStep);
-				logger.info("research_team node -> {} node", nextStep);
-				return updated;
-			}
-			else if (step.getStepType() == Plan.StepType.PROCESSING) {
-				nextStep = "coder";
-				updated.put("research_team_next_node", nextStep);
-				logger.info("research_team node -> {} node", nextStep);
-				return updated;
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
 			}
 		}
-		updated.put("research_team_next_node", nextStep);
-		logger.info("research_team node -> {} node", nextStep);
+
 		return updated;
 	}
 

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/StateUtil.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/StateUtil.java
@@ -29,6 +29,12 @@ import java.util.List;
 
 public class StateUtil {
 
+	public static final String EXECUTION_STATUS_ASSIGNED_PREFIX = "assigned_";
+
+	public static final String EXECUTION_STATUS_PROCESSING_PREFIX = "processing_";
+
+	public static final String EXECUTION_STATUS_COMPLETED_PREFIX = "completed_";
+
 	public static List<String> getMessagesByType(OverAllState state, String name) {
 		return state.value(name, List.class).map(obj -> new ArrayList<>((List<String>) obj)).orElseGet(ArrayList::new);
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it
This feature enables executors including ResearcherNodes and CoderNodes running in parallel mode to accelerate the whole deepresearch process.

### Describe how you did it
1. Modify workflow structure.
2. Dynamically add nodes in TeamNode.
3. Add execution status in steps.
4. Add spin edge in TeamNode.

### Describe how to verify it
Just run and send post request.
![image](https://github.com/user-attachments/assets/891b902a-1ea8-4eaa-9578-c445cdf1840f)
![image](https://github.com/user-attachments/assets/9b62ba04-aaad-4712-9bea-8b187c164262)

### Special notes for reviews
WIP to add error handling and coder post mode.
Need more discussion in self-spin mode inner or outer the TeamNode.
May need to using existing nodes in Graph Core for improvements.