### PR TITLE
fix(mcp): fix #2148 使用 spring-ai-starter-mcp-client 替换 spring-ai-starter-mcp-client-webflux

### DIFF
--- a/spring-ai-alibaba-spring-boot-starters/spring-ai-alibaba-starter-mcp-registry/pom.xml
+++ b/spring-ai-alibaba-spring-boot-starters/spring-ai-alibaba-starter-mcp-registry/pom.xml
@@ -44,7 +44,7 @@
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-starter-mcp-client-webflux</artifactId>
+            <artifactId>spring-ai-starter-mcp-client</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
fix(mcp): fix #2148 使用 spring-ai-starter-mcp-client 替换 spring-ai-starter-mcp-client-webflux

Signed-off-by: traburiss <tingchuan.li@vipshop.com>


### Describe what this PR does / why we need it

不替换会导致使用 pring-ai-starter-mcp-server-webmvc 时产生 404 问题

### Does this pull request fix one issue?

Fixes #2148

