### PR TITLE
fix(graph): enable langfuse input output observation labels

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationLifecycleListener.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationLifecycleListener.java
@@ -85,7 +85,8 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	}
 
 	/**
-	 * Handles the before execution phase of a graph node. Creates node observation and records input state.
+	 * Handles the before execution phase of a graph node. Creates node observation and
+	 * records input state.
 	 * @param nodeId the identifier of the node
 	 * @param state the current state of the graph execution
 	 * @param config the runnable configuration for the node
@@ -97,7 +98,7 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 
 		// Create minimal context for the observation
 		GraphNodeObservationContext context = new GraphNodeObservationContext(nodeId, "execution");
-		
+
 		Observation nodeObservation = Observation.createNotStarted(DEFAULT_GRAPH_NODE_OBSERVATION_CONVENTION,
 				() -> context, observationRegistry);
 
@@ -118,7 +119,8 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	}
 
 	/**
-	 * Handles the after execution phase of a graph node. Adds output state and stops observation.
+	 * Handles the after execution phase of a graph node. Adds output state and stops
+	 * observation.
 	 * @param nodeId the identifier of the node
 	 * @param state the current state of the graph execution
 	 * @param config the runnable configuration for the node
@@ -134,13 +136,13 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 		}
 
 		Observation nodeObservation = nodeObservations.remove(nodeId);
-		
+
 		if (nodeObservation != null) {
 			// Add output state using Documentation constant
 			nodeObservation.highCardinalityKeyValue(
 					GraphNodeObservationDocumentation.HighCardinalityKeyNames.GEN_AI_COMPLETION.asString(),
 					state != null ? state.toString() : "");
-			
+
 			nodeObservation.stop();
 		}
 		else {
@@ -149,7 +151,8 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	}
 
 	/**
-	 * Handles errors during graph node execution. Records the error and stops observation.
+	 * Handles errors during graph node execution. Records the error and stops
+	 * observation.
 	 * @param nodeId the identifier of the node that encountered an error
 	 * @param state the current state of the graph execution
 	 * @param ex the exception that occurred
@@ -165,13 +168,13 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 		}
 
 		Observation nodeObservation = nodeObservations.remove(nodeId);
-		
+
 		if (nodeObservation != null) {
 			// Add error state using Documentation constant
 			nodeObservation.highCardinalityKeyValue(
 					GraphNodeObservationDocumentation.HighCardinalityKeyNames.GEN_AI_COMPLETION.asString(),
 					state != null ? state.toString() : "");
-			
+
 			nodeObservation.error(ex).stop();
 		}
 

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationLifecycleListener.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationLifecycleListener.java
@@ -21,6 +21,7 @@ import com.alibaba.cloud.ai.graph.observation.graph.DefaultGraphObservationConve
 import com.alibaba.cloud.ai.graph.observation.graph.GraphObservationContext;
 import com.alibaba.cloud.ai.graph.observation.node.DefaultGraphNodeObservationConvention;
 import com.alibaba.cloud.ai.graph.observation.node.GraphNodeObservationContext;
+import com.alibaba.cloud.ai.graph.observation.node.GraphNodeObservationDocumentation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
@@ -31,8 +32,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Lifecycle listener for graph observation operations. Implements GraphLifecycleListener
- * to create observations for different graph lifecycle events. Handles cross-thread
- * observation propagation for async execution environments.
+ * to create observations for different graph lifecycle events. Records complete node
+ * execution information including input and output states.
  */
 public class GraphObservationLifecycleListener implements GraphLifecycleListener {
 
@@ -84,8 +85,7 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	}
 
 	/**
-	 * Handles the before execution phase of a graph node. Creates a node-level
-	 * observation and maintains scope for cross-thread propagation.
+	 * Handles the before execution phase of a graph node. Creates node observation and records input state.
 	 * @param nodeId the identifier of the node
 	 * @param state the current state of the graph execution
 	 * @param config the runnable configuration for the node
@@ -95,12 +95,20 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	public void before(String nodeId, Map<String, Object> state, RunnableConfig config, Long curTime) {
 		log.debug("Starting observation for node: {}", nodeId);
 
+		// Create minimal context for the observation
+		GraphNodeObservationContext context = new GraphNodeObservationContext(nodeId, "execution");
+		
 		Observation nodeObservation = Observation.createNotStarted(DEFAULT_GRAPH_NODE_OBSERVATION_CONVENTION,
-				() -> new GraphNodeObservationContext(nodeId, "execution", state, null), observationRegistry);
+				() -> context, observationRegistry);
 
 		if (graphObservation != null) {
 			nodeObservation.parentObservation(graphObservation);
 		}
+
+		// Add input state using Documentation constant
+		nodeObservation.highCardinalityKeyValue(
+				GraphNodeObservationDocumentation.HighCardinalityKeyNames.GEN_AI_PROMPT.asString(),
+				state != null ? state.toString() : "");
 
 		nodeObservation.start();
 		nodeObservations.put(nodeId, nodeObservation);
@@ -110,8 +118,7 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	}
 
 	/**
-	 * Handles the after execution phase of a graph node. Properly closes scope and stops
-	 * the node observation.
+	 * Handles the after execution phase of a graph node. Adds output state and stops observation.
 	 * @param nodeId the identifier of the node
 	 * @param state the current state of the graph execution
 	 * @param config the runnable configuration for the node
@@ -127,7 +134,13 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 		}
 
 		Observation nodeObservation = nodeObservations.remove(nodeId);
+		
 		if (nodeObservation != null) {
+			// Add output state using Documentation constant
+			nodeObservation.highCardinalityKeyValue(
+					GraphNodeObservationDocumentation.HighCardinalityKeyNames.GEN_AI_COMPLETION.asString(),
+					state != null ? state.toString() : "");
+			
 			nodeObservation.stop();
 		}
 		else {
@@ -136,8 +149,7 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	}
 
 	/**
-	 * Handles errors during graph node execution. Records the error and properly cleans
-	 * up scope and observation.
+	 * Handles errors during graph node execution. Records the error and stops observation.
 	 * @param nodeId the identifier of the node that encountered an error
 	 * @param state the current state of the graph execution
 	 * @param ex the exception that occurred
@@ -153,7 +165,13 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 		}
 
 		Observation nodeObservation = nodeObservations.remove(nodeId);
+		
 		if (nodeObservation != null) {
+			// Add error state using Documentation constant
+			nodeObservation.highCardinalityKeyValue(
+					GraphNodeObservationDocumentation.HighCardinalityKeyNames.GEN_AI_COMPLETION.asString(),
+					state != null ? state.toString() : "");
+			
 			nodeObservation.error(ex).stop();
 		}
 
@@ -163,7 +181,7 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 	}
 
 	/**
-	 * Handles the completion of graph execution. Cleans up all observations and scopes.
+	 * Handles the completion of graph execution. Cleans up all observations.
 	 * @param nodeId the identifier of the completed node
 	 * @param state the current state of the graph execution
 	 * @param config the runnable configuration for the node

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/DefaultGraphNodeObservationConvention.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/DefaultGraphNodeObservationConvention.java
@@ -103,11 +103,7 @@ public class DefaultGraphNodeObservationConvention implements GraphNodeObservati
 	 */
 	@Override
 	public KeyValues getHighCardinalityKeyValues(GraphNodeObservationContext context) {
-		return KeyValues.of(
-				KeyValue.of(GraphNodeObservationDocumentation.HighCardinalityKeyNames.GRAPH_NODE_STATE,
-						context.getState() != null ? context.getState().toString() : ""),
-				KeyValue.of(GraphNodeObservationDocumentation.HighCardinalityKeyNames.GRAPH_NODE_OUTPUT,
-						context.getOutput() != null ? context.getOutput().toString() : ""));
+		return KeyValues.empty();
 	}
 
 }

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationContext.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationContext.java
@@ -17,12 +17,10 @@ package com.alibaba.cloud.ai.graph.observation.node;
 
 import io.micrometer.observation.Observation;
 
