### PR TITLE
fix(memories): unify the configuration prefix of memory modules

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/MysqlChatMemoryProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/MysqlChatMemoryProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(MysqlChatMemoryProperties.CONFIG_PREFIX)
 public class MysqlChatMemoryProperties {
 
-	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.jdbc.mysql";
+	public static final String CONFIG_PREFIX = "spring.ai.memory.mysql";
 
 	private boolean initializeSchema = true;
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/OracleChatMemoryProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/OracleChatMemoryProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(OracleChatMemoryProperties.CONFIG_PREFIX)
 public class OracleChatMemoryProperties {
 
-	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.jdbc.oracle";
+	public static final String CONFIG_PREFIX = "spring.ai.memory.oracle";
 
 	private boolean initializeSchema = true;
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/PostgresChatMemoryProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/PostgresChatMemoryProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(PostgresChatMemoryProperties.CONFIG_PREFIX)
 public class PostgresChatMemoryProperties {
 
-	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.jdbc.postgres";
+	public static final String CONFIG_PREFIX = "spring.ai.memory.postgres";
 
 	private boolean initializeSchema = true;
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/SQLiteChatMemoryProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/SQLiteChatMemoryProperties.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(SQLiteChatMemoryProperties.CONFIG_PREFIX)
 public class SQLiteChatMemoryProperties {
 
-	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.jdbc.sqlite";
+	public static final String CONFIG_PREFIX = "spring.ai.memory.sqlite";
 
 	private boolean initializeSchema = true;
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/SqlServerChatMemoryProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/SqlServerChatMemoryProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(SqlServerChatMemoryProperties.CONFIG_PREFIX)
 public class SqlServerChatMemoryProperties {
 
-	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.jdbc.sqlserver";
+	public static final String CONFIG_PREFIX = "spring.ai.memory.sqlserver";
 
 	private boolean initializeSchema = true;
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
修改部分组件错误的memory配置前缀。
包含：mysql、oracle、pg、sqlite、sqlserver。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
