### PR TITLE
fix(core): convert default split character  ";" to "；"

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/transformer/splitter/RecursiveCharacterTextSplitter.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/transformer/splitter/RecursiveCharacterTextSplitter.java
@@ -66,7 +66,7 @@ public class RecursiveCharacterTextSplitter extends TextSplitter {
 
 		this.chunkSize = chunkSize;
 		this.separators = Objects.requireNonNullElse(separators,
-				new String[] { "\n\n", "\n", "。", "！", "？", ";", "，", " " });
+				new String[] { "\n\n", "\n", "。", "！", "？", "；", "，", " " });
 	}
 
 	@Override


### PR DESCRIPTION
### Describe what this PR does / why we need it
修正默认文本分隔符中的分号为全角分号 "；"，与其他标点符号保持一致

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
由于英文中句号和小数点是同一个符号，因此该类逻辑更适合中文环境，故分隔符标点都是中文，但也支持用户自定义分隔符