### PR TITLE
fix(core): correct auto-configuration conditions

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechAutoConfiguration.java
@@ -20,11 +20,11 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.api.DashScopeSpeechSynthesisApi;
 import com.alibaba.cloud.ai.dashscope.audio.DashScopeSpeechSynthesisModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
+
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -32,7 +32,6 @@ import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfigura
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.retry.support.RetryTemplate;
 
 import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUtils.resolveConnectionProperties;
@@ -46,7 +45,8 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 		SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(DashScopeApi.class)
 @ConditionalOnDashScopeEnabled
-@Conditional(DashScopeAudioSpeechAutoConfiguration.Condition.class)
+@ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_SPEECH_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
+		matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeAudioSpeechSynthesisProperties.class })
 @ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
 		WebClientAutoConfiguration.class })
@@ -70,34 +70,6 @@ public class DashScopeAudioSpeechAutoConfiguration {
 				"audio.synthesis");
 
 		return new DashScopeSpeechSynthesisApi(resolved.apiKey(), resolved.workspaceId());
-	}
-
-	public static class Condition extends AllNestedConditions {
-
-		public Condition() {
-			super(ConfigurationPhase.PARSE_CONFIGURATION);
-		}
-
-		/**
-		 * Enable this when `spring.ai.dashscope.audio.synthesis.enabled` is not set or is
-		 * set to `true`.
-		 */
-		@ConditionalOnProperty(prefix = DashScopeAudioSpeechSynthesisProperties.CONFIG_PREFIX, name = "enabled",
-				havingValue = "true", matchIfMissing = true)
-		static class Enabled {
-
-		}
-
-		/**
-		 * Enable this when `spring.ai.model.audio.speech` is not specified or is set to
-		 * `dashscope`.
-		 */
-		@ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_SPEECH_MODEL,
-				havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
-		static class ModelSpecified {
-
-		}
-
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionAutoConfiguration.java
@@ -20,11 +20,11 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.api.DashScopeAudioTranscriptionApi;
 import com.alibaba.cloud.ai.dashscope.audio.DashScopeAudioTranscriptionModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
+
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -32,7 +32,6 @@ import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfigura
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.retry.support.RetryTemplate;
 
 import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUtils.resolveConnectionProperties;
@@ -46,7 +45,8 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 		SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(DashScopeApi.class)
 @ConditionalOnDashScopeEnabled
-@Conditional(DashScopeAudioTranscriptionAutoConfiguration.Condition.class)
+@ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_TRANSCRIPTION_MODEL,
+		havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeAudioTranscriptionProperties.class })
 @ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
 		WebClientAutoConfiguration.class })
@@ -73,34 +73,6 @@ public class DashScopeAudioTranscriptionAutoConfiguration {
 				audioTranscriptionProperties, "audio.transcription");
 
 		return new DashScopeAudioTranscriptionApi(resolved.apiKey());
