### PR TITLE
feat(deepresearch): enable basic report exportation and download as pdf and markdown

### DIFF
--- a/spring-ai-alibaba-deepresearch/README-zh.md
+++ b/spring-ai-alibaba-deepresearch/README-zh.md
@@ -29,6 +29,7 @@
   - 在配置文件的`spring.ai.alibaba.deepreserch.python-coder.docker-host`字段中设置DockerHost，默认为`unix:///var/run/docker.sock`。
   本项目需要使用`python:3-slim`镜像创建临时容器，也可以自己定制包含一些常用的第三方库的镜像，第三方库需要安装在镜像的`/app/dependency`文件夹里，在配置文件中设置`spring.ai.alibaba.deepreserch.python-coder.image-name`的值指定镜像名称。
 - 高德地图MCP
+- 
 #### 相关API、工具、MCP接入文档
 - tavily API文档：https://docs.tavily.com/documentation/api-reference/endpoint/search
 - Jina API文档：https://jina.ai/reader

--- a/spring-ai-alibaba-deepresearch/README-zh.md
+++ b/spring-ai-alibaba-deepresearch/README-zh.md
@@ -21,6 +21,7 @@
 #### 必配
 - DashScope API: `${AI_DASHSCOPE_API_KEY}`
 - TavilySearch API: `${TAVILY_API_KEY}`
+- 报告导出路径: `${AI_DEEPRESEARCH_EXPORT_PATH}`
 
 #### 选配
 - Jina API: `${JINA_API_KEY}`
@@ -28,7 +29,6 @@
   - 在配置文件的`spring.ai.alibaba.deepreserch.python-coder.docker-host`字段中设置DockerHost，默认为`unix:///var/run/docker.sock`。
   本项目需要使用`python:3-slim`镜像创建临时容器，也可以自己定制包含一些常用的第三方库的镜像，第三方库需要安装在镜像的`/app/dependency`文件夹里，在配置文件中设置`spring.ai.alibaba.deepreserch.python-coder.image-name`的值指定镜像名称。
 - 高德地图MCP
-
 #### 相关API、工具、MCP接入文档
 - tavily API文档：https://docs.tavily.com/documentation/api-reference/endpoint/search
 - Jina API文档：https://jina.ai/reader

--- a/spring-ai-alibaba-deepresearch/pom.xml
+++ b/spring-ai-alibaba-deepresearch/pom.xml
@@ -107,6 +107,37 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         
+        <!-- OpenHTMLToPDF依赖 -->
+        <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-core</artifactId>
+            <version>1.0.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-pdfbox</artifactId>
+            <version>1.0.10</version>
+        </dependency>
+        <dependency>
+            <groupId>com.openhtmltopdf</groupId>
+            <artifactId>openhtmltopdf-slf4j</artifactId>
+            <version>1.0.10</version>
+        </dependency>
+        
+        <!-- CommonMark Markdown解析器 -->
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.24.0</version>
+        </dependency>
+        
+        <!-- CommonMark表格扩展 -->
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark-ext-gfm-tables</artifactId>
+            <version>0.24.0</version>
+        </dependency>
+        
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/spring-ai-alibaba-deepresearch/pom.xml
+++ b/spring-ai-alibaba-deepresearch/pom.xml
@@ -23,7 +23,10 @@
 
         <spring-ai.version>1.0.0</spring-ai.version>
         <spring-ai-alibaba.version>1.0.0.3-SNAPSHOT</spring-ai-alibaba.version>
-        
+       
+        <openhtmltopdf.version>1.0.10</openhtmltopdf.version>
+        <commonmark.version>0.24.0</commonmark.version>
+
         <!-- CheckStyle Maven Plugin -->
         <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
         <maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
@@ -107,35 +110,34 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         
-        <!-- OpenHTMLToPDF依赖 -->
         <dependency>
             <groupId>com.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-core</artifactId>
