### PR TITLE
fix(core): fix async generator bug

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperators.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperators.java
@@ -102,7 +102,8 @@ public interface AsyncGeneratorOperators<E> {
 				future = future.thenCompose(v -> finalNext.embed.generator.async(executor()).forEachAsync(consumer));
 			}
 			else {
-				future = future.thenCompose(v -> finalNext.data.thenAcceptAsync(consumer, executor()).thenApply(x -> null));
+				future = future
+					.thenCompose(v -> finalNext.data.thenAcceptAsync(consumer, executor()).thenApply(x -> null));
 			}
 		}
 		return future;

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperators.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperators.java
@@ -95,23 +95,17 @@ public interface AsyncGeneratorOperators<E> {
 	 * @return a CompletableFuture representing the completion of the iteration process.
 	 */
 	default CompletableFuture<Object> forEachAsync(Consumer<E> consumer) {
-
-		final var next = next();
-		if (next.isDone()) {
-			return completedFuture(next.resultValue);
+		CompletableFuture<Object> future = completedFuture(null);
+		for (AsyncGenerator.Data<E> next = next(); !next.isDone(); next = next()) {
+			final AsyncGenerator.Data<E> finalNext = next;
+			if (finalNext.embed != null) {
+				future = future.thenCompose(v -> finalNext.embed.generator.async(executor()).forEachAsync(consumer));
+			}
+			else {
+				future = future.thenCompose(v -> finalNext.data.thenAcceptAsync(consumer, executor()).thenApply(x -> null));
+			}
 		}
-		if (next.embed != null) {
-			return next.embed.generator.async(executor())
-				.forEachAsync(consumer)
-				.thenCompose(v -> forEachAsync(consumer));
-		}
-		else {
-			return next.data.thenApplyAsync(v -> {
-				consumer.accept(v);
-				return null;
-			}, executor()).thenCompose(v -> forEachAsync(consumer));
-		}
-
+		return future;
 	}
 
 	/**
@@ -122,15 +116,15 @@ public interface AsyncGeneratorOperators<E> {
 	 * @return a CompletableFuture representing the completion of the collection process
 	 */
 	default <R extends List<E>> CompletableFuture<R> collectAsync(R result, BiConsumer<R, E> consumer) {
-		final var next = next();
-		if (next.isDone()) {
-			return completedFuture(result);
+		CompletableFuture<R> future = completedFuture(result);
+		for (AsyncGenerator.Data<E> next = next(); !next.isDone(); next = next()) {
+			final AsyncGenerator.Data<E> finalNext = next;
+			future = future.thenCompose(res -> finalNext.data.thenApplyAsync(v -> {
+				consumer.accept(res, v);
+				return res;
+			}, executor()));
 		}
-		return next.data.thenApplyAsync(v -> {
-			consumer.accept(result, v);
-			return null;
-		}, executor()).thenCompose(v -> collectAsync(result, consumer));
-
+		return future;
 	}
 
 }

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperatorsStackOverflowTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperatorsStackOverflowTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.async;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AsyncGeneratorOperatorsStackOverflowTest {
+
+    @Test
+    void forEachAsyncShouldProcessAllElementsWithoutStackOverflow() {
+        // Given a generator with a large number of elements
+        int largeNumberOfElements = 20000;
+        var counter = new AtomicInteger(0);
+        var stream = IntStream.range(0, largeNumberOfElements).iterator();
+
+        AsyncGenerator<Integer> largeGenerator = () -> {
+            if (!stream.hasNext()) {
+                return AsyncGenerator.Data.done(null);
+            }
+            return AsyncGenerator.Data.of(CompletableFuture.completedFuture(stream.next()));
+        };
+
+        // When forEachAsync is called, it should not throw an exception
+        assertDoesNotThrow(() -> {
+            largeGenerator.forEachAsync(i -> counter.incrementAndGet()).join();
+        });
+
+        // Then all elements should be processed
+        assertEquals(largeNumberOfElements, counter.get(), "All elements should have been processed");
+    }
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperatorsStackOverflowTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperatorsStackOverflowTest.java
@@ -27,26 +27,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AsyncGeneratorOperatorsStackOverflowTest {
 
-    @Test
-    void forEachAsyncShouldProcessAllElementsWithoutStackOverflow() {
-        // Given a generator with a large number of elements
-        int largeNumberOfElements = 20000;
-        var counter = new AtomicInteger(0);
-        var stream = IntStream.range(0, largeNumberOfElements).iterator();
+	@Test
+	void forEachAsyncShouldProcessAllElementsWithoutStackOverflow() {
+		// Given a generator with a large number of elements
+		int largeNumberOfElements = 20000;
+		var counter = new AtomicInteger(0);
+		var stream = IntStream.range(0, largeNumberOfElements).iterator();
 
-        AsyncGenerator<Integer> largeGenerator = () -> {
-            if (!stream.hasNext()) {
-                return AsyncGenerator.Data.done(null);
-            }
-            return AsyncGenerator.Data.of(CompletableFuture.completedFuture(stream.next()));
-        };
+		AsyncGenerator<Integer> largeGenerator = () -> {
+			if (!stream.hasNext()) {
+				return AsyncGenerator.Data.done(null);
+			}
+			return AsyncGenerator.Data.of(CompletableFuture.completedFuture(stream.next()));
+		};
 
-        // When forEachAsync is called, it should not throw an exception
-        assertDoesNotThrow(() -> {
-            largeGenerator.forEachAsync(i -> counter.incrementAndGet()).join();
-        });
+		// When forEachAsync is called, it should not throw an exception
+		assertDoesNotThrow(() -> {
+			largeGenerator.forEachAsync(i -> counter.incrementAndGet()).join();
+		});
 
-        // Then all elements should be processed
-        assertEquals(largeNumberOfElements, counter.get(), "All elements should have been processed");
-    }
+		// Then all elements should be processed
+		assertEquals(largeNumberOfElements, counter.get(), "All elements should have been processed");
+	}
+
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

```
2025-07-14T23:30:46.509+08:00 ERROR 79752 --- [onPool-worker-1] c.a.c.a.c.Nl2sqlForGraphController       : Error in stream processing
java.util.concurrent.CompletionException: java.lang.StackOverflowError
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[na:na]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:687) ~[na:na]
	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662) ~[na:na]
	at java.base/java.util.concurrent.CompletableFuture.thenApplyAsync(CompletableFuture.java:2178) ~[na:na]
	at com.alibaba.cloud.ai.graph.async.AsyncGeneratorOperators.forEachAsync(AsyncGeneratorOperators.java:109) `~[classes/:na]
	at com.alibaba.cloud.ai.graph.async.AsyncGeneratorOperators.lambda$forEachAsync$5(AsyncGeneratorOperators.java:112) ~[classes/:na]
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187) ~[na:na]
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2309) ~[na:na]
```

---

When processing an AsyncGenerator with a large number of elements using
AsyncGeneratorOperators.forEachAsync or collectAsync, a java.lang.StackOverflowError is thrown. This error
is typically wrapped in a java.util.concurrent.CompletionException because it occurs within an asynchronous CompletableFuture execution flow.


#### Cause:

  The original implementations of forEachAsync and collectAsync were based on recursion. Specifically, they
  recursively called themselves within a thenCompose block to process the next element in the sequence. For
  a generator with a very large number of elements (e.g., tens of thousands), this approach creates an
  extremely deep CompletableFuture chain, which exceeds the JVM's call stack limit and results in a
  StackOverflowError.

  Solution:

   1. Adopted Iterative Implementation: Replaced the recursive calls with a for loop to iterate through all
      elements of the AsyncGenerator.
   2. Built a Flat Future Chain: Inside the loop, each operation is chained using future.thenCompose(...). This
       approach transforms the vertical, stack-consuming call structure into a horizontal CompletableFuture
      chain that does not increase the call stack depth.
 

  This modification not only fixes the identified StackOverflowError in forEachAsync but also proactively
  strengthens collectAsync, ensuring the stability and reliability of AsyncGenerator when handling
  large-scale data streams.
