### PR TITLE
feat(deepresearch): support users to choose one search engine in deepresearch

### DIFF
--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/pom.xml
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/pom.xml
@@ -14,9 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>com.alibaba.cloud.ai</groupId>
         <artifactId>spring-ai-alibaba</artifactId>
@@ -24,15 +23,19 @@
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>spring-ai-alibaba-starter-tool-calling-searches</artifactId>
-    <name>Spring AI Alibaba Starter Tool Calling Searches</name>
-    <description>Collect All Search Plugins in Tool Calling</description>
+    <artifactId>spring-ai-alibaba-starter-tool-calling-aliyunaisearch</artifactId>
+    <name>Spring AI Alibaba Starter Tool Calling Aliyun AI Search</name>
+    <description>Aliyun AI Search tool for Spring AI Alibaba</description>
     <url>https://github.com/alibaba/spring-ai-alibaba</url>
     <scm>
         <connection>git://github.com/alibaba/spring-ai-alibaba.git</connection>
         <developerConnection>git@github.com:alibaba/spring-ai-alibaba.git</developerConnection>
         <url>https://github.com/alibaba/spring-ai-alibaba</url>
     </scm>
+
+    <properties>
+        <jsoup-version>1.18.1</jsoup-version>
+    </properties>
 
     <dependencies>
 
