### PR TITLE
fix(vector-stores): fixed OpenSearchVectorStore.Builder#build 无限递归问题

### DIFF
--- a/community/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/community/vector-stores/spring-ai-alibaba-starter-opensearch-store/src/main/java/com/alibaba/cloud/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -338,7 +338,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 */
 		@Override
 		public OpenSearchVectorStore build() {
-			return OpenSearchVectorStore.builder(this.openSearchApi, this.embeddingModel).build();
+			return new OpenSearchVectorStore(this);
 		}
 
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it
`
原代码会导致无限递归
public OpenSearchVectorStore build() { 
return OpenSearchVectorStore.builder(this.openSearchApi, this.embeddingModel).build(); 
}
`

### Does this pull request fix one issue?

NONE

### Describe how you did it

使用com.alibaba.cloud.ai.vectorstore.opensearch.OpenSearchVectorStore#OpenSearchVectorStore(com.alibaba.cloud.ai.vectorstore.opensearch.OpenSearchVectorStore.Builder)构造函数 代替OpenSearchVectorStore.builder(this.openSearchApi, this.embeddingModel).build();

### Describe how to verify it
OpenSearchVectorStore.builder(openSearchApi, dashScopeEmbeddingModel).options(openSearchVectorStoreOptions).build();可以成功创建openSearchVectorStore对象并使用。

### Special notes for reviews
