### PR TITLE
fix(nl2sql): fix SimpleVectorStoreManagementService deleteDocuments（） empty input error 

### DIFF
--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/service/SimpleVectorStoreManagementService.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/service/SimpleVectorStoreManagementService.java
@@ -211,7 +211,11 @@ public class SimpleVectorStoreManagementService implements VectorStoreManagement
 				FilterExpressionBuilder b = new FilterExpressionBuilder();
 				Filter.Expression expression = b.eq("vectorType", "column").build();
 				List<Document> documents = vectorStore.similaritySearch(
-						SearchRequest.builder().topK(Integer.MAX_VALUE).filterExpression(expression).build());
+						SearchRequest.builder()
+								.query("*") // 使用通配符查询来获取所有匹配的文档
+								.topK(Integer.MAX_VALUE)
+								.similarityThreshold(0.0) // 设置为0.0以接受所有结果
+								.filterExpression(expression).build());
 				vectorStore.delete(documents.stream().map(Document::getId).toList());
 			}
 			else {

--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/service/SimpleVectorStoreManagementService.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/service/SimpleVectorStoreManagementService.java
@@ -210,12 +210,12 @@ public class SimpleVectorStoreManagementService implements VectorStoreManagement
 			else if (deleteRequest.getVectorType() != null && !deleteRequest.getVectorType().isEmpty()) {
 				FilterExpressionBuilder b = new FilterExpressionBuilder();
 				Filter.Expression expression = b.eq("vectorType", "column").build();
-				List<Document> documents = vectorStore.similaritySearch(
-						SearchRequest.builder()
-								.query("*") // 使用通配符查询来获取所有匹配的文档
-								.topK(Integer.MAX_VALUE)
-								.similarityThreshold(0.0) // 设置为0.0以接受所有结果
-								.filterExpression(expression).build());
+				List<Document> documents = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("*") // 使用通配符查询来获取所有匹配的文档
+					.topK(Integer.MAX_VALUE)
+					.similarityThreshold(0.0) // 设置为0.0以接受所有结果
+					.filterExpression(expression)
+					.build());
 				vectorStore.delete(documents.stream().map(Document::getId).toList());
 			}
 			else {


### PR DESCRIPTION
### Describe what this PR does / why we need it

When using the OpenAI embedding model configuration, the schema method will report an error because the input is empty, but the underlying OpenAI embedding model does not allow empty input and will throw an exception causing an error.

### Does Fixes https://github.com/alibaba/spring-ai-alibaba/issues/1460this pull request fix one issue?

Fixes #1460 

### Describe how you did it

Modify matching similar types of data using the wildcard * and vector thresholds to prevent errors from empty queries.

### Describe how to verify it


### Special notes for reviews
