### PR TITLE
fix(memories): resolve the issue where the starter component that introduces memory and Redis still cannot use Redis as memory

### DIFF
--- a/community/memories/spring-ai-alibaba-starter-memory-redis/pom.xml
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/pom.xml
@@ -53,7 +53,6 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>${jedis.version}</version>
-            <optional>true</optional>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
### Describe what this PR does / why we need it
我今天尝试将jmanus从内存memory切换为redis-mem的时候，发现将auto-mem和redis-mem的starter都引入后依然无法正常使用，甚至启动都会报错。
<img width="1920" height="1032" alt="6e1a2078-b39b-4f55-819e-dc8eb50982a5" src="https://github.com/user-attachments/assets/7b340aa1-7371-44ba-b017-fd0eeaa5d650" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/d0878f42-001e-45db-ab08-f709c6ba651e" />
经过排查我发现是因为在memory-redis项目中引入的jedis限定了不传递
<img width="1391" height="872" alt="image" src="https://github.com/user-attachments/assets/6ff4c98a-21ad-4bfb-b82f-afc13151f048" />
而在autoconfigure-memory中加载RedisChatMemoryAutoConfiguration的条件是需要jedis的
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/bec31f40-df76-4a01-be3b-65e706a92b93" />
所以这就需要在使用的项目中手动引入jedis，这个错误不容易发现，且我认为starter应该是开箱即用的。我理解不传递jedis是怕redis和jedis的兼容性问题，但是兼容性问题很容易在启动或使用过程中发现，并且大家在使用前也会思考到这个问题，会分析是否需要排除已有的jedis版本引入适配的jedis版本。
我认为应该让jedis的引用传递，更符合starter的开箱即用思想，无论如何都尊重管理员的决定，辛苦啦。
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
