### PR TITLE
perf(core): adjust media content sort

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -527,35 +527,35 @@ public class DashScopeChatModel implements ChatModel {
 
 		List<MediaContent> contentList = new ArrayList<>();
 		if (format == MessageFormat.VIDEO) {
-			MediaContent mediaContent = new MediaContent(message.getText());
-			contentList.add(mediaContent);
-
 			List<String> mediaList = message.getMedia()
 				.stream()
 				.map(media -> this.fromMediaData(media.getMimeType(), media.getData()))
 				.toList();
 
 			contentList.add(new MediaContent("video", null, null, mediaList));
-		}
-		else if (format == MessageFormat.AUDIO) {
+
 			MediaContent mediaContent = new MediaContent(message.getText());
 			contentList.add(mediaContent);
-
+		}
+		else if (format == MessageFormat.AUDIO) {
 			contentList.addAll(message.getMedia()
 				.stream()
 				.map(media -> new MediaContent("audio", null, null, null,
 						this.fromMediaData(media.getMimeType(), media.getData())))
 				.toList());
-		}
-		else {
+
 			MediaContent mediaContent = new MediaContent(message.getText());
 			contentList.add(mediaContent);
-
+		}
+		else {
 			contentList.addAll(message.getMedia()
 				.stream()
 				.map(media -> new MediaContent("image", null, this.fromMediaData(media.getMimeType(), media.getData()),
 						null))
 				.toList());
+
+			MediaContent mediaContent = new MediaContent(message.getText());
+			contentList.add(mediaContent);
 		}
 
 		return contentList;


### PR DESCRIPTION



### Describe what this PR does / why we need it
根据百炼平台上下文缓存相关文档，会对输入内容进行前缀匹配，匹配到的可以减少token消耗
典型场景中第五点，video放于text之前，多次提问时有概率命中cache

- refer：https://help.aliyun.com/zh/model-studio/context-cache?spm=a2c4g.11186623.help-menu-2400256.d_0_1_7.fae66ff2TF0es4#9770a010abkbq

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
- 调整了视频、音频和图像消息的处理顺序

### Describe how to verify it


### Special notes for reviews
请帮忙检查下，content顺序是否对其他功能有影响
我目前仅发现ChatCompletionMessage 的 content 方法，当 rawContent 为 List 时，会仅取第一条，但其仅对Map类型进行了处理，而此处修改是 MediaContent 类型