-import java.util.Map;
-
 /**
  * Context class for graph node observation operations. Provides node-specific observation
- * data including node name, event type, state, and output information. Extends
- * Observation.Context to integrate with Micrometer's observation framework.
+ * data including node name and event type. Extends Observation.Context to integrate with
+ * Micrometer's observation framework.
  */
 public class GraphNodeObservationContext extends Observation.Context {
 
@@ -30,30 +28,14 @@ public class GraphNodeObservationContext extends Observation.Context {
 
 	private final String event;
 
-	private final Map<String, Object> state;
-
-	private final Object output;
-
 	/**
 	 * Constructs a new GraphNodeObservationContext with the specified parameters.
 	 * @param nodeName the name of the graph node being observed
 	 * @param event the type of event occurring on the node
-	 * @param state the current state of the node execution
-	 * @param output the output data from the node execution
 	 */
-	public GraphNodeObservationContext(String nodeName, String event, Map<String, Object> state, Object output) {
+	public GraphNodeObservationContext(String nodeName, String event) {
 		this.nodeName = nodeName;
 		this.event = event;
-		this.state = state;
-		this.output = output;
-	}
-
-	/**
-	 * Gets the output data from the node execution.
-	 * @return the node output as a map of key-value pairs
-	 */
-	public Object getOutput() {
-		return this.output;
 	}
 
 	/**
@@ -82,14 +64,6 @@ public class GraphNodeObservationContext extends Observation.Context {
 	}
 
 	/**
-	 * Gets the current state of the node execution.
-	 * @return the node state as a map of key-value pairs
-	 */
-	public Map<String, Object> getState() {
-		return this.state;
-	}
-
-	/**
 	 * Creates a new Builder instance for constructing GraphNodeObservationContext
 	 * objects.
 	 * @return a new Builder instance
@@ -107,10 +81,6 @@ public class GraphNodeObservationContext extends Observation.Context {
 		private String nodeName;
 
 		private String event;
-
-		private Map<String, Object> state;
-
-		private Object output;
 
 		/**
 		 * Sets the node name for the observation context.
@@ -133,32 +103,12 @@ public class GraphNodeObservationContext extends Observation.Context {
 		}
 
 		/**
-		 * Sets the state for the observation context.
-		 * @param state the current state of the node execution
-		 * @return this builder instance for method chaining
-		 */
-		public Builder state(Map<String, Object> state) {
-			this.state = state;
-			return this;
-		}
-
-		/**
-		 * Sets the output for the observation context.
-		 * @param output the output data from the node execution
-		 * @return this builder instance for method chaining
-		 */
-		public Builder output(Object output) {
-			this.output = output;
-			return this;
-		}
-
-		/**
 		 * Builds and returns a new GraphNodeObservationContext instance with the
 		 * configured properties.
 		 * @return a new GraphNodeObservationContext instance
 		 */
 		public GraphNodeObservationContext build() {
-			return new GraphNodeObservationContext(nodeName, event, state, output);
+			return new GraphNodeObservationContext(nodeName, event);
 		}
 
 	}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationDocumentation.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationDocumentation.java
@@ -102,22 +102,24 @@ public enum GraphNodeObservationDocumentation implements ObservationDocumentatio
 	public enum HighCardinalityKeyNames implements KeyName {
 
 		/**
-		 * Represents the current state of the graph node execution.
+		 * Represents the input state when entering the graph node (OpenTelemetry semantic convention).
+		 * Note: This key is dynamically added by GraphObservationLifecycleListener, not by Convention.
 		 */
-		GRAPH_NODE_STATE {
+		GEN_AI_PROMPT {
 			@Override
 			public String asString() {
-				return "spring.ai.alibaba.graph.node.state";
+				return "gen_ai.prompt";
 			}
 		},
 
 		/**
-		 * Represents the output data from the graph node execution.
+		 * Represents the output state after executing the graph node (OpenTelemetry semantic convention).
+		 * Note: This key is dynamically added by GraphObservationLifecycleListener, not by Convention.
 		 */
-		GRAPH_NODE_OUTPUT {
+		GEN_AI_COMPLETION {
 			@Override
 			public String asString() {
-				return "spring.ai.alibaba.graph.node.output";
+				return "gen_ai.completion";
 			}
 		}
 

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationDocumentation.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationDocumentation.java
@@ -102,8 +102,9 @@ public enum GraphNodeObservationDocumentation implements ObservationDocumentatio
 	public enum HighCardinalityKeyNames implements KeyName {
 
 		/**
-		 * Represents the input state when entering the graph node (OpenTelemetry semantic convention).
-		 * Note: This key is dynamically added by GraphObservationLifecycleListener, not by Convention.
+		 * Represents the input state when entering the graph node (OpenTelemetry semantic
+		 * convention). Note: This key is dynamically added by
+		 * GraphObservationLifecycleListener, not by Convention.
 		 */
 		GEN_AI_PROMPT {
 			@Override
@@ -113,8 +114,9 @@ public enum GraphNodeObservationDocumentation implements ObservationDocumentatio
 		},
 
 		/**
-		 * Represents the output state after executing the graph node (OpenTelemetry semantic convention).
-		 * Note: This key is dynamically added by GraphObservationLifecycleListener, not by Convention.
+		 * Represents the output state after executing the graph node (OpenTelemetry
+		 * semantic convention). Note: This key is dynamically added by
+		 * GraphObservationLifecycleListener, not by Convention.
 		 */
 		GEN_AI_COMPLETION {
 			@Override

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationHandler.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/node/GraphNodeObservationHandler.java
@@ -51,8 +51,6 @@ public class GraphNodeObservationHandler implements ObservationHandler<GraphNode
 	 */
 	@Override
 	public void onStop(GraphNodeObservationContext context) {
-		logger.info("Graph nodeName: {} event: {} state: {} output : {}", context.getNodeName(), context.getEvent(),
-				context.getState().toString(), context.getOutput().toString());
 		GraphMetricsGenerator.generate(context, meterRegistry, true);
 	}
 
@@ -63,8 +61,6 @@ public class GraphNodeObservationHandler implements ObservationHandler<GraphNode
 	 */
 	@Override
 	public void onError(GraphNodeObservationContext context) {
-		logger.error("Graph nodeName: {} event: {} state: {} output : {}", context.getNodeName(), context.getEvent(),
-				context.getState().toString(), context.getOutput().toString());
 		GraphMetricsGenerator.generate(context, meterRegistry, false);
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Implement of graph observation cannot display node input state or output state in langfuse.
This PR dynamically add attributes with proper label of OTel gen_ai standard, enabling correct display with langfuse.

### Does this pull request fix one issue?
NONE

### Describe how to verify it
![image](https://github.com/user-attachments/assets/d627efd0-ba6a-4f65-afec-6d5cddc00944)


### Special notes for reviews
