### PR TITLE
feat(studio): add spring-ai-alibaba-starter-dashscope dependencies in…

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/resources/initializr.yml
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/resources/initializr.yml
@@ -210,6 +210,12 @@ initializr:
           artifact-id: spring-ai-alibaba-graph-core
           version: 1.0.0.3-SNAPSHOT
           description: Building agent using Spring AI Alibaba Graph
+        - name: Spring AI Alibaba Dashscope
+          id: spring-ai-alibaba-starter-dashscope
+          group-id: com.alibaba.cloud.ai
+          artifact-id: spring-ai-alibaba-starter-dashscope
+          version: 1.0.0.3-SNAPSHOT
+          description: DashScope Model adapted Starter
     - name: Developer Tools
       content:
         - name: GraalVM Native Support


### PR DESCRIPTION


### Describe what this PR does / why we need it
add spring-ai-alibaba-starter-dashscope dependencies in initializr.yml

can add the spring-ai-alibaba-starter-dashscope dependency to the start.zip interface parameter dependencies and automatically generate it into the pom file
![image](https://github.com/user-attachments/assets/93fc33b7-e7f6-4512-a7e5-da696e12d8fe)
![image](https://github.com/user-attachments/assets/f0f510de-eced-490d-b354-5f4018ecc897)
