### PR TITLE
feat(core): Added support for dimension fields to the embedding model

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -72,6 +72,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 /**
  * @author nuocheng.lxm
  * @author yuluo
+ * @author YunKui Lu
  * @since 1.0.0-M2
  */
 public class DashScopeApi {
@@ -221,9 +222,14 @@ public class DashScopeApi {
 		EMBEDDING_V2("text-embedding-v2"),
 
 		/**
-		 * DIMENSION: 1024/768/512
+		 * DIMENSION: 1024/768/512/256/128/64
 		 */
-		EMBEDDING_V3("text-embedding-v3");
+		EMBEDDING_V3("text-embedding-v3"),
+
+		/**
+		 * DIMENSION: 2048/1536/1024/768/512/256/128/64
+		 */
+		EMBEDDING_V4("text-embedding-v4");
 
 		public final String value;
 
@@ -299,7 +305,43 @@ public class DashScopeApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public record EmbeddingRequestInputParameters(@JsonProperty("text_type") String textType) {
+	public record EmbeddingRequestInputParameters(@JsonProperty("text_type") String textType,
+			@JsonProperty("dimension") Integer dimension) {
+
+		@Deprecated
+		public EmbeddingRequestInputParameters(String textType) {
+			this(textType, null);
+		}
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public static class Builder {
+
+			private String textType;
+
+			private Integer dimension;
+
+			private Builder() {
+
+			}
+
+			public Builder textType(String textType) {
+				this.textType = textType;
+				return this;
+			}
+
+			public Builder dimension(Integer dimension) {
+				this.dimension = dimension;
+				return this;
+			}
+
+			public EmbeddingRequestInputParameters build() {
+				return new EmbeddingRequestInputParameters(textType, dimension);
+			}
+
+		}
 	}
 
 	/**
@@ -309,32 +351,88 @@ public class DashScopeApi {
 	public record EmbeddingRequest(@JsonProperty("model") String model,
 			@JsonProperty("input") EmbeddingRequestInput input,
 			@JsonProperty("parameters") EmbeddingRequestInputParameters parameters) {
+
+		@Deprecated
 		public EmbeddingRequest(String text) {
 			this(DEFAULT_EMBEDDING_MODEL, new EmbeddingRequestInput(List.of(text)),
 					new EmbeddingRequestInputParameters(DEFAULT_EMBEDDING_TEXT_TYPE));
 		}
 
+		@Deprecated
 		public EmbeddingRequest(String text, String model) {
 			this(model, new EmbeddingRequestInput(List.of(text)),
 					new EmbeddingRequestInputParameters(DEFAULT_EMBEDDING_TEXT_TYPE));
 		}
 
+		@Deprecated
 		public EmbeddingRequest(String text, String model, String textType) {
 			this(model, new EmbeddingRequestInput(List.of(text)), new EmbeddingRequestInputParameters(textType));
 		}
 
+		@Deprecated
 		public EmbeddingRequest(List<String> texts) {
 			this(DEFAULT_EMBEDDING_MODEL, new EmbeddingRequestInput(texts),
 					new EmbeddingRequestInputParameters(DEFAULT_EMBEDDING_TEXT_TYPE));
 		}
 
+		@Deprecated
 		public EmbeddingRequest(List<String> texts, String model) {
 			this(model, new EmbeddingRequestInput(texts),
 					new EmbeddingRequestInputParameters(DEFAULT_EMBEDDING_TEXT_TYPE));
 		}
 
+		@Deprecated
 		public EmbeddingRequest(List<String> texts, String model, String textType) {
 			this(model, new EmbeddingRequestInput(texts), new EmbeddingRequestInputParameters(textType));
+		}
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public static class Builder {
+
+			private final List<String> texts = new ArrayList<>();
+
+			private String model = DEFAULT_EMBEDDING_MODEL;
+
+			private String textType;
+
+			private Integer dimension;
+
+			private Builder() {
+			}
+
+			public Builder model(String model) {
+				this.model = model;
+				return this;
+			}
+
+			public Builder texts(String... texts) {
+				this.texts.addAll(List.of(texts));
+				return this;
+			}
+
+			public Builder texts(List<String> texts) {
+				this.texts.addAll(texts);
+				return this;
+			}
+
+			public Builder textType(String textType) {
+				this.textType = textType;
+				return this;
+			}
+
+			public Builder dimension(Integer dimension) {
+				this.dimension = dimension;
+				return this;
+			}
+
+			public EmbeddingRequest build() {
+				return new EmbeddingRequest(model, new EmbeddingRequestInput(texts),
+						EmbeddingRequestInputParameters.builder().textType(textType).dimension(dimension).build());
+			}
+
 		}
 	}
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/embedding/DashScopeEmbeddingModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/embedding/DashScopeEmbeddingModel.java
@@ -207,8 +207,12 @@ public class DashScopeEmbeddingModel extends AbstractEmbeddingModel {
 
 	private DashScopeApi.EmbeddingRequest createRequest(EmbeddingRequest request) {
 		DashScopeEmbeddingOptions requestOptions = (DashScopeEmbeddingOptions) request.getOptions();
-		return new DashScopeApi.EmbeddingRequest(request.getInstructions(), requestOptions.getModel(),
-				requestOptions.getTextType());
+		return DashScopeApi.EmbeddingRequest.builder()
+			.model(requestOptions.getModel())
+			.texts(request.getInstructions())
+			.textType(requestOptions.getTextType())
+			.dimension(requestOptions.getDimensions())
+			.build();
 	}
 
 	private EmbeddingResponseMetadata generateResponseMetadata(String model, Usage usage) {

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/embedding/DashScopeEmbeddingModelTests.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/embedding/DashScopeEmbeddingModelTests.java
@@ -50,13 +50,15 @@ import static org.mockito.Mockito.when;
 class DashScopeEmbeddingModelTests {
 
 	// Test constants
-	private static final String TEST_MODEL = "text-embedding-v2";
+	private static final String TEST_MODEL = "text-embedding-v3";
 
 	private static final String TEST_TEXT_TYPE = "document";
 
 	private static final String TEST_REQUEST_ID = "test-request-id";
 
 	private static final String TEST_TEXT = "Hello, world!";
+
+	private static final Integer TEST_DIMENSION = 512;
 
 	private DashScopeApi dashScopeApi;
 
@@ -68,7 +70,11 @@ class DashScopeEmbeddingModelTests {
 	void setUp() {
 		// Initialize mock objects and test instances
 		dashScopeApi = Mockito.mock(DashScopeApi.class);
-		defaultOptions = DashScopeEmbeddingOptions.builder().withModel(TEST_MODEL).withTextType(TEST_TEXT_TYPE).build();
+		defaultOptions = DashScopeEmbeddingOptions.builder()
+			.withModel(TEST_MODEL)
+			.withTextType(TEST_TEXT_TYPE)
+			.withDimensions(TEST_DIMENSION)
+			.build();
 		embeddingModel = new DashScopeEmbeddingModel(dashScopeApi, MetadataMode.EMBED, defaultOptions);
 	}
 


### PR DESCRIPTION
- Deprecating public constructors in favor of builder API
- Added unit tests and integration tests.


### Describe what this PR does / why we need it
Added support for dimension fields in the vector model.

### Does this pull request fix one issue?
Fixes #1011
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it
Verified through integration tests in the `DashScopeAutoConfigurationIT` class.
And it works fine on my app too.

### Special notes for reviews
