### PR TITLE
feat(jmanus): added the jsx_generator tool and jsx_generator agent

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/model/enums/AgentEnum.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/model/enums/AgentEnum.java
@@ -27,7 +27,8 @@ public enum AgentEnum {
 	MAPREDUCE_FIN_AGENT("MAPREDUCE_FIN_AGENT", "mapreduce_fin_agent"),
 	MAPREDUCE_MAP_TASK_AGENT("MAPREDUCE_MAP_TASK_AGENT", "mapreduce_map_task_agent"),
 	MAPREDUCE_REDUCE_TASK_AGENT("MAPREDUCE_REDUCE_TASK_AGENT", "mapreduce_reduce_task_agent"),
-	PPT_GENERATOR_AGENT("PPT_GENERATOR_AGENT", "ppt_generator_agent");
+	PPT_GENERATOR_AGENT("PPT_GENERATOR_AGENT", "ppt_generator_agent"),
+	JSX_GENERATOR_AGENT("JSX_GENERATOR_AGENT", "jsx_generator_agent");
 
 	private String agentName;
 

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/PlanningFactory.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/planning/PlanningFactory.java
@@ -84,6 +84,7 @@ import com.alibaba.cloud.ai.example.manus.tool.tableProcessor.TableProcessingSer
 import com.alibaba.cloud.ai.example.manus.tool.textOperator.TextFileOperator;
 import com.alibaba.cloud.ai.example.manus.tool.textOperator.TextFileService;
 import com.alibaba.cloud.ai.example.manus.tool.pptGenerator.PptGeneratorOperator;
+import com.alibaba.cloud.ai.example.manus.tool.jsxGenerator.JsxGeneratorOperator;
 import com.alibaba.cloud.ai.example.manus.workflow.SummaryWorkflow;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -152,6 +153,9 @@ public class PlanningFactory implements IPlanningFactory {
 
 	@Autowired
 	private PptGeneratorOperator pptGeneratorOperator;
+
+	@Autowired
+	private JsxGeneratorOperator jsxGeneratorOperator;
 
 	public PlanningFactory(ChromeDriverService chromeDriverService, PlanExecutionRecorder recorder,
 			ManusProperties manusProperties, TextFileService textFileService, McpService mcpService,
@@ -230,6 +234,7 @@ public class PlanningFactory implements IPlanningFactory {
 		toolDefinitions.add(new TextFileOperator(textFileService, innerStorageService, objectMapper));
 		// toolDefinitions.add(new InnerStorageTool(unifiedDirectoryManager));
 		// toolDefinitions.add(pptGeneratorOperator);
+		// toolDefinitions.add(jsxGeneratorOperator);
 		toolDefinitions.add(new InnerStorageContentTool(unifiedDirectoryManager, summaryWorkflow, recorder));
 		toolDefinitions.add(new FileMergeTool(unifiedDirectoryManager));
 		// toolDefinitions.add(new GoogleSearch());

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/ComponentState.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/ComponentState.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.tool.jsxGenerator;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Component state class for storing current component file path, last operation result,
+ * and component metadata
+ */
+public class ComponentState {
+
+	private String currentFilePath = "";
+
+	private String lastOperationResult = "";
+
+	private String componentType = "";
+
+	private Map<String, Object> componentMetadata = new ConcurrentHashMap<>();
+
+	private String lastGeneratedCode = "";
+
+	private final Object componentLock = new Object();
+
+	public String getCurrentFilePath() {
+		return currentFilePath;
+	}
+
+	public void setCurrentFilePath(String currentFilePath) {
+		this.currentFilePath = currentFilePath;
+	}
+
+	public String getLastOperationResult() {
+		return lastOperationResult;
+	}
+
+	public void setLastOperationResult(String lastOperationResult) {
+		this.lastOperationResult = lastOperationResult;
+	}
+
+	public String getComponentType() {
+		return componentType;
+	}
+
+	public void setComponentType(String componentType) {
+		this.componentType = componentType;
+	}
+
+	public Map<String, Object> getComponentMetadata() {
+		return componentMetadata;
+	}
+
+	public void setComponentMetadata(Map<String, Object> componentMetadata) {
+		this.componentMetadata = componentMetadata;
+	}
+
+	public void addComponentMetadata(String key, Object value) {
+		this.componentMetadata.put(key, value);
+	}
+
+	public String getLastGeneratedCode() {
+		return lastGeneratedCode;
+	}
+
+	public void setLastGeneratedCode(String lastGeneratedCode) {
+		this.lastGeneratedCode = lastGeneratedCode;
+	}
+
+	public Object getComponentLock() {
+		return componentLock;
+	}
+
+}

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/IJsxGeneratorService.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/IJsxGeneratorService.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.tool.jsxGenerator;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import com.alibaba.cloud.ai.example.manus.config.ManusProperties;
+
+/**
+ * Interface for JSX/Vue component generation operations. Provides methods for creating,
+ * saving, and previewing Vue SFC components with Handlebars template support.
+ */
+public interface IJsxGeneratorService {
+
+	/**
+	 * Generate Vue Single File Component based on component specifications
+	 * @param componentType Type of the component (e.g., 'button', 'form', 'chart')
+	 * @param componentData Component data including props, data, methods, computed, etc.
+	 * @return Generated Vue SFC code
+	 */
+	String generateVueSFC(String componentType, Map<String, Object> componentData);
+
+	/**
+	 * Generate Vue template section
+	 * @param componentType Component type
+	 * @param templateData Template data
+	 * @return Generated template HTML
+	 */
+	String generateVueTemplate(String componentType, Map<String, Object> templateData);
+
+	/**
+	 * Generate Vue script section
+	 * @param componentData Component data including data, methods, computed, etc.
+	 * @return Generated script section
+	 */
+	String generateVueScript(Map<String, Object> componentData);
+
+	/**
+	 * Generate Vue style section
+	 * @param styleData Style specifications
+	 * @return Generated style section
+	 */
+	String generateVueStyle(Map<String, Object> styleData);
+
+	/**
+	 * Apply Handlebars template for quick code generation
+	 * @param templateName Template name (e.g., 'counter-button', 'data-form')
+	 * @param templateData Data to apply to template
+	 * @return Generated code from template
+	 */
+	String applyHandlebarsTemplate(String templateName, Map<String, Object> templateData);
+
+	/**
+	 * Register a new Handlebars template
+	 * @param templateName Template name
+	 * @param templateContent Template content
+	 */
+	void registerTemplate(String templateName, String templateContent);
+
+	/**
+	 * Get available template names
+	 * @return Set of available template names
+	 */
+	Set<String> getAvailableTemplates();
+
+	/**
+	 * Save Vue SFC code to a file
+	 * @param planId Plan ID
+	 * @param filePath File path to save the Vue SFC code
+	 * @param vueSfcCode Vue SFC code to save
+	 * @return Absolute path of the saved file
+	 * @throws IOException if saving fails
+	 */
+	String saveVueSfcToFile(String planId, String filePath, String vueSfcCode) throws IOException;
+
+	/**
+	 * Update existing Vue component file
+	 * @param planId Plan ID
+	 * @param filePath File path
+	 * @param sectionType Section to update ('template', 'script', 'style')
+	 * @param newContent New content for the section
+	 * @throws IOException if update fails
+	 */
+	void updateVueComponent(String planId, String filePath, String sectionType, String newContent) throws IOException;
+
+	/**
+	 * Generate Sandpack preview configuration
+	 * @param planId Plan ID
+	 * @param filePath Path to the Vue file
+	 * @param dependencies Additional dependencies needed
+	 * @return Sandpack configuration JSON
+	 */
+	String generateSandpackConfig(String planId, String filePath, Map<String, String> dependencies);
+
+	/**
+	 * Generate a preview URL for the Vue component in Sandpack
+	 * @param planId Plan ID
+	 * @param filePath Path to the Vue file
+	 * @return Preview URL
+	 */
+	String generatePreviewUrl(String planId, String filePath);
+
+	/**
+	 * Validate Vue SFC syntax
+	 * @param vueSfcCode Vue SFC code to validate
+	 * @return Validation result with errors if any
+	 */
+	String validateVueSfc(String vueSfcCode);
+
+	/**
+	 * Get component state for specified plan
+	 * @param planId Plan ID
+	 * @return Component state
+	 */
+	Object getComponentState(String planId);
+
+	/**
+	 * Close components for specified plan
+	 * @param planId Plan ID
+	 */
+	void closeComponentForPlan(String planId);
+
+	/**
+	 * Update component state
+	 * @param planId Plan ID
+	 * @param filePath File path
+	 * @param operationResult Operation result
+	 */
+	void updateComponentState(String planId, String filePath, String operationResult);
+
+	/**
+	 * Get current component file path
+	 * @param planId Plan ID
+	 * @return Current component file path
+	 */
+	String getCurrentFilePath(String planId);
+
+	/**
+	 * Get last operation result for a plan
+	 * @param planId Plan ID
+	 * @return Last operation result
+	 */
+	String getLastOperationResult(String planId);
+
+	/**
+	 * Get Manus properties
+	 * @return Manus properties
+	 */
+	ManusProperties getManusProperties();
+
+	/**
+	 * Clean up resources
+	 */
+	void cleanup();
+
+}

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorOperator.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorOperator.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.tool.jsxGenerator;
+
+import com.alibaba.cloud.ai.example.manus.tool.AbstractBaseTool;
+import com.alibaba.cloud.ai.example.manus.tool.code.ToolExecuteResult;
+import com.alibaba.cloud.ai.example.manus.tool.filesystem.UnifiedDirectoryManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsxGeneratorOperator extends AbstractBaseTool<JsxGeneratorTool.JsxInput> {
+
+	private static final Logger log = LoggerFactory.getLogger(JsxGeneratorOperator.class);
+
+	private final IJsxGeneratorService jsxGeneratorService;
+
+	private final ObjectMapper objectMapper;
+
+	private final UnifiedDirectoryManager unifiedDirectoryManager;
+
+	private static final String TOOL_NAME = "jsx_generator_operator";
+
+	public JsxGeneratorOperator(IJsxGeneratorService jsxGeneratorService, ObjectMapper objectMapper,
+			UnifiedDirectoryManager unifiedDirectoryManager) {
+		this.jsxGeneratorService = jsxGeneratorService;
+		this.objectMapper = objectMapper;
+		this.unifiedDirectoryManager = unifiedDirectoryManager;
+	}
+
+	/**
+	 * Helper method to create detailed error messages
+	 */
+	private String createDetailedErrorMessage(String action, String missingParam, JsxGeneratorTool.JsxInput input) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("Error: ")
+			.append(missingParam)
+			.append(" parameter is required for ")
+			.append(action)
+			.append(" operation.\n");
+		sb.append("Received parameters: ").append(input.toString()).append("\n");
+		sb.append("Expected format for ").append(action).append(":\n");
+
+		switch (action) {
+			case "generate_vue":
+				sb.append("{\n");
+				sb.append("  \"action\": \"generate_vue\",\n");
+				sb.append("  \"component_type\": \"<string>\",  // Required: button, form, chart, counter, etc.\n");
+				sb.append("  \"component_data\": {             // Optional: component specifications\n");
+				sb.append("    \"name\": \"<string>\",\n");
+				sb.append("    \"data\": {},\n");
+				sb.append("    \"methods\": {},\n");
+				sb.append("    \"template\": \"<string>\",\n");
+				sb.append("    \"style\": \"<string>\"\n");
+				sb.append("  }\n");
+				sb.append("}");
+				break;
+			case "apply_template":
+				sb.append("{\n");
+				sb.append("  \"action\": \"apply_template\",\n");
+				sb.append("  \"template_name\": \"<string>\",   // Required: template name\n");
+				sb.append("  \"template_data\": {}             // Optional: data for template\n");
+				sb.append("}");
+				break;
+			case "save":
+				sb.append("{\n");
+				sb.append("  \"action\": \"save\",\n");
+				sb.append("  \"file_path\": \"<string>\",       // Required: path to save file\n");
+				sb.append("  \"vue_sfc_code\": \"<string>\"    // Required: Vue SFC code\n");
+				sb.append("}");
+				break;
+			case "validate":
+				sb.append("{\n");
+				sb.append("  \"action\": \"validate\",\n");
+				sb.append("  \"vue_sfc_code\": \"<string>\"    // Required: Vue SFC code to validate\n");
+				sb.append("}");
+				break;
+		}
+
+		return sb.toString();
+	}
+
+	/**
+	 * Run the tool (accepts JsxInput object input)
+	 */
+	@Override
+	public ToolExecuteResult run(JsxGeneratorTool.JsxInput input) {
+		log.info("JsxGeneratorOperator input: {}", input);
+		try {
+			String planId = this.currentPlanId;
+
+			if ("list_templates".equals(input.getAction())) {
+				// Handle list templates operation
+				var templates = jsxGeneratorService.getAvailableTemplates();
+				return new ToolExecuteResult("Available templates: " + String.join(", ", templates));
+			}
+			else if ("generate_vue".equals(input.getAction())) {
+				// Handle generate Vue SFC operation
+				String componentType = input.getComponentType();
+				var componentData = input.getComponentData();
+
+				if (componentType == null || componentType.trim().isEmpty()) {
+					return new ToolExecuteResult(createDetailedErrorMessage("generate_vue", "component_type", input));
+				}
+				if (componentData == null) {
+					componentData = new java.util.HashMap<>();
+					log.info("No component_data provided, using empty map for component generation");
+				}
+
+				log.info("JsxGeneratorOperator - Generating Vue SFC with componentType: {}, componentData keys: {}",
+						componentType, componentData.keySet());
+				String vueSfcCode = jsxGeneratorService.generateVueSFC(componentType, componentData);
+				jsxGeneratorService.updateComponentState(planId, null, "Vue SFC generated successfully");
+				return new ToolExecuteResult(
+						"Vue SFC generated successfully for component type '" + componentType + "':\n" + vueSfcCode);
+			}
+			else if ("apply_template".equals(input.getAction())) {
+				// Handle apply template operation
+				String templateName = input.getTemplateName();
+				var templateData = input.getTemplateData();
+
+				if (templateName == null || templateName.trim().isEmpty()) {
+					return new ToolExecuteResult(createDetailedErrorMessage("apply_template", "template_name", input));
+				}
+				if (templateData == null) {
+					templateData = new java.util.HashMap<>();
+					log.info("No template_data provided, using empty map for template application");
+				}
+
+				log.info("JsxGeneratorOperator - Applying template: {}, with data keys: {}", templateName,
+						templateData.keySet());
+				String generatedCode = jsxGeneratorService.applyHandlebarsTemplate(templateName, templateData);
+				jsxGeneratorService.updateComponentState(planId, null, "Template applied successfully");
+				return new ToolExecuteResult("Template '" + templateName + "' applied successfully:\n" + generatedCode);
+			}
+			else if ("save".equals(input.getAction())) {
+				// Handle save operation
+				String filePath = input.getFilePath();
+				String vueSfcCode = input.getVueSfcCode();
+
+				if (filePath == null || filePath.trim().isEmpty()) {
+					return new ToolExecuteResult(createDetailedErrorMessage("save", "file_path", input));
+				}
+				if (vueSfcCode == null || vueSfcCode.trim().isEmpty()) {
+					return new ToolExecuteResult(createDetailedErrorMessage("save", "vue_sfc_code", input));
+				}
+
+				log.info("JsxGeneratorOperator - Saving Vue SFC to file: {}, code length: {}", filePath,
+						vueSfcCode.length());
+				String savedPath = jsxGeneratorService.saveVueSfcToFile(planId, filePath, vueSfcCode);
+				return new ToolExecuteResult("Vue SFC file saved successfully to: " + savedPath);
+			}
+			else if ("validate".equals(input.getAction())) {
+				// Handle validate operation
+				String vueSfcCode = input.getVueSfcCode();
+
+				if (vueSfcCode == null || vueSfcCode.trim().isEmpty()) {
+					return new ToolExecuteResult(createDetailedErrorMessage("validate", "vue_sfc_code", input));
+				}
+
+				log.info("JsxGeneratorOperator - Validating Vue SFC code, length: {}", vueSfcCode.length());
+				String validationResult = jsxGeneratorService.validateVueSfc(vueSfcCode);
+				return new ToolExecuteResult("Validation result: " + validationResult);
+			}
+			else {
+				return new ToolExecuteResult("Unsupported operation: " + input.getAction()
+						+ ". Supported operations: generate_vue, apply_template, save, validate, list_templates");
+			}
+		}
+		catch (IllegalArgumentException e) {
+			String planId = this.currentPlanId;
+			jsxGeneratorService.updateComponentState(planId, null,
+					"Error: Parameter validation failed: " + e.getMessage());
+			return new ToolExecuteResult("Parameter validation failed: " + e.getMessage());
+		}
+		catch (Exception e) {
+			log.error("JSX generation failed", e);
+			String planId = this.currentPlanId;
+			jsxGeneratorService.updateComponentState(planId, null, "Error: JSX generation failed: " + e.getMessage());
+			return new ToolExecuteResult("JSX generation failed: " + e.getMessage());
+		}
+	}
+
+	@Override
+	public String getName() {
+		return TOOL_NAME;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Tool for generating Vue SFC components with Handlebars templates and preview functionality. "
+				+ "Supports operations: generate_vue (Generate Vue component), apply_template (Apply Handlebars template), "
+				+ "save (Save Vue SFC to file), validate (Validate Vue SFC syntax), list_templates (List available templates). "
+				+ "Generated Vue files will be saved in the project directory structure.";
+	}
+
+	@Override
+	public String getParameters() {
+		return """
+				{
+				    "type": "object",
+				    "properties": {
+				        "action": {
+				            "type": "string",
+				            "description": "Action to perform",
+				            "enum": ["generate_vue", "apply_template", "save", "validate", "list_templates"]
+				        },
+				        "component_type": {
+				            "type": "string",
+				            "description": "Type of component to generate (e.g., button, form, chart)"
+				        },
+				        "component_data": {
+				            "type": "object",
+				            "description": "Component data including name, data, methods, computed, template, style"
+				        },
+				        "template_name": {
+				            "type": "string",
+				            "description": "Handlebars template name (e.g., counter-button, data-form)"
+				        },
+				        "template_data": {
+				            "type": "object",
+				            "description": "Data to apply to Handlebars template"
+				        },
+				        "file_path": {
+				            "type": "string",
+				            "description": "File path to save the Vue SFC code"
+				        },
+				        "vue_sfc_code": {
+				            "type": "string",
+				            "description": "Vue SFC code to save or validate"
+				        }
+				    },
+				    "required": ["action"]
+				}
+				""";
+	}
+
+	@Override
+	public Class<JsxGeneratorTool.JsxInput> getInputType() {
+		return JsxGeneratorTool.JsxInput.class;
+	}
+
+	@Override
+	public String getServiceGroup() {
+		return "frontend-tools";
+	}
+
+	@Override
+	public String getCurrentToolStateString() {
+		return "JSX Generator Operator is ready";
+	}
+
+	@Override
+	public void cleanup(String planId) {
+		if (jsxGeneratorService != null) {
+			jsxGeneratorService.closeComponentForPlan(planId);
+		}
+	}
+
+}

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorService.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorService.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.tool.jsxGenerator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.alibaba.cloud.ai.example.manus.config.ManusProperties;
+import com.alibaba.cloud.ai.example.manus.tool.filesystem.UnifiedDirectoryManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PreDestroy;
+
+@Service
+@Primary
+public class JsxGeneratorService implements ApplicationRunner, IJsxGeneratorService {
+
+	private static final Logger log = LoggerFactory.getLogger(JsxGeneratorService.class);
+
+	@Autowired
+	private ManusProperties manusProperties;
+
+	@Autowired
+	private UnifiedDirectoryManager unifiedDirectoryManager;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	// Store component states for each plan
+	private final ConcurrentHashMap<String, ComponentState> componentStates = new ConcurrentHashMap<>();
+
+	// Store Handlebars templates
+	private final Map<String, String> handlebarsTemplates = new ConcurrentHashMap<>();
+
+	// Supported Vue SFC file extensions (for future validation use)
+	@SuppressWarnings("unused")
+	private static final Set<String> SUPPORTED_EXTENSIONS = new HashSet<>(Set.of(".vue", ".js", ".ts"));
+
+	@Override
+	public void run(ApplicationArguments args) {
+		log.info("JsxGeneratorService initialized");
+		initializeDefaultTemplates();
+	}
+
+	private void initializeDefaultTemplates() {
+		// Initialize default Handlebars templates
+		registerTemplate("counter-button", """
+				<template>
+				  <div class="counter-container">
+				    <button :class="buttonClass" @click="increment">
+				      {{buttonText}} ({{count}})
+				    </button>
+				  </div>
+				</template>
+
+				<script>
+				export default {
+				  name: '{{componentName}}',
+				  data() {
+				    return {
+				      count: {{initialCount}}
+				    };
+				  },
+				  computed: {
+				    buttonClass() {
+				      return {
+				        'btn': true,
+				        'btn-primary': this.count <= {{threshold}},
+				        'btn-danger': this.count > {{threshold}}
+				      };
+				    }
+				  },
+				  methods: {
+				    increment() {
+				      this.count++;
+				    }
+				  }
+				};
+				</script>
+
+				<style scoped>
+				.counter-container {
+				  padding: 20px;
+				}
+				.btn {
+				  padding: 10px 20px;
+				  border: none;
+				  border-radius: 4px;
+				  cursor: pointer;
+				  font-size: 16px;
+				}
+				.btn-primary {
+				  background-color: #007bff;
+				  color: white;
+				}
+				.btn-danger {
+				  background-color: #dc3545;
+				  color: white;
+				}
+				</style>
+				""");
+
+		registerTemplate("data-form", """
+				<template>
+				  <div class="form-container">
+				    <form @submit.prevent="handleSubmit">
+				      {{#each fields}}
+				      <div class="form-group">
+				        <label for="{{name}}">{{label}}</label>
+				        <input
+				          type="{{type}}"
+				          id="{{name}}"
+				          v-model="formData.{{name}}"
+				          :required="{{required}}"
+				        />
+				      </div>
+				      {{/each}}
+				      <button type="submit" class="btn btn-primary">{{submitText}}</button>
+				    </form>
+				  </div>
+				</template>
+
+				<script>
+				export default {
+				  name: '{{componentName}}',
+				  data() {
+				    return {
+				      formData: {
+				        {{#each fields}}
+				        {{name}}: '{{defaultValue}}'{{#unless @last}},{{/unless}}
+				        {{/each}}
+				      }
+				    };
+				  },
+				  methods: {
+				    handleSubmit() {
+				      console.log('Form submitted:', this.formData);
+				      this.$emit('submit', this.formData);
+				    }
+				  }
+				};
+				</script>
+
+				<style scoped>
+				.form-container {
+				  max-width: 400px;
+				  margin: 0 auto;
+				  padding: 20px;
+				}
+				.form-group {
+				  margin-bottom: 15px;
+				}
+				label {
+				  display: block;
+				  margin-bottom: 5px;
+				  font-weight: bold;
+				}
+				input {
+				  width: 100%;
+				  padding: 8px 12px;
+				  border: 1px solid #ddd;
+				  border-radius: 4px;
+				}
+				.btn {
+				  padding: 10px 20px;
+				  background-color: #007bff;
+				  color: white;
+				  border: none;
+				  border-radius: 4px;
+				  cursor: pointer;
+				}
+				</style>
+				""");
+
+		log.info("Default templates initialized: {}", handlebarsTemplates.keySet());
+	}
+
+	private Object getComponentLock(String planId) {
+		return getComponentState(planId).getComponentLock();
+	}
+
+	@Override
+	public ComponentState getComponentState(String planId) {
+		return componentStates.computeIfAbsent(planId, k -> new ComponentState());
+	}
+
+	@Override
+	public void closeComponentForPlan(String planId) {
+		synchronized (getComponentLock(planId)) {
+			componentStates.remove(planId);
+			log.info("Closed component state for plan: {}", planId);
+		}
+	}
+
+	@Override
+	public String generateVueSFC(String componentType, Map<String, Object> componentData) {
+		log.info("Generating Vue SFC for component: {}", componentType);
+
+		StringBuilder sfcBuilder = new StringBuilder();
+
+		// Generate template section
+		String template;
+		Object templateObj = componentData.get("template");
+		if (templateObj instanceof String) {
+			// If template is provided as a string, wrap it in template tags
+			template = "<template>\n" + templateObj + "\n</template>";
+		}
+		else if (templateObj instanceof Map) {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> templateData = (Map<String, Object>) templateObj;
+			template = generateVueTemplate(componentType, templateData);
+		}
+		else {
+			// Use default template generation
+			template = generateVueTemplate(componentType, new HashMap<>());
+		}
+		sfcBuilder.append(template).append("\n\n");
+
+		// Generate script section
+		String script = generateVueScript(componentData);
+		sfcBuilder.append(script).append("\n\n");
+
+		// Generate style section
+		String style;
+		Object styleObj = componentData.get("style");
+		if (styleObj instanceof String) {
+			// If style is provided as a string, wrap it in style tags
+			style = "<style scoped>\n" + styleObj + "\n</style>";
+		}
+		else if (styleObj instanceof Map) {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> styleData = (Map<String, Object>) styleObj;
+			style = generateVueStyle(styleData);
+		}
+		else {
+			// Use default style generation
+			style = generateVueStyle(new HashMap<>());
+		}
+		sfcBuilder.append(style);
+
+		return sfcBuilder.toString();
+	}
+
+	@Override
+	public String generateVueTemplate(String componentType, Map<String, Object> templateData) {
+		StringBuilder template = new StringBuilder();
+		template.append("<template>\n");
+		template.append("  <div class=\"").append(componentType).append("-container\">\n");
+
+		// Generate template content based on component type
+		switch (componentType) {
+			case "button", "counter-button" -> {
+				String buttonText = (String) templateData.getOrDefault("text", "Click Me");
+				String clickAction = (String) templateData.getOrDefault("action", "handleClick");
+				template.append("    <button @click=\"").append(clickAction).append("\">\n");
+				template.append("      ").append(buttonText).append("\n");
+				template.append("    </button>\n");
+			}
+			case "form", "data-form" -> {
+				template.append("    <form @submit.prevent=\"handleSubmit\">\n");
+				template.append("      <!-- Form fields will be generated here -->\n");
+				template.append("      <button type=\"submit\">Submit</button>\n");
+				template.append("    </form>\n");
+			}
+			default -> template.append("    <!-- Default component content -->\n");
+		}
+
+		template.append("  </div>\n");
+		template.append("</template>");
+		return template.toString();
+	}
+
+	@Override
+	public String generateVueScript(Map<String, Object> componentData) {
+		StringBuilder script = new StringBuilder();
+		script.append("<script>\n");
+		script.append("export default {\n");
+
+		// Component name
+		String name = (String) componentData.getOrDefault("name", "CustomComponent");
+		script.append("  name: '").append(name).append("',\n");
+
+		// Data section
+		@SuppressWarnings("unchecked")
+		Map<String, Object> data = (Map<String, Object>) componentData.getOrDefault("data", new HashMap<>());
+		if (!data.isEmpty()) {
+			script.append("  data() {\n");
+			script.append("    return {\n");
+			for (Map.Entry<String, Object> entry : data.entrySet()) {
+				script.append("      ").append(entry.getKey()).append(": ");
+				if (entry.getValue() instanceof String) {
+					script.append("'").append(entry.getValue()).append("'");
+				}
+				else {
+					script.append(entry.getValue());
+				}
+				script.append(",\n");
+			}
+			script.append("    };\n");
+			script.append("  },\n");
+		}
+
+		// Methods section
+		@SuppressWarnings("unchecked")
+		Map<String, Object> methods = (Map<String, Object>) componentData.getOrDefault("methods", new HashMap<>());
+		if (!methods.isEmpty()) {
+			script.append("  methods: {\n");
+			for (Map.Entry<String, Object> entry : methods.entrySet()) {
+				String methodName = entry.getKey();
+				Object methodImpl = entry.getValue();
+
+				script.append("    ").append(methodName).append(": ");
+				if (methodImpl instanceof String) {
+					String methodStr = (String) methodImpl;
+					// Remove 'function' keyword if present and add it properly
+					if (methodStr.startsWith("function")) {
+						methodStr = methodStr.substring(8).trim(); // Remove 'function'
+																	// keyword
+						if (methodStr.startsWith("()")) {
+							script.append("function").append(methodStr);
+						}
+						else {
+							script.append("function() ").append(methodStr);
+						}
+					}
+					else {
+						// Assume it's a function body, wrap it properly
+						script.append("function() ").append(methodStr);
+					}
+				}
+				else {
+					// Fallback to empty method
+					script.append("function() {\n");
+					script.append("      // Method implementation\n");
+					script.append("    }");
+				}
+				script.append(",\n");
+			}
+			script.append("  },\n");
+		}
+
+		// Computed properties
+		@SuppressWarnings("unchecked")
+		Map<String, Object> computed = (Map<String, Object>) componentData.getOrDefault("computed", new HashMap<>());
+		if (!computed.isEmpty()) {
+			script.append("  computed: {\n");
+			for (String computedName : computed.keySet()) {
+				script.append("    ").append(computedName).append("() {\n");
+				script.append("      // Computed property implementation\n");
+				script.append("      return null;\n");
+				script.append("    },\n");
+			}
+			script.append("  }\n");
+		}
+
+		script.append("};\n");
+		script.append("</script>");
+		return script.toString();
+	}
+
+	@Override
+	public String generateVueStyle(Map<String, Object> styleData) {
+		StringBuilder style = new StringBuilder();
+		style.append("<style scoped>\n");
+
+		// Default styles
+		style.append(".component-container {\n");
+		style.append("  padding: 20px;\n");
+		style.append("}\n");
+
+		// Custom styles from styleData
+		if (styleData != null && !styleData.isEmpty()) {
+			for (Map.Entry<String, Object> entry : styleData.entrySet()) {
+				String selector = entry.getKey();
+				Object rules = entry.getValue();
+				style.append(".").append(selector).append(" {\n");
+				if (rules instanceof Map) {
+					@SuppressWarnings("unchecked")
+					Map<String, Object> ruleMap = (Map<String, Object>) rules;
+					for (Map.Entry<String, Object> rule : ruleMap.entrySet()) {
+						style.append("  ").append(rule.getKey()).append(": ").append(rule.getValue()).append(";\n");
+					}
+				}
+				style.append("}\n");
+			}
+		}
+
+		style.append("</style>");
+		return style.toString();
+	}
+
+	@Override
+	public String applyHandlebarsTemplate(String templateName, Map<String, Object> templateData) {
+		String template = handlebarsTemplates.get(templateName);
+		if (template == null) {
+			throw new IllegalArgumentException("Template not found: " + templateName);
+		}
+
+		log.info("Applying Handlebars template: {}", templateName);
+
+		// Simple template replacement (in real implementation, use Handlebars library)
+		String result = template;
+		for (Map.Entry<String, Object> entry : templateData.entrySet()) {
+			String placeholder = "{{" + entry.getKey() + "}}";
+			result = result.replace(placeholder, String.valueOf(entry.getValue()));
+		}
+
+		return result;
+	}
+
+	@Override
+	public void registerTemplate(String templateName, String templateContent) {
+		handlebarsTemplates.put(templateName, templateContent);
+		log.info("Registered template: {}", templateName);
+	}
+
+	@Override
+	public Set<String> getAvailableTemplates() {
+		return new HashSet<>(handlebarsTemplates.keySet());
+	}
+
+	@Override
+	public String saveVueSfcToFile(String planId, String filePath, String vueSfcCode) throws IOException {
+		log.info("Saving Vue SFC to file: {}", filePath);
+
+		// Get absolute path
+		Path absolutePath = getAbsolutePath(planId, filePath);
+
+		// Ensure parent directory exists
+		Files.createDirectories(absolutePath.getParent());
+
+		// Write Vue SFC code to file
+		Files.writeString(absolutePath, vueSfcCode);
+
+		// Update component state
+		updateComponentState(planId, filePath, "Vue SFC file saved successfully");
+
+		return absolutePath.toString();
+	}
+
+	@Override
+	public void updateVueComponent(String planId, String filePath, String sectionType, String newContent)
+			throws IOException {
+		log.info("Updating Vue component section: {} in file: {}", sectionType, filePath);
+
+		Path absolutePath = getAbsolutePath(planId, filePath);
+		if (!Files.exists(absolutePath)) {
+			throw new IOException("File does not exist: " + filePath);
+		}
+
+		String existingContent = Files.readString(absolutePath);
+		String updatedContent = updateVueSfcSection(existingContent, sectionType, newContent);
+
+		Files.writeString(absolutePath, updatedContent);
+		updateComponentState(planId, filePath, "Updated " + sectionType + " section");
+	}
+
+	private String updateVueSfcSection(String sfcContent, String sectionType, String newContent) {
+		Pattern pattern = Pattern.compile("(<" + sectionType + "[^>]*>)(.*?)(</" + sectionType + ">)", Pattern.DOTALL);
+		Matcher matcher = pattern.matcher(sfcContent);
+
+		if (matcher.find()) {
+			return matcher.replaceFirst("$1\n" + newContent + "\n$3");
+		}
+		else {
+			// If section doesn't exist, append it
+			return sfcContent + "\n\n<" + sectionType + ">\n" + newContent + "\n</" + sectionType + ">";
+		}
+	}
+
+	@Override
+	public String generateSandpackConfig(String planId, String filePath, Map<String, String> dependencies) {
+		try {
+			Map<String, Object> config = new HashMap<>();
+			config.put("template", "vue");
+			config.put("files",
+					Map.of("/src/App.vue", Map.of("code", Files.readString(getAbsolutePath(planId, filePath)))));
+
+			if (dependencies != null && !dependencies.isEmpty()) {
+				config.put("dependencies", dependencies);
+			}
+
+			return objectMapper.writeValueAsString(config);
+		}
+		catch (Exception e) {
+			log.error("Error generating Sandpack config", e);
+			return "{}";
+		}
+	}
+
+	@Override
+	public String generatePreviewUrl(String planId, String filePath) {
+		// In a real implementation, this would generate a URL to preview in Sandpack
+		String absolutePath = getAbsolutePath(planId, filePath).toString();
+		String previewUrl = "http://localhost:3000/sandpack?file=" + absolutePath;
+		log.info("Generated preview URL: {}", previewUrl);
+		return previewUrl;
+	}
+
+	@Override
+	public String validateVueSfc(String vueSfcCode) {
+		// Basic validation - check for required sections
+		if (!vueSfcCode.contains("<template>") || !vueSfcCode.contains("</template>")) {
+			return "Error: Missing template section";
+		}
+		if (!vueSfcCode.contains("<script>") || !vueSfcCode.contains("</script>")) {
+			return "Error: Missing script section";
+		}
+		return "Valid Vue SFC";
+	}
+
+	@Override
+	public void updateComponentState(String planId, String filePath, String operationResult) {
+		ComponentState state = getComponentState(planId);
+		synchronized (getComponentLock(planId)) {
+			state.setCurrentFilePath(filePath);
+			state.setLastOperationResult(operationResult);
+		}
+	}
+
+	@Override
+	public String getCurrentFilePath(String planId) {
+		return getComponentState(planId).getCurrentFilePath();
+	}
+
+	@Override
+	public String getLastOperationResult(String planId) {
+		return getComponentState(planId).getLastOperationResult();
+	}
+
+	@Override
+	public ManusProperties getManusProperties() {
+		return manusProperties;
+	}
+
+	@PreDestroy
+	@Override
+	public void cleanup() {
+		log.info("Cleaning up JsxGeneratorService resources");
+		componentStates.clear();
+		handlebarsTemplates.clear();
+	}
+
+	/**
+	 * Get absolute path for a given relative path
+	 * @param planId Plan ID
+	 * @param filePath File path
+	 * @return Absolute Path
+	 */
+	private Path getAbsolutePath(String planId, String filePath) {
+		return unifiedDirectoryManager.getRootPlanDirectory(planId).resolve(filePath);
+	}
+
+	/**
+	 * Clean up component state for specified plan
+	 * @param planId Plan ID
+	 */
+	public void cleanupPlanComponents(String planId) {
+		synchronized (getComponentLock(planId)) {
+			try {
+				componentStates.remove(planId);
+				log.info("Cleaned up component resources for plan: {}", planId);
+			}
+			catch (Exception e) {
+				log.error("Error cleaning up plan components: {}", planId, e);
+			}
+		}
+	}
+
+}

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorTool.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorTool.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.tool.jsxGenerator;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.alibaba.cloud.ai.example.manus.tool.AbstractBaseTool;
+import com.alibaba.cloud.ai.example.manus.tool.code.ToolExecuteResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JsxGeneratorTool extends AbstractBaseTool<JsxGeneratorTool.JsxInput> {
+
+	private static final Logger log = LoggerFactory.getLogger(JsxGeneratorTool.class);
+
+	private static final String TOOL_NAME = "vue_component_generator";
+
+	private static final String TOOL_DESCRIPTION = "Tool for generating Vue SFC components with Handlebars templates and Sandpack preview";
+
+	private static final String PARAMETERS = "{\"type\":\"object\",\"properties\":{\"action\":{\"type\":\"string\",\"description\":\"Action to perform: generate_vue, apply_template, save, update, preview, validate\"},\"component_type\":{\"type\":\"string\",\"description\":\"Type of component to generate (e.g., button, form, chart)\"},\"component_data\":{\"type\":\"object\",\"description\":\"Component data including name, data, methods, computed, template, style\"},\"template_name\":{\"type\":\"string\",\"description\":\"Handlebars template name (e.g., counter-button, data-form)\"},\"template_data\":{\"type\":\"object\",\"description\":\"Data to apply to Handlebars template\"},\"file_path\":{\"type\":\"string\",\"description\":\"File path to save the Vue SFC code\"},\"vue_sfc_code\":{\"type\":\"string\",\"description\":\"Vue SFC code to save or validate\"},\"section_type\":{\"type\":\"string\",\"description\":\"Section type for update operation (template, script, style)\"},\"new_content\":{\"type\":\"string\",\"description\":\"New content for update operation\"},\"dependencies\":{\"type\":\"object\",\"description\":\"Additional dependencies for Sandpack preview\"}},\"required\":[\"action\"]}";
+
+	private final IJsxGeneratorService vueGeneratorService;
+
+	/**
+	 * Internal input class for defining input parameters of Vue component generator tool
+	 */
+	public static class JsxInput {
+
+		private String action;
+
+		@JsonProperty("component_type")
+		private String componentType;
+
+		@JsonProperty("component_data")
+		private Map<String, Object> componentData;
+
+		@JsonProperty("template_name")
+		private String templateName;
+
+		@JsonProperty("template_data")
+		private Map<String, Object> templateData;
+
+		@JsonProperty("file_path")
+		private String filePath;
+
+		@JsonProperty("vue_sfc_code")
+		private String vueSfcCode;
+
+		@JsonProperty("section_type")
+		private String sectionType;
+
+		@JsonProperty("new_content")
+		private String newContent;
+
+		private Map<String, String> dependencies;
+
+		// Getters and setters
+		public String getAction() {
+			return action;
+		}
+
+		public void setAction(String action) {
+			this.action = action;
+		}
+
+		public String getComponentType() {
+			return componentType;
+		}
+
+		public void setComponentType(String componentType) {
+			this.componentType = componentType;
+		}
+
+		public Map<String, Object> getComponentData() {
+			return componentData;
+		}
+
+		public void setComponentData(Map<String, Object> componentData) {
+			this.componentData = componentData;
+		}
+
+		public String getTemplateName() {
+			return templateName;
+		}
+
+		public void setTemplateName(String templateName) {
+			this.templateName = templateName;
+		}
+
+		public Map<String, Object> getTemplateData() {
+			return templateData;
+		}
+
+		public void setTemplateData(Map<String, Object> templateData) {
+			this.templateData = templateData;
+		}
+
+		public String getFilePath() {
+			return filePath;
+		}
+
+		public void setFilePath(String filePath) {
+			this.filePath = filePath;
+		}
+
+		public String getVueSfcCode() {
+			return vueSfcCode;
+		}
+
+		public void setVueSfcCode(String vueSfcCode) {
+			this.vueSfcCode = vueSfcCode;
+		}
+
+		public String getSectionType() {
+			return sectionType;
+		}
+
+		public void setSectionType(String sectionType) {
+			this.sectionType = sectionType;
+		}
+
+		public String getNewContent() {
+			return newContent;
+		}
+
+		public void setNewContent(String newContent) {
+			this.newContent = newContent;
+		}
+
+		public Map<String, String> getDependencies() {
+			return dependencies;
+		}
+
+		public void setDependencies(Map<String, String> dependencies) {
+			this.dependencies = dependencies;
+		}
+
+		@Override
+		public String toString() {
+			return "JsxInput{" + "action='" + action + '\'' + ", componentType='" + componentType + '\''
+					+ ", componentData=" + componentData + ", templateName='" + templateName + '\'' + ", templateData="
+					+ templateData + ", filePath='" + filePath + '\'' + ", vueSfcCode='"
+					+ (vueSfcCode != null ? vueSfcCode.substring(0, Math.min(100, vueSfcCode.length())) + "..." : null)
+					+ '\'' + ", sectionType='" + sectionType + '\'' + ", newContent='" + newContent + '\''
+					+ ", dependencies=" + dependencies + '}';
+		}
+
+	}
+
+	public JsxGeneratorTool(IJsxGeneratorService vueGeneratorService) {
+		this.vueGeneratorService = vueGeneratorService;
+	}
+
+	@Override
+	public String getName() {
+		return TOOL_NAME;
+	}
+
+	@Override
+	public String getDescription() {
+		return TOOL_DESCRIPTION;
+	}
+
+	@Override
+	public String getParameters() {
+		return PARAMETERS;
+	}
+
+	@Override
+	public Class<JsxInput> getInputType() {
+		return JsxInput.class;
+	}
+
+	@Override
+	public String getServiceGroup() {
+		return "frontend-tools";
+	}
+
+	@Override
+	public String getCurrentToolStateString() {
+		return "Vue Component Generator Tool is ready";
+	}
+
+	@Override
+	public void cleanup(String planId) {
+		// Cleanup logic if needed
+	}
+
+	/**
+	 * Helper method to create detailed error messages
+	 */
+	private String createDetailedErrorMessage(String action, String missingParam, JsxInput input) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("Error: ")
+			.append(missingParam)
+			.append(" parameter is required for ")
+			.append(action)
+			.append(" operation.\n");
+		sb.append("Received parameters: ").append(input.toString()).append("\n");
+		sb.append("Expected format for ").append(action).append(":\n");
+
+		switch (action) {
+			case "generate_vue":
+				sb.append("{\n");
+				sb.append("  \"action\": \"generate_vue\",\n");
+				sb.append("  \"component_type\": \"<string>\",  // Required: button, form, chart, counter, etc.\n");
+				sb.append("  \"component_data\": {             // Optional: component specifications\n");
+				sb.append("    \"name\": \"<string>\",\n");
+				sb.append("    \"data\": {},\n");
+				sb.append("    \"methods\": {},\n");
+				sb.append("    \"template\": \"<string>\",\n");
+				sb.append("    \"style\": \"<string>\"\n");
+				sb.append("  }\n");
+				sb.append("}");
+				break;
+			case "apply_template":
+				sb.append("{\n");
+				sb.append("  \"action\": \"apply_template\",\n");
+				sb.append("  \"template_name\": \"<string>\",   // Required: template name\n");
+				sb.append("  \"template_data\": {}             // Optional: data for template\n");
+				sb.append("}");
+				break;
+			case "save":
+				sb.append("{\n");
+				sb.append("  \"action\": \"save\",\n");
+				sb.append("  \"file_path\": \"<string>\",       // Required: path to save file\n");
+				sb.append("  \"vue_sfc_code\": \"<string>\"    // Required: Vue SFC code\n");
+				sb.append("}");
+				break;
+			case "update":
+				sb.append("{\n");
+				sb.append("  \"action\": \"update\",\n");
+				sb.append("  \"file_path\": \"<string>\",       // Required: path to file\n");
+				sb.append("  \"section_type\": \"<string>\",    // Required: template, script, or style\n");
+				sb.append("  \"new_content\": \"<string>\"     // Required: new content\n");
+				sb.append("}");
+				break;
+			case "preview":
+				sb.append("{\n");
+				sb.append("  \"action\": \"preview\",\n");
+				sb.append("  \"file_path\": \"<string>\",       // Required: path to Vue file\n");
+				sb.append("  \"dependencies\": {}             // Optional: additional dependencies\n");
+				sb.append("}");
+				break;
+			case "validate":
+				sb.append("{\n");
+				sb.append("  \"action\": \"validate\",\n");
+				sb.append("  \"vue_sfc_code\": \"<string>\"    // Required: Vue SFC code to validate\n");
+				sb.append("}");
+				break;
+		}
+
+		return sb.toString();
+	}
+
+	/**
+	 * Execute Vue component generation operations with strongly typed input object
+	 */
+	@Override
+	public ToolExecuteResult run(JsxInput input) {
+		log.info("VueGeneratorTool input: {}", input);
+		try {
+			String planId = this.currentPlanId;
+			String action = input.getAction();
+
+			// Basic parameter validation
+			if (action == null) {
+				return new ToolExecuteResult(createDetailedErrorMessage("unknown", "action", input));
+			}
+
+			return switch (action) {
+				case "generate_vue" -> {
+					String componentType = input.getComponentType();
+					Map<String, Object> componentData = input.getComponentData();
+
+					if (componentType == null || componentType.trim().isEmpty()) {
+						yield new ToolExecuteResult(
+								createDetailedErrorMessage("generate_vue", "component_type", input));
+					}
+					if (componentData == null) {
+						componentData = new HashMap<>();
+						log.info("No component_data provided, using empty map for component generation");
+					}
+
+					log.info("Generating Vue SFC with componentType: {}, componentData keys: {}", componentType,
+							componentData.keySet());
+					String vueSfcCode = vueGeneratorService.generateVueSFC(componentType, componentData);
+					yield new ToolExecuteResult("Successfully generated Vue SFC code for component type '"
+							+ componentType + "':\n" + vueSfcCode);
+				}
+				case "apply_template" -> {
+					String templateName = input.getTemplateName();
+					Map<String, Object> templateData = input.getTemplateData();
+
+					if (templateName == null || templateName.trim().isEmpty()) {
+						yield new ToolExecuteResult(
+								createDetailedErrorMessage("apply_template", "template_name", input));
+					}
+					if (templateData == null) {
+						templateData = new HashMap<>();
+						log.info("No template_data provided, using empty map for template application");
+					}
+
+					log.info("Applying template: {}, with data keys: {}", templateName, templateData.keySet());
+					String generatedCode = vueGeneratorService.applyHandlebarsTemplate(templateName, templateData);
+					yield new ToolExecuteResult(
+							"Successfully applied template '" + templateName + "':\n" + generatedCode);
+				}
+				case "save" -> {
+					String filePath = input.getFilePath();
+					String vueSfcCode = input.getVueSfcCode();
+
+					if (filePath == null || filePath.trim().isEmpty()) {
+						yield new ToolExecuteResult(createDetailedErrorMessage("save", "file_path", input));
+					}
+					if (vueSfcCode == null || vueSfcCode.trim().isEmpty()) {
+						yield new ToolExecuteResult(createDetailedErrorMessage("save", "vue_sfc_code", input));
+					}
+
+					log.info("Saving Vue SFC to file: {}, code length: {}", filePath, vueSfcCode.length());
+					String savedPath = vueGeneratorService.saveVueSfcToFile(planId, filePath, vueSfcCode);
+					yield new ToolExecuteResult("Successfully saved Vue SFC to file: " + savedPath);
+				}
+				case "update" -> {
+					String filePath = input.getFilePath();
+					String sectionType = input.getSectionType();
+					String newContent = input.getNewContent();
+
+					if (filePath == null || filePath.trim().isEmpty()) {
+						yield new ToolExecuteResult(createDetailedErrorMessage("update", "file_path", input));
+					}
+					if (sectionType == null || sectionType.trim().isEmpty()) {
+						yield new ToolExecuteResult(createDetailedErrorMessage("update", "section_type", input));
+					}
+					if (newContent == null) {
+						yield new ToolExecuteResult(createDetailedErrorMessage("update", "new_content", input));
+					}
+
+					log.info("Updating Vue component: {}, section: {}, new content length: {}", filePath, sectionType,
+							newContent.length());
+					vueGeneratorService.updateVueComponent(planId, filePath, sectionType, newContent);
+					yield new ToolExecuteResult("Successfully updated " + sectionType + " section in: " + filePath);
+				}
+				case "preview" -> {
+					String filePath = input.getFilePath();
+					Map<String, String> dependencies = input.getDependencies();
+
+					if (filePath == null || filePath.trim().isEmpty()) {
+						yield new ToolExecuteResult(createDetailedErrorMessage("preview", "file_path", input));
+					}
+
+					log.info("Generating preview for Vue component: {}, dependencies: {}", filePath, dependencies);
+					String sandpackConfig = vueGeneratorService.generateSandpackConfig(planId, filePath, dependencies);
+					String previewUrl = vueGeneratorService.generatePreviewUrl(planId, filePath);
+					yield new ToolExecuteResult("Successfully generated Sandpack preview:\nURL: " + previewUrl
+							+ "\nConfig: " + sandpackConfig);
+				}
+				case "validate" -> {
+					String vueSfcCode = input.getVueSfcCode();
+
+					if (vueSfcCode == null || vueSfcCode.trim().isEmpty()) {
+						yield new ToolExecuteResult(createDetailedErrorMessage("validate", "vue_sfc_code", input));
+					}
+
+					log.info("Validating Vue SFC code, length: {}", vueSfcCode.length());
+					String validationResult = vueGeneratorService.validateVueSfc(vueSfcCode);
+					yield new ToolExecuteResult("Validation result: " + validationResult);
+				}
+				case "list_templates" -> {
+					Set<String> templates = vueGeneratorService.getAvailableTemplates();
+					yield new ToolExecuteResult("Available templates: " + String.join(", ", templates));
+				}
+				default -> new ToolExecuteResult("Unknown operation: " + action
+						+ ". Supported operations: generate_vue, apply_template, save, update, preview, validate, list_templates\n"
+						+ "Received input: " + input);
+			};
+
+		}
+		catch (IOException e) {
+			log.error("VueGeneratorTool execution failed", e);
+			return new ToolExecuteResult("Tool execution failed: " + e.getMessage() + "\nInput was: " + input);
+		}
+		catch (Exception e) {
+			log.error("Unexpected error in VueGeneratorTool", e);
+			return new ToolExecuteResult("Unexpected error: " + e.getMessage() + "\nInput was: " + input);
+		}
+	}
+
+}

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
@@ -159,4 +159,3 @@ nextStepPrompt: |
   - Functions in methods field should use complete JavaScript syntax
 
   To extract content from existing text or documents, please use text_file_operator or inner_storage_content_tool.
-  

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
@@ -1,0 +1,161 @@
+# JSX/Vue Component Generation Agent Configuration
+agentName: JSX_GENERATOR_AGENT
+agentDescription: A professional JSX/Vue component generation agent capable of automatically creating Vue Single File Components (SFC) with Handlebars templates, supporting component generation, template application, and Sandpack preview.
+builtIn: false
+availableToolKeys:
+  - jsx_generator_operator
+  - inner_storage_content_tool
+  - text_file_operator
+  - terminate
+
+# Next Step Prompt Configuration
+nextStepPrompt: |
+  You are a professional JSX/Vue component generation operator.
+
+  IMPORTANT: Always use the correct JSON format with underscores in field names (e.g., "component_type", not "componentType").
+
+  Please follow these steps to use the jsx_generator_operator tool to create Vue Single File Components:
+
+  Step 1: Use the generate_vue action to create a new Vue component
+  
+  Required JSON format example:
+  ```json
+  <example>
+    "action": "generate_vue",
+    "component_type": "counter",
+    "component_data": <data>
+      "name": "CounterButton",
+      "data": <dataObj>
+        "count": 0
+      </dataObj>,
+      "methods": <methodsObj>
+        "increment": "function() <openBrace> this.count++; <closeBrace>"
+      </methodsObj>,
+      "template": "<div><button onClick='increment' className='redWhenOver5'>Click me</button><p>Clicked: <count变量> times</p></div>",
+      "style": "button <styleOpen> padding: 10px 20px; font-size: 16px; <styleClose> p <styleOpen> margin-top: 10px; font-size: 18px; color: #333; <styleClose> .redWhenOver5 <styleOpen> color: white; background-color: red; <styleClose>"
+    </data>
+  </example>
+  ```
+  
+  Note: Replace the following placeholders with correct characters when using:
+  - <example> and </example> with opening and closing curly braces
+  - <data> and </data> with opening and closing curly braces
+  - <dataObj> and </dataObj> with opening and closing curly braces
+  - <methodsObj> and </methodsObj> with opening and closing curly braces
+  - <openBrace> and <closeBrace> with opening and closing curly braces
+  - <styleOpen> and <styleClose> with opening and closing curly braces
+  - <count变量> with Vue interpolation syntax (double curly braces around count)
+  - onClick with @click
+  - className with :class
+
+  Parameters:
+  - component_type: REQUIRED. Type of component (button, form, chart, counter, table, etc.)
+  - component_data: OPTIONAL. Object containing component specifications:
+    - name: Component name (string)
+    - data: Vue data object (Map format)
+    - methods: Vue methods object (Map format, values can be string functions)
+    - computed: Vue computed properties (Map format)
+    - template: HTML template (can be string or Map format)
+    - style: CSS style (can be string or Map format)
+
+  Important Notes:
+  - template and style fields support two formats:
+    1. String format: Direct HTML/CSS code
+    2. Map format: Structured configuration data
+  - methods field values should be string-formatted JavaScript functions
+
+  Step 2: Use the apply_template action to apply Handlebars templates
+  
+  Required JSON format example:
+  ```json
+  <templateExample>
+    "action": "apply_template",
+    "template_name": "counter-button",
+    "template_data": <templateData>
+      "componentName": "MyCounter",
+      "initialValue": 0,
+      "buttonText": "Click Count",
+      "threshold": 5
+    </templateData>
+  </templateExample>
+  ```
+
+  Parameters:
+  - template_name: REQUIRED. Name of the Handlebars template
+  - template_data: OPTIONAL. Data object to populate the template
+
+  Step 3: Use the save action to save the generated Vue SFC code
+  
+  Required JSON format example:
+  ```json
+  <saveExample>
+    "action": "save",
+    "file_path": "components/CounterButton.vue",
+    "vue_sfc_code": "<template>...</template><script>...</script><style>...</style>"
+  </saveExample>
+  ```
+
+  Parameters:
+  - file_path: REQUIRED. Path where the Vue component file should be saved
+  - vue_sfc_code: REQUIRED. The complete Vue SFC code to save
+
+  Step 4: Use the preview action to generate a Sandpack preview
+  
+  Required JSON format example:
+  ```json
+  <previewExample>
+    "action": "preview",
+    "file_path": "components/CounterButton.vue",
+    "dependencies": <deps>
+      "vue": "^3.0.0"
+    </deps>
+  </previewExample>
+  ```
+
+  Parameters:
+  - file_path: REQUIRED. Path to the Vue component file
+  - dependencies: OPTIONAL. Additional npm dependencies object
+
+  Step 5: Use the validate action to validate Vue SFC code syntax
+  
+  Required JSON format example:
+  ```json
+  <validateExample>
+    "action": "validate",
+    "vue_sfc_code": "<template>...</template><script>...</script><style>...</style>"
+  </validateExample>
+  ```
+
+  Parameters:
+  - vue_sfc_code: REQUIRED. The Vue SFC code to validate
+
+  Available actions:
+  - generate_vue: Create a new Vue component
+  - apply_template: Apply a Handlebars template
+  - save: Save Vue SFC code to file
+  - update: Update specific sections of a Vue component
+  - preview: Generate Sandpack preview
+  - validate: Validate Vue SFC code syntax
+  - list_templates: List available Handlebars templates
+
+  ERROR HANDLING:
+  If you receive an error message, it will include:
+  1. The specific missing or invalid parameter
+  2. The received parameters for debugging
+  3. The expected JSON format for that operation
+  
+  Common issues and solutions:
+  - "component_type parameter is required": Ensure you include "component_type" field in your JSON
+  - JSON parsing errors: Check that your JSON syntax is valid with double quotes
+  - Type casting errors: Ensure template and style fields are in correct format (string or Map)
+  - Missing required fields: Refer to the required parameters for each action above
+
+  BEST PRACTICES:
+  - Always include the "action" parameter
+  - Use proper Vue 3 Composition API syntax when generating components
+  - Ensure proper CSS scoping using the 'scoped' attribute in style blocks
+  - Test your JSON format before sending to avoid errors
+  - Use meaningful component names and file paths
+  - Functions in methods field should use complete JavaScript syntax
+
+  To extract content from existing text or documents, please use text_file_operator or inner_storage_content_tool. 

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
@@ -158,4 +158,5 @@ nextStepPrompt: |
   - Use meaningful component names and file paths
   - Functions in methods field should use complete JavaScript syntax
 
-  To extract content from existing text or documents, please use text_file_operator or inner_storage_content_tool. 
+  To extract content from existing text or documents, please use text_file_operator or inner_storage_content_tool.
+  

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/en/jsx_generator_agent/agent-config.yml
@@ -17,7 +17,7 @@ nextStepPrompt: |
   Please follow these steps to use the jsx_generator_operator tool to create Vue Single File Components:
 
   Step 1: Use the generate_vue action to create a new Vue component
-  
+
   Required JSON format example:
   ```json
   <example>
@@ -36,7 +36,7 @@ nextStepPrompt: |
     </data>
   </example>
   ```
-  
+
   Note: Replace the following placeholders with correct characters when using:
   - <example> and </example> with opening and closing curly braces
   - <data> and </data> with opening and closing curly braces
@@ -65,7 +65,7 @@ nextStepPrompt: |
   - methods field values should be string-formatted JavaScript functions
 
   Step 2: Use the apply_template action to apply Handlebars templates
-  
+
   Required JSON format example:
   ```json
   <templateExample>
@@ -85,7 +85,7 @@ nextStepPrompt: |
   - template_data: OPTIONAL. Data object to populate the template
 
   Step 3: Use the save action to save the generated Vue SFC code
-  
+
   Required JSON format example:
   ```json
   <saveExample>
@@ -100,7 +100,7 @@ nextStepPrompt: |
   - vue_sfc_code: REQUIRED. The complete Vue SFC code to save
 
   Step 4: Use the preview action to generate a Sandpack preview
-  
+
   Required JSON format example:
   ```json
   <previewExample>
@@ -117,7 +117,7 @@ nextStepPrompt: |
   - dependencies: OPTIONAL. Additional npm dependencies object
 
   Step 5: Use the validate action to validate Vue SFC code syntax
-  
+
   Required JSON format example:
   ```json
   <validateExample>
@@ -143,7 +143,7 @@ nextStepPrompt: |
   1. The specific missing or invalid parameter
   2. The received parameters for debugging
   3. The expected JSON format for that operation
-  
+
   Common issues and solutions:
   - "component_type parameter is required": Ensure you include "component_type" field in your JSON
   - JSON parsing errors: Check that your JSON syntax is valid with double quotes

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
@@ -154,4 +154,5 @@ nextStepPrompt: |
   - 使用有意义的组件名称路径
   - methods字段中的函数应使用完整的JavaScript语法
 
-  如需从已有文本或文档中提取内容，请使用 text_file_operator 或 inner_storage_content_tool。 
+  如需从已有文本或文档中提取内容，请使用 text_file_operator 或 inner_storage_content_tool。
+  

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
@@ -155,4 +155,3 @@ nextStepPrompt: |
   - methods字段中的函数应使用完整的JavaScript语法
 
   如需从已有文本或文档中提取内容，请使用 text_file_operator 或 inner_storage_content_tool。
-  

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
@@ -1,0 +1,157 @@
+# JSX/Vue组件生成代理配置
+agentName: JSX_GENERATOR_AGENT
+agentDescription: 专业的JSX Vue组件生成代理，可以自动创建Vue单文件组件，支持Handlebars模板，组件生成，模板应用，Sandpack预览功能
+builtIn: false
+availableToolKeys:
+  - jsx_generator_operator
+  - inner_storage_content_tool
+  - text_file_operator
+  - terminate
+
+# 下一步操作提示配置
+nextStepPrompt: |
+  您是一名专业的JSX/Vue组件生成操作员。
+
+  重要提示：请始终使用正确的JSON格式，字段名使用下划线（如："component_type"，而不是"componentType"）。
+
+  请按照以下步骤使用 jsx_generator_operator 工具创建Vue单文件组件：
+
+  步骤1: 使用 generate_vue 操作创建新的Vue组件
+  
+  必需的JSON格式示例：
+  ```json
+  <BRACE>
+    "action": "generate_vue",
+    "component_type": "counter",
+    "component_data": <BRACE>
+      "name": "CounterButton",
+      "data": <BRACE>
+        "count": 0
+      <SLASH_BRACE>,
+      "methods": <BRACE>
+        "increment": "function() <BRACE> this.count++; <SLASH_BRACE>"
+      <SLASH_BRACE>,
+      "template": "<div><button onClick='increment' className='redWhenOver5'>点击我</button><p>已点击：<COUNT_VAR> 次</p></div>",
+      "style": "button <BRACE> padding: 10px 20px; font-size: 16px; <SLASH_BRACE> p <BRACE> margin-top: 10px; font-size: 18px; color: #333; <SLASH_BRACE> .redWhenOver5 <BRACE> color: white; background-color: red; <SLASH_BRACE>"
+    <SLASH_BRACE>
+  <SLASH_BRACE>
+  ```
+  
+  占位符说明（请在实际使用时替换）：
+  - BRACE 替换为左花括号
+  - SLASH_BRACE 替换为右花括号
+  - COUNT_VAR 替换为Vue插值语法（双花括号包围count）
+  - onClick 替换为 @click
+  - className 替换为 :class
+
+  参数说明：
+  - component_type: 必需。组件类型（button、form、chart、counter、table等）
+  - component_data: 可选。包含组件规格的对象：
+    - name: 组件名称（字符串）
+    - data: Vue数据对象（Map格式）
+    - methods: Vue方法对象（Map格式，值可以是字符串形式的函数）
+    - computed: Vue计算属性（Map格式）
+    - template: HTML模板（可以是字符串或Map格式）
+    - style: CSS样式（可以是字符串或Map格式）
+
+  重要提示：
+  - template字段支持两种格式：字符串格式直接提供HTML代码，Map格式提供结构化配置数据
+  - style字段支持两种格式：字符串格式直接提供CSS代码，Map格式提供结构化配置数据
+  - methods字段的值应为字符串格式的JavaScript函数
+
+  步骤2: 使用 apply_template 操作应用Handlebars模板
+  
+  必需的JSON格式示例：
+  ```json
+  <BRACE>
+    "action": "apply_template",
+    "template_name": "counter-button",
+    "template_data": <BRACE>
+      "componentName": "MyCounter",
+      "initialValue": 0,
+      "buttonText": "点击计数",
+      "threshold": 5
+    <SLASH_BRACE>
+  <SLASH_BRACE>
+  ```
+
+  参数说明：
+  - template_name: 必需。Handlebars模板名称
+  - template_data: 可选。用于填充模板的数据对象
+
+  步骤3: 使用 save 操作保存生成的Vue SFC代码
+  
+  必需的JSON格式示例：
+  ```json
+  <BRACE>
+    "action": "save",
+    "file_path": "components/CounterButton.vue",
+    "vue_sfc_code": "<template>...</template><script>...</script><style>...</style>"
+  <SLASH_BRACE>
+  ```
+
+  参数说明：
+  - file_path: 必需。Vue组件文件应保存的路径
+  - vue_sfc_code: 必需。要保存的完整Vue SFC代码
+
+  步骤4: 使用 preview 操作生成Sandpack预览
+  
+  必需的JSON格式示例：
+  ```json
+  <BRACE>
+    "action": "preview",
+    "file_path": "components/CounterButton.vue",
+    "dependencies": <BRACE>
+      "vue": "^3.0.0"
+    <SLASH_BRACE>
+  <SLASH_BRACE>
+  ```
+
+  参数说明：
+  - file_path: 必需。Vue组件文件的路径
+  - dependencies: 可选。额外的npm依赖对象
+
+  步骤5: 使用 validate 操作验证Vue SFC代码语法
+  
+  必需的JSON格式示例：
+  ```json
+  <BRACE>
+    "action": "validate",
+    "vue_sfc_code": "<template>...</template><script>...</script><style>...</style>"
+  <SLASH_BRACE>
+  ```
+
+  参数说明：
+  - vue_sfc_code: 必需。要验证的Vue SFC代码
+
+  可用操作：
+  - generate_vue: 创建新的Vue组件
+  - apply_template: 应用Handlebars模板
+  - save: 将Vue SFC代码保存到文件
+  - update: 更新Vue组件的特定部分
+  - preview: 生成Sandpack预览
+  - validate: 验证Vue SFC代码语法
+  - list_templates: 列出可用的Handlebars模板
+
+  错误处理：
+  如果您收到错误消息，它将包括：
+  1. 特定的缺失或无效参数
+  2. 接收到的参数用于调试
+  3. 该操作的预期JSON格式
+  
+  常见问题说明：
+  - "component_type parameter is required"：确保在JSON中包含"component_type"字段
+  - JSON解析错误：检查JSON语法是否有效，确保使用双引号
+  - 类型转换错误：确保template字段格式正确（字符串或Map）
+  - 类型转换错误：确保style字段格式正确（字符串或Map）
+  - 缺少必需字段：参考上述每个操作的必需参数
+
+  最佳实践：
+  - 始终包含"action"参数
+  - 生成组件时请使用正确的Vue 3 Composition API语法
+  - 确保在style块中使用'scoped'属性进行CSS作用域限制
+  - 发送前测试JSON格式以避免错误
+  - 使用有意义的组件名称路径
+  - methods字段中的函数应使用完整的JavaScript语法
+
+  如需从已有文本或文档中提取内容，请使用 text_file_operator 或 inner_storage_content_tool。 

--- a/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/prompts/startup-agents/zh/jsx_generator_agent/agent-config.yml
@@ -17,7 +17,7 @@ nextStepPrompt: |
   请按照以下步骤使用 jsx_generator_operator 工具创建Vue单文件组件：
 
   步骤1: 使用 generate_vue 操作创建新的Vue组件
-  
+
   必需的JSON格式示例：
   ```json
   <BRACE>
@@ -36,7 +36,7 @@ nextStepPrompt: |
     <SLASH_BRACE>
   <SLASH_BRACE>
   ```
-  
+
   占位符说明（请在实际使用时替换）：
   - BRACE 替换为左花括号
   - SLASH_BRACE 替换为右花括号
@@ -60,7 +60,7 @@ nextStepPrompt: |
   - methods字段的值应为字符串格式的JavaScript函数
 
   步骤2: 使用 apply_template 操作应用Handlebars模板
-  
+
   必需的JSON格式示例：
   ```json
   <BRACE>
@@ -80,7 +80,7 @@ nextStepPrompt: |
   - template_data: 可选。用于填充模板的数据对象
 
   步骤3: 使用 save 操作保存生成的Vue SFC代码
-  
+
   必需的JSON格式示例：
   ```json
   <BRACE>
@@ -95,7 +95,7 @@ nextStepPrompt: |
   - vue_sfc_code: 必需。要保存的完整Vue SFC代码
 
   步骤4: 使用 preview 操作生成Sandpack预览
-  
+
   必需的JSON格式示例：
   ```json
   <BRACE>
@@ -112,7 +112,7 @@ nextStepPrompt: |
   - dependencies: 可选。额外的npm依赖对象
 
   步骤5: 使用 validate 操作验证Vue SFC代码语法
-  
+
   必需的JSON格式示例：
   ```json
   <BRACE>
@@ -138,7 +138,7 @@ nextStepPrompt: |
   1. 特定的缺失或无效参数
   2. 接收到的参数用于调试
   3. 该操作的预期JSON格式
-  
+
   常见问题说明：
   - "component_type parameter is required"：确保在JSON中包含"component_type"字段
   - JSON解析错误：检查JSON语法是否有效，确保使用双引号

--- a/spring-ai-alibaba-jmanus/src/test/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorIntegrationTest.java
+++ b/spring-ai-alibaba-jmanus/src/test/java/com/alibaba/cloud/ai/example/manus/tool/jsxGenerator/JsxGeneratorIntegrationTest.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.tool.jsxGenerator;
+
+import com.alibaba.cloud.ai.example.manus.config.ManusProperties;
+import com.alibaba.cloud.ai.example.manus.tool.code.ToolExecuteResult;
+import com.alibaba.cloud.ai.example.manus.tool.filesystem.UnifiedDirectoryManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JSX Generator Integration Test Class
+ */
+public class JsxGeneratorIntegrationTest {
+
+	private static final Logger log = LoggerFactory.getLogger(JsxGeneratorIntegrationTest.class);
+
+	private JsxGeneratorService jsxGeneratorService;
+
+	private ObjectMapper objectMapper;
+
+	private UnifiedDirectoryManager unifiedDirectoryManager;
+
+	private ManusProperties manusProperties;
+
+	private JsxGeneratorOperator jsxGeneratorOperator;
+
+	Path tempDir;
+
+	@BeforeEach
+	void setUp() {
+		log.info("===== Starting Test Setup =====");
+
+		// Initialize mock dependencies
+		manusProperties = mock(ManusProperties.class);
+		unifiedDirectoryManager = mock(UnifiedDirectoryManager.class);
+		objectMapper = new ObjectMapper();
+
+		// Create JsxGeneratorService instance
+		jsxGeneratorService = new JsxGeneratorService();
+		log.info("JsxGeneratorService initialization completed");
+
+		// Inject dependencies using reflection
+		try {
+			Field manusField = JsxGeneratorService.class.getDeclaredField("manusProperties");
+			manusField.setAccessible(true);
+			manusField.set(jsxGeneratorService, manusProperties);
+
+			Field unifiedDirField = JsxGeneratorService.class.getDeclaredField("unifiedDirectoryManager");
+			unifiedDirField.setAccessible(true);
+			unifiedDirField.set(jsxGeneratorService, unifiedDirectoryManager);
+
+			log.info("Successfully injected dependencies to JsxGeneratorService");
+		}
+		catch (Exception e) {
+			log.error("Failed to inject dependencies", e);
+			throw new RuntimeException("Failed to inject dependencies", e);
+		}
+
+		// Manually call run method to initialize default templates
+		try {
+			jsxGeneratorService.run(null);
+			log.info("Successfully initialized default templates");
+		}
+		catch (Exception e) {
+			log.error("Failed to initialize default templates", e);
+			throw new RuntimeException("Failed to initialize default templates", e);
+		}
+
+		// Initialize operator
+		jsxGeneratorOperator = new JsxGeneratorOperator((IJsxGeneratorService) jsxGeneratorService, objectMapper,
+				unifiedDirectoryManager);
+		log.info("JsxGeneratorOperator initialization completed");
+
+		// Set test directory
+		tempDir = Path.of("./extensions");
+		log.info("Set test output directory: {}", tempDir);
+
+		// Set mock behavior
+		try {
+			when(unifiedDirectoryManager.getRootPlanDirectory(anyString())).thenAnswer(invocation -> {
+				String planId = invocation.getArgument(0);
+				return tempDir.resolve("test-jsx-output").resolve(planId);
+			});
+			log.info("UnifiedDirectoryManager mock behavior setup completed");
+		}
+		catch (Exception e) {
+			log.error("Error occurred while setting UnifiedDirectoryManager mock", e);
+			throw new RuntimeException(e);
+		}
+
+		log.info("===== Test Setup Completed =====");
+	}
+
+	@Test
+	void testGenerateBasicVueComponent() throws Exception {
+		log.info("\n===== Starting Test: Generate Basic Vue Component =====");
+
+		String planId = "test-plan-vue";
+		log.info("Prepare test data: planId={}", planId);
+
+		// Prepare input data
+		JsxGeneratorTool.JsxInput input = new JsxGeneratorTool.JsxInput();
+		input.setAction("generate_vue");
+		input.setComponentType("button");
+
+		Map<String, Object> componentData = new HashMap<>();
+		componentData.put("name", "TestButton");
+		Map<String, Object> data = new HashMap<>();
+		data.put("count", 0);
+		componentData.put("data", data);
+		input.setComponentData(componentData);
+
+		log.info("Vue component data setup completed: componentType={}, name={}", input.getComponentType(),
+				componentData.get("name"));
+
+		// Set current plan ID
+		jsxGeneratorOperator.setCurrentPlanId(planId);
+		log.info("Set current plan ID: {}", planId);
+
+		// Execute test
+		log.info("Starting Vue component generation operation...");
+		ToolExecuteResult result = jsxGeneratorOperator.run(input);
+		log.info("Vue component generation operation completed");
+
+		// Verify results
+		log.info("Starting result verification...");
+		assertNotNull(result);
+		log.info("Verify result is not null: success");
+		assertTrue(result.getOutput().contains("successfully"));
+		log.info("Verify result contains success message: success");
+		assertTrue(result.getOutput().contains("<template>"));
+		log.info("Verify result contains template tag: success");
+		assertTrue(result.getOutput().contains("<script>"));
+		log.info("Verify result contains script tag: success");
+		assertTrue(result.getOutput().contains("<style"));
+		log.info("Verify result contains style tag: success");
+
+		log.info("===== Test Completed: Generate Basic Vue Component =====");
+	}
+
+	@Test
+	void testApplyHandlebarsTemplate() throws Exception {
+		log.info("\n===== Starting Test: Apply Handlebars Template =====");
+
+		String planId = "test-plan-template";
+		log.info("Prepare test data: planId={}", planId);
+
+		// Prepare input data
+		JsxGeneratorTool.JsxInput input = new JsxGeneratorTool.JsxInput();
+		input.setAction("apply_template");
+		input.setTemplateName("counter-button");
+
+		Map<String, Object> templateData = new HashMap<>();
+		templateData.put("componentName", "TestCounterButton");
+		templateData.put("buttonText", "Click Me");
+		templateData.put("initialCount", "0");
+		templateData.put("threshold", "5");
+		input.setTemplateData(templateData);
+
+		log.info("Template data setup completed: templateName={}, componentName={}", input.getTemplateName(),
+				templateData.get("componentName"));
+
+		// Set current plan ID
+		jsxGeneratorOperator.setCurrentPlanId(planId);
+		log.info("Set current plan ID: {}", planId);
+
+		// Execute test
+		log.info("Starting apply template operation...");
+		ToolExecuteResult result = jsxGeneratorOperator.run(input);
+		log.info("Apply template operation completed");
+
+		// Verify results
+		log.info("Starting result verification...");
+		assertNotNull(result);
+		log.info("Verify result is not null: success");
+		assertTrue(result.getOutput().contains("applied successfully"));
+		log.info("Verify result contains success message: success");
+		assertTrue(result.getOutput().contains("TestCounterButton"));
+		log.info("Verify result contains component name: success");
+		assertTrue(result.getOutput().contains("Click Me"));
+		log.info("Verify result contains button text: success");
+
+		log.info("===== Test Completed: Apply Handlebars Template =====");
+	}
+
+	@Test
+	void testSaveVueSfcToFile() throws Exception {
+		log.info("\n===== Starting Test: Save Vue SFC File =====");
+
+		String planId = "test-plan-save";
+		String fileName = "TestComponent.vue";
+		log.info("Prepare test data: planId={}, fileName={}", planId, fileName);
+
+		// Prepare Vue SFC code
+		String vueSfcCode = """
+				<template>
+				  <div class="test-component">
+				    <h1>Test Component</h1>
+				    <button @click="handleClick">Click Me</button>
+				  </div>
+				</template>
+
+				<script>
+				export default {
+				  name: 'TestComponent',
+				  methods: {
+				    handleClick() {
+				      console.log('Button clicked');
+				    }
+				  }
+				};
+				</script>
+
+				<style scoped>
+				.test-component {
+				  padding: 20px;
+				}
+				</style>
+				""";
+
+		// Prepare input data
+		JsxGeneratorTool.JsxInput input = new JsxGeneratorTool.JsxInput();
+		input.setAction("save");
+		input.setFilePath(fileName);
+		input.setVueSfcCode(vueSfcCode);
+
+		log.info("Save data setup completed: filePath={}", input.getFilePath());
+
+		// Set current plan ID
+		jsxGeneratorOperator.setCurrentPlanId(planId);
+		log.info("Set current plan ID: {}", planId);
+
+		// Execute test
+		log.info("Starting save file operation...");
+		ToolExecuteResult result = jsxGeneratorOperator.run(input);
+		log.info("Save file operation completed");
+
+		// Verify results
+		log.info("Starting result verification...");
+		assertNotNull(result);
+		log.info("Verify result is not null: success");
+		assertTrue(result.getOutput().contains("successfully"));
+		log.info("Verify result contains success message: success");
+		assertTrue(result.getOutput().contains(fileName));
+		log.info("Verify result contains file name: success");
+
+		// Verify file creation
+		Path expectedPath = tempDir.resolve("test-jsx-output").resolve(planId).resolve(fileName);
+		log.info("Verify file creation: {}", expectedPath);
+		assertTrue(Files.exists(expectedPath));
+		log.info("Verify file exists: success");
+
+		String savedContent = Files.readString(expectedPath);
+		assertTrue(savedContent.contains("TestComponent"));
+		log.info("Verify file content is correct: success");
+
+		log.info("===== Test Completed: Save Vue SFC File =====");
+	}
+
+	@Test
+	void testValidateVueSfcCode() throws Exception {
+		log.info("\n===== Starting Test: Validate Vue SFC Code =====");
+
+		String planId = "test-plan-validate";
+		log.info("Prepare test data: planId={}", planId);
+
+		// Test valid Vue SFC code
+		String validVueSfcCode = """
+				<template>
+				  <div>Valid component</div>
+				</template>
+
+				<script>
+				export default {
+				  name: 'ValidComponent'
+				};
+				</script>
+
+				<style>
+				div { color: blue; }
+				</style>
+				""";
+
+		// Prepare input data
+		JsxGeneratorTool.JsxInput input = new JsxGeneratorTool.JsxInput();
+		input.setAction("validate");
+		input.setVueSfcCode(validVueSfcCode);
+
+		log.info("Validation data setup completed");
+
+		// Set current plan ID
+		jsxGeneratorOperator.setCurrentPlanId(planId);
+		log.info("Set current plan ID: {}", planId);
+
+		// Execute test
+		log.info("Starting validation operation...");
+		ToolExecuteResult result = jsxGeneratorOperator.run(input);
+		log.info("Validation operation completed");
+
+		// Verify results
+		log.info("Starting result verification...");
+		assertNotNull(result);
+		log.info("Verify result is not null: success");
+		assertTrue(result.getOutput().contains("Valid Vue SFC"));
+		log.info("Verify result contains valid message: success");
+
+		// Test invalid Vue SFC code
+		log.info("Starting test for invalid code validation...");
+		String invalidVueSfcCode = "<div>Missing template tags</div>";
+
+		input.setVueSfcCode(invalidVueSfcCode);
+		ToolExecuteResult invalidResult = jsxGeneratorOperator.run(input);
+
+		assertNotNull(invalidResult);
+		assertTrue(invalidResult.getOutput().contains("Error"));
+		log.info("Verify invalid code detection: success");
+
+		log.info("===== Test Completed: Validate Vue SFC Code =====");
+	}
+
+	@Test
+	void testListAvailableTemplates() throws Exception {
+		log.info("\n===== Starting Test: List Available Templates =====");
+
+		String planId = "test-plan-list";
+		log.info("Prepare test data: planId={}", planId);
+
+		// Prepare input data
+		JsxGeneratorTool.JsxInput input = new JsxGeneratorTool.JsxInput();
+		input.setAction("list_templates");
+
+		log.info("List operation data setup completed");
+
+		// Set current plan ID
+		jsxGeneratorOperator.setCurrentPlanId(planId);
+		log.info("Set current plan ID: {}", planId);
+
+		// Execute test
+		log.info("Starting list templates operation...");
+		ToolExecuteResult result = jsxGeneratorOperator.run(input);
+		log.info("List templates operation completed");
+
+		// Verify results
+		log.info("Starting result verification...");
+		assertNotNull(result);
+		log.info("Verify result is not null: success");
+		assertTrue(result.getOutput().contains("Available templates"));
+		log.info("Verify result contains available templates info: success");
+		assertTrue(result.getOutput().contains("counter-button"));
+		log.info("Verify result contains counter-button template: success");
+		assertTrue(result.getOutput().contains("data-form"));
+		log.info("Verify result contains data-form template: success");
+
+		log.info("===== Test Completed: List Available Templates =====");
+	}
+
+	@Test
+	void testMinimalInput() throws Exception {
+		log.info("\n===== Starting Test: Generate Component with Minimal Input =====");
+
+		String planId = "test-plan-minimal";
+		log.info("Prepare test data: planId={}", planId);
+
+		// Prepare minimal input data
+		JsxGeneratorTool.JsxInput input = new JsxGeneratorTool.JsxInput();
+		input.setAction("generate_vue");
+		input.setComponentType("button");
+		// Don't set componentData, should use default values
+
+		log.info("Minimal component data setup completed: componentType={}", input.getComponentType());
+
+		// Set current plan ID
+		jsxGeneratorOperator.setCurrentPlanId(planId);
+		log.info("Set current plan ID: {}", planId);
+
+		// Execute test
+		log.info("Starting minimal input component generation operation...");
+		ToolExecuteResult result = jsxGeneratorOperator.run(input);
+		log.info("Minimal input component generation operation completed");
+
+		// Verify results
+		log.info("Starting result verification...");
+		assertNotNull(result);
+		log.info("Verify result is not null: success");
+		assertTrue(result.getOutput().contains("successfully"));
+		log.info("Verify result contains success message: success");
+
+		log.info("===== Test Completed: Generate Component with Minimal Input =====");
+	}
+
+	@Test
+	void testInvalidOperations() throws Exception {
+		log.info("\n===== Starting Test: Invalid Operation Handling =====");
+
+		String planId = "test-plan-invalid";
+		log.info("Prepare test data: planId={}", planId);
+
+		// Test invalid action
+		JsxGeneratorTool.JsxInput input = new JsxGeneratorTool.JsxInput();
+		input.setAction("invalid_action");
+
+		log.info("Invalid operation data setup completed: action={}", input.getAction());
+
+		// Set current plan ID
+		jsxGeneratorOperator.setCurrentPlanId(planId);
+		log.info("Set current plan ID: {}", planId);
+
+		// Execute test
+		log.info("Starting invalid operation test...");
+		ToolExecuteResult result = jsxGeneratorOperator.run(input);
+		log.info("Invalid operation test completed");
+
+		// Verify results
+		log.info("Starting result verification...");
+		assertNotNull(result);
+		log.info("Verify result is not null: success");
+		assertTrue(result.getOutput().contains("Unsupported operation"));
+		log.info("Verify result contains unsupported operation message: success");
+
+		log.info("===== Test Completed: Invalid Operation Handling =====");
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Added the jsxGenerator tool and jsxGeneratorAgent, enabling the generation of valid and executable Vue SFC components from natural language descriptions. 

Supported operations include: generate_vue, apply_template, save, validate, list_templates, with corresponding tests added.

### Does this pull request fix one issue?
#1472 

### Describe how you did it
LLM -> JSON -> Vue SFC -> Handlebars

### Describe how to verify it

```json
{
  "planType": "simple",
  "title": "创建计数器按钮JSX Vue组件",
  "directResponse": false,
  "steps": [
    {
      "stepRequirement": "[JSX_GENERATOR_AGENT] 创建基础的JSX Vue组件结构",
      "terminateColumns": null
    },
    {
      "stepRequirement": "[JSX_GENERATOR_AGENT] 添加响应式计数器数据和点击事件处理函数",
      "terminateColumns": null
    },
    {
      "stepRequirement": "[JSX_GENERATOR_AGENT] 实现按钮点击次数超过5次后改变按钮颜色的逻辑",
      "terminateColumns": null
    }
  ],
  "planId": "planTemplate-1754630962001"
}
```

### Special notes for reviews
Preview is not available yet. The generated code is saved to innerstorage for manual execution checks.