### PR TITLE
fix(jmanus): fix jmanus promptService is null

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/PlanningFactory.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/PlanningFactory.java
@@ -225,7 +225,7 @@ public class PlanningFactory implements IPlanningFactory {
 		toolDefinitions.add(new FileMergeTool(unifiedDirectoryManager));
 		// toolDefinitions.add(new GoogleSearch());
 		// toolDefinitions.add(new PythonExecute());
-		toolDefinitions.add(new FormInputTool(objectMapper));
+		toolDefinitions.add(new FormInputTool(objectMapper, promptService));
 		toolDefinitions
 			.add(new DataSplitTool(planId, manusProperties, sharedStateManager, unifiedDirectoryManager, objectMapper));
 		toolDefinitions.add(new MapOutputTool(planId, manusProperties, sharedStateManager, unifiedDirectoryManager,

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/FormInputTool.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/FormInputTool.java
@@ -15,14 +15,13 @@
  */
 package com.alibaba.cloud.ai.example.manus.tool;
 
-import com.alibaba.cloud.ai.example.manus.tool.code.ToolExecuteResult;
 import com.alibaba.cloud.ai.example.manus.dynamic.prompt.service.PromptService;
+import com.alibaba.cloud.ai.example.manus.tool.code.ToolExecuteResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/FormInputTool.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/FormInputTool.java
@@ -37,8 +37,7 @@ public class FormInputTool extends AbstractBaseTool<FormInputTool.UserFormInput>
 
 	private final ObjectMapper objectMapper;
 
-	@Autowired
-	private PromptService promptService;
+	private final PromptService promptService;
 
 	private static final Logger log = LoggerFactory.getLogger(FormInputTool.class);
 
@@ -182,8 +181,9 @@ public class FormInputTool extends AbstractBaseTool<FormInputTool.UserFormInput>
 
 	}
 
-	public FormInputTool(ObjectMapper objectMapper) {
+	public FormInputTool(ObjectMapper objectMapper, PromptService promptService) {
 		this.objectMapper = objectMapper;
+		this.promptService = promptService;
 	}
 
 	public enum InputState {


### PR DESCRIPTION
### Describe what this PR does / why we need it
查询任务加载agent时无法查询对应的提示词，报错promptService is null

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
因为代码里面想通过bean注入PromptService实例到FormInputTool，而真正使用的时候是新建FormInputTool对象，没有托管到spring，我修复了这一问题。

### Describe how to verify it


### Special notes for reviews
