### PR TITLE
修复bug:PlanFinalizer执行完成清除不了当前plan的会话

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/creator/PlanCreator.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/creator/PlanCreator.java
@@ -32,6 +32,8 @@ import org.springframework.ai.chat.prompt.PromptTemplate;
 
 import java.util.List;
 
+import static org.springframework.ai.chat.memory.ChatMemory.CONVERSATION_ID;
+
 /**
  * 负责创建执行计划的类
  */
@@ -81,6 +83,7 @@ public class PlanCreator {
 				.prompt(prompt)
 				.toolCallbacks(List.of(planningTool.getFunctionToolCallback()));
 			if (useMemory) {
+                requestSpec.advisors(memoryAdvisor -> memoryAdvisor.param(CONVERSATION_ID, context.getPlanId()));
 				requestSpec.advisors(MessageChatMemoryAdvisor.builder(llmService.getConversationMemory()).build());
 			}
 			ChatClient.CallResponseSpec response = requestSpec.call();

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/finalizer/PlanFinalizer.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/finalizer/PlanFinalizer.java
@@ -18,18 +18,21 @@ package com.alibaba.cloud.ai.example.manus.planning.finalizer;
 import java.util.List;
 import java.util.Map;
 
+import com.alibaba.cloud.ai.example.manus.llm.LlmService;
+import com.alibaba.cloud.ai.example.manus.planning.model.vo.ExecutionContext;
+import com.alibaba.cloud.ai.example.manus.planning.model.vo.ExecutionPlan;
+import com.alibaba.cloud.ai.example.manus.recorder.PlanExecutionRecorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.chat.prompt.SystemPromptTemplate;
 
-import com.alibaba.cloud.ai.example.manus.llm.LlmService;
-import com.alibaba.cloud.ai.example.manus.planning.model.vo.ExecutionContext;
-import com.alibaba.cloud.ai.example.manus.planning.model.vo.ExecutionPlan;
-import com.alibaba.cloud.ai.example.manus.recorder.PlanExecutionRecorder;
+import static org.springframework.ai.chat.memory.ChatMemory.CONVERSATION_ID;
 
 /**
  * 负责生成计划执行总结的类
@@ -89,11 +92,13 @@ public class PlanFinalizer {
 
 			Prompt prompt = new Prompt(List.of(systemMessage, userMessage));
 
-			ChatResponse response = llmService.getPlanningChatClient()
-				.prompt(prompt)
-
-				.call()
-				.chatResponse();
+            ChatClient.ChatClientRequestSpec requestSpec = llmService.getPlanningChatClient()
+                .prompt(prompt);
+            if (context.isUseMemory()) {
+                requestSpec.advisors(memoryAdvisor -> memoryAdvisor.param(CONVERSATION_ID, context.getPlanId()));
+                requestSpec.advisors(MessageChatMemoryAdvisor.builder(llmService.getConversationMemory()).build());
+            }
+            ChatResponse response = requestSpec.call().chatResponse();
 
 			String summary = response.getResult().getOutput().getText();
 			context.setResultSummary(summary);


### PR DESCRIPTION
### Describe what this PR does / why we need it
PlanFinalizer执行完成之后清除不了conversationMemory的会话，因为conversationMemory里面存储的key是default,不是planId值

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1.创建plan的是设置CONVERSATION_ID为planId值
2.com.alibaba.cloud.ai.example.manus.planning.finalizer.PlanFinalizer#generateSummary与com.alibaba.cloud.ai.example.manus.planning.creator.PlanCreator#createPlan共享会话内存

### Describe how to verify it


### Special notes for reviews
