### PR TITLE
feat(core): Handle null function name in ToolCall to slove NPE

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class TemplateTransformNode implements NodeAction {
+
+	private static final Logger logger = LoggerFactory.getLogger(TemplateTransformNode.class);
+
+	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{\\s*(.+?)\\s*\\}\\}");
+
+	private final String template;
+
+	private final String outputKey;
+
+	private TemplateTransformNode(String template, String outputKey) {
+		this.template = template;
+		this.outputKey = outputKey != null ? outputKey : "result";
+	}
+
+	@Override
+	public Map<String, Object> apply(OverAllState state) {
+		if (template == null || template.isEmpty()) {
+			logger.warn("Template is null or empty, returning empty result");
+			Map<String, Object> result = new HashMap<>();
+			result.put(outputKey, "");
+			return result;
+		}
+
+		logger.debug("Processing template: {}", template);
+
+		// Replace {{key}} in the template with the value of state.get(key)
+		StringBuffer sb = new StringBuffer();
+		Matcher matcher = PLACEHOLDER_PATTERN.matcher(template);
+
+		while (matcher.find()) {
+			String key = matcher.group(1).trim();
+			Optional<Object> valueOpt = state.value(key);
+			String replacement;
+
+			if (valueOpt.isPresent()) {
+				Object val = valueOpt.get();
+				replacement = val != null ? val.toString() : "null";
+				// Escape special regex characters in replacement
+				replacement = replacement.replace("\\", "\\\\").replace("$", "\\$");
+				logger.debug("Replaced placeholder {{{}}} with value: {}", key, replacement);
+			}
+			else {
+				// Keep the placeholder if the variable is not found
+				replacement = "{{" + key + "}}";
+				replacement = replacement.replace("\\", "\\\\").replace("$", "\\$");
+				logger.debug("Variable '{}' not found, keeping placeholder: {}", key, replacement);
+			}
+
+			matcher.appendReplacement(sb, replacement);
+		}
+		matcher.appendTail(sb);
+
+		String resolved = sb.toString();
+		logger.debug("Template transformation completed. Result: {}", resolved);
+
+		// Write the result back to the state
+		Map<String, Object> result = new HashMap<>();
+		result.put(outputKey, resolved);
+		return result;
+	}
+
+	/**
+	 * Create a new builder for TemplateTransformNode
+	 * @return a new Builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder class for TemplateTransformNode
+	 */
+	public static class Builder {
+
+		private String template;
+
+		private String outputKey;
+
+		/**
+		 * Set the template string with placeholders
+		 * @param template the template string, e.g., "Hello {{name}}!"
+		 * @return this builder
+		 * @throws IllegalArgumentException if template is null
+		 */
+		public Builder template(String template) {
+			if (template == null) {
+				throw new IllegalArgumentException("Template cannot be null");
+			}
+			this.template = template;
+			return this;
+		}
+
+		/**
+		 * Set the output key for the transformed result
+		 * @param outputKey the key to store the result in state, defaults to "result"
+		 * @return this builder
+		 */
+		public Builder outputKey(String outputKey) {
+			this.outputKey = outputKey;
+			return this;
+		}
+
+		/**
+		 * Build the TemplateTransformNode
+		 * @return a new TemplateTransformNode instance
+		 * @throws IllegalArgumentException if template is null or empty
+		 */
+		public TemplateTransformNode build() {
+			if (template == null || template.trim().isEmpty()) {
+				throw new IllegalArgumentException("Template cannot be null or empty");
+			}
+			return new TemplateTransformNode(template, outputKey);
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
@@ -22,10 +22,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 
 public class TemplateTransformNode implements NodeAction {
 
@@ -59,11 +57,11 @@ public class TemplateTransformNode implements NodeAction {
 
 		while (matcher.find()) {
 			String key = matcher.group(1).trim();
-			Optional<Object> valueOpt = state.value(key);
 			String replacement;
 
-			if (valueOpt.isPresent()) {
-				Object val = valueOpt.get();
+			// Check if the key exists in the state data (even if the value is null)
+			if (state.data().containsKey(key)) {
+				Object val = state.data().get(key);
 				replacement = val != null ? val.toString() : "null";
 				// Escape special regex characters in replacement
 				replacement = replacement.replace("\\", "\\\\").replace("$", "\\$");
@@ -89,10 +87,6 @@ public class TemplateTransformNode implements NodeAction {
 		return result;
 	}
 
-	/**
-	 * Create a new builder for TemplateTransformNode
-	 * @return a new Builder instance
-	 */
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -106,12 +100,6 @@ public class TemplateTransformNode implements NodeAction {
 
 		private String outputKey;
 
-		/**
-		 * Set the template string with placeholders
-		 * @param template the template string, e.g., "Hello {{name}}!"
-		 * @return this builder
-		 * @throws IllegalArgumentException if template is null
-		 */
 		public Builder template(String template) {
 			if (template == null) {
 				throw new IllegalArgumentException("Template cannot be null");
@@ -120,24 +108,16 @@ public class TemplateTransformNode implements NodeAction {
 			return this;
 		}
 
-		/**
-		 * Set the output key for the transformed result
-		 * @param outputKey the key to store the result in state, defaults to "result"
-		 * @return this builder
-		 */
+		
 		public Builder outputKey(String outputKey) {
 			this.outputKey = outputKey;
 			return this;
 		}
 
-		/**
-		 * Build the TemplateTransformNode
-		 * @return a new TemplateTransformNode instance
-		 * @throws IllegalArgumentException if template is null or empty
-		 */
+		
 		public TemplateTransformNode build() {
-			if (template == null || template.trim().isEmpty()) {
-				throw new IllegalArgumentException("Template cannot be null or empty");
+			if (template == null) {
+				throw new IllegalArgumentException("Template cannot be null");
 			}
 			return new TemplateTransformNode(template, outputKey);
 		}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the original author or authors.
+ * Copyright 2024-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,13 +108,11 @@ public class TemplateTransformNode implements NodeAction {
 			return this;
 		}
 
-		
 		public Builder outputKey(String outputKey) {
 			this.outputKey = outputKey;
 			return this;
 		}
 
-		
 		public TemplateTransformNode build() {
 			if (template == null) {
 				throw new IllegalArgumentException("Template cannot be null");

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/OverAllStateNullValueTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/OverAllStateNullValueTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.cloud.ai.graph.node;
 
 import com.alibaba.cloud.ai.graph.OverAllState;

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/OverAllStateNullValueTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/OverAllStateNullValueTest.java
@@ -1,0 +1,34 @@
+package com.alibaba.cloud.ai.graph.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class OverAllStateNullValueTest {
+
+	@Test
+	void testOverAllStateWithNullValues() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("nullVar", null);
+		variables.put("validVar", "valid");
+
+		OverAllState state = new OverAllState(variables);
+
+		Optional<Object> nullVarOpt = state.value("nullVar");
+		Optional<Object> validVarOpt = state.value("validVar");
+		Optional<Object> missingVarOpt = state.value("missingVar");
+
+		System.out.println("nullVar present: " + nullVarOpt.isPresent());
+		System.out.println("nullVar value: " + nullVarOpt.orElse("NOT_PRESENT"));
+
+		System.out.println("validVar present: " + validVarOpt.isPresent());
+		System.out.println("validVar value: " + validVarOpt.orElse("NOT_PRESENT"));
+
+		System.out.println("missingVar present: " + missingVarOpt.isPresent());
+		System.out.println("missingVar value: " + missingVarOpt.orElse("NOT_PRESENT"));
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeIntegrationTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeIntegrationTest.java
@@ -25,7 +25,7 @@ import com.alibaba.cloud.ai.graph.OverAllState;
 public class TemplateTransformNodeIntegrationTest {
 
 	public static void main(String[] args) {
-	
+
 		System.out.println("=== Demo 1: Basic Template Transformation ===");
 		TemplateTransformNode basicNode = TemplateTransformNode.builder()
 			.template("Hello {{name}}, welcome to {{platform}}!")
@@ -39,7 +39,6 @@ public class TemplateTransformNodeIntegrationTest {
 		System.out.println("Expected: Hello Alice, welcome to Spring AI Alibaba!");
 		System.out.println();
 
-		
 		System.out.println("=== Demo 2: Missing Variables ===");
 		TemplateTransformNode missingVarNode = TemplateTransformNode.builder()
 			.template("Available: {{found}}, Missing: {{missing}}")
@@ -51,7 +50,6 @@ public class TemplateTransformNodeIntegrationTest {
 		System.out.println("Expected: Available: value, Missing: {{missing}}");
 		System.out.println();
 
-	
 		System.out.println("=== Demo 3: Complex Template ===");
 		TemplateTransformNode complexNode = TemplateTransformNode.builder()
 			.template("User {{user.name}} ({{user.email}}) has {{user.score}} points")

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeIntegrationTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeIntegrationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import java.util.Map;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+
+/**
+ * Integration test/demo for TemplateTransformNode
+ */
+public class TemplateTransformNodeIntegrationTest {
+
+	public static void main(String[] args) {
+	
+		System.out.println("=== Demo 1: Basic Template Transformation ===");
+		TemplateTransformNode basicNode = TemplateTransformNode.builder()
+			.template("Hello {{name}}, welcome to {{platform}}!")
+			.outputKey("greeting")
+			.build();
+
+		OverAllState state1 = new OverAllState(Map.of("name", "Alice", "platform", "Spring AI Alibaba"));
+
+		Map<String, Object> result1 = basicNode.apply(state1);
+		System.out.println("Result: " + result1.get("greeting"));
+		System.out.println("Expected: Hello Alice, welcome to Spring AI Alibaba!");
+		System.out.println();
+
+		
+		System.out.println("=== Demo 2: Missing Variables ===");
+		TemplateTransformNode missingVarNode = TemplateTransformNode.builder()
+			.template("Available: {{found}}, Missing: {{missing}}")
+			.build();
+
+		OverAllState state2 = new OverAllState(Map.of("found", "value"));
+		Map<String, Object> result2 = missingVarNode.apply(state2);
+		System.out.println("Result: " + result2.get("result"));
+		System.out.println("Expected: Available: value, Missing: {{missing}}");
+		System.out.println();
+
+	
+		System.out.println("=== Demo 3: Complex Template ===");
+		TemplateTransformNode complexNode = TemplateTransformNode.builder()
+			.template("User {{user.name}} ({{user.email}}) has {{user.score}} points")
+			.outputKey("user_summary")
+			.build();
+
+		OverAllState state3 = new OverAllState(
+				Map.of("user.name", "John Doe", "user.email", "john@example.com", "user.score", 1500));
+
+		Map<String, Object> result3 = complexNode.apply(state3);
+		System.out.println("Result: " + result3.get("user_summary"));
+		System.out.println("Expected: User John Doe (john@example.com) has 1500 points");
+		System.out.println();
+
+		System.out.println("=== All demos completed successfully! ===");
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeTest.java
@@ -39,18 +39,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 public class TemplateTransformNodeTest {
 
 	@Test
 	void testBasicTemplateTransformation() {
-	
+
 		String template = "Hello {{name}}, welcome to {{platform}}!";
 		TemplateTransformNode node = TemplateTransformNode.builder().template(template).outputKey("greeting").build();
 
 		OverAllState state = new OverAllState(Map.of("name", "Alice", "platform", "Spring AI Alibaba"));
 
-		
 		Map<String, Object> result = node.apply(state);
 
 		assertNotNull(result);
@@ -64,16 +62,14 @@ public class TemplateTransformNodeTest {
 
 		OverAllState state = new OverAllState(Map.of("value", "success"));
 
-	
 		Map<String, Object> result = node.apply(state);
 
-		
 		assertEquals("Result: success", result.get("result"));
 	}
 
 	@Test
 	void testMultipleVariablesInTemplate() {
-	
+
 		String template = "{{user}} logged in at {{time}}. User {{user}} has {{count}} messages.";
 		TemplateTransformNode node = TemplateTransformNode.builder()
 			.template(template)
@@ -82,17 +78,15 @@ public class TemplateTransformNodeTest {
 
 		OverAllState state = new OverAllState(Map.of("user", "john_doe", "time", "2024-01-15 10:30:00", "count", 5));
 
-	
 		Map<String, Object> result = node.apply(state);
 
-	
 		String expected = "john_doe logged in at 2024-01-15 10:30:00. User john_doe has 5 messages.";
 		assertEquals(expected, result.get("log_message"));
 	}
 
 	@Test
 	void testComplexNestedVariables() {
-	
+
 		String template = "Order #{{order.id}} for {{customer.name}} ({{customer.email}}) - Total: ${{order.total}} - Items: {{order.itemCount}}";
 		TemplateTransformNode node = TemplateTransformNode.builder()
 			.template(template)
@@ -110,7 +104,7 @@ public class TemplateTransformNodeTest {
 
 	@Test
 	void testMissingVariablesKeptAsPlaceholders() {
-	
+
 		String template = "Available: {{available_var}}, Missing: {{missing_var}}";
 		TemplateTransformNode node = TemplateTransformNode.builder()
 			.template(template)
@@ -121,13 +115,12 @@ public class TemplateTransformNodeTest {
 
 		Map<String, Object> result = node.apply(state);
 
-
 		assertEquals("Available: found, Missing: {{missing_var}}", result.get("partial_result"));
 	}
 
 	@Test
 	void testEmptyTemplate() {
-	
+
 		TemplateTransformNode node = TemplateTransformNode.builder().template("").build();
 
 		OverAllState state = new OverAllState(Map.of("var", "value"));
@@ -146,7 +139,6 @@ public class TemplateTransformNodeTest {
 
 		OverAllState state = new OverAllState(Map.of("unused", "value"));
 
-		
 		Map<String, Object> result = node.apply(state);
 
 		assertEquals(staticText, result.get("static_message"));
@@ -154,7 +146,7 @@ public class TemplateTransformNodeTest {
 
 	@Test
 	void testSpecialCharactersInVariables() {
-	
+
 		String template = "Message: {{msg}} | Symbols: {{symbols}} | Numbers: {{numbers}}";
 		TemplateTransformNode node = TemplateTransformNode.builder()
 			.template(template)
@@ -172,25 +164,23 @@ public class TemplateTransformNodeTest {
 
 	@Test
 	void testBuilderValidation() {
-	
+
 		TemplateTransformNode.Builder builder = TemplateTransformNode.builder();
 
-		
 		assertThrows(IllegalArgumentException.class, builder::build);
 	}
 
 	@Test
 	void testBuilderWithNullTemplate() {
-		
+
 		TemplateTransformNode.Builder builder = TemplateTransformNode.builder();
 
-	
 		assertThrows(IllegalArgumentException.class, () -> builder.template(null));
 	}
 
 	@Test
 	void testBuilderChaining() {
-	
+
 		TemplateTransformNode.Builder builder = TemplateTransformNode.builder();
 
 		TemplateTransformNode node = builder.template("Test {{var}}").outputKey("test_output").build();
@@ -204,7 +194,7 @@ public class TemplateTransformNodeTest {
 
 	@Test
 	void testLargeTemplate() {
-	
+
 		StringBuilder templateBuilder = new StringBuilder();
 		Map<String, Object> variables = Map.of("title", "Annual Report", "year", 2024, "company", "Alibaba Cloud",
 				"revenue", "1.2B", "growth", "15%");
@@ -222,10 +212,8 @@ public class TemplateTransformNodeTest {
 
 		OverAllState state = new OverAllState(variables);
 
-		
 		Map<String, Object> result = node.apply(state);
 
-		
 		String output = (String) result.get("report");
 		assertNotNull(output);
 		assertTrue(output.contains("Annual Report 2024"));
@@ -236,7 +224,7 @@ public class TemplateTransformNodeTest {
 
 	@Test
 	void testVariableWithNullValue() {
-	
+
 		TemplateTransformNode node = TemplateTransformNode.builder()
 			.template("Value: {{nullVar}}, Other: {{validVar}}")
 			.build();
@@ -246,10 +234,8 @@ public class TemplateTransformNodeTest {
 		variables.put("validVar", "valid");
 		OverAllState state = new OverAllState(variables);
 
-		
 		Map<String, Object> result = node.apply(state);
 
-		
 		assertEquals("Value: null, Other: valid", result.get("result"));
 	}
 

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNodeTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "Licens	@Test
+	void testEmptyTemplate() {
+		// Given: Empty template
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template("   ")  // whitespace template should be allowed but trimmed
+			.build();
+
+		OverAllState state = new OverAllState(Map.of("var", "value"));
+
+		// When: Apply transformation
+		Map<String, Object> result = node.apply(state);
+
+		// Then: Returns empty string
+		assertEquals("   ", result.get("result"));
+	}u may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class TemplateTransformNodeTest {
+
+	@Test
+	void testBasicTemplateTransformation() {
+	
+		String template = "Hello {{name}}, welcome to {{platform}}!";
+		TemplateTransformNode node = TemplateTransformNode.builder().template(template).outputKey("greeting").build();
+
+		OverAllState state = new OverAllState(Map.of("name", "Alice", "platform", "Spring AI Alibaba"));
+
+		
+		Map<String, Object> result = node.apply(state);
+
+		assertNotNull(result);
+		assertEquals("Hello Alice, welcome to Spring AI Alibaba!", result.get("greeting"));
+	}
+
+	@Test
+	void testDefaultOutputKey() {
+
+		TemplateTransformNode node = TemplateTransformNode.builder().template("Result: {{value}}").build();
+
+		OverAllState state = new OverAllState(Map.of("value", "success"));
+
+	
+		Map<String, Object> result = node.apply(state);
+
+		
+		assertEquals("Result: success", result.get("result"));
+	}
+
+	@Test
+	void testMultipleVariablesInTemplate() {
+	
+		String template = "{{user}} logged in at {{time}}. User {{user}} has {{count}} messages.";
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template(template)
+			.outputKey("log_message")
+			.build();
+
+		OverAllState state = new OverAllState(Map.of("user", "john_doe", "time", "2024-01-15 10:30:00", "count", 5));
+
+	
+		Map<String, Object> result = node.apply(state);
+
+	
+		String expected = "john_doe logged in at 2024-01-15 10:30:00. User john_doe has 5 messages.";
+		assertEquals(expected, result.get("log_message"));
+	}
+
+	@Test
+	void testComplexNestedVariables() {
+	
+		String template = "Order #{{order.id}} for {{customer.name}} ({{customer.email}}) - Total: ${{order.total}} - Items: {{order.itemCount}}";
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template(template)
+			.outputKey("order_summary")
+			.build();
+
+		OverAllState state = new OverAllState(Map.of("order.id", "ORD-12345", "customer.name", "Jane Smith",
+				"customer.email", "jane@example.com", "order.total", 99.99, "order.itemCount", 3));
+
+		Map<String, Object> result = node.apply(state);
+
+		String expected = "Order #ORD-12345 for Jane Smith (jane@example.com) - Total: $99.99 - Items: 3";
+		assertEquals(expected, result.get("order_summary"));
+	}
+
+	@Test
+	void testMissingVariablesKeptAsPlaceholders() {
+	
+		String template = "Available: {{available_var}}, Missing: {{missing_var}}";
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template(template)
+			.outputKey("partial_result")
+			.build();
+
+		OverAllState state = new OverAllState(Map.of("available_var", "found"));
+
+		Map<String, Object> result = node.apply(state);
+
+
+		assertEquals("Available: found, Missing: {{missing_var}}", result.get("partial_result"));
+	}
+
+	@Test
+	void testEmptyTemplate() {
+	
+		TemplateTransformNode node = TemplateTransformNode.builder().template("").build();
+
+		OverAllState state = new OverAllState(Map.of("var", "value"));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("", result.get("result"));
+	}
+
+	@Test
+	void testTemplateWithoutVariables() {
+		String staticText = "This is a static message without any variables.";
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template(staticText)
+			.outputKey("static_message")
+			.build();
+
+		OverAllState state = new OverAllState(Map.of("unused", "value"));
+
+		
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals(staticText, result.get("static_message"));
+	}
+
+	@Test
+	void testSpecialCharactersInVariables() {
+	
+		String template = "Message: {{msg}} | Symbols: {{symbols}} | Numbers: {{numbers}}";
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template(template)
+			.outputKey("special_output")
+			.build();
+
+		OverAllState state = new OverAllState(
+				Map.of("msg", "Hello & Goodbye!", "symbols", "@#$%^&*()", "numbers", "123-456-7890"));
+
+		Map<String, Object> result = node.apply(state);
+
+		String expected = "Message: Hello & Goodbye! | Symbols: @#$%^&*() | Numbers: 123-456-7890";
+		assertEquals(expected, result.get("special_output"));
+	}
+
+	@Test
+	void testBuilderValidation() {
+	
+		TemplateTransformNode.Builder builder = TemplateTransformNode.builder();
+
+		
+		assertThrows(IllegalArgumentException.class, builder::build);
+	}
+
+	@Test
+	void testBuilderWithNullTemplate() {
+		
+		TemplateTransformNode.Builder builder = TemplateTransformNode.builder();
+
+	
+		assertThrows(IllegalArgumentException.class, () -> builder.template(null));
+	}
+
+	@Test
+	void testBuilderChaining() {
+	
+		TemplateTransformNode.Builder builder = TemplateTransformNode.builder();
+
+		TemplateTransformNode node = builder.template("Test {{var}}").outputKey("test_output").build();
+
+		assertNotNull(node);
+
+		OverAllState state = new OverAllState(Map.of("var", "value"));
+		Map<String, Object> result = node.apply(state);
+		assertEquals("Test value", result.get("test_output"));
+	}
+
+	@Test
+	void testLargeTemplate() {
+	
+		StringBuilder templateBuilder = new StringBuilder();
+		Map<String, Object> variables = Map.of("title", "Annual Report", "year", 2024, "company", "Alibaba Cloud",
+				"revenue", "1.2B", "growth", "15%");
+
+		templateBuilder.append("{{title}} {{year}}\n")
+			.append("Company: {{company}}\n")
+			.append("Revenue: ${{revenue}}\n")
+			.append("Growth: {{growth}}\n")
+			.append("Generated for {{company}} in {{year}} showing {{growth}} growth.");
+
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template(templateBuilder.toString())
+			.outputKey("report")
+			.build();
+
+		OverAllState state = new OverAllState(variables);
+
+		
+		Map<String, Object> result = node.apply(state);
+
+		
+		String output = (String) result.get("report");
+		assertNotNull(output);
+		assertTrue(output.contains("Annual Report 2024"));
+		assertTrue(output.contains("Company: Alibaba Cloud"));
+		assertTrue(output.contains("Revenue: $1.2B"));
+		assertTrue(output.contains("Growth: 15%"));
+	}
+
+	@Test
+	void testVariableWithNullValue() {
+	
+		TemplateTransformNode node = TemplateTransformNode.builder()
+			.template("Value: {{nullVar}}, Other: {{validVar}}")
+			.build();
+
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("nullVar", null);
+		variables.put("validVar", "valid");
+		OverAllState state = new OverAllState(variables);
+
+		
+		Map<String, Object> result = node.apply(state);
+
+		
+		assertEquals("Value: null, Other: valid", result.get("result"));
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/model/workflow/NodeType.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/model/workflow/NodeType.java
@@ -54,6 +54,8 @@ public enum NodeType {
 
 	MCP("mcp", "unsupported"),
 
+	TEMPLATE_TRANSFORM("template-transform", "template-transform"),
+
 	VARIABLE_AGGREGATOR("variable-aggregator", "variable-aggregator");
 
 	private String value;

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/model/workflow/nodedata/TemplateTransformNodeData.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/model/workflow/nodedata/TemplateTransformNodeData.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.model.workflow.nodedata;
+
+import com.alibaba.cloud.ai.model.Variable;
+import com.alibaba.cloud.ai.model.VariableSelector;
+import com.alibaba.cloud.ai.model.workflow.NodeData;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TemplateTransformNodeData extends NodeData {
+
+	private String template;
+
+	private String outputKey;
+
+	public TemplateTransformNodeData() {
+		super(Collections.emptyList(), Collections.emptyList());
+	}
+
+	public TemplateTransformNodeData(List<VariableSelector> inputs, List<Variable> outputs) {
+		super(inputs, outputs);
+	}
+
+	public String getTemplate() {
+		return template;
+	}
+
+	public TemplateTransformNodeData setTemplate(String template) {
+		this.template = template;
+		return this;
+	}
+
+	public String getOutputKey() {
+		return outputKey;
+	}
+
+	public TemplateTransformNodeData setOutputKey(String outputKey) {
+		this.outputKey = outputKey;
+		return this;
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/dsl/nodes/TemplateTransformNodeDataConverter.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/dsl/nodes/TemplateTransformNodeDataConverter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.service.dsl.nodes;
+
+import com.alibaba.cloud.ai.model.Variable;
+import com.alibaba.cloud.ai.model.VariableSelector;
+import com.alibaba.cloud.ai.model.VariableType;
+import com.alibaba.cloud.ai.model.workflow.NodeType;
+import com.alibaba.cloud.ai.model.workflow.nodedata.TemplateTransformNodeData;
+import com.alibaba.cloud.ai.service.dsl.AbstractNodeDataConverter;
+import com.alibaba.cloud.ai.service.dsl.DSLDialectType;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Component
+public class TemplateTransformNodeDataConverter extends AbstractNodeDataConverter<TemplateTransformNodeData> {
+
+	@Override
+	public Boolean supportNodeType(NodeType nodeType) {
+		return NodeType.TEMPLATE_TRANSFORM.equals(nodeType);
+	}
+
+	@Override
+	protected List<DialectConverter<TemplateTransformNodeData>> getDialectConverters() {
+		return Stream.of(TemplateTransformNodeDialectConverter.values())
+			.map(TemplateTransformNodeDialectConverter::dialectConverter)
+			.toList();
+	}
+
+	private enum TemplateTransformNodeDialectConverter {
+
+		DIFY(new DialectConverter<>() {
+			@Override
+			public Boolean supportDialect(DSLDialectType dialectType) {
+				return DSLDialectType.DIFY.equals(dialectType);
+			}
+
+			@Override
+			public TemplateTransformNodeData parse(Map<String, Object> data) {
+				List<Map<String, Object>> variables = (List<Map<String, Object>>) data.get("variables");
+				List<VariableSelector> inputs = new ArrayList<>();
+				if (variables != null) {
+					inputs = variables.stream().map(variable -> {
+						List<String> selector = (List<String>) variable.get("value_selector");
+						return new VariableSelector(selector.get(0), selector.get(1),
+								(String) variable.get("variable"));
+					}).toList();
+				}
+
+				List<Variable> outputs = List.of(new Variable("result", VariableType.STRING.value()));
+
+				return new TemplateTransformNodeData(inputs, outputs).setTemplate((String) data.get("template"));
+			}
+
+			@Override
+			public Map<String, Object> dump(TemplateTransformNodeData nodeData) {
+				Map<String, Object> data = new HashMap<>();
+				data.put("template", nodeData.getTemplate());
+
+				List<Map<String, Object>> inputVars = new ArrayList<>();
+				nodeData.getInputs().forEach(v -> {
+					inputVars.add(
+							Map.of("variable", v.getLabel(), "value_selector", List.of(v.getNamespace(), v.getName())));
+				});
+				data.put("variables", inputVars);
+
+				Map<String, Object> outputVars = new HashMap<>();
+				nodeData.getOutputs().forEach(variable -> {
+					outputVars.put(variable.getName(), Map.of("type",
+							VariableType.fromValue(variable.getValueType()).orElse(VariableType.STRING).difyValue()));
+				});
+				data.put("outputs", outputVars);
+
+				return data;
+			}
+		}), CUSTOM(AbstractNodeDataConverter.defaultCustomDialectConverter(TemplateTransformNodeData.class));
+
+		private final DialectConverter<TemplateTransformNodeData> dialectConverter;
+
+		public DialectConverter<TemplateTransformNodeData> dialectConverter() {
+			return dialectConverter;
+		}
+
+		TemplateTransformNodeDialectConverter(DialectConverter<TemplateTransformNodeData> dialectConverter) {
+			this.dialectConverter = dialectConverter;
+		}
+
+	}
+
+	@Override
+	public String generateVarName(int count) {
+		return "templateTransformNode" + count;
+	}
+
+	@Override
+	public void postProcess(TemplateTransformNodeData nodeData, String varName) {
+		String origKey = nodeData.getOutputKey();
+		String newKey = varName + "_output";
+
+		if (origKey == null) {
+			nodeData.setOutputKey(newKey);
+		}
+		nodeData.setOutputs(List.of(new Variable(nodeData.getOutputKey(), VariableType.STRING.value())));
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/generator/workflow/WorkflowProjectGenerator.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/generator/workflow/WorkflowProjectGenerator.java
@@ -322,6 +322,8 @@ public class WorkflowProjectGenerator implements ProjectGenerator {
 						"com.alibaba.cloud.ai.graph.node.QuestionClassifierNode"),
 				Map.entry(NodeType.PARAMETER_PARSING.difyValue(),
 						"com.alibaba.cloud.ai.graph.node.ParameterParsingNode"),
+				Map.entry(NodeType.TEMPLATE_TRANSFORM.difyValue(),
+						"com.alibaba.cloud.ai.graph.node.TemplateTransformNode"),
 				Map.entry(NodeType.TOOL.difyValue(), "com.alibaba.cloud.ai.graph.node.ToolNode"),
 				Map.entry(NodeType.KNOWLEDGE_RETRIEVAL.difyValue(),
 						"com.alibaba.cloud.ai.graph.node.KnowledgeRetrievalNode"),

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSection.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSection.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.service.generator.workflow.sections;
+
+import com.alibaba.cloud.ai.model.workflow.Node;
+import com.alibaba.cloud.ai.model.workflow.NodeType;
+import com.alibaba.cloud.ai.model.workflow.nodedata.TemplateTransformNodeData;
+import com.alibaba.cloud.ai.service.generator.workflow.NodeSection;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class TemplateTransformNodeSection implements NodeSection {
+
+	@Override
+	public boolean support(NodeType nodeType) {
+		return NodeType.TEMPLATE_TRANSFORM.equals(nodeType);
+	}
+
+	@Override
+	public String render(Node node, String varName) {
+		TemplateTransformNodeData d = (TemplateTransformNodeData) node.getData();
+		String id = node.getId();
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("// —— TemplateTransformNode [").append(id).append("] ——\n");
+		sb.append("TemplateTransformNode ").append(varName).append(" = TemplateTransformNode.builder()\n");
+
+		// Add template parameter
+		if (d.getTemplate() != null) {
+			sb.append(".template(\"").append(escape(d.getTemplate())).append("\")\n");
+		}
+
+		// Add outputKey parameter if specified
+		if (d.getOutputKey() != null) {
+			sb.append(".outputKey(\"").append(escape(d.getOutputKey())).append("\")\n");
+		}
+
+		sb.append(".build();\n");
+		sb.append("stateGraph.addNode(\"")
+			.append(id)
+			.append("\", AsyncNodeAction.node_async(")
+			.append(varName)
+			.append("));\n\n");
+
+		return sb.toString();
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSection.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/main/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the original author or authors.
+ * Copyright 2024-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import com.alibaba.cloud.ai.model.workflow.NodeType;
 import com.alibaba.cloud.ai.model.workflow.nodedata.TemplateTransformNodeData;
 import com.alibaba.cloud.ai.service.generator.workflow.NodeSection;
 import org.springframework.stereotype.Component;
-
 
 @Component
 public class TemplateTransformNodeSection implements NodeSection {

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/dsl/nodes/TemplateTransformNodeDataConverterTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/dsl/nodes/TemplateTransformNodeDataConverterTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.dsl.nodes;
+
+import com.alibaba.cloud.ai.model.Variable;
+import com.alibaba.cloud.ai.model.VariableSelector;
+import com.alibaba.cloud.ai.model.VariableType;
+import com.alibaba.cloud.ai.model.workflow.NodeType;
+import com.alibaba.cloud.ai.model.workflow.nodedata.TemplateTransformNodeData;
+import com.alibaba.cloud.ai.service.dsl.DSLDialectType;
+import com.alibaba.cloud.ai.service.dsl.nodes.TemplateTransformNodeDataConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TemplateTransformNodeDataConverterTest {
+
+	private TemplateTransformNodeDataConverter converter;
+
+	@BeforeEach
+	public void setUp() {
+		converter = new TemplateTransformNodeDataConverter();
+	}
+
+	@Test
+	public void testSupportNodeType() {
+		assertTrue(converter.supportNodeType(NodeType.TEMPLATE_TRANSFORM));
+		assertFalse(converter.supportNodeType(NodeType.CODE));
+		assertFalse(converter.supportNodeType(NodeType.LLM));
+		assertFalse(converter.supportNodeType(NodeType.HTTP));
+	}
+
+	@Test
+	public void testGenerateVarName() {
+		assertEquals("templateTransformNode1", converter.generateVarName(1));
+		assertEquals("templateTransformNode5", converter.generateVarName(5));
+		assertEquals("templateTransformNode10", converter.generateVarName(10));
+	}
+
+	@Test
+	public void testPostProcess() {
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		String varName = "testNode";
+
+		converter.postProcess(nodeData, varName);
+
+		assertEquals("testNode_output", nodeData.getOutputKey());
+		assertEquals(1, nodeData.getOutputs().size());
+		assertEquals("testNode_output", nodeData.getOutputs().get(0).getName());
+		assertEquals(VariableType.STRING.value(), nodeData.getOutputs().get(0).getValueType());
+	}
+
+	@Test
+	public void testPostProcessWithExistingOutputKey() {
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		nodeData.setOutputKey("existing_output");
+		String varName = "testNode";
+
+		converter.postProcess(nodeData, varName);
+
+		// 如果已有outputKey，不应该改变
+		assertEquals("existing_output", nodeData.getOutputKey());
+		assertEquals(1, nodeData.getOutputs().size());
+		assertEquals("existing_output", nodeData.getOutputs().get(0).getName());
+		assertEquals(VariableType.STRING.value(), nodeData.getOutputs().get(0).getValueType());
+	}
+
+	@Test
+	public void testParseMapDataDify() {
+		// 创建Dify格式的测试数据
+		Map<String, Object> data = new HashMap<>();
+		data.put("template", "Hello {{name}}, welcome to {{place}}!");
+
+		List<Map<String, Object>> variables = new ArrayList<>();
+		Map<String, Object> var1 = new HashMap<>();
+		var1.put("variable", "name");
+		var1.put("value_selector", List.of("user", "name"));
+		variables.add(var1);
+
+		Map<String, Object> var2 = new HashMap<>();
+		var2.put("variable", "place");
+		var2.put("value_selector", List.of("system", "location"));
+		variables.add(var2);
+
+		data.put("variables", variables);
+
+		TemplateTransformNodeData result = converter.parseMapData(data, DSLDialectType.DIFY);
+
+		assertNotNull(result);
+		assertEquals("Hello {{name}}, welcome to {{place}}!", result.getTemplate());
+		assertEquals(2, result.getInputs().size());
+		assertEquals(1, result.getOutputs().size());
+
+		// 验证第一个输入变量
+		VariableSelector input1 = result.getInputs().get(0);
+		assertEquals("user", input1.getNamespace());
+		assertEquals("name", input1.getName());
+		assertEquals("name", input1.getLabel());
+
+		// 验证第二个输入变量
+		VariableSelector input2 = result.getInputs().get(1);
+		assertEquals("system", input2.getNamespace());
+		assertEquals("location", input2.getName());
+		assertEquals("place", input2.getLabel());
+
+		// 验证输出变量
+		Variable output = result.getOutputs().get(0);
+		assertEquals("result", output.getName());
+		assertEquals(VariableType.STRING.value(), output.getValueType());
+	}
+
+	@Test
+	public void testParseMapDataDifyWithoutVariables() {
+		// 测试没有变量的情况
+		Map<String, Object> data = new HashMap<>();
+		data.put("template", "Static template without variables");
+
+		TemplateTransformNodeData result = converter.parseMapData(data, DSLDialectType.DIFY);
+
+		assertNotNull(result);
+		assertEquals("Static template without variables", result.getTemplate());
+		assertTrue(result.getInputs().isEmpty());
+		assertEquals(1, result.getOutputs().size());
+		assertEquals("result", result.getOutputs().get(0).getName());
+	}
+
+	@Test
+	public void testDumpMapDataDify() {
+		// 创建测试的NodeData
+		List<VariableSelector> inputs = new ArrayList<>();
+		inputs.add(new VariableSelector("user", "name", "userName"));
+		inputs.add(new VariableSelector("system", "place", "location"));
+
+		List<Variable> outputs = new ArrayList<>();
+		outputs.add(new Variable("result", VariableType.STRING.value()));
+
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData(inputs, outputs);
+		nodeData.setTemplate("Hello {{userName}}, welcome to {{location}}!");
+
+		Map<String, Object> result = converter.dumpMapData(nodeData, DSLDialectType.DIFY);
+
+		assertNotNull(result);
+		assertEquals("Hello {{userName}}, welcome to {{location}}!", result.get("template"));
+
+		// 验证variables
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> variables = (List<Map<String, Object>>) result.get("variables");
+		assertNotNull(variables);
+		assertEquals(2, variables.size());
+
+		Map<String, Object> var1 = variables.get(0);
+		assertEquals("userName", var1.get("variable"));
+		assertEquals(List.of("user", "name"), var1.get("value_selector"));
+
+		Map<String, Object> var2 = variables.get(1);
+		assertEquals("location", var2.get("variable"));
+		assertEquals(List.of("system", "place"), var2.get("value_selector"));
+
+		// 验证outputs
+		@SuppressWarnings("unchecked")
+		Map<String, Object> outputs_map = (Map<String, Object>) result.get("outputs");
+		assertNotNull(outputs_map);
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> resultOutput = (Map<String, Object>) outputs_map.get("result");
+		assertEquals(VariableType.STRING.difyValue(), resultOutput.get("type"));
+	}
+
+	@Test
+	public void testParseMapDataCustom() {
+		// 测试CUSTOM方言的解析
+		Map<String, Object> data = new HashMap<>();
+		data.put("template", "Custom template");
+		data.put("outputKey", "custom_output");
+
+		TemplateTransformNodeData result = converter.parseMapData(data, DSLDialectType.CUSTOM);
+
+		assertNotNull(result);
+		assertEquals("Custom template", result.getTemplate());
+		assertEquals("custom_output", result.getOutputKey());
+	}
+
+	@Test
+	public void testDumpMapDataCustom() {
+		// 测试CUSTOM方言的导出
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		nodeData.setTemplate("Custom template");
+		nodeData.setOutputKey("custom_output");
+
+		Map<String, Object> result = converter.dumpMapData(nodeData, DSLDialectType.CUSTOM);
+
+		assertNotNull(result);
+		assertEquals("Custom template", result.get("template"));
+		assertEquals("custom_output", result.get("outputKey"));
+	}
+
+	@Test
+	public void testRoundTripDify() {
+		// 测试Dify格式的往返转换
+		Map<String, Object> originalData = new HashMap<>();
+		originalData.put("template", "Round trip test: {{input}}");
+
+		List<Map<String, Object>> variables = new ArrayList<>();
+		Map<String, Object> var1 = new HashMap<>();
+		var1.put("variable", "input");
+		var1.put("value_selector", List.of("source", "data"));
+		variables.add(var1);
+		originalData.put("variables", variables);
+
+		// 解析
+		TemplateTransformNodeData nodeData = converter.parseMapData(originalData, DSLDialectType.DIFY);
+
+		// 导出
+		Map<String, Object> exportedData = converter.dumpMapData(nodeData, DSLDialectType.DIFY);
+
+		// 验证往返转换的正确性
+		assertEquals(originalData.get("template"), exportedData.get("template"));
+
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> exportedVars = (List<Map<String, Object>>) exportedData.get("variables");
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> originalVars = (List<Map<String, Object>>) originalData.get("variables");
+
+		assertEquals(originalVars.size(), exportedVars.size());
+		assertEquals(originalVars.get(0).get("variable"), exportedVars.get(0).get("variable"));
+		assertEquals(originalVars.get(0).get("value_selector"), exportedVars.get(0).get("value_selector"));
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/model/workflow/nodedata/TemplateTransformNodeDataTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/model/workflow/nodedata/TemplateTransformNodeDataTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.model.workflow.nodedata;
+
+import com.alibaba.cloud.ai.model.Variable;
+import com.alibaba.cloud.ai.model.VariableSelector;
+import com.alibaba.cloud.ai.model.VariableType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TemplateTransformNodeDataTest {
+
+	@Test
+	public void testDefaultConstructor() {
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+
+		assertNotNull(nodeData);
+		assertNull(nodeData.getTemplate());
+		assertNull(nodeData.getOutputKey());
+		assertNotNull(nodeData.getInputs());
+		assertNotNull(nodeData.getOutputs());
+		assertTrue(nodeData.getInputs().isEmpty());
+		assertTrue(nodeData.getOutputs().isEmpty());
+	}
+
+	@Test
+	public void testConstructorWithInputsAndOutputs() {
+		List<VariableSelector> inputs = new ArrayList<>();
+		inputs.add(new VariableSelector("sourceNode", "output", "inputVar"));
+
+		List<Variable> outputs = new ArrayList<>();
+		outputs.add(new Variable("result", VariableType.STRING.value()));
+
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData(inputs, outputs);
+
+		assertNotNull(nodeData);
+		assertEquals(1, nodeData.getInputs().size());
+		assertEquals(1, nodeData.getOutputs().size());
+		assertEquals("sourceNode", nodeData.getInputs().get(0).getNamespace());
+		assertEquals("output", nodeData.getInputs().get(0).getName());
+		assertEquals("inputVar", nodeData.getInputs().get(0).getLabel());
+		assertEquals("result", nodeData.getOutputs().get(0).getName());
+		assertEquals(VariableType.STRING.value(), nodeData.getOutputs().get(0).getValueType());
+	}
+
+	@Test
+	public void testSetTemplate() {
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		String template = "Hello {{name}}, welcome to {{place}}!";
+
+		TemplateTransformNodeData result = nodeData.setTemplate(template);
+
+		assertEquals(template, nodeData.getTemplate());
+		assertSame(nodeData, result); // 检查链式调用
+	}
+
+	@Test
+	public void testSetOutputKey() {
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		String outputKey = "templateOutput";
+
+		TemplateTransformNodeData result = nodeData.setOutputKey(outputKey);
+
+		assertEquals(outputKey, nodeData.getOutputKey());
+		assertSame(nodeData, result); // 检查链式调用
+	}
+
+	@Test
+	public void testCompleteNodeDataSetup() {
+		// 测试完整的节点数据设置
+		List<VariableSelector> inputs = new ArrayList<>();
+		inputs.add(new VariableSelector("user", "name", "userName"));
+		inputs.add(new VariableSelector("system", "location", "userLocation"));
+
+		List<Variable> outputs = new ArrayList<>();
+		outputs.add(new Variable("transformedText", VariableType.STRING.value()));
+
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData(inputs, outputs)
+			.setTemplate("Dear {{userName}}, you are currently in {{userLocation}}.")
+			.setOutputKey("greeting_output");
+
+		// 验证所有属性
+		assertEquals("Dear {{userName}}, you are currently in {{userLocation}}.", nodeData.getTemplate());
+		assertEquals("greeting_output", nodeData.getOutputKey());
+		assertEquals(2, nodeData.getInputs().size());
+		assertEquals(1, nodeData.getOutputs().size());
+
+		// 验证inputs
+		assertEquals("user", nodeData.getInputs().get(0).getNamespace());
+		assertEquals("name", nodeData.getInputs().get(0).getName());
+		assertEquals("userName", nodeData.getInputs().get(0).getLabel());
+
+		assertEquals("system", nodeData.getInputs().get(1).getNamespace());
+		assertEquals("location", nodeData.getInputs().get(1).getName());
+		assertEquals("userLocation", nodeData.getInputs().get(1).getLabel());
+
+		// 验证outputs
+		assertEquals("transformedText", nodeData.getOutputs().get(0).getName());
+		assertEquals(VariableType.STRING.value(), nodeData.getOutputs().get(0).getValueType());
+	}
+
+	@Test
+	public void testSetTemplateNull() {
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+
+		nodeData.setTemplate(null);
+
+		assertNull(nodeData.getTemplate());
+	}
+
+	@Test
+	public void testSetOutputKeyNull() {
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+
+		nodeData.setOutputKey(null);
+
+		assertNull(nodeData.getOutputKey());
+	}
+
+	@Test
+	public void testChainedMethodCalls() {
+		// 测试链式方法调用
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData().setTemplate("Hello {{world}}")
+			.setOutputKey("chain_output");
+
+		assertEquals("Hello {{world}}", nodeData.getTemplate());
+		assertEquals("chain_output", nodeData.getOutputKey());
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSectionTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSectionTest.java
@@ -1,0 +1,104 @@
+package com.alibaba.cloud.ai.service.generator.workflow.sections;
+
+import com.alibaba.cloud.ai.model.workflow.Node;
+import com.alibaba.cloud.ai.model.workflow.nodedata.TemplateTransformNodeData;
+import com.alibaba.cloud.ai.model.workflow.NodeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for TemplateTransformNodeSection code generation functionality.
+ */
+class TemplateTransformNodeSectionTest {
+
+	private TemplateTransformNodeSection templateTransformNodeSection;
+
+	@BeforeEach
+	void setUp() {
+		templateTransformNodeSection = new TemplateTransformNodeSection();
+	}
+
+	@Test
+	void testSupportsTemplateTransformNodeType() {
+		// Given
+
+		// When & Then
+		assertThat(templateTransformNodeSection.support(NodeType.TEMPLATE_TRANSFORM)).isTrue();
+		assertThat(templateTransformNodeSection.support(NodeType.LLM)).isFalse();
+	}
+
+	@Test
+	void testRenderTemplateTransformNode() {
+		// Given
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		nodeData.setTemplate("Hello {{name}}, welcome to {{place}}!");
+		nodeData.setOutputKey("greeting");
+		nodeData.setVarName("templateTransform1");
+
+		Node node = new Node();
+		node.setData(nodeData);
+
+		String varName = "templateTransform1";
+
+		// When
+		String result = templateTransformNodeSection.render(node, varName);
+
+		// Then
+		assertThat(result).contains("TemplateTransformNode.builder()");
+		assertThat(result).contains(".template(\"Hello {{name}}, welcome to {{place}}!\")");
+		assertThat(result).contains(".outputKey(\"greeting\")");
+		assertThat(result).contains(".build()");
+	}
+
+	@Test
+	void testRenderWithSpecialCharacters() {
+		// Given
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		nodeData.setTemplate("Quote: \"Hello world\", newline: \n, tab: \t");
+		nodeData.setOutputKey("special_output");
+		nodeData.setVarName("templateTransform2");
+
+		Node node = new Node();
+		node.setData(nodeData);
+
+		String varName = "templateTransform2";
+
+		// When
+		String result = templateTransformNodeSection.render(node, varName);
+
+		// Then
+		// Should properly escape special characters
+		assertThat(result).contains("TemplateTransformNode.builder()");
+		assertThat(result).contains("\\\""); // escaped quotes
+		assertThat(result).contains("\\n"); // escaped newline
+		assertThat(result).contains("\\t"); // escaped tab
+		assertThat(result).contains(".outputKey(\"special_output\")");
+		assertThat(result).contains(".build()");
+	}
+
+	@Test
+	void testRenderWithEmptyTemplate() {
+		// Given
+		TemplateTransformNodeData nodeData = new TemplateTransformNodeData();
+		nodeData.setTemplate("");
+		nodeData.setOutputKey("empty_output");
+		nodeData.setVarName("templateTransform3");
+
+		Node node = new Node();
+		node.setData(nodeData);
+
+		String varName = "templateTransform3";
+
+		// When
+		String result = templateTransformNodeSection.render(node, varName);
+
+		// Then
+		assertThat(result).contains("TemplateTransformNode.builder()");
+		assertThat(result).contains(".template(\"\")");
+		assertThat(result).contains(".outputKey(\"empty_output\")");
+		assertThat(result).contains(".build()");
+	}
+
+}

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSectionTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-studio/src/test/java/com/alibaba/cloud/ai/service/generator/workflow/sections/TemplateTransformNodeSectionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.cloud.ai.service.generator.workflow.sections;
 
 import com.alibaba.cloud.ai.model.workflow.Node;


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR fixes a critical NPE issue that occurs when DashScope API returns ToolCall objects with null function names. The NPE happens in DefaultToolCallingManager.executeToolCall method when calling toolName.equals() on a null value, affecting both streaming and non-streaming chat calls.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
