### PR TITLE
feat(mcp): decouple the construction logic of WebFluxSseClientTransport in Nacos MCP client

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-mcp-client/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/client/NacosMcpTransportBuilderAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-mcp-client/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/client/NacosMcpTransportBuilderAutoConfiguration.java
@@ -1,0 +1,22 @@
+package com.alibaba.cloud.ai.autoconfigure.mcp.client;
+
+import com.alibaba.cloud.ai.mcp.nacos.client.builder.WebFluxSseClientTransportBuilder;
+import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author Sunrisea
+ * @since 2025/7/4 11:16
+ */
+@AutoConfiguration(before = { NacosMcpClientAutoConfiguration.class })
+@ConditionalOnClass(WebFluxSseClientTransport.class)
+public class NacosMcpTransportBuilderAutoConfiguration {
+
+	@Bean
+	public WebFluxSseClientTransportBuilder webFluxSseClientTransportBuilder() {
+		return new WebFluxSseClientTransportBuilder();
+	}
+
+}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-mcp-client/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/client/NacosMcpTransportBuilderAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-mcp-client/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/client/NacosMcpTransportBuilderAutoConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.cloud.ai.autoconfigure.mcp.client;
 
 import com.alibaba.cloud.ai.mcp.nacos.client.builder.WebFluxSseClientTransportBuilder;

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-mcp-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-mcp-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -16,5 +16,6 @@
 com.alibaba.cloud.ai.autoconfigure.mcp.client.NacosMcpAutoConfiguration
 com.alibaba.cloud.ai.autoconfigure.mcp.client.NacosMcpClientAutoConfiguration
 com.alibaba.cloud.ai.autoconfigure.mcp.client.NacosMcpToolCallbackAutoConfiguration
+com.alibaba.cloud.ai.autoconfigure.mcp.client.NacosMcpTransportBuilderAutoConfiguration
 
 

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/builder/WebFluxSseClientTransportBuilder.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/builder/WebFluxSseClientTransportBuilder.java
@@ -1,0 +1,17 @@
+package com.alibaba.cloud.ai.mcp.nacos.client.builder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
+import org.springframework.web.reactive.function.client.WebClient;
+
+public class WebFluxSseClientTransportBuilder {
+
+	public WebFluxSseClientTransport build(WebClient.Builder webClientBuilder, ObjectMapper objectMapper,
+			String sseEndpoint) {
+		return WebFluxSseClientTransport.builder(webClientBuilder)
+			.sseEndpoint(sseEndpoint)
+			.objectMapper(objectMapper)
+			.build();
+	}
+
+}

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/builder/WebFluxSseClientTransportBuilder.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/builder/WebFluxSseClientTransportBuilder.java
@@ -1,9 +1,29 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.cloud.ai.mcp.nacos.client.builder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
 import org.springframework.web.reactive.function.client.WebClient;
 
