### PR TITLE
fix(graph): resolve issue in forEachAsync method

### DIFF
--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperators.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperators.java
@@ -94,8 +94,6 @@ public interface AsyncGeneratorOperators<E> {
 	 * @param consumer the consumer function to be applied to each element
 	 * @return a CompletableFuture representing the completion of the iteration process.
 	 *
-	 * fix: zhangr: 2025/08/05 1. 解决异常未正常传递，陷入循环的问题
-	 *
 	 */
 	default CompletableFuture<Object> forEachAsync(Consumer<E> consumer) {
 		CompletableFuture<Object> future = completedFuture(null);

--- a/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperatorsInfiniteLoopTest.java
+++ b/spring-ai-alibaba-graph/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/async/AsyncGeneratorOperatorsInfiniteLoopTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.async;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AsyncGeneratorOperatorsInfiniteLoopTest {
+
+	@Test
+	public void testForEachAsyncHandlesExceptionProperly() {
+		// Arrange: Create a mock AsyncGenerator that throws an exception
+		AsyncGenerator<Integer> generator = new AsyncGenerator<>() {
+			private final AtomicInteger counter = new AtomicInteger(0);
+
+			@Override
+			public Data<Integer> next() {
+				int count = counter.getAndIncrement();
+				if (count == 0) {
+					// Return a normal data element
+					return Data.of(CompletableFuture.completedFuture(count));
+				}
+				else if (count == 1) {
+					// Simulate an exception
+					return Data.of(CompletableFuture.failedFuture(new RuntimeException("Test exception")));
+				}
+				else {
+					throw new RuntimeException("Infinite loop detected");
+				}
+			}
+		};
+
+		// Act: Call forEachAsync and capture the exception
+		CompletableFuture<Object> future = generator.forEachAsync(value -> {
+			// Simulate processing the value
+			System.out.println("Processing value: " + value);
+		}).exceptionally(ex -> {
+			// Handle the exception and return null to avoid infinite loop
+			System.out.println("Exception caught: " + ex.getMessage());
+
+			// Assert: Verify that the exception is handled properly
+			assertTrue(ex.getCause() instanceof RuntimeException);
+			assertEquals("Test exception", ex.getCause().getMessage());
+
+			return null;
+		});
+
+		System.out.println("Passed");
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
This pull request addresses a issue in the `forEachAsync`  method of the `AsyncGeneratorOperators` interface, where exceptions were not properly propagated, leading to an infinite loop in certain scenarios.

### Cause
The `forEachAsync` method is designed to asynchronously iterate over elements of an `AsyncGenerator` and apply a `consumer` function to each element. However, when an exception occurs during the processing of an element (e.g., in `finalNext.data.thenAcceptAsync`), the exception is not properly propagated. Instead, the loop continues, causing an infinite iteration. This not only leads to prolonged resource consumption but also results in the request remaining in a blocked state indefinitely without returning any response. The SSE session will not disconnect automatically and will remain persistently connected.

```
2025-08-05T20:53:42.449+08:00 ERROR 453564 --- [ai-agent-graph] [pool-2-thread-1] .a.g.o.GraphObservationLifecycleListener : Error occurred in node: __START__

java.lang.IllegalArgumentException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4663) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	...

Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1781) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1406) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:310) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromString(BeanDeserializerBase.java:1594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:189) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:179) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4658) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	... 24 common frames omitted

2025-08-05T20:53:42.457+08:00 ERROR 453564 --- [ai-agent-graph] [pool-2-thread-1] c.alibaba.cloud.ai.graph.CompiledGraph   : Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]

java.lang.IllegalArgumentException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4663) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	...

Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1781) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1406) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:310) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromString(BeanDeserializerBase.java:1594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:189) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:179) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4658) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	... 24 common frames omitted

2025-08-05T20:53:42.464+08:00 ERROR 453564 --- [ai-agent-graph] [pool-2-thread-1] .a.g.o.GraphObservationLifecycleListener : Error occurred in node: __START__

java.lang.IllegalArgumentException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4663) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	...
	
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1781) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1406) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:310) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromString(BeanDeserializerBase.java:1594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:189) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:179) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4658) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	... 24 common frames omitted

2025-08-05T20:53:42.465+08:00 ERROR 453564 --- [ai-agent-graph] [pool-2-thread-1] c.alibaba.cloud.ai.graph.CompiledGraph   : Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]

java.lang.IllegalArgumentException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4663) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	...
	
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `com.ctg.ai.agent.graph.model.dto.Plan` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('debug')
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:63) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1781) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1406) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._deserializeFromString(StdDeserializer.java:310) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromString(BeanDeserializerBase.java:1594) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:189) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:179) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4658) ~[jackson-databind-2.19.2.jar!/:2.19.2]
	... 24 common frames omitted

...<LOOP >
```

### Solution: 
Terminate the iteration immediately when an exception occurs, ensuring that the loop does not continue indefinitely.
