### PR TITLE
fix(jmanus): After modifying McpTool injection to new object, multiple MCP tools can be executed

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/PlanningFactory.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/PlanningFactory.java
@@ -116,9 +116,6 @@ public class PlanningFactory {
 	private DynamicAgentLoader dynamicAgentLoader;
 
 	@Autowired
-	private McpStateHolderService mcpStateHolderService;
-
-	@Autowired
 	private MapReduceSharedStateManager sharedStateManager;
 
 	@Autowired
@@ -209,7 +206,7 @@ public class PlanningFactory {
 			ToolCallback[] tCallbacks = toolCallback.getAsyncMcpToolCallbackProvider().getToolCallbacks();
 			for (ToolCallback tCallback : tCallbacks) {
 				// The serviceGroup is the name of the tool
-				toolDefinitions.add(new McpTool(tCallback, serviceGroup, planId, mcpStateHolderService));
+				toolDefinitions.add(new McpTool(tCallback, serviceGroup, planId, new McpStateHolderService()));
 			}
 		}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

mcp工具初始化的时候McpStateHolderService 需要new 一个新的，因为McpStateHolderService没有隔离mcp工具。在多个mcp工具的时候会串状态
### Does this pull request fix one issue?
yes
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
