### PR TITLE
fix(jmanus):agent namespace incapable with old config

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/entity/DynamicAgentEntity.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/entity/DynamicAgentEntity.java
@@ -21,14 +21,15 @@ import com.alibaba.cloud.ai.example.manus.dynamic.model.entity.DynamicModelEntit
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "dynamic_agents")
+@Table(name = "dynamic_agents", uniqueConstraints = {
+		@UniqueConstraint(columnNames = { "namespace", "agent_name" }, name = "unique_namespace_agent_name") })
 public class DynamicAgentEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false, unique = false)
 	private String agentName;
 
 	@Column(nullable = false, length = 1000)


### PR DESCRIPTION
### Describe what this PR does / why we need it
和prompt&namespace一样的问题。在agent初始化时，由于agent_name唯一索引导致的报错。
参考链接：https://github.com/alibaba/spring-ai-alibaba/pull/1644

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
（1）按prompt方法修复了agent
（2）优化了一点agent初始化代码，将两次sql查询变成了一次。

### Describe how to verify it


### Special notes for reviews
