### PR TITLE
fix(jmanus): avoid accidental overwrite of dynamic model configuration

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/llm/LlmService.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/llm/LlmService.java
@@ -224,6 +224,8 @@ public class LlmService implements ILlmService, JmanusListener<ModelChangeEvent>
 			chatOptionsBuilder.topP(model.getTopP());
 		}
 
+		chatOptionsBuilder.internalToolExecutionEnabled(false);
+
 		OpenAiChatOptions chatOptions = chatOptionsBuilder.build();
 		if (headers != null) {
 			chatOptions.setHttpHeaders(headers);
@@ -235,7 +237,6 @@ public class LlmService implements ILlmService, JmanusListener<ModelChangeEvent>
 		ChatClient client = ChatClient.builder(openAiChatModel)
 			// .defaultAdvisors(MessageChatMemoryAdvisor.builder(agentMemory).build())
 			.defaultAdvisors(new SimpleLoggerAdvisor())
-			.defaultOptions(OpenAiChatOptions.builder().internalToolExecutionEnabled(false).build())
 			.build();
 		clients.put(modelId, client);
 		log.info("Build or update dynamic chat client for model: {}", modelName);

--- a/spring-ai-alibaba-jmanus/src/test/java/com/alibaba/cloud/ai/example/manus/llm/DynamicHeaderPreservationTest.java
+++ b/spring-ai-alibaba-jmanus/src/test/java/com/alibaba/cloud/ai/example/manus/llm/DynamicHeaderPreservationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.manus.llm;
+
+import com.alibaba.cloud.ai.example.manus.config.ManusProperties;
+import com.alibaba.cloud.ai.example.manus.dynamic.model.entity.DynamicModelEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+public class DynamicHeaderPreservationTest {
+
+	@Mock
+	private ManusProperties manusProperties;
+
+	private LlmService llmService;
+
+	@BeforeEach
+	void setUp() {
+		llmService = new LlmService();
+	}
+
+	@Test
+	void testDynamicChatClientCreationWithHeaders() {
+		DynamicModelEntity model = new DynamicModelEntity();
+		model.setId(1L);
+		model.setBaseUrl("https://test.example.com");
+		model.setApiKey("test-api-key");
+		model.setModelName("test-model");
+
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Custom-Header", "test-value");
+		headers.put("Authorization", "Bearer test-token");
+		model.setHeaders(headers);
+
+		ChatClient chatClient = llmService.buildOrUpdateDynamicChatClient(model);
+
+		assertNotNull(chatClient, "ChatClient should be created successfully");
+
+	}
+
+	@Test
+	void testDynamicChatClientCreationWithoutHeaders() {
+		DynamicModelEntity model = new DynamicModelEntity();
+		model.setId(2L);
+		model.setBaseUrl("https://test.example.com");
+		model.setApiKey("test-api-key");
+		model.setModelName("test-model");
+
+		ChatClient chatClient = llmService.buildOrUpdateDynamicChatClient(model);
+		assertNotNull(chatClient, "ChatClient should be created successfully even without headers");
+	}
+
+}


### PR DESCRIPTION
…ritten


### Describe what this PR does / why we need it
The header of the jmanus dynamic configuration will not be reset when the prompt is obtained from the client
Close #2074 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
