### PR TITLE
fix(jmanus): resolve the search error issue after jmanus startup

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/ManusProperties.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/ManusProperties.java
@@ -136,7 +136,7 @@ public class ManusProperties {
 	}
 
 	@ConfigProperty(group = "manus", subGroup = "agents", key = "forceOverrideFromYaml",
-			path = "manus.agents.forceOverrideFromYaml", description = "强制使用YAML配置文件覆盖同名Agent", defaultValue = "false",
+			path = "manus.agents.forceOverrideFromYaml", description = "强制使用YAML配置文件覆盖同名Agent", defaultValue = "true",
 			inputType = ConfigInputType.CHECKBOX,
 			options = { @ConfigOption(value = "true", label = "是"), @ConfigOption(value = "false", label = "否") })
 	private volatile Boolean forceOverrideFromYaml;


### PR DESCRIPTION
### Describe what this PR does / why we need it
解决jmanus启动后搜索报错问题，因为manus.agents.forceOverrideFromYaml现在默认值为false，初始化项目的时候默认的一些agent无法加载到，所以交互时无法执行任务。（这里因为h2数据库是本地文件存储的问题，所以已经初始化过的项目需要删除本地缓存文件后才能复现）
![f087823b-119a-4fdb-bcf2-f957ef7f8406](https://github.com/user-attachments/assets/a6a51ea8-b47b-468d-bcd2-0110f873a792)
![3ba6809f-bb52-4ad8-aaa7-e29816b822bf](https://github.com/user-attachments/assets/30562375-07f2-45a7-a45b-ea754dab2d99)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
修改配置：强制使用YAML配置文件覆盖同名Agent配置默认值改为true

### Describe how to verify it
启动项目后，搜索：阿里巴巴股票。

### Special notes for reviews