@@ -44,38 +47,36 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <!--Search Plugins-->
-        <dependency>
-            <groupId>com.alibaba.cloud.ai</groupId>
-            <artifactId>spring-ai-alibaba-starter-tool-calling-tavilysearch</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.alibaba.cloud.ai</groupId>
-            <artifactId>spring-ai-alibaba-starter-tool-calling-baidusearch</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.alibaba.cloud.ai</groupId>
-            <artifactId>spring-ai-alibaba-starter-tool-calling-serpapi</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.alibaba.cloud.ai</groupId>
-            <artifactId>spring-ai-alibaba-starter-tool-calling-aliyunaisearch</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchAutoConfiguration.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchAutoConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.aliyunaisearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.JsonParseTool;
+import com.alibaba.cloud.ai.toolcalling.common.WebClientTool;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+
+@Configuration
+@EnableConfigurationProperties(AliyunAiSearchProperties.class)
+@ConditionalOnProperty(prefix = AliyunAiSearchConstants.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+public class AliyunAiSearchAutoConfiguration {
+
+	@Bean(name = AliyunAiSearchConstants.TOOL_NAME)
+	@ConditionalOnMissingBean
+	@Description("Aliyun AI Web Search Service")
+	public AliyunAiSearchService aliyunAiSearchService(JsonParseTool jsonParseTool,
+			AliyunAiSearchProperties properties) {
+		return new AliyunAiSearchService(
+				WebClientTool.builder(jsonParseTool, properties).httpHeadersConsumer(httpHeaders -> {
+					httpHeaders.add("Content-Type", "application/json");
+					httpHeaders.add("Authorization", "Bearer " + properties.getApiKey());
+				}).build(), jsonParseTool, properties);
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchConstants.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.aliyunaisearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallConstants;
+
+public class AliyunAiSearchConstants {
+
+	public static final String CONFIG_PREFIX = CommonToolCallConstants.TOOL_CALLING_CONFIG_PREFIX + ".aliyunaisearch";
+
+	public static final String BASE_URL_ENV = "ALIYUN_AI_SEARCH_BASE_URL";
+
+	public static final String API_KEY_ENV = "ALIYUN_AI_SEARCH_API_KEY";
+
+	public static final String TOOL_NAME = "aliyunAiSearch";
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchProperties.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchProperties.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.aliyunaisearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * Docs:
+ * https://help.aliyun.com/zh/open-search/search-platform/developer-reference/web-search?spm=opensearchspma.rag-server-market-detail.0.0.268e6857xmmLNT
+ * base-url and api-key is required
+ *
+ * @author vlsmb
+ */
+@ConfigurationProperties(prefix = AliyunAiSearchConstants.CONFIG_PREFIX)
+public class AliyunAiSearchProperties extends CommonToolCallProperties {
+
+	public AliyunAiSearchProperties() {
+		super("");
+		this.setPropertiesFromEnv(AliyunAiSearchConstants.API_KEY_ENV, null, null, null);
+		if (!StringUtils.hasText(this.getBaseUrl())) {
+			this.setBaseUrl(System.getenv(AliyunAiSearchConstants.BASE_URL_ENV));
+		}
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.aliyunaisearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallUtils;
+import com.alibaba.cloud.ai.toolcalling.common.JsonParseTool;
+import com.alibaba.cloud.ai.toolcalling.common.WebClientTool;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Aliyun AI Web Search
+ * https://opensearch.console.aliyun.com/cn-shanghai/rag/server-market/detail?serverType=web-search
+ *
+ * @author vlsmb
+ */
+public class AliyunAiSearchService
+		implements SearchService, Function<AliyunAiSearchService.Request, AliyunAiSearchService.Response> {
+
+	private static final Logger log = LoggerFactory.getLogger(AliyunAiSearchService.class);
+
+	private final WebClientTool webClientTool;
+
+	private final JsonParseTool jsonParseTool;
+
+	private final AliyunAiSearchProperties properties;
+
+	public AliyunAiSearchService(WebClientTool webClientTool, JsonParseTool jsonParseTool,
+			AliyunAiSearchProperties properties) {
+		this.webClientTool = webClientTool;
+		this.jsonParseTool = jsonParseTool;
+		this.properties = properties;
+	}
+
+	@Override
+	public SearchService.Response query(String query) {
+		return this.apply(Request.simplyQuery(query));
+	}
+
+	@Override
+	public Response apply(Request request) {
+		if (!CommonToolCallUtils.isValidUrl(properties.getBaseUrl())) {
+			throw new RuntimeException("Service Base Url is Invalid.");
+		}
+		if (!StringUtils.hasText(properties.getApiKey())) {
+			throw new RuntimeException("Service Api Key is Invalid.");
+		}
+		try {
+			String responseStr = webClientTool.post("/", request).block();
+			log.debug("Response: {}", responseStr);
+			return jsonParseTool.getFieldValue(responseStr, new TypeReference<Response>() {
+			}, "result");
+		}
+		catch (Exception e) {
+			log.error("Service AliyunAiSearch Request Error: ", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	@JsonClassDescription("Aliyun AI Web Search Request. If you're unsure what to enter, fill in the default value.")
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Request(
+			@JsonProperty(required = true, value = "query") @JsonPropertyDescription("Search query") String query,
+			@JsonProperty(value = "way",
+					defaultValue = "fast") @JsonPropertyDescription("Search result filtering modes: `normal` (applies vector-based filtering to results), `fast` (performs no vector-based filtering on results), `full` (uses large models to conduct evaluation and filtering of results).") String way,
+			@JsonProperty(value = "query_rewrite",
+					defaultValue = "true") @JsonPropertyDescription("Whether to enable LLM-based query rewriting. (Default value: `true`)") Boolean isRewrite,
+			@JsonProperty(value = "top_k",
+					defaultValue = "5") @JsonPropertyDescription("The number of search results returned. Default: 5") Integer topK,
+			@JsonProperty(value = "history",
+					defaultValue = "null") @JsonPropertyDescription("The conversation history between user and model uses a list of {\"role\": role, \"content\": content} elements, where role accepts `system`, `user`, or `assistant`; the optional system role can only appear as the first message (messages[0]) if present, while user and assistant roles must strictly alternate throughout the dialogue to simulate real conversation flow.") List<History> history,
+			@JsonProperty(value = "content_type",
+					defaultValue = "snippet") @JsonPropertyDescription("Search result content types: `snippet` (a brief description of webpage content) and `summary` (a text summary of webpage content, which takes longer to generate than a snippet).") String contentType)
+			implements
+				SearchService.Request {
+
+		@Override
+		public String getQuery() {
+			return this.query();
+		}
+
+		public record History(
+				@JsonProperty(value = "role",
+						defaultValue = "system") @JsonPropertyDescription("Role: system, user, assistant") String role,
+				@JsonProperty(value = "content") @JsonPropertyDescription("content") String content) {
+
+		}
+
+		public static Request simplyQuery(String query) {
+			return new Request(query, "fast", true, 5, null, "snippet");
+		}
+	}
+
+	@JsonClassDescription("Aliyun AI Web Search Response")
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Response(
+			@JsonProperty("search_result") List<SearchResult> results) implements SearchService.Response {
+
+		@Override
+		public SearchService.SearchResult getSearchResult() {
+			return new SearchService.SearchResult(this.results()
+				.stream()
+				.map(item -> new SearchService.SearchContent(item.title(), item.content(), item.link()))
+				.toList());
+		}
+
+		public record SearchResult(String title, String link, String snippet, String content, Integer position) {
+
+		}
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.alibaba.cloud.ai.toolcalling.aliyunaisearch.AliyunAiSearchAutoConfiguration

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/test/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchTest.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch/src/test/java/com/alibaba/cloud/ai/toolcalling/aliyunaisearch/AliyunAiSearchTest.java
@@ -1,0 +1,51 @@
+package com.alibaba.cloud.ai.toolcalling.aliyunaisearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallAutoConfiguration;
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallConstants;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.logging.Logger;
+
+@SpringBootTest(classes = { CommonToolCallAutoConfiguration.class, AliyunAiSearchAutoConfiguration.class })
+@DisplayName("Aliyun AI Search Test")
+public class AliyunAiSearchTest {
+
+	@Autowired
+	private AliyunAiSearchService aliyunAiSearchService;
+
+	private static final Logger log = Logger.getLogger(AliyunAiSearchTest.class.getName());
+
+	@Test
+	@DisplayName("Tool-Calling Test")
+	@EnabledIfEnvironmentVariable(named = AliyunAiSearchConstants.API_KEY_ENV,
+			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
+	@EnabledIfEnvironmentVariable(named = AliyunAiSearchConstants.BASE_URL_ENV,
+			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
+	public void testAliyunAiSearch() {
+		var resp = aliyunAiSearchService.apply(AliyunAiSearchService.Request.simplyQuery("Spring AI Alibaba"));
+		assert resp != null && resp.results() != null;
+		log.info("results: " + resp.results());
+	}
+
+	@Autowired
+	private SearchService searchService;
+
+	@Test
+	@DisplayName("Abstract Search Service Test")
+	@EnabledIfEnvironmentVariable(named = AliyunAiSearchConstants.API_KEY_ENV,
+			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
+	@EnabledIfEnvironmentVariable(named = AliyunAiSearchConstants.BASE_URL_ENV,
+			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
+	public void testAbstractSearch() {
+		var resp = searchService.query("Spring AI Alibaba");
+		assert resp != null && resp.getSearchResult() != null && resp.getSearchResult().results() != null
+				&& !resp.getSearchResult().results().isEmpty();
+		log.info("results: " + resp.getSearchResult());
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchService.java
@@ -187,7 +187,7 @@ public class BaiduSearchService
 		public SearchService.SearchResult getSearchResult() {
 			return new SearchService.SearchResult(this.results()
 				.stream()
-				.map(item -> new SearchService.SearchContent(item.title(), item.abstractText))
+				.map(item -> new SearchService.SearchContent(item.title(), item.abstractText(), item.sourceUrl()))
 				.toList());
 		}
 	}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/main/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchService.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallUtils;
 import com.alibaba.cloud.ai.toolcalling.common.JsonParseTool;
 import com.alibaba.cloud.ai.toolcalling.common.WebClientTool;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,7 +40,8 @@ import org.springframework.util.CollectionUtils;
 /**
  * @author KrakenZJC
  **/
-public class BaiduSearchService implements Function<BaiduSearchService.Request, BaiduSearchService.Response> {
+public class BaiduSearchService
+		implements SearchService, Function<BaiduSearchService.Request, BaiduSearchService.Response> {
 
 	private static final Logger logger = LoggerFactory.getLogger(BaiduSearchService.class);
 
@@ -51,6 +53,11 @@ public class BaiduSearchService implements Function<BaiduSearchService.Request, 
 			WebClientTool webClientTool) {
 		this.webClientTool = webClientTool;
 		this.properties = properties;
+	}
+
+	@Override
+	public SearchService.Response query(String query) {
+		return this.apply(new Request(query, null));
 	}
 
 	@Override
@@ -162,16 +169,27 @@ public class BaiduSearchService implements Function<BaiduSearchService.Request, 
 	public record Request(
 			@JsonProperty(required = true, value = "query") @JsonPropertyDescription("The search query") String query,
 			@JsonProperty(required = false,
-					value = "limit") @JsonPropertyDescription("Maximum number of results to return") Integer limit) {
-
+					value = "limit") @JsonPropertyDescription("Maximum number of results to return") Integer limit)
+			implements
+				SearchService.Request {
+		@Override
+		public String getQuery() {
+			return this.query();
+		}
 	}
 
 	/**
 	 * Baidu search Function response.
 	 */
 	@JsonClassDescription("Baidu search API response")
-	public record Response(List<SearchResult> results) {
-
+	public record Response(List<SearchResult> results) implements SearchService.Response {
+		@Override
+		public SearchService.SearchResult getSearchResult() {
+			return new SearchService.SearchResult(this.results()
+				.stream()
+				.map(item -> new SearchService.SearchContent(item.title(), item.abstractText))
+				.toList());
+		}
 	}
 
 	public record SearchResult(String title, String abstractText, String sourceUrl) {

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/test/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchTest.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/test/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchTest.java
@@ -48,7 +48,8 @@ public class BaiduSearchTest {
 	@DisplayName("Abstract Search Service Test")
 	public void testAbstractSearch() {
 		var resp = searchService.query("Spring AI Alibaba");
-		assert resp != null && resp.getSearchResult() != null;
+		assert resp != null && resp.getSearchResult() != null && resp.getSearchResult().results() != null
+				&& !resp.getSearchResult().results().isEmpty();
 		log.info("results: " + resp.getSearchResult());
 	}
 

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/test/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchTest.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch/src/test/java/com/alibaba/cloud/ai/toolcalling/baidusearch/BaiduSearchTest.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.toolcalling.baidusearch;
 
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallAutoConfiguration;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,9 +36,20 @@ public class BaiduSearchTest {
 	@Test
 	@DisplayName("Tool-Calling Test")
 	public void testBaiduSearch() {
-		var resp = baiduSearchService.apply(new BaiduSearchService.Request("Spring AI Alibab", 10));
+		var resp = baiduSearchService.apply(new BaiduSearchService.Request("Spring AI Alibaba", 10));
 		assert resp != null && resp.results() != null;
 		log.info("results: " + resp.results());
+	}
+
+	@Autowired
+	private SearchService searchService;
+
+	@Test
+	@DisplayName("Abstract Search Service Test")
+	public void testAbstractSearch() {
+		var resp = searchService.query("Spring AI Alibaba");
+		assert resp != null && resp.getSearchResult() != null;
+		log.info("results: " + resp.getSearchResult());
 	}
 
 }

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/pom.xml
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>spring-ai-alibaba-starter-tool-calling-bravesearch</artifactId>
     <name>Spring AI Alibaba Starter Tool Calling Brave Search</name>
-    <description>Baidu search tool for Spring AI Alibaba</description>
+    <description>Brave search tool for Spring AI Alibaba</description>
     <url>https://github.com/alibaba/spring-ai-alibaba</url>
     <scm>
         <connection>git://github.com/alibaba/spring-ai-alibaba.git</connection>

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/pom.xml
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-ai-alibaba-starter-tool-calling-bravesearch</artifactId>
+    <name>Spring AI Alibaba Starter Tool Calling Brave Search</name>
+    <description>Baidu search tool for Spring AI Alibaba</description>
+    <url>https://github.com/alibaba/spring-ai-alibaba</url>
+    <scm>
+        <connection>git://github.com/alibaba/spring-ai-alibaba.git</connection>
+        <developerConnection>git@github.com:alibaba/spring-ai-alibaba.git</developerConnection>
+        <url>https://github.com/alibaba/spring-ai-alibaba</url>
+    </scm>
+
+    <properties>
+        <jsoup-version>1.18.1</jsoup-version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-starter-tool-calling-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup-version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchAutoConfiguration.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchAutoConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.bravesearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallConstants;
+import com.alibaba.cloud.ai.toolcalling.common.JsonParseTool;
+import com.alibaba.cloud.ai.toolcalling.common.WebClientTool;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+import org.springframework.http.HttpHeaders;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+
+/**
+ * @author vlsmb
+ */
+@Configuration
+@EnableConfigurationProperties(BraveSearchProperties.class)
+@ConditionalOnProperty(prefix = BraveSearchConstants.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+public class BraveSearchAutoConfiguration {
+
+	@Bean(name = BraveSearchConstants.TOOL_NAME)
+	@ConditionalOnMissingBean
+	@Description("Use brave search engine to query.")
+	public BraveSearchService braveSearch(BraveSearchProperties properties, JsonParseTool jsonParseTool) {
+		Consumer<HttpHeaders> consumer = headers -> {
+			headers.add(HttpHeaders.USER_AGENT, CommonToolCallConstants.DEFAULT_USER_AGENTS[ThreadLocalRandom.current()
+				.nextInt(CommonToolCallConstants.DEFAULT_USER_AGENTS.length)]);
+			headers.add(HttpHeaders.CONNECTION, "keep-alive");
+			headers.add(HttpHeaders.ACCEPT, "application/json");
+			headers.add("X-Subscription-Token", properties.getApiKey());
+		};
+		return new BraveSearchService(
+				WebClientTool.builder(jsonParseTool, properties).httpHeadersConsumer(consumer).build(), jsonParseTool);
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchConstants.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.bravesearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallConstants;
+
+public class BraveSearchConstants {
+
+	public static final String CONFIG_PREFIX = CommonToolCallConstants.TOOL_CALLING_CONFIG_PREFIX + ".bravesearch";
+
+	public static final String TOOL_NAME = "braveSearch";
+
+	public static final String API_KEY_ENV = "BRAVE_SEARCH_API_KEY";
+
+	public static final String BASE_URL = "https://api.search.brave.com/res/v1/web/search";
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchProperties.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.bravesearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author vlsmb
+ */
+@ConfigurationProperties(prefix = BraveSearchConstants.CONFIG_PREFIX)
+public class BraveSearchProperties extends CommonToolCallProperties {
+
+	public BraveSearchProperties() {
+		super(BraveSearchConstants.BASE_URL);
+		this.setPropertiesFromEnv(BraveSearchConstants.API_KEY_ENV, null, null, null);
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchService.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.bravesearch;
+
+import com.alibaba.cloud.ai.toolcalling.common.JsonParseTool;
+import com.alibaba.cloud.ai.toolcalling.common.WebClientTool;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.MultiValueMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Document:
+ * https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
+ *
+ * @author vlsmb
+ */
+public class BraveSearchService
+		implements SearchService, Function<BraveSearchService.Request, BraveSearchService.Response> {
+
+	private static final Logger log = LoggerFactory.getLogger(BraveSearchService.class);
+
+	private final WebClientTool webClientTool;
+
+	private final JsonParseTool jsonParseTool;
+
+	public BraveSearchService(WebClientTool webClientTool, JsonParseTool jsonParseTool) {
+		this.webClientTool = webClientTool;
+		this.jsonParseTool = jsonParseTool;
+	}
+
+	@Override
+	public SearchService.Response query(String query) {
+		return this.apply(new BraveSearchService.Request(query));
+	}
+
+	@Override
+	public Response apply(Request request) {
+		try {
+			String responseStr = webClientTool.get("/", MultiValueMap.fromSingleValue(Map.of("q", request.query())))
+				.block();
+			return jsonParseTool.jsonToObject(responseStr, new TypeReference<BraveSearchService.Response>() {
+			});
+		}
+		catch (Exception e) {
+			log.error("BraveSearchService apply exception: ", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Request Object. Currently, only the most basic queries are implemented
+	 */
+	@JsonClassDescription("Brave Search API request")
+	public record Request(
+			@JsonProperty(required = true, value = "query") @JsonPropertyDescription("The search query") String query)
+			implements
+				SearchService.Request {
+		@Override
+		public String getQuery() {
+			return this.query();
+		}
+	}
+
+	/**
+	 * Response Object. Currently, only the most basic queries are implemented
+	 */
+	@JsonClassDescription("Brave Search API response")
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Response(@JsonProperty("type") String type,
+			@JsonProperty("web") @JsonPropertyDescription("Web search results relevant to the query.") Response.Search web)
+			implements
+				SearchService.Response {
+
+		@Override
+		public SearchService.SearchResult getSearchResult() {
+			return new SearchService.SearchResult(this.web()
+				.results()
+				.stream()
+				.map(item -> new SearchService.SearchContent(item.title(), item.description(), item.url()))
+				.toList());
+		}
+
+		public record SearchResult(@JsonProperty("title") String title, @JsonProperty("url") String url,
+				@JsonProperty("description") String description) {
+
+		}
+
+		public record Search(@JsonProperty("type") String type,
+				@JsonProperty("results") List<Response.SearchResult> results) {
+
+		}
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.alibaba.cloud.ai.toolcalling.bravesearch.BraveSearchAutoConfiguration

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/test/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchTest.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch/src/test/java/com/alibaba/cloud/ai/toolcalling/bravesearch/BraveSearchTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.cloud.ai.toolcalling.serpapi;
+package com.alibaba.cloud.ai.toolcalling.bravesearch;
 
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallAutoConfiguration;
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallConstants;
@@ -26,31 +26,31 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.logging.Logger;
 
-@SpringBootTest(classes = { CommonToolCallAutoConfiguration.class, SerpApiAutoConfiguration.class })
-@DisplayName("SerpApi Test")
-public class SerpApiServiceTest {
+@SpringBootTest(classes = { BraveSearchAutoConfiguration.class, CommonToolCallAutoConfiguration.class })
+@DisplayName("Brave Search Test")
+public class BraveSearchTest {
 
 	@Autowired
-	private SerpApiService serpApiSearch;
+	private BraveSearchService braveSearchService;
 
-	private static final Logger log = Logger.getLogger(SerpApiServiceTest.class.getName());
+	private static final Logger log = Logger.getLogger(BraveSearchTest.class.getName());
 
 	@Test
 	@DisplayName("Tool-Calling Test")
-	@EnabledIfEnvironmentVariable(named = SerpApiConstants.API_KEY_ENV,
+	@EnabledIfEnvironmentVariable(named = BraveSearchConstants.API_KEY_ENV,
 			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
-	public void testSerpApiApply() {
-		var resp = serpApiSearch.apply(new SerpApiService.Request("Spring AI Alibaba"));
-		assert resp != null && resp.results() != null;
-		log.info("results: " + resp.results());
+	public void testBraveSearch() {
+		var resp = braveSearchService.apply(new BraveSearchService.Request("Spring AI Alibaba"));
+		assert resp != null && resp.web() != null && resp.web().results() != null && !resp.web().results().isEmpty();
+		log.info("results: " + resp.web().results());
 	}
 
 	@Autowired
 	private SearchService searchService;
 
 	@Test
-	@DisplayName("Abstract Search Test")
-	@EnabledIfEnvironmentVariable(named = SerpApiConstants.API_KEY_ENV,
+	@DisplayName("Abstract Search Service Test")
+	@EnabledIfEnvironmentVariable(named = BraveSearchConstants.API_KEY_ENV,
 			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
 	public void testAbstractSearch() {
 		var resp = searchService.query("Spring AI Alibaba");

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-common/src/main/java/com/alibaba/cloud/ai/toolcalling/common/CommonToolCallUtils.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-common/src/main/java/com/alibaba/cloud/ai/toolcalling/common/CommonToolCallUtils.java
@@ -128,7 +128,9 @@ public final class CommonToolCallUtils {
 	 * @author <a href="mailto:yuluo08290126@gmail.com">yuluo</a>
 	 */
 	public static boolean isValidUrl(String target) {
-
+		if (!StringUtils.hasText(target)) {
+			return false;
+		}
 		return pattern.matcher(target).matches();
 	}
 

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-common/src/main/java/com/alibaba/cloud/ai/toolcalling/common/interfaces/SearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-common/src/main/java/com/alibaba/cloud/ai/toolcalling/common/interfaces/SearchService.java
@@ -57,7 +57,7 @@ public interface SearchService {
 
 	}
 
-	record SearchContent(String title, String content) {
+	record SearchContent(String title, String content, String url) {
 
 	}
 

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-common/src/main/java/com/alibaba/cloud/ai/toolcalling/common/interfaces/SearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-common/src/main/java/com/alibaba/cloud/ai/toolcalling/common/interfaces/SearchService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.common.interfaces;
+
+import java.util.List;
+
+/**
+ * Define an abstract SearchService interface that must be implemented by all search
+ * plugins to provide basic query capabilities. Additionally, each plugin must fully
+ * implement the Function interface to support its unique search functionality. Typically,
+ * users can directly import a specific search plugin's starter for standard use. However,
+ * when dynamic switching between multiple search plugins is required, this abstract
+ * interface serves as the unified invocation point.
+ *
+ * @author vlsmb
+ */
+public interface SearchService {
+
+	/**
+	 * Each search plugin's implementation class must implement the core simple query
+	 * functionality in the method.
+	 */
+	Response query(String query);
+
+	/**
+	 * Each plugin's Request class must implement this interface.
+	 */
+	interface Request {
+
+		String getQuery();
+
+	}
+
+	/**
+	 * Each plugin's Response class must implement this interface.
+	 */
+	interface Response {
+
+		SearchResult getSearchResult();
+
+	}
+
+	record SearchResult(List<SearchContent> results) {
+
+	}
+
+	record SearchContent(String title, String content) {
+
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/pom.xml
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/pom.xml
@@ -26,6 +26,7 @@
 
     <artifactId>spring-ai-alibaba-starter-tool-calling-searches</artifactId>
     <name>Spring AI Alibaba Starter Tool Calling Searches</name>
+    <description>Collect All Search Plugins in Tool Calling</description>
     <url>https://github.com/alibaba/spring-ai-alibaba</url>
     <scm>
         <connection>git://github.com/alibaba/spring-ai-alibaba.git</connection>

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/pom.xml
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.alibaba.cloud.ai</groupId>
+        <artifactId>spring-ai-alibaba</artifactId>
+        <version>${revision}</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-ai-alibaba-starter-tool-calling-searches</artifactId>
+    <name>Spring AI Alibaba Starter Tool Calling Searches</name>
+    <url>https://github.com/alibaba/spring-ai-alibaba</url>
+    <scm>
+        <connection>git://github.com/alibaba/spring-ai-alibaba.git</connection>
+        <developerConnection>git@github.com:alibaba/spring-ai-alibaba.git</developerConnection>
+        <url>https://github.com/alibaba/spring-ai-alibaba</url>
+    </scm>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-starter-tool-calling-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--Search Plugins-->
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-starter-tool-calling-tavilysearch</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-starter-tool-calling-baidusearch</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-starter-tool-calling-serpapi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/src/main/java/com/alibaba/cloud/ai/toolcalling/searches/SearchEnum.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/src/main/java/com/alibaba/cloud/ai/toolcalling/searches/SearchEnum.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.searches;
+
+import com.alibaba.cloud.ai.toolcalling.baidusearch.BaiduSearchConstants;
+import com.alibaba.cloud.ai.toolcalling.serpapi.SerpApiConstants;
+import com.alibaba.cloud.ai.toolcalling.tavily.TavilySearchConstants;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * List available services
+ *
+ * @author vlsmb
+ */
+public enum SearchEnum {
+
+	TAVILY("tavily", TavilySearchConstants.TOOL_NAME), BAIDU("baidu", BaiduSearchConstants.TOOL_NAME),
+	SERPAPI("serpapi", SerpApiConstants.TOOL_NAME);
+
+	private final String name;
+
+	private final String toolName;
+
+	SearchEnum(String name, String toolName) {
+		this.name = name;
+		this.toolName = toolName;
+	}
+
+	@JsonValue
+	public String getName() {
+		return name;
+	}
+
+	public String getToolName() {
+		return toolName;
+	}
+
+	@Override
+	public String toString() {
+		return "SearchEnum{" + "name='" + name + '\'' + ", toolName='" + toolName + '\'' + '}';
+	}
+
+	@JsonCreator
+	public static SearchEnum fromName(String name) {
+		for (SearchEnum searchEnum : SearchEnum.values()) {
+			if (searchEnum.getName().equalsIgnoreCase(name)) {
+				return searchEnum;
+			}
+		}
+		throw new IllegalArgumentException("Invalid Search name: " + name);
+	}
+
+	public static SearchEnum fromToolName(String toolName) {
+		for (SearchEnum searchEnum : SearchEnum.values()) {
+			if (searchEnum.getToolName().equals(toolName)) {
+				return searchEnum;
+			}
+		}
+		throw new IllegalArgumentException("Invalid Search tool name: " + toolName);
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/src/main/java/com/alibaba/cloud/ai/toolcalling/searches/SearchEnum.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/src/main/java/com/alibaba/cloud/ai/toolcalling/searches/SearchEnum.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.toolcalling.searches;
 
+import com.alibaba.cloud.ai.toolcalling.aliyunaisearch.AliyunAiSearchConstants;
 import com.alibaba.cloud.ai.toolcalling.baidusearch.BaiduSearchConstants;
 import com.alibaba.cloud.ai.toolcalling.serpapi.SerpApiConstants;
 import com.alibaba.cloud.ai.toolcalling.tavily.TavilySearchConstants;
@@ -29,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum SearchEnum {
 
 	TAVILY("tavily", TavilySearchConstants.TOOL_NAME), BAIDU("baidu", BaiduSearchConstants.TOOL_NAME),
-	SERPAPI("serpapi", SerpApiConstants.TOOL_NAME);
+	SERPAPI("serpapi", SerpApiConstants.TOOL_NAME), ALIYUN("aliyun", AliyunAiSearchConstants.TOOL_NAME);
 
 	private final String name;
 

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/src/main/java/com/alibaba/cloud/ai/toolcalling/searches/SearchUtil.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches/src/main/java/com/alibaba/cloud/ai/toolcalling/searches/SearchUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.searches;
+
+import com.alibaba.cloud.ai.toolcalling.baidusearch.BaiduSearchConstants;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
+import com.alibaba.cloud.ai.toolcalling.serpapi.SerpApiConstants;
+import com.alibaba.cloud.ai.toolcalling.tavily.TavilySearchConstants;
+import org.springframework.context.ApplicationContext;
+
+import java.util.Arrays;
+
+/**
+ * @author vlsmb
+ * @since 2025/6/23
+ */
+public final class SearchUtil {
+
+	private static final String[] SEARCH_TOOL_NAMES = { TavilySearchConstants.TOOL_NAME, BaiduSearchConstants.TOOL_NAME,
+			SerpApiConstants.TOOL_NAME };
+
+	private SearchUtil() {
+
+	}
+
+	/**
+	 * Query the currently available implementations of the SearchService plugin. If
+	 * multiple implementations exist, return the first available instance according to
+	 * the defined loading order.
+	 * @param context ApplicationContext
+	 * @return the first available SearchService
+	 * @throws RuntimeException When there is no available Service, throw RuntimeException
+	 */
+	public static SearchService getAvailableSearchService(ApplicationContext context) throws RuntimeException {
+		String toolName = getAvailableSearchToolName(context);
+		if (toolName == null) {
+			throw new RuntimeException("No Available Search Tool");
+		}
+		return getSearchService(context, toolName);
+	}
+
+	/**
+	 * Query the currently available implementations of the SearchService plugin. If
+	 * multiple implementations exist, return the first available instance according to
+	 * the defined loading order.
+	 * @param context ApplicationContext
+	 * @return the first available SearchService Tool Name, or null.
+	 */
+	public static String getAvailableSearchToolName(ApplicationContext context) {
+		return Arrays.stream(SEARCH_TOOL_NAMES).filter(context::containsBean).findFirst().orElse(null);
+	}
+
+	/**
+	 * Get SearchService by tool name.
+	 * @param context ApplicationContext
+	 * @param toolName search tool name
+	 * @return available SearchService
+	 * @throws RuntimeException When this tool is unavailable, throw RuntimeException
+	 */
+	public static SearchService getSearchService(ApplicationContext context, String toolName) throws RuntimeException {
+		try {
+			return context.getBean(toolName, SearchService.class);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("The tool is unavailable.", e);
+		}
+	}
+
+}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-serpapi/src/main/java/com/alibaba/cloud/ai/toolcalling/serpapi/SerpApiService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-serpapi/src/main/java/com/alibaba/cloud/ai/toolcalling/serpapi/SerpApiService.java
@@ -147,7 +147,7 @@ public class SerpApiService implements SearchService, Function<SerpApiService.Re
 		public SearchService.SearchResult getSearchResult() {
 			return new SearchService.SearchResult(this.results()
 				.stream()
-				.map(item -> new SearchService.SearchContent(item.title(), item.text()))
+				.map(item -> new SearchService.SearchContent(item.title(), item.text(), null))
 				.toList());
 		}
 	}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-serpapi/src/main/java/com/alibaba/cloud/ai/toolcalling/serpapi/SerpApiService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-serpapi/src/main/java/com/alibaba/cloud/ai/toolcalling/serpapi/SerpApiService.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.toolcalling.serpapi;
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallUtils;
 import com.alibaba.cloud.ai.toolcalling.common.JsonParseTool;
 import com.alibaba.cloud.ai.toolcalling.common.WebClientTool;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,7 +40,7 @@ import java.util.function.Function;
  * @author 北极星
  * @author sixiyida
  */
-public class SerpApiService implements Function<SerpApiService.Request, SerpApiService.Response> {
+public class SerpApiService implements SearchService, Function<SerpApiService.Request, SerpApiService.Response> {
 
 	private static final Logger logger = LoggerFactory.getLogger(SerpApiService.class);
 
@@ -53,6 +54,11 @@ public class SerpApiService implements Function<SerpApiService.Request, SerpApiS
 		this.properties = properties;
 		this.jsonParseTool = jsonParseTool;
 		this.webClientTool = webClientTool;
+	}
+
+	@Override
+	public SearchService.Response query(String query) {
+		return this.apply(new Request(query));
 	}
 
 	/**
@@ -126,11 +132,24 @@ public class SerpApiService implements Function<SerpApiService.Request, SerpApiS
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	@JsonClassDescription("serpapi search request")
 	public record Request(@JsonProperty(required = true,
-			value = "query") @JsonPropertyDescription("The query " + "keyword e.g. Alibaba") String query) {
+			value = "query") @JsonPropertyDescription("The query " + "keyword e.g. Alibaba") String query)
+			implements
+				SearchService.Request {
+		@Override
+		public String getQuery() {
+			return this.query();
+		}
 	}
 
 	@JsonClassDescription("serpapi search response")
-	public record Response(List<SearchResult> results) {
+	public record Response(List<SearchResult> results) implements SearchService.Response {
+		@Override
+		public SearchService.SearchResult getSearchResult() {
+			return new SearchService.SearchResult(this.results()
+				.stream()
+				.map(item -> new SearchService.SearchContent(item.title(), item.text()))
+				.toList());
+		}
 	}
 
 	public record SearchResult(String title, String text) {

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-serpapi/src/test/java/com/alibaba/cloud/ai/toolcalling/serpapi/SerpApiServiceTest.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-serpapi/src/test/java/com/alibaba/cloud/ai/toolcalling/serpapi/SerpApiServiceTest.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.toolcalling.serpapi;
 
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallAutoConfiguration;
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallConstants;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -42,6 +43,19 @@ public class SerpApiServiceTest {
 		var resp = serpApiSearch.apply(new SerpApiService.Request("Spring AI Alibaba"));
 		assert resp != null && resp.results() != null;
 		log.info("results: " + resp.results());
+	}
+
+	@Autowired
+	private SearchService searchService;
+
+	@Test
+	@DisplayName("Abstract Search Test")
+	@EnabledIfEnvironmentVariable(named = SerpApiConstants.API_KEY_ENV,
+			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
+	public void testAbstractSearch() {
+		var resp = searchService.query("Spring AI Alibaba");
+		assert resp != null && resp.getSearchResult() != null;
+		log.info("results: " + resp.getSearchResult());
 	}
 
 }

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/main/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/main/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchService.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.toolcalling.tavily;
 
 import com.alibaba.cloud.ai.toolcalling.common.JsonParseTool;
 import com.alibaba.cloud.ai.toolcalling.common.WebClientTool;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -43,7 +44,8 @@ import java.util.function.Function;
  *
  * @author Allen Hu
  */
-public class TavilySearchService implements Function<TavilySearchService.Request, TavilySearchService.Response> {
+public class TavilySearchService
+		implements SearchService, Function<TavilySearchService.Request, TavilySearchService.Response> {
 
 	private static final Logger logger = LoggerFactory.getLogger(TavilySearchService.class);
 
@@ -54,6 +56,11 @@ public class TavilySearchService implements Function<TavilySearchService.Request
 	public TavilySearchService(JsonParseTool jsonParseTool, WebClientTool webClientTool) {
 		this.jsonParseTool = jsonParseTool;
 		this.webClientTool = webClientTool;
+	}
+
+	@Override
+	public SearchService.Response query(String query) {
+		return this.apply(Request.simpleQuery(query));
 	}
 
 	@Override
@@ -110,17 +117,23 @@ public class TavilySearchService implements Function<TavilySearchService.Request
 			@JsonProperty(value = "exclude_domains",
 					defaultValue = "[]") @JsonPropertyDescription("A list of domains to specifically exclude from the search results.") List<String> excludeDomains)
 			implements
-				Serializable {
+				Serializable,
+				SearchService.Request {
 
 		public static Request simpleQuery(String query) {
 			return new Request(query, null, null, null, null, null, null, null, null, null, null, null, null);
+		}
+
+		@Override
+		public String getQuery() {
+			return this.query();
 		}
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Response(@JsonProperty("query") String query, @JsonProperty("answer") String answer,
 			@JsonProperty("images") List<ImageInfo> images, @JsonProperty("results") List<ResultInfo> results,
-			@JsonProperty("response_time") String responseTime) {
+			@JsonProperty("response_time") String responseTime) implements SearchService.Response {
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		@JsonDeserialize(using = ImageInfoDeserializer.class)
 		public record ImageInfo(@JsonProperty("url") String url, @JsonProperty("description") String description) {
@@ -135,10 +148,14 @@ public class TavilySearchService implements Function<TavilySearchService.Request
 		public static Response errorResponse(String query, String errorMsg) {
 			return new Response(query, errorMsg, null, null, null);
 		}
-	}
 
-	public record SearchContent(@JsonProperty("title") String title, @JsonProperty("content") String content) {
-
+		@Override
+		public SearchResult getSearchResult() {
+			return new SearchResult(this.results()
+				.stream()
+				.map(item -> new SearchService.SearchContent(item.title(), item.content()))
+				.toList());
+		}
 	}
 
 }

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/main/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchService.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/main/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchService.java
@@ -153,7 +153,7 @@ public class TavilySearchService
 		public SearchResult getSearchResult() {
 			return new SearchResult(this.results()
 				.stream()
-				.map(item -> new SearchService.SearchContent(item.title(), item.content()))
+				.map(item -> new SearchService.SearchContent(item.title(), item.content(), item.url()))
 				.toList());
 		}
 	}

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/test/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchServiceTest.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/test/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchServiceTest.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.toolcalling.tavily;
 
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallAutoConfiguration;
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallConstants;
+import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -43,6 +44,19 @@ public class TavilySearchServiceTest {
 				null, null, null, null, null, null, null));
 		assert resp != null && resp.results() != null;
 		log.info("results: " + resp.results());
+	}
+
+	@Autowired
+	private SearchService searchService;
+
+	@Test
+	@DisplayName("Abstract Search Test")
+	@EnabledIfEnvironmentVariable(named = TavilySearchConstants.API_KEY_ENV,
+			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
+	public void abstractSearchTest() {
+		var resp = searchService.query("Spring AI Alibaba");
+		assert resp != null && resp.getSearchResult() != null;
+		log.info("results: " + resp.getSearchResult());
 	}
 
 }

--- a/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/test/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchServiceTest.java
+++ b/community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch/src/test/java/com/alibaba/cloud/ai/toolcalling/tavily/TavilySearchServiceTest.java
@@ -55,7 +55,8 @@ public class TavilySearchServiceTest {
 			matches = CommonToolCallConstants.NOT_BLANK_REGEX)
 	public void abstractSearchTest() {
 		var resp = searchService.query("Spring AI Alibaba");
-		assert resp != null && resp.getSearchResult() != null;
+		assert resp != null && resp.getSearchResult() != null && resp.getSearchResult().results() != null
+				&& !resp.getSearchResult().results().isEmpty();
 		log.info("results: " + resp.getSearchResult());
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-youdaotranslate</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-duckduckgo</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-tavilysearch</module>
+        <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-searches</module>
 
         <!-- Spring AI Alibaba Document Readers -->
         <module>community/document-readers/spring-ai-alibaba-starter-document-reader-arxiv</module>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidutranslate</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidumap</module>
+        <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-bravesearch</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-dingtalk</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-sensitivefilter</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-amap</module>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <!-- Spring AI Alibaba Tool Call Plugins -->
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-common</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-time</module>
+        <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-aliyunaisearch</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidusearch</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidutranslate</module>
         <module>community/tool-calls/spring-ai-alibaba-starter-tool-calling-baidumap</module>

--- a/spring-ai-alibaba-bom/pom.xml
+++ b/spring-ai-alibaba-bom/pom.xml
@@ -248,6 +248,12 @@
 
             <dependency>
                 <groupId>com.alibaba.cloud.ai</groupId>
+                <artifactId>spring-ai-alibaba-starter-tool-calling-bravesearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.alibaba.cloud.ai</groupId>
                 <artifactId>spring-ai-alibaba-starter-tool-calling-jinacrawler</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/spring-ai-alibaba-bom/pom.xml
+++ b/spring-ai-alibaba-bom/pom.xml
@@ -230,6 +230,12 @@
 
             <dependency>
                 <groupId>com.alibaba.cloud.ai</groupId>
+                <artifactId>spring-ai-alibaba-starter-tool-calling-aliyunaisearch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.alibaba.cloud.ai</groupId>
                 <artifactId>spring-ai-alibaba-starter-tool-calling-baidumap</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/spring-ai-alibaba-bom/pom.xml
+++ b/spring-ai-alibaba-bom/pom.xml
@@ -366,6 +366,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.alibaba.cloud.ai</groupId>
+                <artifactId>spring-ai-alibaba-starter-tool-calling-searches</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- Spring AI Alibaba Vector Stores -->
             <dependency>
                 <groupId>com.alibaba.cloud.ai</groupId>

--- a/spring-ai-alibaba-deepresearch/pom.xml
+++ b/spring-ai-alibaba-deepresearch/pom.xml
@@ -69,7 +69,7 @@
 
         <dependency>
             <groupId>com.alibaba.cloud.ai</groupId>
-            <artifactId>spring-ai-alibaba-starter-tool-calling-tavilysearch</artifactId>
+            <artifactId>spring-ai-alibaba-starter-tool-calling-searches</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/agents/AgentsConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/agents/AgentsConfiguration.java
@@ -21,7 +21,6 @@ import com.alibaba.cloud.ai.example.deepresearch.tool.PlannerTool;
 import com.alibaba.cloud.ai.example.deepresearch.tool.PythonReplTool;
 import com.alibaba.cloud.ai.example.deepresearch.util.ResourceUtil;
 import com.alibaba.cloud.ai.toolcalling.jinacrawler.JinaCrawlerConstants;
-import com.alibaba.cloud.ai.toolcalling.searches.SearchUtil;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.mcp.AsyncMcpToolCallbackProvider;
 import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
@@ -92,11 +91,12 @@ public class AgentsConfiguration {
 	public ChatClient researchAgent(ChatClient.Builder researchChatClientBuilder) {
 		ToolCallback[] mcpCallbacks = getMcpToolCallbacks("researchAgent");
 
-		return researchChatClientBuilder.defaultSystem(ResourceUtil.loadResourceAsString(researcherPrompt))
-			.defaultToolNames(this.getAvailableTools(SearchUtil.getAvailableSearchToolName(context),
-					JinaCrawlerConstants.TOOL_NAME))
-			.defaultToolCallbacks(mcpCallbacks)
-			.build();
+		var builder = researchChatClientBuilder.defaultSystem(ResourceUtil.loadResourceAsString(researcherPrompt));
+		var toolArray = this.getAvailableTools(JinaCrawlerConstants.TOOL_NAME);
+		if (toolArray.length > 0) {
+			builder = builder.defaultToolNames(toolArray);
+		}
+		return builder.defaultToolCallbacks(mcpCallbacks).build();
 	}
 
 	/**

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/agents/AgentsConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/agents/AgentsConfiguration.java
@@ -21,7 +21,7 @@ import com.alibaba.cloud.ai.example.deepresearch.tool.PlannerTool;
 import com.alibaba.cloud.ai.example.deepresearch.tool.PythonReplTool;
 import com.alibaba.cloud.ai.example.deepresearch.util.ResourceUtil;
 import com.alibaba.cloud.ai.toolcalling.jinacrawler.JinaCrawlerConstants;
-import com.alibaba.cloud.ai.toolcalling.tavily.TavilySearchConstants;
+import com.alibaba.cloud.ai.toolcalling.searches.SearchUtil;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.mcp.AsyncMcpToolCallbackProvider;
 import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
@@ -93,7 +93,8 @@ public class AgentsConfiguration {
 		ToolCallback[] mcpCallbacks = getMcpToolCallbacks("researchAgent");
 
 		return researchChatClientBuilder.defaultSystem(ResourceUtil.loadResourceAsString(researcherPrompt))
-			.defaultToolNames(this.getAvailableTools(TavilySearchConstants.TOOL_NAME, JinaCrawlerConstants.TOOL_NAME))
+			.defaultToolNames(this.getAvailableTools(SearchUtil.getAvailableSearchToolName(context),
+					JinaCrawlerConstants.TOOL_NAME))
 			.defaultToolCallbacks(mcpCallbacks)
 			.build();
 	}

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
@@ -151,7 +151,8 @@ public class DeepResearchConfiguration {
 				new DeepResearchStateSerializer(OverAllState::new))
 			.addNode("coordinator", node_async(new CoordinatorNode(coordinatorAgent)))
 			.addNode("background_investigator",
-					node_async(new BackgroundInvestigationNode(SearchUtil.getAvailableSearchService(context), jinaCrawlerService)))
+					node_async(new BackgroundInvestigationNode(SearchUtil.getAvailableSearchService(context),
+							jinaCrawlerService)))
 			.addNode("planner", node_async((new PlannerNode(plannerAgent))))
 			.addNode("information", node_async((new InformationNode())))
 			.addNode("human_feedback", node_async(new HumanFeedbackNode()))

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
@@ -44,13 +44,14 @@ import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import com.alibaba.cloud.ai.toolcalling.jinacrawler.JinaCrawlerService;
-import com.alibaba.cloud.ai.toolcalling.tavily.TavilySearchService;
+import com.alibaba.cloud.ai.toolcalling.searches.SearchUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.rag.advisor.RetrievalAugmentationAdvisor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -73,8 +74,8 @@ public class DeepResearchConfiguration {
 
 	private static final Logger logger = LoggerFactory.getLogger(DeepResearchConfiguration.class);
 
-	@Autowired(required = false)
-	private TavilySearchService tavilySearchService;
+	@Autowired
+	private ApplicationContext context;
 
 	@Autowired
 	private ChatClient coderAgent;
@@ -150,7 +151,7 @@ public class DeepResearchConfiguration {
 				new DeepResearchStateSerializer(OverAllState::new))
 			.addNode("coordinator", node_async(new CoordinatorNode(coordinatorAgent)))
 			.addNode("background_investigator",
-					node_async(new BackgroundInvestigationNode(tavilySearchService, jinaCrawlerService)))
+					node_async(new BackgroundInvestigationNode(SearchUtil.getAvailableSearchService(context), jinaCrawlerService)))
 			.addNode("planner", node_async((new PlannerNode(plannerAgent))))
 			.addNode("information", node_async((new InformationNode())))
 			.addNode("human_feedback", node_async(new HumanFeedbackNode()))

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
@@ -44,7 +44,6 @@ import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import com.alibaba.cloud.ai.toolcalling.jinacrawler.JinaCrawlerService;
-import com.alibaba.cloud.ai.toolcalling.searches.SearchUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
@@ -151,8 +150,7 @@ public class DeepResearchConfiguration {
 				new DeepResearchStateSerializer(OverAllState::new))
 			.addNode("coordinator", node_async(new CoordinatorNode(coordinatorAgent)))
 			.addNode("background_investigator",
-					node_async(new BackgroundInvestigationNode(SearchUtil.getAvailableSearchService(context),
-							jinaCrawlerService)))
+					node_async(new BackgroundInvestigationNode(context, jinaCrawlerService)))
 			.addNode("planner", node_async((new PlannerNode(plannerAgent))))
 			.addNode("information", node_async((new InformationNode())))
 			.addNode("human_feedback", node_async(new HumanFeedbackNode()))

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/controller/request/ChatRequestProcess.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/controller/request/ChatRequestProcess.java
@@ -17,6 +17,9 @@
 package com.alibaba.cloud.ai.example.deepresearch.controller.request;
 
 import com.alibaba.cloud.ai.example.deepresearch.model.req.ChatRequest;
+import com.alibaba.cloud.ai.toolcalling.searches.SearchEnum;
+import com.alibaba.cloud.ai.toolcalling.searches.SearchUtil;
+import org.springframework.context.ApplicationContext;
 import org.springframework.util.StringUtils;
 
 import java.util.Collections;
@@ -32,9 +35,10 @@ public class ChatRequestProcess {
 	/**
 	 * Creates a default ChatRequest instance or set some default value for an instance.
 	 */
-	public static ChatRequest getDefaultChatRequest(ChatRequest chatRequest) {
+	public static ChatRequest getDefaultChatRequest(ChatRequest chatRequest, ApplicationContext context) {
 		if (chatRequest == null) {
-			return new ChatRequest("__default__", 1, 3, true, null, true, Collections.emptyMap(), "草莓蛋糕怎么做呀。");
+			return new ChatRequest("__default__", 1, 3, true, null, true, Collections.emptyMap(), "草莓蛋糕怎么做呀。",
+					SearchEnum.fromToolName(SearchUtil.getAvailableSearchToolName(context).orElse(null)));
 		}
 		else {
 			return new ChatRequest(StringUtils.hasText(chatRequest.threadId()) ? chatRequest.threadId() : "__default__",
@@ -44,7 +48,10 @@ public class ChatRequestProcess {
 					chatRequest.interruptFeedback(),
 					chatRequest.enableBackgroundInvestigation() == null || chatRequest.enableBackgroundInvestigation(),
 					chatRequest.mcpSettings() == null ? Collections.emptyMap() : chatRequest.mcpSettings(),
-					StringUtils.hasText(chatRequest.query()) ? chatRequest.query() : "草莓蛋糕怎么做呀");
+					StringUtils.hasText(chatRequest.query()) ? chatRequest.query() : "草莓蛋糕怎么做呀",
+					chatRequest.searchEngine() == null
+							? SearchEnum.fromToolName(SearchUtil.getAvailableSearchToolName(context).orElse(null))
+							: chatRequest.searchEngine());
 		}
 	}
 
@@ -56,6 +63,7 @@ public class ChatRequestProcess {
 		objectMap.put("max_step_num", chatRequest.maxStepNum());
 		objectMap.put("max_plan_iterations", chatRequest.maxPlanIterations());
 		objectMap.put("mcp_settings", chatRequest.mcpSettings());
+		objectMap.put("search_engine", chatRequest.searchEngine());
 	}
 
 }

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/req/ChatRequest.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/model/req/ChatRequest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.ai.example.deepresearch.model.req;
 
+import com.alibaba.cloud.ai.toolcalling.searches.SearchEnum;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
@@ -57,5 +58,10 @@ public record ChatRequest(
 		 */
 		@JsonProperty(value = "mcp_settings") Map<String, Object> mcpSettings,
 
-		@JsonProperty(value = "query", defaultValue = "草莓蛋糕怎么做呀") String query) {
+		@JsonProperty(value = "query", defaultValue = "草莓蛋糕怎么做呀") String query,
+
+		/**
+		 * 搜索引擎，默认为Tavily
+		 */
+		@JsonProperty(value = "search_engine", defaultValue = "tavily") SearchEnum searchEngine) {
 }

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationNode.java
@@ -22,8 +22,11 @@ import com.alibaba.cloud.ai.graph.action.NodeAction;
 import com.alibaba.cloud.ai.toolcalling.common.CommonToolCallUtils;
 import com.alibaba.cloud.ai.toolcalling.jinacrawler.JinaCrawlerService;
 import com.alibaba.cloud.ai.toolcalling.common.interfaces.SearchService;
+import com.alibaba.cloud.ai.toolcalling.searches.SearchEnum;
+import com.alibaba.cloud.ai.toolcalling.searches.SearchUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,23 +43,26 @@ public class BackgroundInvestigationNode implements NodeAction {
 
 	private static final Logger logger = LoggerFactory.getLogger(BackgroundInvestigationNode.class);
 
-	private final SearchService searchService;
-
 	private final Integer MAX_RETRY_COUNT = 3;
 
 	private final Long RETRY_DELAY_MS = 500L;
 
 	private final JinaCrawlerService jinaCrawlerService;
 
-	public BackgroundInvestigationNode(SearchService searchService, JinaCrawlerService jinaCrawlerService) {
-		this.searchService = searchService;
+	private final ApplicationContext context;
+
+	public BackgroundInvestigationNode(ApplicationContext context, JinaCrawlerService jinaCrawlerService) {
 		this.jinaCrawlerService = jinaCrawlerService;
+		this.context = context;
 	}
 
 	@Override
 	public Map<String, Object> apply(OverAllState state) throws Exception {
 		logger.info("background investigation node is running.");
 		String query = StateUtil.getQuery(state);
+		SearchService searchService = SearchUtil
+			.getSearchService(context, state.value("search_engine", SearchEnum.class).orElseThrow().getToolName())
+			.orElseThrow();
 
 		List<Map<String, String>> results = new ArrayList<>();
 

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ResearcherNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/ResearcherNode.java
@@ -21,6 +21,7 @@ import com.alibaba.cloud.ai.example.deepresearch.util.StateUtil;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
 import com.alibaba.cloud.ai.graph.streaming.StreamingChatGenerator;
+import com.alibaba.cloud.ai.toolcalling.searches.SearchEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
@@ -96,8 +97,14 @@ public class ResearcherNode implements NodeAction {
 		messages.add(citationMessage);
 
 		logger.debug("{} Node messages: {}", nodeName, messages);
+		// 获取搜索工具
+		SearchEnum searchTool = state.value("search_engine", SearchEnum.class).orElse(null);
 		// 调用agent
-		var streamResult = researchAgent.prompt().messages(messages).stream().chatResponse();
+		var requestSpec = researchAgent.prompt().messages(messages);
+		if (searchTool != null) {
+			requestSpec = requestSpec.toolNames(searchTool.getToolName());
+		}
+		var streamResult = requestSpec.stream().chatResponse();
 		Plan.Step finalAssignedStep = assignedStep;
 		logger.info("ResearcherNode {} starting streaming with key: {}", executorNodeId,
 				"researcher_llm_stream_" + executorNodeId);

--- a/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
+++ b/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
@@ -31,17 +31,14 @@ spring:
         type: async
     alibaba:
       toolcalling:
-        baidu:
-          search:
-            enabled: false
-        serpapi:
-          enabled: false
         tavilysearch:
-          enabled: true
           api-key: ${TAVILY_API_KEY}
         jinacrawler:
           enabled: false
           api-key: ${JINA_API_KEY}
+        serpapi:
+          api-key: ${SERPAPI_KEY}
+          enabled: false
       deepresearch:
         mcp:
           enabled: false

--- a/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
+++ b/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
@@ -31,6 +31,11 @@ spring:
         type: async
     alibaba:
       toolcalling:
+        baidu:
+          search:
+            enabled: false
+        serpapi:
+          enabled: false
         tavilysearch:
           enabled: true
           api-key: ${TAVILY_API_KEY}

--- a/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
+++ b/spring-ai-alibaba-deepresearch/src/main/resources/application.yml
@@ -31,14 +31,22 @@ spring:
         type: async
     alibaba:
       toolcalling:
+        baidu:
+          search:
+            enabled: true
         tavilysearch:
           api-key: ${TAVILY_API_KEY}
+          enabled: true
         jinacrawler:
           enabled: false
           api-key: ${JINA_API_KEY}
         serpapi:
           api-key: ${SERPAPI_KEY}
-          enabled: false
+          enabled: true
+        aliyunaisearch:
+          api-key: ${ALIYUN_AI_SEARCH_API_KEY}
+          base-url: ${ALIYUN_AI_SEARCH_BASE_URL}
+          enabled: true
       deepresearch:
         mcp:
           enabled: false


### PR DESCRIPTION
### Describe what this PR does / why we need it

- Define search service interface in community/tool-call/common module.
- Add brave search and aliyun ai web search tool-call
- Add a 'searches' module in community/tool-call that imports all available search plugins and manages their organization.
- In the Deepresearch project, the frontend user specifies a search plugin via the `search_engine` field in the JSON object, and the code dynamically locates the corresponding plugin service object.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Firstly, in the `tool-call/common` module, the `SearchService` interface along with `Request` and `Response` interfaces are defined to standardize the basic query functionality for search plugins. Secondly, the `searches` module imports all implemented search plugins, uses the `SearchEnum` enumeration to record plugin information, and defines a `SearchUtil` class that leverages Spring Framework's `ApplicationContext` to query the corresponding bean based on the search plugin name specified by the user.

In the Deepresearch project, the specified search plugin's corresponding `SearchEnum` object is stored in the state; the `BackgroundNode` then retrieves the `SearchService` instance for operations based on this state, while the `ResearcherNode` passes the plugin's tool name to `ChatClient`.

### Describe how to verify it


### Special notes for reviews

NOTE: Since the Brave Search API requires a foreign credit card to apply for a free API key, I implemented the plugin according to the documentation but could not test it; consequently, this plugin was not included in the searches module. A separate issue might need to be created for others with access to complete this task.

