### PR TITLE
fix(graph): httpNode return complete response

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/HttpNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/HttpNode.java
@@ -120,7 +120,7 @@ public class HttpNode implements NodeAction {
 			Map<String, Object> updatedState = new HashMap<>();
 			updatedState.put("messages", httpResponse);
 			if (StringUtils.hasLength(this.outputKey)) {
-                updatedState.put(this.outputKey, httpResponse);
+				updatedState.put(this.outputKey, httpResponse);
 			}
 			return updatedState;
 		}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/HttpNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/HttpNode.java
@@ -120,7 +120,7 @@ public class HttpNode implements NodeAction {
 			Map<String, Object> updatedState = new HashMap<>();
 			updatedState.put("messages", httpResponse);
 			if (StringUtils.hasLength(this.outputKey)) {
-				updatedState.put(this.outputKey, String.valueOf(httpResponse.get("body")));
+                updatedState.put(this.outputKey, httpResponse);
 			}
 			return updatedState;
 		}


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix httpNode return complete response not just the body

However, at present, the node state flow is completely dependent on the upstream node to output a structure that meets the downstream expectations, such as json, md, string, map, etc. If  can't fully account which downstream nodes the output will be sent to, do we need to think about defining a formatNode?