-            <version>1.0.10</version>
+            <version>${openhtmltopdf.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-pdfbox</artifactId>
-            <version>1.0.10</version>
+            <version>${openhtmltopdf.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.openhtmltopdf</groupId>
             <artifactId>openhtmltopdf-slf4j</artifactId>
-            <version>1.0.10</version>
+            <version>${openhtmltopdf.version}</version>
         </dependency>
         
-        <!-- CommonMark Markdown解析器 -->
         <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
-            <version>0.24.0</version>
+            <version>${commonmark.version}</version>
         </dependency>
         
-        <!-- CommonMark表格扩展 -->
         <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark-ext-gfm-tables</artifactId>
-            <version>0.24.0</version>
+            <version>${commonmark.version}</version>
         </dependency>
         
     </dependencies>

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/export/ExportConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/export/ExportConfiguration.java
@@ -1,0 +1,24 @@
+package com.alibaba.cloud.ai.example.deepresearch.config.export;
+
+import com.alibaba.cloud.ai.example.deepresearch.service.ExportService;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 导出服务配置类
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ *
+ */
+@Configuration
+@EnableConfigurationProperties(ExportProperties.class)
+public class ExportConfiguration {
+
+	@Bean
+	public ExportService exportService(ExportProperties exportProperties) {
+		return new ExportService(exportProperties.getPath());
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/export/ExportProperties.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/export/ExportProperties.java
@@ -1,0 +1,27 @@
+package com.alibaba.cloud.ai.example.deepresearch.config.export;
+
+import com.alibaba.cloud.ai.example.deepresearch.config.DeepResearchProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 导出功能相关的配置属性
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+@ConfigurationProperties(prefix = ExportProperties.EXPORT_PREFIX)
+public class ExportProperties {
+
+	public static final String EXPORT_PREFIX = DeepResearchProperties.PREFIX + ".export";
+
+	private String path = "${user.home}/reports";
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/controller/ExportController.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/controller/ExportController.java
@@ -1,0 +1,134 @@
+package com.alibaba.cloud.ai.example.deepresearch.controller;
+
+import com.alibaba.cloud.ai.example.deepresearch.model.req.ExportRequest;
+import com.alibaba.cloud.ai.example.deepresearch.model.response.ExportResponse;
+import com.alibaba.cloud.ai.example.deepresearch.service.ExportService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 报告导出控制器，提供报告导出和下载的API 支持用户选择下载格式，一键导出并下载
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+@RestController
+@RequestMapping("/api/reports")
+public class ExportController {
+
+	private static final Logger logger = LoggerFactory.getLogger(ExportController.class);
+
+	@Autowired
+	private ExportService exportService;
+
+	/**
+	 * 导出报告，返回导出文件的元数据信息
+	 * @param request 包含线程ID和导出格式的请求
+	 * @return 导出文件的元数据信息
+	 */
+	@PostMapping("/export")
+	public ResponseEntity<ExportResponse> exportReport(@RequestBody ExportRequest request) {
+		if (request == null) {
+			return ResponseEntity.badRequest().body(ExportResponse.error("Report request cannot be null"));
+		}
+
+		try {
+			String threadId = request.threadId();
+			String format = request.format().toLowerCase();
+
+			logger.info("Exporting report for threadId: {}, format: {}", threadId, format);
+
+			// 检查线程ID对应的报告是否存在
+			if (!exportService.existsReportByThreadId(threadId)) {
+				return ResponseEntity.badRequest()
+					.body(ExportResponse.error("Report not found for thread: " + threadId));
+			}
+
+			// 检查请求的格式是否支持
+			if (!exportService.isSupportedFormat(format)) {
+				return ResponseEntity.badRequest()
+					.body(ExportResponse
+						.error("Unsupported format: " + format + ", only markdown and pdf are supported"));
+			}
+
+			// 实际保存文件
+			String filePath = exportReport(threadId, format);
+			if (filePath == null) {
+				return ResponseEntity.badRequest()
+					.body(ExportResponse.error("Failed to export report to format: " + format));
+			}
+
+			// 构建下载URL
+			String downloadUrl = "/api/reports/download/" + threadId + "?format=" + format;
+
+			// 构建成功响应
+			ExportResponse response = ExportResponse.success(threadId, format, filePath, downloadUrl);
+			return ResponseEntity.ok(response);
+		}
+		catch (Exception e) {
+			logger.error("Failed to export report", e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ExportResponse.error(e.getMessage()));
+		}
+	}
+
+	/**
+	 * 下载指定格式的报告文件
+	 * @param threadId 线程ID
+	 * @param format 文件格式
+	 * @return 文件下载响应
+	 */
+	@GetMapping("/download/{threadId}")
+	public ResponseEntity<?> downloadReport(@PathVariable String threadId,
+			@RequestParam(required = false, defaultValue = "markdown") String format) {
+
+		format = format.toLowerCase();
+
+		try {
+			// 检查格式是否支持
+			if (!exportService.isSupportedFormat(format)) {
+				return ResponseEntity.badRequest()
+					.body(ExportResponse
+						.error("Unsupported format: " + format + ", only markdown and pdf are supported"));
+			}
+
+			// 统一使用markdown作为键
+			if ("md".equals(format)) {
+				format = "markdown";
+			}
+
+			return exportService.downloadReport(threadId, format);
+		}
+		catch (Exception e) {
+			logger.error("Failed to download report", e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ExportResponse.error(e.getMessage()));
+		}
+	}
+
+	/**
+	 * 根据线程ID和格式导出报告
+	 * @param threadId 线程ID
+	 * @param format 导出格式
+	 * @return 导出文件的路径
+	 */
+	private String exportReport(String threadId, String format) {
+		if ("markdown".equals(format) || "md".equals(format)) {
+			String filePath = exportService.saveAsMarkdown(threadId);
+			return filePath;
+		}
+		else if ("pdf".equals(format)) {
+			return exportService.saveAsPdf(threadId);
+		}
+		return null;
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/controller/ReportController.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/controller/ReportController.java
@@ -51,32 +51,20 @@ public class ReportController {
 	@GetMapping("/{threadId}")
 	public ResponseEntity<ReportResponse> getReport(@PathVariable String threadId) {
 		try {
-			logger.info("查询报告，线程ID: {}", threadId);
+			logger.info("Querying report for thread ID: {}", threadId);
 			String report = reportService.getReport(threadId);
 
 			if (report != null) {
-				ReportResponse response = new ReportResponse();
-				response.setThreadId(threadId);
-				response.setReport(report);
-				response.setStatus("success");
-				response.setMessage("报告获取成功");
-				return ResponseEntity.ok(response);
+				return ResponseEntity.ok(ReportResponse.success(threadId, report));
 			}
 			else {
-				ReportResponse response = new ReportResponse();
-				response.setThreadId(threadId);
-				response.setStatus("not_found");
-				response.setMessage("未找到指定线程ID的报告");
 				return ResponseEntity.notFound().build();
 			}
 		}
 		catch (Exception e) {
-			logger.error("获取报告失败，线程ID: {}", threadId, e);
-			ReportResponse response = new ReportResponse();
-			response.setThreadId(threadId);
-			response.setStatus("error");
-			response.setMessage("获取报告失败: " + e.getMessage());
-			return ResponseEntity.internalServerError().body(response);
+			logger.error("Failed to get report for thread ID: {}", threadId, e);
+			return ResponseEntity.internalServerError()
+				.body(ReportResponse.error(threadId, "Failed to get report: " + e.getMessage()));
 		}
 	}
 
@@ -88,25 +76,15 @@ public class ReportController {
 	@GetMapping("/{threadId}/exists")
 	public ResponseEntity<ExistsResponse> existsReport(@PathVariable String threadId) {
 		try {
-			logger.info("检查报告是否存在，线程ID: {}", threadId);
+			logger.info("Checking if report exists for thread ID: {}", threadId);
 			boolean exists = reportService.existsReport(threadId);
 
-			ExistsResponse response = new ExistsResponse();
-			response.setThreadId(threadId);
-			response.setExists(exists);
-			response.setStatus("success");
-			response.setMessage(exists ? "报告存在" : "报告不存在");
-
-			return ResponseEntity.ok(response);
+			return ResponseEntity.ok(ExistsResponse.success(threadId, exists));
 		}
 		catch (Exception e) {
-			logger.error("检查报告是否存在失败，线程ID: {}", threadId, e);
-			ExistsResponse response = new ExistsResponse();
-			response.setThreadId(threadId);
-			response.setExists(false);
-			response.setStatus("error");
-			response.setMessage("检查失败: " + e.getMessage());
-			return ResponseEntity.internalServerError().body(response);
+			logger.error("Failed to check if report exists for thread ID: {}", threadId, e);
+			return ResponseEntity.internalServerError()
+				.body(ExistsResponse.error(threadId, "Check failed: " + e.getMessage()));
 		}
 	}
 
@@ -118,32 +96,19 @@ public class ReportController {
 	@DeleteMapping("/{threadId}")
 	public ResponseEntity<BaseResponse> deleteReport(@PathVariable String threadId) {
 		try {
-			logger.info("删除报告，线程ID: {}", threadId);
+			logger.info("Deleting report for thread ID: {}", threadId);
 
 			if (!reportService.existsReport(threadId)) {
-				BaseResponse response = new BaseResponse();
-				response.setThreadId(threadId);
-				response.setStatus("not_found");
-				response.setMessage("未找到指定线程ID的报告");
 				return ResponseEntity.notFound().build();
 			}
 
 			reportService.deleteReport(threadId);
-
-			BaseResponse response = new BaseResponse();
-			response.setThreadId(threadId);
-			response.setStatus("success");
-			response.setMessage("报告删除成功");
-
-			return ResponseEntity.ok(response);
+			return ResponseEntity.ok(BaseResponse.success(threadId, "Report deleted successfully"));
 		}
 		catch (Exception e) {
-			logger.error("删除报告失败，线程ID: {}", threadId, e);
-			BaseResponse response = new BaseResponse();
-			response.setThreadId(threadId);
-			response.setStatus("error");
-			response.setMessage("删除报告失败: " + e.getMessage());
-			return ResponseEntity.internalServerError().body(response);
+			logger.error("Failed to delete report for thread ID: {}", threadId, e);
+			return ResponseEntity.internalServerError()
+				.body(BaseResponse.error(threadId, "Failed to delete report: " + e.getMessage()));
 		}
 	}
 

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/req/ExportRequest.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/req/ExportRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.deepresearch.model.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 报告导出请求
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+public record ExportRequest(
+		/**
+		 * 导出格式，支持 "markdown"/"md"、"pdf"
+		 */
+		@JsonProperty(value = "format", defaultValue = "markdown") String format,
+
+		/**
+		 * 线程ID，用于标识当前对话的唯一性 默认值为 "__default__"，表示使用默认线程
+		 */
+		@JsonProperty(value = "thread_id", defaultValue = "__default__") String threadId) {
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/BaseResponse.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/BaseResponse.java
@@ -16,42 +16,35 @@
 
 package com.alibaba.cloud.ai.example.deepresearch.model.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * 基础响应类
  *
  * @author huangzhen
  * @since 2025/6/20
  */
-public class BaseResponse {
+public record BaseResponse(
+		/**
+		 * 线程ID，用于标识当前对话的唯一性
+		 */
+		@JsonProperty("thread_id") String threadId,
 
-	private String threadId;
+		/**
+		 * 状态
+		 */
+		@JsonProperty("status") String status,
 
-	private String status;
+		/**
+		 * 消息
+		 */
+		@JsonProperty("message") String message) {
 
-	private String message;
-
-	public String getThreadId() {
-		return threadId;
+	public static BaseResponse success(String threadId, String message) {
+		return new BaseResponse(threadId, "success", message);
 	}
 
-	public void setThreadId(String threadId) {
-		this.threadId = threadId;
+	public static BaseResponse error(String threadId, String message) {
+		return new BaseResponse(threadId, "error", message);
 	}
-
-	public String getStatus() {
-		return status;
-	}
-
-	public void setStatus(String status) {
-		this.status = status;
-	}
-
-	public String getMessage() {
-		return message;
-	}
-
-	public void setMessage(String message) {
-		this.message = message;
-	}
-
 }

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/ExistsResponse.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/ExistsResponse.java
@@ -16,22 +16,41 @@
 
 package com.alibaba.cloud.ai.example.deepresearch.model.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * 存在性检查响应类
  *
  * @author huangzhen
  * @since 2025/6/20
  */
-public class ExistsResponse extends BaseResponse {
+public record ExistsResponse(
+		/**
+		 * 线程ID，用于标识当前对话的唯一性
+		 */
+		@JsonProperty("thread_id") String threadId,
 
-	private boolean exists;
+		/**
+		 * 状态
+		 */
+		@JsonProperty("status") String status,
 
-	public boolean isExists() {
-		return exists;
+		/**
+		 * 消息
+		 */
+		@JsonProperty("message") String message,
+
+		/**
+		 * 是否存在
+		 */
+		@JsonProperty("exists") boolean exists) {
+
+	public static ExistsResponse success(String threadId, boolean exists) {
+		String message = exists ? "Resource exists" : "Resource does not exist";
+		return new ExistsResponse(threadId, "success", message, exists);
 	}
 
-	public void setExists(boolean exists) {
-		this.exists = exists;
+	public static ExistsResponse error(String threadId, String message) {
+		return new ExistsResponse(threadId, "error", message, false);
 	}
-
 }

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/ExportResponse.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/ExportResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.example.deepresearch.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 报告导出响应
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+public record ExportResponse(
+		/**
+		 * 操作是否成功
+		 */
+		@JsonProperty("success") boolean success,
+
+		/**
+		 * 线程ID，用于标识当前对话的唯一性
+		 */
+		@JsonProperty("thread_id") String threadId,
+
+		/**
+		 * 导出格式
+		 */
+		@JsonProperty("format") String format,
+
+		/**
+		 * 导出文件路径
+		 */
+		@JsonProperty("file_path") String filePath,
+
+		/**
+		 * 下载URL
+		 */
+		@JsonProperty("download_url") String downloadUrl,
+
+		/**
+		 * 错误信息，仅当success为false时有值
+		 */
+		@JsonProperty("error") String error) {
+
+	public static ExportResponse success(String threadId, String format, String filePath, String downloadUrl) {
+		return new ExportResponse(true, threadId, format, filePath, downloadUrl, null);
+	}
+
+	public static ExportResponse error(String errorMessage) {
+		return new ExportResponse(false, null, null, null, null, errorMessage);
+	}
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/ReportResponse.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/response/ReportResponse.java
@@ -16,22 +16,40 @@
 
 package com.alibaba.cloud.ai.example.deepresearch.model.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * 报告响应类
  *
  * @author huangzhen
  * @since 2025/6/20
  */
-public class ReportResponse extends BaseResponse {
+public record ReportResponse(
+		/**
+		 * 线程ID，用于标识当前对话的唯一性
+		 */
+		@JsonProperty("thread_id") String threadId,
 
-	private String report;
+		/**
+		 * 状态
+		 */
+		@JsonProperty("status") String status,
 
-	public String getReport() {
-		return report;
+		/**
+		 * 消息
+		 */
+		@JsonProperty("message") String message,
+
+		/**
+		 * 报告内容
+		 */
+		@JsonProperty("report") String report) {
+
+	public static ReportResponse success(String threadId, String report) {
+		return new ReportResponse(threadId, "success", "Report retrieved successfully", report);
 	}
 
-	public void setReport(String report) {
-		this.report = report;
+	public static ReportResponse error(String threadId, String message) {
+		return new ReportResponse(threadId, "error", message, null);
 	}
-
 }

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ReporterNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ReporterNode.java
@@ -70,7 +70,6 @@ public class ReporterNode implements NodeAction {
 		String threadId = state.value("thread_id", String.class)
 			.orElseThrow(() -> new IllegalArgumentException("thread_id is missing from state"));
 		logger.info("Thread ID from state: {}", threadId);
-
 		// 1. 添加消息
 		List<Message> messages = new ArrayList<>();
 		// 1.1 添加预置提示消息
@@ -102,10 +101,10 @@ public class ReporterNode implements NodeAction {
 				String finalReport = Objects.requireNonNull(response.getResult().getOutput().getText());
 				try {
 					reportService.saveReport(threadId, finalReport);
-					logger.info("报告已成功保存，线程ID: {}", threadId);
+					logger.info("Report saved successfully, Thread ID: {}", threadId);
 				}
 				catch (Exception e) {
-					logger.error("保存报告失败，线程ID: {}", threadId, e);
+					logger.error("Failed to save report, Thread ID: {}", threadId, e);
 				}
 				return Map.of("final_report", finalReport, "thread_id", threadId);
 			})

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/service/ExportService.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/service/ExportService.java
@@ -1,0 +1,244 @@
+package com.alibaba.cloud.ai.example.deepresearch.service;
+
+import com.alibaba.cloud.ai.example.deepresearch.util.export.FileOperationUtil;
+import com.alibaba.cloud.ai.example.deepresearch.util.export.FormatConversionUtil;
+import com.openhtmltopdf.slf4j.Slf4jLogger;
+import com.openhtmltopdf.util.XRLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.core.io.Resource;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 报告导出服务，负责将报告转换为不同格式并保存到本地 支持Markdown和PDF格式，并提供文件下载功能
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+@Service
+public class ExportService {
+
+	private static final Logger logger = LoggerFactory.getLogger(ExportService.class);
+
+	private static final Set<String> SUPPORTED_FORMATS = Set.of("markdown", "md", "pdf");
+
+	private static final Pattern TITLE_PATTERN = Pattern.compile("^#\\s+(.+)$", Pattern.MULTILINE);
+
+	@Autowired
+	private ReportService reportService;
+
+	private final String basePath;
+
+	/**
+	 * 构造函数，初始化导出路径
+	 * @param basePath 导出基础路径
+	 */
+	public ExportService(String basePath) {
+		this.basePath = basePath;
+		XRLog.setLoggerImpl(new Slf4jLogger());
+		FileOperationUtil.createDirectoryIfNotExists(this.basePath);
+		logger.info("ExportService initialized with base path: {}", this.basePath);
+	}
+
+	/**
+	 * 将内容保存到文件
+	 * @param content 内容
+	 * @param filePath 文件路径
+	 * @return 保存的文件路径
+	 */
+	public String saveContentToFile(String content, String filePath) {
+		return FileOperationUtil.saveContentToFile(content, filePath);
+	}
+
+	/**
+	 * 将报告内容保存为Markdown格式
+	 * @param threadId 线程ID
+	 * @return 保存的文件路径，如果报告不存在则返回null
+	 */
+	public String saveAsMarkdown(String threadId) {
+		String content = reportService.getReport(threadId);
+		if (content == null) {
+			logger.warn("No report content found for thread: {}", threadId);
+			return null;
+		}
+
+		String filePath = getReportFilePath(threadId, "md");
+		return saveContentToFile(content, filePath);
+	}
+
+	/**
+	 * 将报告内容转换为PDF并保存
+	 * @param threadId 线程ID
+	 * @return 保存的PDF文件路径，如果报告不存在则返回null
+	 */
+	public String saveAsPdf(String threadId) {
+		String content = reportService.getReport(threadId);
+		if (content == null) {
+			logger.warn("No report content found for thread: {}", threadId);
+			return null;
+		}
+
+		String pdfFilePath = getReportFilePath(threadId, "pdf");
+		FormatConversionUtil.convertMarkdownToPdfFile(content, pdfFilePath);
+		return pdfFilePath;
+	}
+
+	/**
+	 * 获取指定格式报告的文件路径
+	 * @param threadId 线程ID
+	 * @param format 文件格式
+	 * @return 文件路径，如果格式不支持则返回null
+	 */
+	public String getReportFilePath(String threadId, String format) {
+		if (!isSupportedFormat(format)) {
+			return null;
+		}
+
+		String extension = "markdown".equals(format) || "md".equals(format) ? "md" : format;
+		String filename = FileOperationUtil.generateFilename(threadId, extension);
+		return basePath + File.separator + filename;
+	}
+
+	/**
+	 * 检查指定格式的报告文件是否存在
+	 * @param threadId 线程ID
+	 * @param format 文件格式
+	 * @return 文件是否存在
+	 */
+	public boolean reportFileExists(String threadId, String format) {
+		String filePath = getReportFilePath(threadId, format);
+		return FileOperationUtil.fileExists(filePath);
+	}
+
+	/**
+	 * 从Markdown内容中提取标题
+	 * @param content Markdown内容
+	 * @return 提取的标题，如果未找到则返回null
+	 */
+	public String extractTitleFromContent(String content) {
+		if (content == null || content.isEmpty()) {
+			return null;
+		}
+
+		Matcher matcher = TITLE_PATTERN.matcher(content);
+		if (matcher.find()) {
+			return matcher.group(1).trim();
+		}
+
+		return null;
+	}
+
+	/**
+	 * 直接下载报告文件
+	 * @param threadId 线程ID
+	 * @param format 文件格式
+	 * @return 文件下载响应
+	 * @throws IOException 如果文件不存在或不可读
+	 * @throws RuntimeException 如果报告不存在或格式不支持
+	 */
+	public ResponseEntity<Resource> downloadReport(String threadId, String format) throws IOException {
+		// 检查线程ID对应导出的报告是否存在
+		if (!existsReportByThreadId(threadId)) {
+			throw new RuntimeException("Report not found for thread: " + threadId);
+		}
+
+		// 获取文件路径
+		String filePath = getReportFilePath(threadId, format);
+		if (filePath == null) {
+			throw new RuntimeException("Unsupported format: " + format);
+		}
+
+		// 获取报告内容以提取标题
+		String content = reportService.getReport(threadId);
+		String title = extractTitleFromContent(content);
+
+		logger.debug("Extracted title: {}", title);
+
+		// 如果文件不存在，则生成文件
+		if (!FileOperationUtil.fileExists(filePath)) {
+			logger.info("File does not exist, generating: {}", filePath);
+
+			// 根据请求的格式导出文件
+			filePath = "markdown".equals(format) || "md".equals(format) ? saveAsMarkdown(threadId)
+					: saveAsPdf(threadId);
+
+			// 统一使用markdown作为键
+			if ("md".equals(format)) {
+				format = "markdown";
+			}
+
+			if (filePath == null) {
+				throw new RuntimeException("Failed to export report to format: " + format);
+			}
+		}
+		else {
+			logger.info("File already exists, using: {}", filePath);
+		}
+
+		// 准备文件下载显示名称
+		String extension = "markdown".equals(format) || "md".equals(format) ? "md" : format;
+		String displayFilename = null;
+
+		if (title != null && !title.isEmpty()) {
+			displayFilename = FileOperationUtil.generateFilenameFromTitle(title, extension);
+			logger.info("Using title for download filename: {}", displayFilename);
+		}
+
+		// 返回文件下载响应
+		MediaType mediaType = getMediaTypeForFormat(format);
+		return displayFilename != null ? FileOperationUtil.getFileDownload(filePath, mediaType, displayFilename)
+				: FileOperationUtil.getFileDownload(filePath, mediaType);
+	}
+
+	/**
+	 * 获取格式对应的媒体类型
+	 * @param format 文件格式
+	 * @return 对应的媒体类型
+	 */
+	private MediaType getMediaTypeForFormat(String format) {
+		return switch (format) {
+			case "markdown", "md" -> MediaType.TEXT_MARKDOWN;
+			case "pdf" -> MediaType.APPLICATION_PDF;
+			default -> MediaType.APPLICATION_OCTET_STREAM;
+		};
+	}
+
+	/**
+	 * 获取文件下载的ResponseEntity
+	 * @param filePath 文件路径
+	 * @param mediaType 媒体类型
+	 * @return 包含文件的ResponseEntity
+	 * @throws IOException 如果文件不存在或不可读
+	 */
+	public ResponseEntity<Resource> getFileDownload(String filePath, MediaType mediaType) throws IOException {
+		return FileOperationUtil.getFileDownload(filePath, mediaType);
+	}
+
+	/**
+	 * 检查线程ID对应的报告是否存在
+	 * @param threadId 线程ID
+	 * @return 是否存在
+	 */
+	public boolean existsReportByThreadId(String threadId) {
+		return reportService.existsReport(threadId);
+	}
+
+	/**
+	 * 检查格式是否支持
+	 * @param format 导出格式
+	 * @return 是否支持
+	 */
+	public boolean isSupportedFormat(String format) {
+		return SUPPORTED_FORMATS.contains(format);
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/service/ReportMemoryService.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/service/ReportMemoryService.java
@@ -50,11 +50,11 @@ public class ReportMemoryService implements ReportService {
 	public void saveReport(String threadId, String report) {
 		try {
 			reportStorage.put(threadId, report);
-			logger.info("报告已保存到内存，线程ID: {}", threadId);
+			logger.info("Report saved to memory, thread ID: {}", threadId);
 		}
 		catch (Exception e) {
-			logger.error("保存报告到内存失败，线程ID: {}", threadId, e);
-			throw new RuntimeException("保存报告失败", e);
+			logger.error("Failed to save report to memory, thread ID: {}", threadId, e);
+			throw new RuntimeException("Failed to save report", e);
 		}
 	}
 
@@ -68,17 +68,17 @@ public class ReportMemoryService implements ReportService {
 		try {
 			String report = reportStorage.get(threadId);
 			if (report != null) {
-				logger.info("从内存获取报告成功，线程ID: {}", threadId);
+				logger.info("Successfully retrieved report from memory, thread ID: {}", threadId);
 				return report;
 			}
 			else {
-				logger.warn("内存中未找到报告，线程ID: {}", threadId);
+				logger.warn("Report not found in memory, thread ID: {}", threadId);
 				return null;
 			}
 		}
 		catch (Exception e) {
-			logger.error("从内存获取报告失败，线程ID: {}", threadId, e);
-			throw new RuntimeException("获取报告失败", e);
+			logger.error("Failed to get report from memory, thread ID: {}", threadId, e);
+			throw new RuntimeException("Failed to get report", e);
 		}
 	}
 
@@ -91,11 +91,11 @@ public class ReportMemoryService implements ReportService {
 	public boolean existsReport(String threadId) {
 		try {
 			boolean exists = reportStorage.containsKey(threadId);
-			logger.debug("检查报告是否存在，线程ID: {}, 存在: {}", threadId, exists);
+			logger.debug("Checking if report exists, thread ID: {}, exists: {}", threadId, exists);
 			return exists;
 		}
 		catch (Exception e) {
-			logger.error("检查报告是否存在失败，线程ID: {}", threadId, e);
+			logger.error("Failed to check if report exists, thread ID: {}", threadId, e);
 			return false;
 		}
 	}
@@ -108,11 +108,11 @@ public class ReportMemoryService implements ReportService {
 	public void deleteReport(String threadId) {
 		try {
 			reportStorage.remove(threadId);
-			logger.info("已删除内存中的报告，线程ID: {}", threadId);
+			logger.info("Report deleted from memory, thread ID: {}", threadId);
 		}
 		catch (Exception e) {
-			logger.error("删除报告失败，线程ID: {}", threadId, e);
-			throw new RuntimeException("删除报告失败", e);
+			logger.error("Failed to delete report, thread ID: {}", threadId, e);
+			throw new RuntimeException("Failed to delete report", e);
 		}
 	}
 

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/service/ReportRedisService.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/service/ReportRedisService.java
@@ -62,11 +62,11 @@ public class ReportRedisService implements ReportService {
 		try {
 			String key = buildKey(threadId);
 			redisTemplate.opsForValue().set(key, report, DEFAULT_EXPIRE_HOURS, TimeUnit.HOURS);
-			logger.info("报告已保存到 Redis，线程ID: {}, key: {}", threadId, key);
+			logger.info("Report saved to Redis, thread ID: {}, key: {}", threadId, key);
 		}
 		catch (Exception e) {
-			logger.error("保存报告到 Redis 失败，线程ID: {}", threadId, e);
-			throw new RuntimeException("保存报告失败", e);
+			logger.error("Failed to save report to Redis, thread ID: {}", threadId, e);
+			throw new RuntimeException("Failed to save report", e);
 		}
 	}
 
@@ -81,17 +81,17 @@ public class ReportRedisService implements ReportService {
 			String key = buildKey(threadId);
 			Object result = redisTemplate.opsForValue().get(key);
 			if (result != null) {
-				logger.info("从 Redis 获取报告成功，线程ID: {}, key: {}", threadId, key);
+				logger.info("Successfully retrieved report from Redis, thread ID: {}, key: {}", threadId, key);
 				return result.toString();
 			}
 			else {
-				logger.warn("Redis 中未找到报告，线程ID: {}, key: {}", threadId, key);
+				logger.warn("Report not found in Redis, thread ID: {}, key: {}", threadId, key);
 				return null;
 			}
 		}
 		catch (Exception e) {
-			logger.error("从 Redis 获取报告失败，线程ID: {}", threadId, e);
-			throw new RuntimeException("获取报告失败", e);
+			logger.error("Failed to get report from Redis, thread ID: {}", threadId, e);
+			throw new RuntimeException("Failed to get report", e);
 		}
 	}
 
@@ -108,7 +108,7 @@ public class ReportRedisService implements ReportService {
 			return exists != null && exists;
 		}
 		catch (Exception e) {
-			logger.error("检查报告是否存在失败，线程ID: {}", threadId, e);
+			logger.error("Failed to check if report exists, thread ID: {}", threadId, e);
 			return false;
 		}
 	}
@@ -122,11 +122,11 @@ public class ReportRedisService implements ReportService {
 		try {
 			String key = buildKey(threadId);
 			redisTemplate.delete(key);
-			logger.info("已删除 Redis 中的报告，线程ID: {}, key: {}", threadId, key);
+			logger.info("Report deleted from Redis, thread ID: {}, key: {}", threadId, key);
 		}
 		catch (Exception e) {
-			logger.error("删除报告失败，线程ID: {}", threadId, e);
-			throw new RuntimeException("删除报告失败", e);
+			logger.error("Failed to delete report, thread ID: {}", threadId, e);
+			throw new RuntimeException("Failed to delete report", e);
 		}
 	}
 

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/AsyncExportUtil.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/AsyncExportUtil.java
@@ -1,0 +1,52 @@
+package com.alibaba.cloud.ai.example.deepresearch.util.export;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * 异步导出工具类，提供异步PDF转换功能
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+public class AsyncExportUtil {
+
+	private static final Logger logger = LoggerFactory.getLogger(AsyncExportUtil.class);
+
+	/**
+	 * 异步将内容转换为PDF
+	 * @param content 报告内容
+	 * @param title 报告标题
+	 * @param basePath 基础路径
+	 * @return CompletableFuture包含PDF文件路径
+	 */
+	public static CompletableFuture<String> saveAsPdfAsync(String content, String title, String basePath,
+			ThreadPoolTaskExecutor executor) {
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				String filename = FileOperationUtil.generateFilename(title, "pdf");
+				String pdfFilePath = basePath + File.separator + filename;
+
+				// 直接将Markdown转换为PDF
+				byte[] pdfBytes = FormatConversionUtil.convertMarkdownToPdfBytes(content);
+
+				// 保存到文件
+				try (java.io.FileOutputStream fos = new java.io.FileOutputStream(pdfFilePath)) {
+					fos.write(pdfBytes);
+				}
+
+				logger.info("Async PDF conversion completed: {}", pdfFilePath);
+				return pdfFilePath;
+			}
+			catch (Exception e) {
+				logger.error("Failed to convert to PDF asynchronously", e);
+				throw new RuntimeException("Failed to convert to PDF asynchronously", e);
+			}
+		}, executor);
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/FileOperationUtil.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/FileOperationUtil.java
@@ -1,0 +1,238 @@
+package com.alibaba.cloud.ai.example.deepresearch.util.export;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+/**
+ * 文件操作工具类，提供基础的文件读写功能
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+public final class FileOperationUtil {
+
+	private static final Logger logger = LoggerFactory.getLogger(FileOperationUtil.class);
+
+	private static final Pattern INVALID_FILENAME_CHARS = Pattern.compile("[^a-zA-Z0-9\\-_\\s]");
+
+	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+	private static final String DEFAULT_FILENAME = "report";
+
+	/**
+	 * 从文件读取内容
+	 * @param filePath 文件路径
+	 * @return 文件内容
+	 * @throws RuntimeException 如果文件读取失败
+	 */
+	public static String readFromFile(String filePath) {
+		try {
+			return Files.readString(Paths.get(filePath));
+		}
+		catch (IOException e) {
+			logger.error("Failed to read file: {}", filePath, e);
+			throw new RuntimeException("Failed to read file: " + filePath, e);
+		}
+	}
+
+	/**
+	 * 将内容保存到文件
+	 * @param content 内容
+	 * @param filePath 文件路径
+	 * @return 保存的文件路径
+	 * @throws RuntimeException 如果文件保存失败
+	 */
+	public static String saveContentToFile(String content, String filePath) {
+		try {
+			// 确保父目录存在
+			Path path = Paths.get(filePath);
+			createParentDirectories(path);
+
+			// 写入内容
+			Files.writeString(path, content);
+			logger.info("Content saved to file: {}", filePath);
+			return filePath;
+		}
+		catch (IOException e) {
+			logger.error("Failed to save content to file: {}", filePath, e);
+			throw new RuntimeException("Failed to save content to file: " + filePath, e);
+		}
+	}
+
+	/**
+	 * 创建父目录（如果不存在）
+	 * @param path 文件路径
+	 * @throws IOException 如果目录创建失败
+	 */
+	private static void createParentDirectories(Path path) throws IOException {
+		Path parent = path.getParent();
+		if (parent != null && !Files.exists(parent)) {
+			Files.createDirectories(parent);
+		}
+	}
+
+	/**
+	 * 创建目录（如果不存在）
+	 * @param directoryPath 目录路径
+	 * @throws IllegalArgumentException 如果目录路径为null
+	 * @throws RuntimeException 如果目录创建失败
+	 */
+	public static void createDirectoryIfNotExists(String directoryPath) {
+		if (directoryPath == null) {
+			logger.error("Directory path is null");
+			throw new IllegalArgumentException("Directory path cannot be null");
+		}
+
+		try {
+			Path path = Paths.get(directoryPath);
+			if (!Files.exists(path)) {
+				Files.createDirectories(path);
+				logger.info("Created directory: {}", directoryPath);
+			}
+		}
+		catch (IOException e) {
+			logger.error("Failed to create directory: {}", directoryPath, e);
+			throw new RuntimeException("Failed to create directory: " + directoryPath, e);
+		}
+	}
+
+	/**
+	 * 生成文件名，使用线程ID作为文件名
+	 * @param threadId 线程ID
+	 * @param extension 扩展名
+	 * @return 生成的文件名
+	 */
+	public static String generateFilename(String threadId, String extension) {
+		// 清理线程ID，移除不适合作为文件名的字符
+		String cleanThreadId = INVALID_FILENAME_CHARS.matcher(threadId).replaceAll("").trim();
+
+		cleanThreadId = WHITESPACE.matcher(cleanThreadId).replaceAll("_");
+
+		// 如果清理后线程ID为空，使用"report"作为默认名称
+		if (cleanThreadId.isEmpty()) {
+			cleanThreadId = DEFAULT_FILENAME;
+		}
+
+		return cleanThreadId + "." + extension;
+	}
+
+	/**
+	 * 生成文件名，使用自定义标题作为文件名
+	 * @param title 标题
+	 * @param extension 扩展名
+	 * @return 生成的文件名
+	 */
+	public static String generateFilenameFromTitle(String title, String extension) {
+		if (title == null || title.trim().isEmpty()) {
+			return DEFAULT_FILENAME + "." + extension;
+		}
+
+		String cleanTitle = title.replaceAll("[\\\\/:*?\"<>|]", "").trim();
+
+		cleanTitle = cleanTitle.replaceAll("\\s+", "_");
+
+		if (cleanTitle.isEmpty()) {
+			cleanTitle = DEFAULT_FILENAME;
+		}
+
+		if (cleanTitle.length() > 50) {
+			cleanTitle = cleanTitle.substring(0, 50);
+		}
+
+		return cleanTitle + "." + extension;
+	}
+
+	/**
+	 * 获取文件下载的ResponseEntity
+	 * @param filePath 文件路径
+	 * @param mediaType 媒体类型
+	 * @return 包含文件的ResponseEntity
+	 * @throws IOException 如果文件不存在或不可读
+	 * @throws RuntimeException 如果文件无法读取
+	 */
+	public static ResponseEntity<Resource> getFileDownload(String filePath, MediaType mediaType) throws IOException {
+		Path path = Paths.get(filePath);
+		Resource resource = new UrlResource(path.toUri());
+
+		if (resource.exists() && resource.isReadable()) {
+			return ResponseEntity.ok()
+				.contentType(mediaType)
+				.header(HttpHeaders.CONTENT_DISPOSITION,
+						"attachment; filename=\"" + path.getFileName().toString() + "\"")
+				.body(resource);
+		}
+		else {
+			throw new RuntimeException("Could not read file: " + filePath);
+		}
+	}
+
+	/**
+	 * 获取文件下载的ResponseEntity，使用自定义的显示文件名
+	 * @param filePath 文件路径
+	 * @param mediaType 媒体类型
+	 * @param displayFilename 显示的文件名
+	 * @return 包含文件的ResponseEntity
+	 * @throws IOException 如果文件不存在或不可读
+	 * @throws RuntimeException 如果文件无法读取
+	 */
+	public static ResponseEntity<Resource> getFileDownload(String filePath, MediaType mediaType, String displayFilename)
+			throws IOException {
+		Path path = Paths.get(filePath);
+		Resource resource = new UrlResource(path.toUri());
+
+		if (resource.exists() && resource.isReadable()) {
+			// 获取文件扩展名
+			String originalFilename = path.getFileName().toString();
+			String extension = originalFilename.contains(".")
+					? originalFilename.substring(originalFilename.lastIndexOf(".")) : "";
+
+			// 确保显示文件名有正确的扩展名
+			if (displayFilename == null || displayFilename.trim().isEmpty()) {
+				displayFilename = originalFilename;
+			}
+			else if (!displayFilename.contains(".") && !extension.isEmpty()) {
+				displayFilename = displayFilename + extension;
+			}
+
+			String encodedFilename;
+			try {
+				encodedFilename = java.net.URLEncoder.encode(displayFilename, StandardCharsets.UTF_8);
+				encodedFilename = encodedFilename.replace("+", "%20");
+			}
+			catch (Exception e) {
+				logger.warn("Failed to encode filename: {}, using fallback", displayFilename, e);
+				encodedFilename = displayFilename.replaceAll("[^\\p{ASCII}]", "_");
+			}
+
+			return ResponseEntity.ok()
+				.contentType(mediaType)
+				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedFilename)
+				.body(resource);
+		}
+		else {
+			throw new RuntimeException("Could not read file: " + filePath);
+		}
+	}
+
+	/**
+	 * 检查文件是否存在
+	 * @param filePath 文件路径
+	 * @return 文件是否存在
+	 */
+	public static boolean fileExists(String filePath) {
+		return filePath != null && Files.exists(Paths.get(filePath));
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/FormatConversionUtil.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/FormatConversionUtil.java
@@ -1,0 +1,169 @@
+package com.alibaba.cloud.ai.example.deepresearch.util.export;
+
+import com.openhtmltopdf.outputdevice.helper.BaseRendererBuilder;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.openhtmltopdf.swing.NaiveUserAgent.DefaultHttpStreamFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.net.URL;
+
+/**
+ * 格式转换工具类，提供Markdown到PDF的转换
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+public final class FormatConversionUtil {
+
+	private static final Logger logger = LoggerFactory.getLogger(FormatConversionUtil.class);
+
+	// HTTP连接超时设置（毫秒）
+	private static final int RESOURCE_HTTP_CONNECT_TIMEOUT = 1000;
+
+	private static final int RESOURCE_HTTP_READ_TIMEOUT = 1000;
+
+	// 字体路径
+	private static final String FONT_PATH = "report/fonts/AlibabaPuHuiTi-3-55-Regular.ttf";
+
+	private static final String FONT_FAMILY = "AlibabaPuHuiTi";
+
+	private static final int FONT_WEIGHT = 400; // Regular
+
+	/**
+	 * 将HTML内容转换为PDF字节数组
+	 * @param htmlContent HTML内容
+	 * @return PDF内容的字节数组
+	 * @throws RuntimeException 如果转换失败
+	 */
+	public static byte[] convertHtmlToPdfBytes(String htmlContent) {
+		try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+			PdfRendererBuilder builder = createPdfRendererBuilder();
+			configureFont(builder);
+			configureBaseUri(builder);
+
+			builder.withHtmlContent(htmlContent, getBaseUri());
+			builder.toStream(baos);
+			builder.run();
+
+			return baos.toByteArray();
+		}
+		catch (Exception e) {
+			logger.error("Failed to convert HTML to PDF", e);
+			throw new RuntimeException("Failed to convert HTML to PDF", e);
+		}
+	}
+
+	/**
+	 * 创建PDF渲染器构建器
+	 * @return 配置好的PdfRendererBuilder实例
+	 */
+	private static PdfRendererBuilder createPdfRendererBuilder() {
+		PdfRendererBuilder builder = new PdfRendererBuilder();
+		builder.useHttpStreamImplementation(
+				new DefaultHttpStreamFactory(RESOURCE_HTTP_CONNECT_TIMEOUT, RESOURCE_HTTP_READ_TIMEOUT));
+		builder.useFastMode();
+		return builder;
+	}
+
+	/**
+	 * 配置字体
+	 * @param builder PDF渲染器构建器
+	 */
+	private static void configureFont(PdfRendererBuilder builder) {
+		try {
+			Resource fontResource = new ClassPathResource(FONT_PATH);
+			if (fontResource.exists()) {
+				File fontFile = fontResource.getFile();
+				builder.useFont(fontFile, FONT_FAMILY, FONT_WEIGHT, BaseRendererBuilder.FontStyle.NORMAL, true // 嵌入PDF
+				);
+				logger.info("Font loaded from classpath for PDF conversion");
+			}
+			else {
+				logger.warn("AlibabaPuHuiTi font file not found in classpath, using default fonts");
+			}
+		}
+		catch (Exception e) {
+			logger.warn("Error loading font from classpath: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * 配置基础URI
+	 * @param builder PDF渲染器构建器
+	 */
+	private static void configureBaseUri(PdfRendererBuilder builder) {
+		String baseUri = getBaseUri();
+		if (baseUri != null) {
+			builder.withHtmlContent(null, baseUri);
+		}
+	}
+
+	/**
+	 * 获取基础URI
+	 * @return 基础URI，如果获取失败则返回null
+	 */
+	private static String getBaseUri() {
+		try {
+			URL resourceUrl = FormatConversionUtil.class.getClassLoader().getResource("");
+			if (resourceUrl != null) {
+				String baseUri = resourceUrl.toString();
+				logger.info("Using base URI for PDF conversion: {}", baseUri);
+				return baseUri;
+			}
+		}
+		catch (Exception e) {
+			logger.warn("Error getting classpath base URL: {}", e.getMessage());
+		}
+		return null;
+	}
+
+	/**
+	 * 将HTML内容转换为PDF并保存到文件
+	 * @param htmlContent HTML内容
+	 * @param pdfFilePath 输出PDF文件路径
+	 * @throws RuntimeException 如果保存失败
+	 */
+	public static void convertHtmlToPdfFile(String htmlContent, String pdfFilePath) {
+		try (OutputStream os = new FileOutputStream(pdfFilePath)) {
+			byte[] pdfBytes = convertHtmlToPdfBytes(htmlContent);
+			os.write(pdfBytes);
+			logger.info("HTML converted to PDF and saved to: {}", pdfFilePath);
+		}
+		catch (Exception e) {
+			logger.error("Failed to save PDF to file", e);
+			throw new RuntimeException("Failed to save PDF to file", e);
+		}
+	}
+
+	/**
+	 * 将Markdown内容直接转换为PDF字节数组
+	 * @param markdownContent Markdown内容
+	 * @return PDF内容的字节数组
+	 */
+	public static byte[] convertMarkdownToPdfBytes(String markdownContent) {
+		// 将Markdown转换为HTML
+		String htmlContent = HtmlGenerationUtil.markdownToHtml(markdownContent);
+		// 将HTML转换为PDF
+		return convertHtmlToPdfBytes(htmlContent);
+	}
+
+	/**
+	 * 将Markdown内容直接转换为PDF并保存到文件
+	 * @param markdownContent Markdown内容
+	 * @param pdfFilePath 输出PDF文件路径
+	 */
+	public static void convertMarkdownToPdfFile(String markdownContent, String pdfFilePath) {
+		// 将Markdown转换为HTML
+		String htmlContent = HtmlGenerationUtil.markdownToHtml(markdownContent);
+		// 将HTML转换为PDF并保存
+		convertHtmlToPdfFile(htmlContent, pdfFilePath);
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/HtmlGenerationUtil.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/util/export/HtmlGenerationUtil.java
@@ -1,0 +1,139 @@
+package com.alibaba.cloud.ai.example.deepresearch.util.export;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.List;
+
+/**
+ * HTML生成工具类，提供Markdown到HTML的转换功能
+ *
+ * @author sixiyida
+ * @since 2025/6/20
+ */
+public final class HtmlGenerationUtil {
+
+	private static final Logger logger = LoggerFactory.getLogger(HtmlGenerationUtil.class);
+
+	// 资源路径
+	private static final String FONT_PATH = "report/fonts/AlibabaPuHuiTi-3-55-Regular.ttf";
+
+	private static final String CSS_PATH = "report/css/github-markdown.css";
+
+	private static final String FONT_FAMILY = "AlibabaPuHuiTi";
+
+	// HTML模板部分
+	private static final String HTML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+			+ "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
+			+ "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" + "<head>\n"
+			+ "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"/>\n";
+
+	private static final String HTML_STYLE_START = "    <style type=\"text/css\">\n";
+
+	private static final String HTML_STYLE_END = "    </style>\n" + "</head>\n" + "<body class=\"markdown-body\">\n";
+
+	private static final String HTML_FOOTER = "\n</body>\n</html>";
+
+	private static final Parser markdownParser;
+
+	private static final HtmlRenderer htmlRenderer;
+
+	static {
+		List<Extension> extensions = List.of(TablesExtension.create());
+		markdownParser = Parser.builder().extensions(extensions).build();
+		htmlRenderer = HtmlRenderer.builder().extensions(extensions).build();
+	}
+
+	/**
+	 * 将Markdown内容转换为HTML
+	 * @param markdownContent Markdown内容
+	 * @return 转换后的HTML内容
+	 */
+	public static String convertMarkdownToHtml(String markdownContent) {
+		Node document = markdownParser.parse(markdownContent);
+		return htmlRenderer.render(document);
+	}
+
+	/**
+	 * 将HTML内容包装成完整的HTML文档
+	 * @param htmlContent HTML内容
+	 * @return 完整的HTML文档
+	 */
+	public static String wrapHtmlContent(String htmlContent) {
+		StringBuilder html = new StringBuilder(HTML_HEADER);
+
+		// 添加CSS链接 - 确保CSS始终被加载
+		String cssUrl = getResourceUrl(CSS_PATH);
+		if (cssUrl != null && !cssUrl.isEmpty()) {
+			html.append("    <link rel=\"stylesheet\" type=\"text/css\" href=\"").append(cssUrl).append("\"/>\n");
+		}
+		else {
+			logger.warn("External CSS file not found. Styling may be affected.");
+		}
+
+		// 添加样式
+		html.append(HTML_STYLE_START);
+
+		// 添加字体
+		String fontUrl = getResourceUrl(FONT_PATH);
+		if (fontUrl != null && !fontUrl.isEmpty()) {
+			html.append("        @font-face {\n")
+				.append("            font-family: '")
+				.append(FONT_FAMILY)
+				.append("';\n")
+				.append("            src: url('")
+				.append(fontUrl)
+				.append("') format('truetype');\n")
+				.append("            font-weight: 400;\n")
+				.append("            font-style: normal;\n")
+				.append("        }\n");
+		}
+
+		// 结束样式，添加HTML内容和页脚
+		html.append(HTML_STYLE_END).append(htmlContent).append(HTML_FOOTER);
+
+		String result = html.toString();
+		logger.debug("Generated HTML document with {} bytes", result.length());
+		return result;
+	}
+
+	/**
+	 * 获取资源URL
+	 * @param resourcePath 资源路径
+	 * @return 资源URL字符串，如果获取失败则返回null
+	 */
+	private static String getResourceUrl(String resourcePath) {
+		try {
+			URL resourceUrl = HtmlGenerationUtil.class.getClassLoader().getResource(resourcePath);
+			if (resourceUrl != null) {
+				String url = resourceUrl.toString();
+				logger.info("Resource URL for {}: {}", resourcePath, url);
+				return url;
+			}
+			else {
+				logger.warn("Resource not found in classpath: {}", resourcePath);
+			}
+		}
+		catch (Exception e) {
+			logger.error("Error getting resource URL for {}: {}", resourcePath, e.getMessage());
+		}
+		return null;
+	}
+
+	/**
+	 * 将Markdown内容转换为完整的HTML文档
+	 * @param markdownContent Markdown内容
+	 * @return 完整的HTML文档
+	 */
+	public static String markdownToHtml(String markdownContent) {
+		String htmlContent = convertMarkdownToHtml(markdownContent);
+		return wrapHtmlContent(htmlContent);
+	}
+
+}

--- a/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
+++ b/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
@@ -52,6 +52,9 @@ spring:
             # 启动时加载 classpath下data目录中的所有文件
             locations:
               - "classpath:/data/"
+        # 报告导出路径配置
+        export:
+          path: ${AI_DEEPRESEARCH_EXPORT_PATH}
 logging:
   level:
     com.alibaba.cloud.ai.example.deepresearch: debug

--- a/spring-ai-alibaba-deepresearch/src/main/resources/report/css/github-markdown.css
+++ b/spring-ai-alibaba-deepresearch/src/main/resources/report/css/github-markdown.css
@@ -1,0 +1,1033 @@
+/* light */
+.markdown-body {
+  margin: 0 auto;
+  color: #1f2328;
+  background-color: #ffffff;
+  font-family: "AlibabaPuHuiTi", sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+  max-width: 800px;
+  padding: 40px;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  vertical-align: text-bottom;
+}
+
+.markdown-body h1:hover .anchor .octicon-link:before,
+.markdown-body h2:hover .anchor .octicon-link:before,
+.markdown-body h3:hover .anchor .octicon-link:before,
+.markdown-body h4:hover .anchor .octicon-link:before,
+.markdown-body h5:hover .anchor .octicon-link:before,
+.markdown-body h6:hover .anchor .octicon-link:before {
+  width: 16px;
+  height: 16px;
+  content: ' ';
+  display: inline-block;
+  background-color: #1f2328;
+}
+
+.markdown-body details,
+.markdown-body figcaption,
+.markdown-body figure {
+  display: block;
+}
+
+.markdown-body summary {
+  display: list-item;
+}
+
+.markdown-body [hidden] {
+  display: none !important;
+}
+
+.markdown-body a {
+  background-color: transparent;
+  color: #0969da;
+  text-decoration: none;
+}
+
+.markdown-body abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+}
+
+.markdown-body b,
+.markdown-body strong {
+  font-weight: 600;
+}
+
+.markdown-body dfn {
+  font-style: italic;
+}
+
+.markdown-body h1 {
+  margin: .67em 0;
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 2em;
+  border-bottom: none;
+}
+
+.markdown-body mark {
+  background-color: #fff8c5;
+  color: #1f2328;
+}
+
+.markdown-body small {
+  font-size: 90%;
+}
+
+.markdown-body sub,
+.markdown-body sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.markdown-body sub {
+  bottom: -0.25em;
+}
+
+.markdown-body sup {
+  top: -0.5em;
+}
+
+.markdown-body img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.markdown-body code,
+.markdown-body kbd,
+.markdown-body pre,
+.markdown-body samp {
+  font-family: "AlibabaPuHuiTi", sans-serif;
+  font-size: 1em;
+}
+
+.markdown-body figure {
+  margin: 1em 2.5rem;
+}
+
+.markdown-body hr {
+  display: none !important;
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid #d1d9e0;
+  height: .25em;
+  padding: 0;
+  margin: 1.5rem 0;
+  background-color: #d1d9e0;
+  border: 0;
+}
+
+.markdown-body input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.markdown-body [type=button],
+.markdown-body [type=reset],
+.markdown-body [type=submit] {
+  /* 移除appearance属性 */
+}
+
+.markdown-body [type=checkbox],
+.markdown-body [type=radio] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body hr::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: table;
+  width: 90%;
+  max-width: 100%;
+  margin: 0 auto 16px auto;
+  table-layout: fixed;
+}
+
+.markdown-body table tr {
+  background-color: #ffffff;
+  border: 1px solid #d1d9e0;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}
+
+.markdown-body table tr:hover {
+  background-color: #f0f0f0;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 8px 13px;
+  border: 1px solid #d1d9e0;
+  text-align: center;
+  vertical-align: middle;
+  word-wrap: break-word;
+}
+
+.markdown-body table th {
+  font-weight: 600;
+  background-color: #f6f8fa;
+}
+
+.markdown-body table td>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table img {
+  background-color: transparent;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.markdown-body details summary {
+  cursor: pointer;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.25rem;
+  font: 11px "AlibabaPuHuiTi", sans-serif;
+  line-height: 10px;
+  color: #1f2328;
+  vertical-align: middle;
+  background-color: #f6f8fa;
+  border: solid 1px #d1d9e0;
+  border-bottom-color: #d1d9e0;
+  border-radius: 6px;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.markdown-body h2 {
+  font-weight: 600;
+  padding-bottom: .3em;
+  font-size: 1.5em;
+  border-bottom: none;
+}
+
+.markdown-body h3 {
+  font-weight: 600;
+  font-size: 1.25em;
+}
+
+.markdown-body h4 {
+  font-weight: 600;
+  font-size: 1em;
+}
+
+.markdown-body h5 {
+  font-weight: 600;
+  font-size: .875em;
+}
+
+.markdown-body h6 {
+  font-weight: 600;
+  font-size: .85em;
+  color: #59636e;
+}
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: #59636e;
+  border-left: .25em solid #d1d9e0;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body dd {
+  margin-left: 0;
+}
+
+.markdown-body tt,
+.markdown-body code,
+.markdown-body samp {
+  font-family: "AlibabaPuHuiTi", sans-serif;
+  font-size: 12px;
+}
+
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-family: "AlibabaPuHuiTi", sans-serif;
+  font-size: 12px;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+}
+
+.markdown-body .mr-2 {
+  margin-right: 0.5rem !important;
+}
+
+.markdown-body::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+/* 移除 a:not([href]) 选择器，改为通用的链接样式 */
+.markdown-body a.no-href {
+  color: inherit;
+  text-decoration: none;
+}
+
+.markdown-body .absent {
+  color: #d1242f;
+}
+
+.markdown-body .anchor {
+  float: left;
+  padding-right: 0.25rem;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.markdown-body .anchor:focus {
+  /* 移除outline属性 */
+}
+
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre,
+.markdown-body details {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.markdown-body blockquote>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body h1 .octicon-link,
+.markdown-body h2 .octicon-link,
+.markdown-body h3 .octicon-link,
+.markdown-body h4 .octicon-link,
+.markdown-body h5 .octicon-link,
+.markdown-body h6 .octicon-link {
+  color: #1f2328;
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+  text-decoration: none;
+}
+
+.markdown-body h1:hover .anchor .octicon-link,
+.markdown-body h2:hover .anchor .octicon-link,
+.markdown-body h3:hover .anchor .octicon-link,
+.markdown-body h4:hover .anchor .octicon-link,
+.markdown-body h5:hover .anchor .octicon-link,
+.markdown-body h6:hover .anchor .octicon-link {
+  visibility: visible;
+}
+
+.markdown-body h1 tt,
+.markdown-body h1 code,
+.markdown-body h2 tt,
+.markdown-body h2 code,
+.markdown-body h3 tt,
+.markdown-body h3 code,
+.markdown-body h4 tt,
+.markdown-body h4 code,
+.markdown-body h5 tt,
+.markdown-body h5 code,
+.markdown-body h6 tt,
+.markdown-body h6 code {
+  padding: 0 .2em;
+  font-size: inherit;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2,
+.markdown-body summary h3,
+.markdown-body summary h4,
+.markdown-body summary h5,
+.markdown-body summary h6 {
+  display: inline-block;
+}
+
+.markdown-body summary h1 .anchor,
+.markdown-body summary h2 .anchor,
+.markdown-body summary h3 .anchor,
+.markdown-body summary h4 .anchor,
+.markdown-body summary h5 .anchor,
+.markdown-body summary h6 .anchor {
+  margin-left: -40px;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2 {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.markdown-body ul.no-list,
+.markdown-body ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.markdown-body ol[type="a s"] {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type="A s"] {
+  list-style-type: upper-alpha;
+}
+
+.markdown-body ol[type="i s"] {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ol[type="I s"] {
+  list-style-type: upper-roman;
+}
+
+.markdown-body ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.markdown-body div>ol {
+  list-style-type: decimal;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body li>p {
+  margin-top: 1rem;
+}
+
+.markdown-body li+li {
+  margin-top: .25em;
+}
+
+.markdown-body dl {
+  padding: 0;
+}
+
+.markdown-body dl dt {
+  padding: 0;
+  margin-top: 1rem;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: 600;
+}
+
+.markdown-body dl dd {
+  padding: 0 1rem;
+  margin-bottom: 1rem;
+}
+
+.markdown-body table th {
+  font-weight: 600;
+  background-color: #f6f8fa;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid #d1d9e0;
+  text-align: center;
+}
+
+.markdown-body table td>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table tr {
+  background-color: #ffffff;
+  border-top: 1px solid #d1d9e0;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}
+
+.markdown-body table img {
+  background-color: transparent;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.markdown-body img[align=right] {
+  padding-left: 20px;
+}
+
+.markdown-body img[align=left] {
+  padding-right: 20px;
+}
+
+.markdown-body .emoji {
+  max-width: none;
+  vertical-align: text-top;
+  background-color: transparent;
+}
+
+.markdown-body span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.markdown-body span.frame>span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid #d1d9e0;
+}
+
+.markdown-body span.frame span img {
+  display: block;
+  float: left;
+}
+
+.markdown-body span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: #1f2328;
+}
+
+.markdown-body span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-center>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.markdown-body span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.markdown-body span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-right>span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.markdown-body span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-left span {
+  margin: 13px 0 0;
+}
+
+.markdown-body span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-right>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: normal;
+  background-color: #f6f8fa;
+  border-radius: 6px;
+  font-family: "AlibabaPuHuiTi", sans-serif;
+}
+
+.markdown-body code br,
+.markdown-body tt br {
+  display: none;
+}
+
+.markdown-body del code {
+  text-decoration: inherit;
+}
+
+.markdown-body samp {
+  font-size: 85%;
+}
+
+.markdown-body pre code {
+  font-size: 100%;
+}
+
+.markdown-body pre>code {
+  padding: 0;
+  margin: 0;
+  white-space: pre-wrap;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body .highlight {
+  margin-bottom: 1rem;
+}
+
+.markdown-body .highlight pre {
+  margin-bottom: 0;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+  padding: 1rem;
+  overflow: visible;
+  font-size: 85%;
+  line-height: 1.45;
+  color: #1f2328;
+  background-color: #f6f8fa;
+  border-radius: 6px;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.markdown-body pre code,
+.markdown-body pre tt {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border: 0;
+}
+
+.markdown-body .csv-data td,
+.markdown-body .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.markdown-body .csv-data .blob-num {
+  padding: 10px 0.5rem 9px;
+  text-align: right;
+  background: #ffffff;
+  border: 0;
+}
+
+.markdown-body .csv-data tr {
+  border-top: 0;
+}
+
+.markdown-body .csv-data th {
+  font-weight: 600;
+  background: #f6f8fa;
+  border-top: 0;
+}
+
+.markdown-body [data-footnote-ref]::before {
+  content: "[";
+}
+
+.markdown-body [data-footnote-ref]::after {
+  content: "]";
+}
+
+.markdown-body .footnotes {
+  font-size: 12px;
+  color: #59636e;
+  border-top: 1px solid #d1d9e0;
+}
+
+.markdown-body .footnotes ol {
+  padding-left: 1rem;
+}
+
+.markdown-body .footnotes ol ul {
+  display: inline-block;
+  padding-left: 1rem;
+  margin-top: 1rem;
+}
+
+.markdown-body .footnotes li {
+  position: relative;
+}
+
+.markdown-body .pl-c {
+  color: #59636e;
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-s .pl-v {
+  color: #0550ae;
+}
+
+.markdown-body .pl-e,
+.markdown-body .pl-en {
+  color: #6639ba;
+}
+
+.markdown-body .pl-smi,
+.markdown-body .pl-s .pl-s1 {
+  color: #1f2328;
+}
+
+.markdown-body .pl-ent {
+  color: #0550ae;
+}
+
+.markdown-body .pl-k {
+  color: #cf222e;
+}
+
+.markdown-body .pl-s,
+.markdown-body .pl-pds,
+.markdown-body .pl-s .pl-pse .pl-s1,
+.markdown-body .pl-sr,
+.markdown-body .pl-sr .pl-cce,
+.markdown-body .pl-sr .pl-sre,
+.markdown-body .pl-sr .pl-sra {
+  color: #0a3069;
+}
+
+.markdown-body .pl-v,
+.markdown-body .pl-smw {
+  color: #953800;
+}
+
+.markdown-body .pl-bu {
+  color: #82071e;
+}
+
+.markdown-body .pl-ii {
+  color: #f6f8fa;
+  background-color: #82071e;
+}
+
+.markdown-body .pl-c2 {
+  color: #f6f8fa;
+  background-color: #cf222e;
+}
+
+.markdown-body .pl-sr .pl-cce {
+  font-weight: bold;
+  color: #116329;
+}
+
+.markdown-body .pl-ml {
+  color: #3b2300;
+}
+
+.markdown-body .pl-mh,
+.markdown-body .pl-mh .pl-en,
+.markdown-body .pl-ms {
+  font-weight: bold;
+  color: #0550ae;
+}
+
+.markdown-body .pl-mi {
+  font-style: italic;
+  color: #1f2328;
+}
+
+.markdown-body .pl-mb {
+  font-weight: bold;
+  color: #1f2328;
+}
+
+.markdown-body .pl-md {
+  color: #82071e;
+  background-color: #ffebe9;
+}
+
+.markdown-body .pl-mi1 {
+  color: #116329;
+  background-color: #dafbe1;
+}
+
+.markdown-body .pl-mc {
+  color: #953800;
+  background-color: #ffd8b5;
+}
+
+.markdown-body .pl-mi2 {
+  color: #d1d9e0;
+  background-color: #0550ae;
+}
+
+.markdown-body .pl-mdr {
+  font-weight: bold;
+  color: #8250df;
+}
+
+.markdown-body .pl-ba {
+  color: #59636e;
+}
+
+.markdown-body .pl-sg {
+  color: #818b98;
+}
+
+.markdown-body .pl-corl {
+  text-decoration: underline;
+  color: #0a3069;
+}
+
+.markdown-body g-emoji {
+  display: inline-block;
+  font-family: "AlibabaPuHuiTi", sans-serif;
+  font-size: 1em;
+  font-style: normal !important;
+  font-weight: 400;
+  line-height: 1;
+  vertical-align: -0.075em;
+}
+
+.markdown-body g-emoji img {
+  width: 1em;
+  height: 1em;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+}
+
+.markdown-body .task-list-item label {
+  font-weight: 400;
+}
+
+.markdown-body .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.markdown-body .task-list-item+.task-list-item {
+  margin-top: 0.25rem;
+}
+
+.markdown-body .task-list-item .handle {
+  display: none;
+}
+
+.markdown-body .task-list-item-checkbox {
+  margin: 0 .2em .25em -1.4em;
+  vertical-align: middle;
+}
+
+.markdown-body .markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  color: inherit;
+  border-left: .25em solid #d1d9e0;
+}
+
+.markdown-body .markdown-alert>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: block;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note {
+  border-left-color: #0969da;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+  color: #0969da;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important {
+  border-left-color: #8250df;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+  color: #8250df;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning {
+  border-left-color: #9a6700;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+  color: #9a6700;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip {
+  border-left-color: #1a7f37;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+  color: #1a7f37;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution {
+  border-left-color: #cf222e;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+  color: #d1242f;
+}
+
+.markdown-body>*:first-child>.heading-element:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body .highlight pre {
+  min-height: 52px;
+}
+
+/* 确保表格在PDF中正确分页 */
+@media print {
+  .markdown-body {
+    padding: 15px;
+  }
+  
+  .markdown-body table {
+    page-break-inside: avoid;
+  }
+  
+  .markdown-body tr {
+    page-break-inside: avoid;
+  }
+  
+  .markdown-body td, 
+  .markdown-body th {
+    page-break-inside: avoid;
+  }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR enable basic report export and download service as format of .md or .pdf. 

### Does this pull request fix one issue?
None

### Describe how you did it
1. Add exportation controller/service/req/response.
2. Add file operation and format conversion utils classes for service.
3. Use CommonMark markdown analysis tool to convert markdown to html, using openhtmltopdf to generate pdf file.
4. provide basic css for pdf generation.

### Describe how to verify it
Just run.
**For review, below is pdf generated with table and img.**
![image](https://github.com/user-attachments/assets/a21e24d1-3eb1-4500-b556-2c42f888f6ad)
below is file download with correct title.
![image](https://github.com/user-attachments/assets/c6d7fd17-891a-4fa5-af29-77918ea70453)
### Special notes for reviews
None