### PR TITLE
fix(tool-calls): remove unused `messageHistory`

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/tool/ObservableToolCallingManager.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/tool/ObservableToolCallingManager.java
@@ -157,10 +157,6 @@ public class ObservableToolCallingManager implements ToolCallingManager {
 				&& !CollectionUtils.isEmpty(toolCallingChatOptions.getToolContext())) {
 			toolContextMap = new HashMap<>(toolCallingChatOptions.getToolContext());
 
-			List<Message> messageHistory = new ArrayList<>(prompt.copy().getInstructions());
-			messageHistory.add(new AssistantMessage(assistantMessage.getText(), assistantMessage.getMetadata(),
-					assistantMessage.getToolCalls()));
-
 			toolContextMap.put(ToolContext.TOOL_CALL_HISTORY,
 					buildConversationHistoryBeforeToolExecution(prompt, assistantMessage));
 		}


### PR DESCRIPTION
### Describe what this PR does / why we need it
The `messageHistory` in the `buildToolContext` method is actually unused. The real `messageHistory` construction happens in the `buildConversationHistoryBeforeToolExecution` method.

```
private static List<Message> buildConversationHistoryBeforeToolExecution(Prompt prompt,
			AssistantMessage assistantMessage) {
  List<Message> messageHistory = new ArrayList<>(prompt.copy().getInstructions());
  messageHistory.add(new AssistantMessage(assistantMessage.getText(), assistantMessage.getMetadata(),
		  assistantMessage.getToolCalls()));
  return messageHistory;
}
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
related: https://github.com/spring-projects/spring-ai/pull/3574

### Describe how to verify it


### Special notes for reviews