-	}
-
-	public static class Condition extends AllNestedConditions {
-
-		public Condition() {
-			super(ConfigurationPhase.PARSE_CONFIGURATION);
-		}
-
-		/**
-		 * Enable this when `spring.ai.dashscope.audio.transcription.enabled` is not set
-		 * or is set to `true`.
-		 */
-		@ConditionalOnProperty(prefix = DashScopeAudioTranscriptionProperties.CONFIG_PREFIX, name = "enabled",
-				havingValue = "true", matchIfMissing = true)
-		static class Enabled {
-
-		}
-
-		/**
-		 * Enable this when `spring.ai.model.audio.transcription` is not specified or is
-		 * set to `dashscope`.
-		 */
-		@ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_TRANSCRIPTION_MODEL,
-				havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
-		static class ModelSpecified {
-
-		}
-
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
@@ -19,6 +19,7 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
 import io.micrometer.observation.ObservationRegistry;
+
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
@@ -29,7 +30,6 @@ import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -37,7 +37,6 @@ import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfigura
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
@@ -56,7 +55,8 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 // @formatter:off
 @ConditionalOnClass(DashScopeApi.class)
 @ConditionalOnDashScopeEnabled
-@Conditional(DashScopeChatAutoConfiguration.Condition.class)
+@ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
+		matchIfMissing = true)
 @AutoConfiguration(after = {
 		RestClientAutoConfiguration.class,
 		SpringAiRetryAutoConfiguration.class,
@@ -137,32 +137,6 @@ public class DashScopeChatAutoConfiguration {
 					.restClientBuilder(restClientBuilder)
 					.responseErrorHandler(responseErrorHandler)
 					.build();
-		}
-
-		public static class Condition extends AllNestedConditions {
-
-			public Condition() {
-				super(ConfigurationPhase.PARSE_CONFIGURATION);
-			}
-
-			/**
-			 * Enable this when `spring.ai.dashscope.chat.enabled` is not set or is set to `true`.
-			 */
-			@ConditionalOnProperty(prefix = DashScopeChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
-					matchIfMissing = true)
-			static class Enabled {
-
-			}
-
-			/**
-			 * Enable this when `spring.ai.model.chat` is not specified or is set to `dashscope`.
-			 */
-			@ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
-					matchIfMissing = true)
-			static class ModelSpecified {
-
-			}
-
 		}
 }
 // @formatter:on

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeEmbeddingAutoConfiguration.java
@@ -20,13 +20,13 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.embedding.DashScopeEmbeddingModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
 import io.micrometer.observation.ObservationRegistry;
+
 import org.springframework.ai.embedding.observation.EmbeddingModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,7 +34,6 @@ import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfigura
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
@@ -51,7 +50,8 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 		SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(DashScopeApi.class)
 @ConditionalOnDashScopeEnabled
-@Conditional(DashScopeEmbeddingAutoConfiguration.Condition.class)
+@ConditionalOnProperty(name = SpringAIModelProperties.EMBEDDING_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
+		matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeEmbeddingProperties.class })
 @ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
 		WebClientAutoConfiguration.class })
@@ -94,34 +94,6 @@ public class DashScopeEmbeddingAutoConfiguration {
 			.restClientBuilder(restClientBuilder)
 			.responseErrorHandler(responseErrorHandler)
 			.build();
-	}
-
-	public static class Condition extends AllNestedConditions {
-
-		public Condition() {
-			super(ConfigurationPhase.PARSE_CONFIGURATION);
-		}
-
-		/**
-		 * Enable this when `spring.ai.dashscope.embedding.enabled` is not set or is set
-		 * to `true`.
-		 */
-		@ConditionalOnProperty(prefix = DashScopeEmbeddingProperties.CONFIG_PREFIX, name = "enabled",
-				havingValue = "true", matchIfMissing = true)
-		static class Enabled {
-
-		}
-
-		/**
-		 * Enable this when `spring.ai.model.embedding` is not specified or is set to
-		 * `dashscope`.
-		 */
-		@ConditionalOnProperty(name = SpringAIModelProperties.EMBEDDING_MODEL,
-				havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
-		static class ModelSpecified {
-
-		}
-
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeImageAutoConfiguration.java
@@ -21,13 +21,13 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeImageApi;
 import com.alibaba.cloud.ai.dashscope.image.DashScopeImageModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
 import io.micrometer.observation.ObservationRegistry;
+
 import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,7 +35,6 @@ import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfigura
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
@@ -52,7 +51,8 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 		SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(DashScopeApi.class)
 @ConditionalOnDashScopeEnabled
-@Conditional(DashScopeImageAutoConfiguration.Condition.class)
+@ConditionalOnProperty(name = SpringAIModelProperties.IMAGE_MODEL, havingValue = SpringAIAlibabaModels.DASHSCOPE,
+		matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeImageProperties.class })
 @ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
 		WebClientAutoConfiguration.class })
