### PR TITLE
fix(jmanus): fix the bug where Playwright cannot run when using the Spring Boot fat jar

### DIFF
--- a/spring-ai-alibaba-jmanus/pom.xml
+++ b/spring-ai-alibaba-jmanus/pom.xml
@@ -28,6 +28,9 @@
 
         <webdrivermanager.version>6.1.0</webdrivermanager.version>
 
+        <!-- Playwright Configuration -->
+        <playwright.version>1.53.0</playwright.version>
+
         <!-- CheckStyle Maven Plugin -->
         <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
         <maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
@@ -168,7 +171,7 @@
         <dependency>
             <groupId>com.microsoft.playwright</groupId>
             <artifactId>playwright</artifactId>
-            <version>1.52.0</version>
+            <version>${playwright.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/ChromeDriverService.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/ChromeDriverService.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
@@ -56,6 +57,9 @@ public class ChromeDriverService implements IChromeDriverService {
 	private UnifiedDirectoryManager unifiedDirectoryManager;
 
 	private final ObjectMapper objectMapper;
+
+	@Autowired(required = false)
+	private SpringBootPlaywrightInitializer playwrightInitializer;
 
 	/**
 	 * Shared directory for storing cookies
@@ -197,21 +201,90 @@ public class ChromeDriverService implements IChromeDriverService {
 	}
 
 	private DriverWrapper createNewDriver() {
+		try {
+			// Check if running in Spring Boot environment
+			if (isSpringBootEnvironment()) {
+				log.info("Detected Spring Boot environment, using special handling");
+				return createNewDriverForSpringBoot();
+			}
+
+			// Standard handling approach
+			try (Playwright playwright = Playwright.create()) {
+				// Get browser type, supports environment variable configuration
+				BrowserType browserType = getBrowserTypeFromEnv(playwright);
+				log.info("Using browser type: {}", browserType.name());
+
+				BrowserType.LaunchOptions options = new BrowserType.LaunchOptions();
+
+				// Basic configuration
+				options.setArgs(Arrays.asList("--remote-allow-origins=*",
+						"--disable-blink-features=AutomationControlled", "--disable-infobars",
+						"--disable-notifications", "--disable-dev-shm-usage", "--lang=zh-CN,zh,en-US,en",
+						"--user-agent=" + getRandomUserAgent(), "--window-size=1920,1080"));
+
+				// Decide whether to use headless mode based on configuration
+				if (manusProperties.getBrowserHeadless()) {
+					log.info("Enable Playwright headless mode");
+					options.setHeadless(true);
+				}
+				else {
+					log.info("Enable Playwright non-headless mode");
+					options.setHeadless(false);
+				}
+
+				// Use browserType.launch() instead of playwright.chromium().launch()
+				Browser browser = browserType.launch(options);
+				log.info("Created new Playwright Browser instance with anti-detection");
+
+				// Create DriverWrapper, but don't close playwright here, let
+				// DriverWrapper manage it
+				DriverWrapper wrapper = new DriverWrapper(playwright, browser, browser.newPage(), this.sharedDir,
+						objectMapper);
+
+				return wrapper;
+			}
+		}
+		catch (Exception e) {
+			log.error("Failed to create Playwright Browser instance", e);
+			throw new RuntimeException("Failed to initialize Playwright Browser", e);
+		}
+	}
+
+	/**
+	 * Create browser driver for Spring Boot environment
+	 */
+	private DriverWrapper createNewDriverForSpringBoot() {
+		// In Spring Boot environment, we need to manually set system properties
+		System.setProperty("playwright.browsers.path", System.getProperty("user.home") + "/.cache/ms-playwright");
+
+		// Set custom driver temp directory to avoid classpath issues
+		System.setProperty("playwright.driver.tmpdir", System.getProperty("java.io.tmpdir"));
+
+		// Skip browser download if browsers are already installed
+		System.setProperty("PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", "1");
+
+		// Try to create Playwright instance using Spring Boot initializer
 		Playwright playwright = null;
 		try {
-
-			if (playwright == null) {
+			if (playwrightInitializer != null && playwrightInitializer.canInitialize()) {
+				log.info("Using SpringBootPlaywrightInitializer");
+				playwright = playwrightInitializer.createPlaywright();
+			}
+			else {
+				log.info("Using standard Playwright initialization");
 				playwright = Playwright.create();
 			}
+
+			// Get browser type
+			BrowserType browserType = getBrowserTypeFromEnv(playwright);
+			log.info("Using browser type: {}", browserType.name());
+
 			BrowserType.LaunchOptions options = new BrowserType.LaunchOptions();
 
 			// Basic configuration
 			options.setArgs(Arrays.asList("--remote-allow-origins=*", "--disable-blink-features=AutomationControlled",
 					"--disable-infobars", "--disable-notifications", "--disable-dev-shm-usage",
-					"--lang=zh-CN,zh,en-US,en", "--user-agent=" + getRandomUserAgent(), "--window-size=1920,1080" // Default
-																													// window
-																													// size
-			));
+					"--lang=zh-CN,zh,en-US,en", "--user-agent=" + getRandomUserAgent(), "--window-size=1920,1080"));
 
 			// Decide whether to use headless mode based on configuration
 			if (manusProperties.getBrowserHeadless()) {
@@ -223,9 +296,9 @@ public class ChromeDriverService implements IChromeDriverService {
 				options.setHeadless(false);
 			}
 
-			Browser browser = playwright.chromium().launch(options);
-			log.info("Created new Playwright Browser instance with anti-detection");
-			// Pass the sharedDir to the DriverWrapper constructor
+			Browser browser = browserType.launch(options);
+			log.info("Created new Playwright Browser instance for Spring Boot environment");
+
 			return new DriverWrapper(playwright, browser, browser.newPage(), this.sharedDir, objectMapper);
 		}
 		catch (Exception e) {
@@ -237,8 +310,42 @@ public class ChromeDriverService implements IChromeDriverService {
 					log.warn("Failed to close failed Playwright instance", ex);
 				}
 			}
-			log.error("Failed to create Playwright Browser instance", e);
-			throw new RuntimeException("Failed to initialize Playwright Browser", e);
+			throw new RuntimeException("Failed to initialize Playwright Browser in Spring Boot environment", e);
+		}
+	}
+
+	/**
+	 * Detect if running in Spring Boot environment
+	 */
+	private boolean isSpringBootEnvironment() {
+		try {
+			// Simple check for Spring Boot application class
+			Class.forName("org.springframework.boot.SpringApplication");
+			return true;
+		}
+		catch (ClassNotFoundException e) {
+			// If Spring Boot is not found, assume standard environment
+			return false;
+		}
+	}
+
+	/**
+	 * Get browser type, supports environment variable configuration
+	 */
+	private BrowserType getBrowserTypeFromEnv(Playwright playwright) {
+		String browserName = System.getenv("BROWSER");
+		if (browserName == null) {
+			browserName = "chromium";
+		}
+
+		switch (browserName.toLowerCase()) {
+			case "webkit":
+				return playwright.webkit();
+			case "firefox":
+				return playwright.firefox();
+			case "chromium":
+			default:
+				return playwright.chromium();
 		}
 	}
 

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/ChromeDriverService.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/ChromeDriverService.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.annotation.PreDestroy;
@@ -201,60 +202,15 @@ public class ChromeDriverService implements IChromeDriverService {
 	}
 
 	private DriverWrapper createNewDriver() {
-		try {
-			// Check if running in Spring Boot environment
-			if (isSpringBootEnvironment()) {
-				log.info("Detected Spring Boot environment, using special handling");
-				return createNewDriverForSpringBoot();
-			}
-
-			// Standard handling approach
-			try (Playwright playwright = Playwright.create()) {
-				// Get browser type, supports environment variable configuration
-				BrowserType browserType = getBrowserTypeFromEnv(playwright);
-				log.info("Using browser type: {}", browserType.name());
-
-				BrowserType.LaunchOptions options = new BrowserType.LaunchOptions();
-
-				// Basic configuration
-				options.setArgs(Arrays.asList("--remote-allow-origins=*",
-						"--disable-blink-features=AutomationControlled", "--disable-infobars",
-						"--disable-notifications", "--disable-dev-shm-usage", "--lang=zh-CN,zh,en-US,en",
-						"--user-agent=" + getRandomUserAgent(), "--window-size=1920,1080"));
-
-				// Decide whether to use headless mode based on configuration
-				if (manusProperties.getBrowserHeadless()) {
-					log.info("Enable Playwright headless mode");
-					options.setHeadless(true);
-				}
-				else {
-					log.info("Enable Playwright non-headless mode");
-					options.setHeadless(false);
-				}
-
-				// Use browserType.launch() instead of playwright.chromium().launch()
-				Browser browser = browserType.launch(options);
-				log.info("Created new Playwright Browser instance with anti-detection");
-
-				// Create DriverWrapper, but don't close playwright here, let
-				// DriverWrapper manage it
-				DriverWrapper wrapper = new DriverWrapper(playwright, browser, browser.newPage(), this.sharedDir,
-						objectMapper);
-
-				return wrapper;
-			}
-		}
-		catch (Exception e) {
-			log.error("Failed to create Playwright Browser instance", e);
-			throw new RuntimeException("Failed to initialize Playwright Browser", e);
-		}
+		log.info("Creating new browser driver");
+		return createDriverInstance();
 	}
 
 	/**
-	 * Create browser driver for Spring Boot environment
+	 * Create browser driver instance
 	 */
-	private DriverWrapper createNewDriverForSpringBoot() {
-		// In Spring Boot environment, we need to manually set system properties
+	private DriverWrapper createDriverInstance() {
+		// Set system properties for Playwright configuration
 		System.setProperty("playwright.browsers.path", System.getProperty("user.home") + "/.cache/ms-playwright");
 
 		// Set custom driver temp directory to avoid classpath issues
@@ -297,9 +253,19 @@ public class ChromeDriverService implements IChromeDriverService {
 			}
 
 			Browser browser = browserType.launch(options);
-			log.info("Created new Playwright Browser instance for Spring Boot environment");
+			log.info("Created new Playwright Browser instance");
 
-			return new DriverWrapper(playwright, browser, browser.newPage(), this.sharedDir, objectMapper);
+			// Create new page and configure timeout
+			Page page = browser.newPage();
+
+			// Set default timeout based on configuration
+			Integer timeout = manusProperties.getBrowserRequestTimeout();
+			if (timeout != null && timeout > 0) {
+				log.info("Setting browser page timeout to {} seconds", timeout);
+				page.setDefaultTimeout(timeout * 1000); // Convert to milliseconds
+			}
+
+			return new DriverWrapper(playwright, browser, page, this.sharedDir, objectMapper);
 		}
 		catch (Exception e) {
 			if (playwright != null) {
@@ -310,16 +276,8 @@ public class ChromeDriverService implements IChromeDriverService {
 					log.warn("Failed to close failed Playwright instance", ex);
 				}
 			}
-			throw new RuntimeException("Failed to initialize Playwright Browser in Spring Boot environment", e);
+			throw new RuntimeException("Failed to initialize Playwright Browser", e);
 		}
-	}
-
-	/**
-	 * Detect if running in Spring Boot environment , default return true because we are
-	 * in spring boot env .
-	 */
-	private boolean isSpringBootEnvironment() {
-		return true;
 	}
 
 	/**

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/ChromeDriverService.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/ChromeDriverService.java
@@ -315,18 +315,11 @@ public class ChromeDriverService implements IChromeDriverService {
 	}
 
 	/**
-	 * Detect if running in Spring Boot environment
+	 * Detect if running in Spring Boot environment , default return true because we are
+	 * in spring boot env .
 	 */
 	private boolean isSpringBootEnvironment() {
-		try {
-			// Simple check for Spring Boot application class
-			Class.forName("org.springframework.boot.SpringApplication");
-			return true;
-		}
-		catch (ClassNotFoundException e) {
-			// If Spring Boot is not found, assume standard environment
-			return false;
-		}
+		return true;
 	}
 
 	/**

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/SpringBootPlaywrightInitializer.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/browser/SpringBootPlaywrightInitializer.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.tool.browser;
+
+import com.microsoft.playwright.Playwright;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Spring Boot environment Playwright initializer Handles the special requirements for
+ * running Playwright in Spring Boot fat jar
+ */
+@Component
+public class SpringBootPlaywrightInitializer {
+
+	private static final Logger log = LoggerFactory.getLogger(SpringBootPlaywrightInitializer.class);
+
+	/**
+	 * Initialize Playwright for Spring Boot environment
+	 */
+	public Playwright createPlaywright() {
+		try {
+			// Set up environment for Spring Boot
+			setupSpringBootEnvironment();
+
+			// Save current context class loader
+			ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+
+			try {
+				// Use this class's classloader (LaunchedClassLoader in Spring Boot)
+				Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
+				return Playwright.create();
+			}
+			finally {
+				// Always restore original class loader
+				Thread.currentThread().setContextClassLoader(originalClassLoader);
+			}
+		}
+		catch (Exception e) {
+			log.error("Failed to create Playwright in Spring Boot environment", e);
+			throw new RuntimeException("Failed to initialize Playwright", e);
+		}
+	}
+
+	/**
+	 * Set up environment properties for Spring Boot
+	 */
+	private void setupSpringBootEnvironment() {
+		// Set browser path
+		String browserPath = System.getProperty("user.home") + "/.cache/ms-playwright";
+		System.setProperty("playwright.browsers.path", browserPath);
+
+		// Set driver temp directory
+		String tempDir = System.getProperty("java.io.tmpdir");
+		System.setProperty("playwright.driver.tmpdir", tempDir);
+
+		// Check if browsers are installed
+		Path browsersPath = Paths.get(browserPath);
+		if (Files.exists(browsersPath)) {
+			log.info("Playwright browsers found at: {}", browserPath);
+			System.setProperty("PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD", "1");
+		}
+		else {
+			log.warn("Playwright browsers not found at: {}. They will be downloaded on first use.", browserPath);
+		}
+
+		log.info("Spring Boot Playwright environment configured:");
+		log.info("  - Browser path: {}", browserPath);
+		log.info("  - Temp directory: {}", tempDir);
+	}
+
+	/**
+	 * Check if Playwright can be initialized
+	 */
+	public boolean canInitialize() {
+		try {
+			// Try to find the required classes
+			Class.forName("com.microsoft.playwright.Playwright");
+			return true;
+		}
+		catch (ClassNotFoundException e) {
+			log.error("Playwright classes not found in classpath", e);
+			return false;
+		}
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

#2018 

原理：
this.getClass().getClassLoader() 返回的是Spring Boot的LaunchedClassLoader
这个类加载器知道如何正确访问fat JAR中的嵌套资源
Playwright的资源查找依赖于当前线程的上下文类加载器

用这个规避 loadURI==null后的报错

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
