### PR TITLE
fix(core): add observability support in dashscope autoconfigure pom

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/pom.xml
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/pom.xml
@@ -64,6 +64,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
### Describe what this PR does / why we need it
Existing dashscope autoconfigure pom / stater cannot support spring-ai observation with 1.0.0 version. This PR add observation dependencies in it.
**Image below shows spring-ai-autoconfigure-model-openai pom with corresponding dependencies.**
![image](https://github.com/user-attachments/assets/fe80ba08-dee6-404a-bd64-2b3f2ef0661d)

### Does this pull request fix one issue?
None

### Describe how you did it
Just add

