### PR TITLE
fix(jmanus): optimize the configuration and use of memory function

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/resources/application-h2.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/application-h2.yml
@@ -16,3 +16,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
+  ai:
+    memory:
+      h2:
+        enabled: true

--- a/spring-ai-alibaba-jmanus/src/main/resources/application-mysql.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/application-mysql.yml
@@ -6,3 +6,7 @@ spring:
     password: your_mysql_password
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
+  ai:
+    memory:
+      mysql:
+        enabled: true

--- a/spring-ai-alibaba-jmanus/src/main/resources/application-postgres.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/application-postgres.yml
@@ -6,3 +6,7 @@ spring:
     password: 123456
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  ai:
+    memory:
+      postgres:
+        enabled: true

--- a/spring-ai-alibaba-jmanus/src/main/resources/application.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/application.yml
@@ -32,10 +32,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-  ai:
-    memory:
-      h2:
-        enabled: true
 
 logging:
   file:


### PR DESCRIPTION
### Describe what this PR does / why we need it
优化记忆功能的配置方式，目前是需要手动在主配置文件中指定记忆的配置，但其实记忆组件需要复用主数据库连接，这会给使用者一种误解，即可以配置与数据库不同的记忆存储组件，但这是错误的。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
将配置迁移到对应的子配置中，这样使用者无需关心记忆组件的具体配置，也避免配置误解。

### Describe how to verify it


### Special notes for reviews