@@ -78,34 +78,6 @@ public class DashScopeImageAutoConfiguration {
 		observationConvention.ifAvailable(dashScopeImageModel::setObservationConvention);
 
 		return dashScopeImageModel;
-	}
-
-	public static class Condition extends AllNestedConditions {
-
-		public Condition() {
-			super(ConfigurationPhase.PARSE_CONFIGURATION);
-		}
-
-		/**
-		 * Enable this when `spring.ai.dashscope.image.enabled` is not set or is set to
-		 * `true`.
-		 */
-		@ConditionalOnProperty(prefix = DashScopeImageProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
-				matchIfMissing = true)
-		static class Enabled {
-
-		}
-
-		/**
-		 * Enable this when `spring.ai.model.image` is not specified or is set to
-		 * `dashscope`.
-		 */
-		@ConditionalOnProperty(name = SpringAIModelProperties.IMAGE_MODEL,
-				havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
-		static class ModelSpecified {
-
-		}
-
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeRerankAutoConfiguration.java
@@ -20,10 +20,10 @@ import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.rerank.DashScopeRerankModel;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModelProperties;
 import com.alibaba.cloud.ai.model.SpringAIAlibabaModels;
+
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,7 +31,6 @@ import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfigura
 import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
@@ -48,7 +47,8 @@ import static com.alibaba.cloud.ai.autoconfigure.dashscope.DashScopeConnectionUt
 		SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(DashScopeApi.class)
 @ConditionalOnDashScopeEnabled
-@Conditional(DashScopeRerankAutoConfiguration.Condition.class)
+@ConditionalOnProperty(name = SpringAIAlibabaModelProperties.RERANK_MODEL,
+		havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
 @EnableConfigurationProperties({ DashScopeConnectionProperties.class, DashScopeRerankProperties.class })
 @ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
 		WebClientAutoConfiguration.class })
@@ -75,34 +75,6 @@ public class DashScopeRerankAutoConfiguration {
 			.build();
 
 		return new DashScopeRerankModel(dashScopeApi, rerankProperties.getOptions(), retryTemplate);
-	}
-
-	public static class Condition extends AllNestedConditions {
-
-		public Condition() {
-			super(ConfigurationPhase.PARSE_CONFIGURATION);
-		}
-
-		/**
-		 * Enable this when `spring.ai.dashscope.rerank.enabled` is not set or is set to
-		 * `true`.
-		 */
-		@ConditionalOnProperty(prefix = DashScopeRerankProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
-				matchIfMissing = true)
-		static class Enabled {
-
-		}
-
-		/**
-		 * Enable this when `spring.ai.model.rerank` is not specified or is set to
-		 * `dashscope`.
-		 */
-		@ConditionalOnProperty(name = SpringAIAlibabaModelProperties.RERANK_MODEL,
-				havingValue = SpringAIAlibabaModels.DASHSCOPE, matchIfMissing = true)
-		static class ModelSpecified {
-
-		}
-
 	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAutoConfigurationIT.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAutoConfigurationIT.java
@@ -152,8 +152,9 @@ public class DashScopeAutoConfigurationIT {
 	}
 
 	@Test
-	void embedding() {
+	void embeddingV2() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
+			.withPropertyValues("spring.ai.dashscope.embedding.options.model=text-embedding-v2")
 			.run(context -> {
 				DashScopeEmbeddingModel embeddingModel = context.getBean(DashScopeEmbeddingModel.class);
 
@@ -170,7 +171,7 @@ public class DashScopeAutoConfigurationIT {
 	}
 
 	@Test
-	void embeddingWithTextEmbeddingV3Mode() {
+	void embeddingV3() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
 			.withPropertyValues("spring.ai.dashscope.embedding.options.model=text-embedding-v3")
 			.withPropertyValues("spring.ai.dashscope.embedding.options.dimensions=512")

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeModelConfigurationTests.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeModelConfigurationTests.java
@@ -23,6 +23,7 @@ import com.alibaba.cloud.ai.dashscope.embedding.DashScopeEmbeddingModel;
 import com.alibaba.cloud.ai.dashscope.image.DashScopeImageModel;
 import com.alibaba.cloud.ai.dashscope.rerank.DashScopeRerankModel;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -55,13 +56,6 @@ class DashScopeModelConfigurationTests {
 				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isEmpty();
 			});
 
-		this.contextRunner.withPropertyValues("spring.ai.dashscope.chat.enabled=false")
-			.withConfiguration(AutoConfigurations.of(DashScopeChatAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(DashScopeChatProperties.class)).isEmpty();
-				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isEmpty();
-			});
-
 		this.contextRunner.withPropertyValues("spring.ai.model.chat=dashscope")
 			.withConfiguration(AutoConfigurations.of(DashScopeChatAutoConfiguration.class))
 			.run(context -> {
@@ -74,10 +68,16 @@ class DashScopeModelConfigurationTests {
 					DashScopeEmbeddingAutoConfiguration.class, DashScopeImageAutoConfiguration.class,
 					DashScopeAudioSpeechAutoConfiguration.class, DashScopeAudioTranscriptionAutoConfiguration.class,
 					DashScopeRerankAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=dashscope", "spring.ai.model.embedding=none",
-					"spring.ai.model.image=none", "spring.ai.model.audio.speech=none",
-					"spring.ai.model.audio.transcription=none", "spring.ai.model.moderation=none",
+			.withPropertyValues(
+			// @formatter:off
+					"spring.ai.model.chat=dashscope",
+					"spring.ai.model.embedding=none",
+					"spring.ai.model.image=none",
+					"spring.ai.model.audio.speech=none",
+					"spring.ai.model.audio.transcription=none",
+					"spring.ai.model.moderation=none",
 					"spring.ai.model.rerank=none")
+			// @formatter:on
 			.run(context -> {
 				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(DashScopeEmbeddingModel.class)).isEmpty();
@@ -107,13 +107,6 @@ class DashScopeModelConfigurationTests {
 				assertThat(context.getBeansOfType(DashScopeEmbeddingModel.class)).isEmpty();
 			});
 
-		this.contextRunner.withPropertyValues("spring.ai.dashscope.embedding.enabled=false")
-			.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(DashScopeEmbeddingProperties.class)).isEmpty();
-				assertThat(context.getBeansOfType(DashScopeEmbeddingModel.class)).isEmpty();
-			});
-
 		this.contextRunner.withPropertyValues("spring.ai.model.embedding=dashscope")
 			.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
 			.run(context -> {
@@ -126,10 +119,16 @@ class DashScopeModelConfigurationTests {
 					DashScopeEmbeddingAutoConfiguration.class, DashScopeImageAutoConfiguration.class,
 					DashScopeAudioSpeechAutoConfiguration.class, DashScopeAudioTranscriptionAutoConfiguration.class,
 					DashScopeRerankAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=none", "spring.ai.model.embedding=dashscope",
-					"spring.ai.model.image=none", "spring.ai.model.audio.speech=none",
-					"spring.ai.model.audio.transcription=none", "spring.ai.model.moderation=none",
+			.withPropertyValues(
+			// @formatter:off
+					"spring.ai.model.chat=none",
+					"spring.ai.model.embedding=dashscope",
+					"spring.ai.model.image=none",
+					"spring.ai.model.audio.speech=none",
+					"spring.ai.model.audio.transcription=none",
+					"spring.ai.model.moderation=none",
 					"spring.ai.model.rerank=none")
+				// @formatter
 			.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isEmpty();
@@ -160,13 +159,6 @@ class DashScopeModelConfigurationTests {
 				assertThat(context.getBeansOfType(DashScopeImageModel.class)).isEmpty();
 			});
 
-		this.contextRunner.withPropertyValues("spring.ai.dashscope.image.enabled=false")
-			.withConfiguration(AutoConfigurations.of(DashScopeImageAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(DashScopeImageProperties.class)).isEmpty();
-				assertThat(context.getBeansOfType(DashScopeImageModel.class)).isEmpty();
-			});
-
 		this.contextRunner.withPropertyValues("spring.ai.model.image=dashscope")
 			.withConfiguration(AutoConfigurations.of(DashScopeImageAutoConfiguration.class))
 			.run(context -> {
@@ -179,10 +171,16 @@ class DashScopeModelConfigurationTests {
 					DashScopeEmbeddingAutoConfiguration.class, DashScopeImageAutoConfiguration.class,
 					DashScopeAudioSpeechAutoConfiguration.class, DashScopeAudioTranscriptionAutoConfiguration.class,
 					DashScopeRerankAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=none", "spring.ai.model.embedding=none",
-					"spring.ai.model.image=dashscope", "spring.ai.model.audio.speech=none",
-					"spring.ai.model.audio.transcription=none", "spring.ai.model.moderation=none",
+			.withPropertyValues(
+					// @formatter:off
+					"spring.ai.model.chat=none",
+					"spring.ai.model.embedding=none",
+					"spring.ai.model.image=dashscope",
+					"spring.ai.model.audio.speech=none",
+					"spring.ai.model.audio.transcription=none",
+					"spring.ai.model.moderation=none",
 					"spring.ai.model.rerank=none")
+				// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isEmpty();
@@ -213,13 +211,6 @@ class DashScopeModelConfigurationTests {
 				assertThat(context.getBeansOfType(DashScopeSpeechSynthesisModel.class)).isEmpty();
 			});
 
-		this.contextRunner.withPropertyValues("spring.ai.dashscope.audio.synthesis.enabled=false")
-			.withConfiguration(AutoConfigurations.of(DashScopeAudioSpeechAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(DashScopeAudioSpeechSynthesisProperties.class)).isEmpty();
-				assertThat(context.getBeansOfType(DashScopeSpeechSynthesisModel.class)).isEmpty();
-			});
-
 		this.contextRunner.withPropertyValues("spring.ai.model.audio.speech=dashscope")
 			.withConfiguration(AutoConfigurations.of(DashScopeAudioSpeechAutoConfiguration.class))
 			.run(context -> {
@@ -232,10 +223,16 @@ class DashScopeModelConfigurationTests {
 					DashScopeEmbeddingAutoConfiguration.class, DashScopeImageAutoConfiguration.class,
 					DashScopeAudioSpeechAutoConfiguration.class, DashScopeAudioTranscriptionAutoConfiguration.class,
 					DashScopeRerankAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=none", "spring.ai.model.embedding=none",
-					"spring.ai.model.image=none", "spring.ai.model.audio.speech=dashscope",
-					"spring.ai.model.audio.transcription=none", "spring.ai.model.moderation=none",
+			.withPropertyValues(
+			// @formatter:off
+					"spring.ai.model.chat=none",
+					"spring.ai.model.embedding=none",
+					"spring.ai.model.image=none",
+					"spring.ai.model.audio.speech=dashscope",
+					"spring.ai.model.audio.transcription=none",
+					"spring.ai.model.moderation=none",
 					"spring.ai.model.rerank=none")
+				// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isEmpty();
@@ -266,13 +263,6 @@ class DashScopeModelConfigurationTests {
 				assertThat(context.getBeansOfType(DashScopeAudioTranscriptionModel.class)).isEmpty();
 			});
 
-		this.contextRunner.withPropertyValues("spring.ai.dashscope.audio.transcription.enabled=false")
-			.withConfiguration(AutoConfigurations.of(DashScopeAudioTranscriptionAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(DashScopeAudioTranscriptionProperties.class)).isEmpty();
-				assertThat(context.getBeansOfType(DashScopeAudioTranscriptionModel.class)).isEmpty();
-			});
-
 		this.contextRunner.withPropertyValues("spring.ai.model.audio.transcription=dashscope")
 			.withConfiguration(AutoConfigurations.of(DashScopeAudioTranscriptionAutoConfiguration.class))
 			.run(context -> {
@@ -285,10 +275,16 @@ class DashScopeModelConfigurationTests {
 					DashScopeEmbeddingAutoConfiguration.class, DashScopeImageAutoConfiguration.class,
 					DashScopeAudioSpeechAutoConfiguration.class, DashScopeAudioTranscriptionAutoConfiguration.class,
 					DashScopeRerankAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=none", "spring.ai.model.embedding=none",
-					"spring.ai.model.image=none", "spring.ai.model.audio.speech=none",
-					"spring.ai.model.audio.transcription=dashscope", "spring.ai.model.moderation=none",
+			.withPropertyValues(
+			// @formatter:off
+					"spring.ai.model.chat=none",
+					"spring.ai.model.embedding=none",
+					"spring.ai.model.image=none",
+					"spring.ai.model.audio.speech=none",
+					"spring.ai.model.audio.transcription=dashscope",
+					"spring.ai.model.moderation=none",
 					"spring.ai.model.rerank=none")
+				// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isEmpty();
@@ -319,13 +315,6 @@ class DashScopeModelConfigurationTests {
 				assertThat(context.getBeansOfType(DashScopeRerankModel.class)).isEmpty();
 			});
 
-		this.contextRunner.withPropertyValues("spring.ai.dashscope.rerank.enabled=false")
-			.withConfiguration(AutoConfigurations.of(DashScopeRerankAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(DashScopeRerankProperties.class)).isEmpty();
-				assertThat(context.getBeansOfType(DashScopeRerankModel.class)).isEmpty();
-			});
-
 		this.contextRunner.withPropertyValues("spring.ai.model.rerank=dashscope")
 			.withConfiguration(AutoConfigurations.of(DashScopeRerankAutoConfiguration.class))
 			.run(context -> {
@@ -338,18 +327,24 @@ class DashScopeModelConfigurationTests {
 					DashScopeEmbeddingAutoConfiguration.class, DashScopeImageAutoConfiguration.class,
 					DashScopeAudioSpeechAutoConfiguration.class, DashScopeAudioTranscriptionAutoConfiguration.class,
 					DashScopeRerankAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=none", "spring.ai.model.embedding=none",
-					"spring.ai.model.image=none", "spring.ai.model.audio.speech=none",
-					"spring.ai.model.audio.transcription=dashscope", "spring.ai.model.moderation=none",
-					"spring.ai.model.rerank=none")
+			.withPropertyValues(
+			// @formatter:off
+					"spring.ai.model.chat=none",
+					"spring.ai.model.embedding=none",
+					"spring.ai.model.image=none",
+					"spring.ai.model.audio.speech=none",
+					"spring.ai.model.audio.transcription=none",
+					"spring.ai.model.moderation=none",
+					"spring.ai.model.rerank=dashscope")
+				// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DashScopeEmbeddingAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(DashScopeChatModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(DashScopeEmbeddingModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(DashScopeImageModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(DashScopeSpeechSynthesisModel.class)).isEmpty();
-				assertThat(context.getBeansOfType(DashScopeAudioTranscriptionModel.class)).isNotEmpty();
-				assertThat(context.getBeansOfType(DashScopeRerankModel.class)).isEmpty();
+				assertThat(context.getBeansOfType(DashScopeAudioTranscriptionModel.class)).isEmpty();
+				assertThat(context.getBeansOfType(DashScopeRerankModel.class)).isNotEmpty();
 			});
 	}
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/model/SpringAIAlibabaModelProperties.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/model/SpringAIAlibabaModelProperties.java
@@ -20,6 +20,7 @@ import org.springframework.ai.model.SpringAIModelProperties;
 
 /**
  * @author YunKui Lu
+ * @see org.springframework.ai.model.SpringAIModelProperties
  */
 public final class SpringAIAlibabaModelProperties {
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/model/SpringAIAlibabaModels.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/model/SpringAIAlibabaModels.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.model;
 
 /**
  * @author YunKui Lu
+ * @see org.springframework.ai.model.SpringAIModels
  */
 public final class SpringAIAlibabaModels {
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Right now, the condition for AutoConfiguration in all models is spring.ai.model.audio.speech=openai. This can cause conflicts when using it with Spring AI.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
- Refined the conditions for auto-configuring different DashScope models
- Introduced SpringAIAlibabaModelProperties and SpringAIAlibabaModels classes
- Adjusted conditional checks in auto-configuration logic
- Removed @Primary from the DashScopeEmbeddingModel bean
- Added unit tests to ensure correct model setup

### Describe how to verify it
Used unit test.

### Special notes for reviews
This might be a breaking change, though I didn't see a designated place to call that out in our current setup.

By the way, I also made some fixes to the DashScopeAutoConfigurationIT integration test.