### PR TITLE
fix(graph): replace deprecated method signatures

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-example/src/main/java/com/alibaba/cloud/ai/example/graph/reflection/RelectionAutoconfiguration.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-example/src/main/java/com/alibaba/cloud/ai/example/graph/reflection/RelectionAutoconfiguration.java
@@ -17,8 +17,8 @@
 package com.alibaba.cloud.ai.example.graph.reflection;
 
 import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.OverAllState;
-import com.alibaba.cloud.ai.graph.OverAllStateFactory;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
 import com.alibaba.cloud.ai.graph.agent.ReflectAgent;
@@ -35,6 +35,7 @@ import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.UnaryOperator;
@@ -99,15 +100,11 @@ public class RelectionAutoconfiguration {
 
 			List<Message> messages = (List<Message>) overAllState.value(MESSAGES).get();
 
-			OverAllStateFactory stateFactory = () -> {
-				OverAllState state = new OverAllState();
-				state.registerKeyAndStrategy(MESSAGES, new AppendStrategy());
-				return state;
-			};
-
-			StateGraph stateGraph = new StateGraph(stateFactory).addNode(this.NODE_ID, node_async(llmNode))
-				.addEdge(START, this.NODE_ID)
-				.addEdge(this.NODE_ID, END);
+			StateGraph stateGraph = new StateGraph(() -> {
+				Map<String, KeyStrategy> strategies = new HashMap<>();
+				strategies.put(MESSAGES, new AppendStrategy());
+				return strategies;
+			}).addNode(this.NODE_ID, node_async(llmNode)).addEdge(START, this.NODE_ID).addEdge(this.NODE_ID, END);
 
 			OverAllState invokeState = stateGraph.compile().invoke(Map.of(MESSAGES, messages)).get();
 			List<Message> reactMessages = (List<Message>) invokeState.value(MESSAGES).orElseThrow();
@@ -177,15 +174,11 @@ public class RelectionAutoconfiguration {
 		public Map<String, Object> apply(OverAllState allState) throws Exception {
 			List<Message> messages = (List<Message>) allState.value(MESSAGES).get();
 
-			OverAllStateFactory stateFactory = () -> {
-				OverAllState state = new OverAllState();
-				state.registerKeyAndStrategy(MESSAGES, new AppendStrategy());
-				return state;
-			};
-
-			StateGraph stateGraph = new StateGraph(stateFactory).addNode(this.NODE_ID, node_async(llmNode))
-				.addEdge(START, this.NODE_ID)
-				.addEdge(this.NODE_ID, END);
+			StateGraph stateGraph = new StateGraph(() -> {
+				Map<String, KeyStrategy> strategies = new HashMap<>();
+				strategies.put(MESSAGES, new AppendStrategy());
+				return strategies;
+			}).addNode(this.NODE_ID, node_async(llmNode)).addEdge(START, this.NODE_ID).addEdge(this.NODE_ID, END);
 
 			CompiledGraph compile = stateGraph.compile();
 

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-example/src/main/java/com/alibaba/cloud/ai/example/graph/workflow/WorkflowAutoconfiguration.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-example/src/main/java/com/alibaba/cloud/ai/example/graph/workflow/WorkflowAutoconfiguration.java
@@ -17,8 +17,7 @@
 package com.alibaba.cloud.ai.example.graph.workflow;
 
 import com.alibaba.cloud.ai.graph.GraphRepresentation;
-import com.alibaba.cloud.ai.graph.OverAllState;
-import com.alibaba.cloud.ai.graph.OverAllStateFactory;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.node.QuestionClassifierNode;
@@ -29,6 +28,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,14 +44,6 @@ public class WorkflowAutoconfiguration {
 	public StateGraph workflowGraph(ChatModel chatModel) throws GraphStateException {
 
 		ChatClient chatClient = ChatClient.builder(chatModel).defaultAdvisors(new SimpleLoggerAdvisor()).build();
-
-		OverAllStateFactory stateFactory = () -> {
-			OverAllState state = new OverAllState();
-			state.registerKeyAndStrategy("input", new ReplaceStrategy());
-			state.registerKeyAndStrategy("classifier_output", new ReplaceStrategy());
-			state.registerKeyAndStrategy("solution", new ReplaceStrategy());
-			return state;
-		};
 
 		QuestionClassifierNode feedbackClassifier = QuestionClassifierNode.builder()
 			.chatClient(chatClient)
@@ -69,8 +61,13 @@ public class WorkflowAutoconfiguration {
 				.of("What kind of service or help the customer is trying to get from us? Classify the question based on your understanding."))
 			.build();
 
-		StateGraph stateGraph = new StateGraph("Consumer Service Workflow Demo", stateFactory)
-			.addNode("feedback_classifier", node_async(feedbackClassifier))
+		StateGraph stateGraph = new StateGraph("Consumer Service Workflow Demo", () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("classifier_output", new ReplaceStrategy());
+			strategies.put("solution", new ReplaceStrategy());
+			return strategies;
+		}).addNode("feedback_classifier", node_async(feedbackClassifier))
 			.addNode("specific_question_classifier", node_async(specificQuestionClassifier))
 			.addNode("recorder", node_async(new RecordingNode()))
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
replace graph-example deprecated 'new StateGraph' signatures, like:

before :
new StateGraph("Consumer Service Workflow Demo", stateFactory)

now :
StateGraph stateGraph = new StateGraph("Consumer Service Workflow Demo", () -> {
			Map<String, KeyStrategy> strategies = new HashMap<>();
			strategies.put("input", new ReplaceStrategy());
			strategies.put("classifier_output", new ReplaceStrategy());
			strategies.put("solution", new ReplaceStrategy());
			return strategies;
		})

