### PR TITLE
feat(larksuite): 添加获取飞书文档和表格内容的服务

### DIFF
--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/LarkSuiteAutoConfiguration.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/LarkSuiteAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Description;
 
 /**
  * @author 北极星
+ * @author huaiziqing
  */
 @Configuration
 @EnableConfigurationProperties({ LarkSuiteProperties.class })
@@ -52,6 +53,20 @@ public class LarkSuiteAutoConfiguration {
 	@Description("It calls the document api to invoke a method to create a larksuite sheet")
 	public LarkSuiteCreateSheetService larksuiteCreateSheetFunction(LarkSuiteProperties properties) {
 		return new LarkSuiteCreateSheetService(properties);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@Description("It calls the document api to get content of a larksuite document")
+	public LarkSuiteGetDocContentService larksuiteGetDocContentFunction(LarkSuiteProperties properties) {
+		return new LarkSuiteGetDocContentService(properties);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@Description("It calls the sheet api to get content of a larksuite sheet")
+	public LarkSuiteGetSheetContentService larksuiteGetSheetContentFunction(LarkSuiteProperties properties) {
+		return new LarkSuiteGetSheetContentService(properties);
 	}
 
 }

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/LarkSuiteGetSheetContentService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/LarkSuiteGetSheetContentService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite;
+
+import com.alibaba.cloud.ai.toolcalling.larksuite.param.req.ValuesGetReq;
+import com.alibaba.cloud.ai.toolcalling.larksuite.param.resp.ValuesGetResp;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.lark.oapi.Client;
+import com.lark.oapi.core.response.RawResponse;
+import com.lark.oapi.core.token.AccessTokenType;
+import com.lark.oapi.core.utils.UnmarshalRespUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.ObjectUtils;
+
+import java.util.function.Function;
+
+/**
+ * @author huaiziqing
+ */
+public class LarkSuiteGetSheetContentService
+		implements Function<LarkSuiteGetSheetContentService.SheetGetRequest, Object> {
+
+	private static final String LARK_SHEET_GET_URL = "https://open.feishu.cn/open-apis/sheets/v3/spreadsheets/:spreadsheet_token";
+
+	private static final Logger logger = LoggerFactory.getLogger(LarkSuiteGetSheetContentService.class);
+
+	LarkSuiteProperties larkSuiteProperties;
+
+	public LarkSuiteGetSheetContentService(LarkSuiteProperties properties) {
+		this.larkSuiteProperties = properties;
+	}
+
+	@Override
+	public Object apply(SheetGetRequest request) {
+		if (ObjectUtils.isEmpty(larkSuiteProperties.getAppId())
+				|| ObjectUtils.isEmpty(larkSuiteProperties.getAppSecret())) {
+			logger.error("current larksuite appId or appSecret must not be null.");
+			throw new IllegalArgumentException("current larksuite appId or appSecret must not be null.");
+		}
+
+		Client client = Client.newBuilder(larkSuiteProperties.getAppId(), larkSuiteProperties.getAppSecret()).build();
+
+		try {
+			ValuesGetReq req = ValuesGetReq.newBuilder()
+				.spreadsheetToken(request.spreadsheetToken())
+				.range(request.range())
+				.build();
+
+			RawResponse httpResponse = client.get(
+					String.format(LARK_SHEET_GET_URL, req.getSpreadsheetToken(), req.getRange()), null,
+					AccessTokenType.Tenant);
+
+			ValuesGetResp resp = UnmarshalRespUtil.unmarshalResp(httpResponse, ValuesGetResp.class);
+			if (resp == null) {
+				throw new IllegalArgumentException("The result returned by the server is illegal");
+			}
+
+			if (!resp.success()) {
+				throw new RuntimeException("获取表格数据失败: " + resp.getMsg());
+			}
+
+			return resp.getData().getValues();
+		}
+		catch (Exception e) {
+			logger.error("获取表格数据异常", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	public record SheetGetRequest(@JsonProperty(required = true, value = "spreadsheetToken") String spreadsheetToken,
+			@JsonProperty(required = true, value = "range") String range) {
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/param/req/ValuesGetReq.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/param/req/ValuesGetReq.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite.param.req;
+
+/**
+ * @author huaiziqing
+ */
+public class ValuesGetReq {
+
+    private String spreadsheetToken;
+
+    private String range;
+
+    public String getSpreadsheetToken() {
+        return spreadsheetToken;
+    }
+
+    public void setSpreadsheetToken(String spreadsheetToken) {
+        this.spreadsheetToken = spreadsheetToken;
+    }
+
+    public String getRange() {
+        return range;
+    }
+
+    public void setRange(String range) {
+        this.range = range;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String spreadsheetToken;
+
+        private String range;
+
+        public Builder spreadsheetToken(String spreadsheetToken) {
+            this.spreadsheetToken = spreadsheetToken;
+            return this;
+        }
+
+        public Builder range(String range) {
+            this.range = range;
+            return this;
+        }
+
+        public ValuesGetReq build() {
+            ValuesGetReq req = new ValuesGetReq();
+            req.setSpreadsheetToken(this.spreadsheetToken);
+            req.setRange(this.range);
+            return req;
+        }
+    }
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/param/resp/ValuesGetResp.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-larksuite/src/main/java/com/alibaba/cloud/ai/toolcalling/larksuite/param/resp/ValuesGetResp.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite.param.resp;
+
+import com.lark.oapi.core.response.BaseResponse;
+
+import java.util.List;
+
+/**
+ * @author huaiziqing
+ */
+public class ValuesGetResp extends BaseResponse<ValuesGetResp.ValuesGetRespBody> {
+
+	public static class ValuesGetRespBody {
+
+		private List<List<String>> values;
+
+		public List<List<String>> getValues() {
+			return values;
+		}
+
+		public void setValues(List<List<String>> values) {
+			this.values = values;
+		}
+
+	}
+
+}


### PR DESCRIPTION
新增LarkSuiteGetDocContentService和LarkSuiteGetSheetContentService服务类 添加ValuesGetReq和ValuesGetResp请求响应类
支持通过API获取飞书文档和表格内容
