### PR TITLE
fix(studio): fix frontend build error

### DIFF
--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/README.md
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/README.md
@@ -7,8 +7,9 @@ cd docker/middleware
 
 ```shell
 chmod a+x ./run.sh
-./run.sh
+sudo ./run.sh
 ```
+等待 60秒， `rmq-init-topic` 脚本会自动创建 RocketMQ 相关的 Topic。
 
 3. 进入 spring-ai-alibaba-studio-server-admin 目录，启动后端应用
 

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/docker/middleware/run.sh
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/docker/middleware/run.sh
@@ -13,8 +13,8 @@ TZ=Asia/Shanghai
 MIDDLEWARE_HOME=.
 EOF
 
-sudo chown -R 1000:0 elasticsearch/data
-sudo chown -R 1000:0 kibana/data
+sudo chmod -R 777 elasticsearch/data
+sudo chmod -R 777 kibana/data
 
 echo "Created .env file with UID=$(id -u) and GID=$(id -g)"
 

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/frontend/.npmrc
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/frontend/.npmrc
@@ -1,3 +1,3 @@
 legacy-peer-deps=true
 loglevel=error
-registry=https://registry.anpm.alibaba-inc.com/
+registry=https://registry.npmmirror.com/

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/frontend/README.zh-CN.md
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/frontend/README.zh-CN.md
@@ -85,7 +85,7 @@ DEFAULT_PASSWORD=123456
 最后，运行开发服务器：
 
 ```bash
-cd main
+cd packages/main
 npm run dev
 ```
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
1. Change https://registry.anpm.alibaba-inc.com/ to https://registry.npmmirror.com  because registry.anpm.alibaba-inc.com appears to be an internal network address and is inaccessible.

2. Modify chown -R 1000:0 to chmod -R 777， because I found that even if I change it to chown -R 1000:1000 (the docker-compose file specifies 1000:1000), Elasticsearch still fails to start.

### Does this pull request fix one issue?

NONE

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