+/**
+ * @author Sunrisea
+ * @since 2025/7/4 11:16
+ */
 public class WebFluxSseClientTransportBuilder {
 
 	public WebFluxSseClientTransport build(WebClient.Builder webClientBuilder, ObjectMapper objectMapper,

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/transport/LoadbalancedMcpAsyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/transport/LoadbalancedMcpAsyncClient.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.ai.mcp.nacos.client.transport;
 
+import com.alibaba.cloud.ai.mcp.nacos.client.builder.WebFluxSseClientTransportBuilder;
 import com.alibaba.cloud.ai.mcp.nacos.client.utils.NacosMcpClientUtils;
 import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
 import com.alibaba.cloud.ai.mcp.nacos.service.model.NacosMcpServerEndpoint;
@@ -64,6 +65,8 @@ public class LoadbalancedMcpAsyncClient {
 
 	private final McpAsyncClientConfigurer mcpAsyncClientConfigurer;
 
+	private final WebFluxSseClientTransportBuilder webFluxSseClientTransportBuilder;
+
 	private final ObjectMapper objectMapper;
 
 	private final ApplicationContext applicationContext;
@@ -102,6 +105,7 @@ public class LoadbalancedMcpAsyncClient {
 		mcpAsyncClientConfigurer = this.applicationContext.getBean(McpAsyncClientConfigurer.class);
 		objectMapper = this.applicationContext.getBean(ObjectMapper.class);
 		webClientBuilderTemplate = this.applicationContext.getBean(WebClient.Builder.class);
+		webFluxSseClientTransportBuilder = this.applicationContext.getBean(WebFluxSseClientTransportBuilder.class);
 	}
 
 	public void init() {
@@ -338,7 +342,8 @@ public class LoadbalancedMcpAsyncClient {
 
 		String baseUrl = "http://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
 		WebClient.Builder webClientBuilder = webClientBuilderTemplate.clone().baseUrl(baseUrl);
-		WebFluxSseClientTransport transport = new WebFluxSseClientTransport(webClientBuilder, objectMapper, exportPath);
+		WebFluxSseClientTransport transport = webFluxSseClientTransportBuilder.build(webClientBuilder, objectMapper,
+				exportPath);
 		NamedClientMcpTransport namedTransport = new NamedClientMcpTransport(
 				serverName + "-" + NacosMcpClientUtils.getMcpEndpointInfoId(mcpEndpointInfo, exportPath), transport);
 		McpSchema.Implementation clientInfo = new McpSchema.Implementation(

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/transport/LoadbalancedMcpSyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-nacos/src/main/java/com/alibaba/cloud/ai/mcp/nacos/client/transport/LoadbalancedMcpSyncClient.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.ai.mcp.nacos.client.transport;
 
+import com.alibaba.cloud.ai.mcp.nacos.client.builder.WebFluxSseClientTransportBuilder;
 import com.alibaba.cloud.ai.mcp.nacos.client.utils.NacosMcpClientUtils;
 import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
 import com.alibaba.cloud.ai.mcp.nacos.service.model.NacosMcpServerEndpoint;
@@ -62,6 +63,8 @@ public class LoadbalancedMcpSyncClient {
 
 	private final McpSyncClientConfigurer mcpSyncClientConfigurer;
 
+	private final WebFluxSseClientTransportBuilder webFluxSseClientTransportBuilder;
+
 	private final ObjectMapper objectMapper;
 
 	private final ApplicationContext applicationContext;
@@ -100,6 +103,7 @@ public class LoadbalancedMcpSyncClient {
 		mcpSyncClientConfigurer = this.applicationContext.getBean(McpSyncClientConfigurer.class);
 		objectMapper = this.applicationContext.getBean(ObjectMapper.class);
 		webClientBuilderTemplate = this.applicationContext.getBean(WebClient.Builder.class);
+		webFluxSseClientTransportBuilder = this.applicationContext.getBean(WebFluxSseClientTransportBuilder.class);
 	}
 
 	public void init() {
@@ -278,7 +282,8 @@ public class LoadbalancedMcpSyncClient {
 		McpSyncClient syncClient;
 		String baseUrl = "http://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
 		WebClient.Builder webClientBuilder = webClientBuilderTemplate.clone().baseUrl(baseUrl);
-		WebFluxSseClientTransport transport = new WebFluxSseClientTransport(webClientBuilder, objectMapper, exportPath);
+		WebFluxSseClientTransport transport = webFluxSseClientTransportBuilder.build(webClientBuilder, objectMapper,
+				exportPath);
 		NamedClientMcpTransport namedTransport = new NamedClientMcpTransport(
 				serverName + "-" + NacosMcpClientUtils.getMcpEndpointInfoId(mcpEndpointInfo, exportPath), transport);
 		McpSchema.Implementation clientInfo = new McpSchema.Implementation(


### PR DESCRIPTION
### Describe what this PR does / why we need it
Decouple the construction logic of WebFluxSseClientTransport in Nacos MCP client to to ensure extensibility
解耦 Nacos mcp client 中 WebFluxSseClientTransport 构建逻辑,预留扩展


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
