### PR TITLE
fix(memory): fix the compatibility issue between redis chat memory and spring-boot-starter-data-redis (#2188)

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryAutoConfiguration.java
@@ -17,7 +17,6 @@ package com.alibaba.cloud.ai.autoconfigure.memory.redis;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -36,7 +35,7 @@ import org.springframework.context.annotation.Import;
 public class RedisChatMemoryAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(RedisConnectionDetails.class)
+	@ConditionalOnMissingBean(RedisMemoryConnectionDetails.class)
 	RedisChatMemoryConnectionDetails redisChatMemoryConnectionDetails(RedisChatMemoryProperties properties) {
 		return new RedisChatMemoryConnectionDetails(properties);
 	}

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryConnectionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryConnectionAutoConfiguration.java
@@ -16,7 +16,6 @@
 package com.alibaba.cloud.ai.autoconfigure.memory.redis;
 
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
-import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
@@ -101,7 +100,7 @@ public abstract class RedisChatMemoryConnectionAutoConfiguration<T extends ChatM
 	 * @return Fully configured standalone Redis chat memory configuration
 	 */
 	protected final RedisChatMemoryStandaloneConfiguration getStandaloneConfiguration() {
-		RedisConnectionDetails.Standalone standalone = connectionDetails.getStandalone();
+		RedisMemoryConnectionDetails.Standalone standalone = connectionDetails.getStandalone();
 		return new RedisChatMemoryStandaloneConfiguration(standalone.getHost(), standalone.getPort(),
 				connectionDetails.getUsername(), connectionDetails.getPassword(), properties.getTimeout());
 	}
@@ -124,9 +123,9 @@ public abstract class RedisChatMemoryConnectionAutoConfiguration<T extends ChatM
 	 * @param cluster The cluster connection details containing node information
 	 * @return List of Redis node connection strings
 	 */
-	private List<String> getNodes(RedisConnectionDetails.Cluster cluster) {
+	private List<String> getNodes(RedisMemoryConnectionDetails.Cluster cluster) {
 		List<String> clusterNodes = new ArrayList<>();
-		for (RedisConnectionDetails.Node node : cluster.getNodes()) {
+		for (RedisMemoryConnectionDetails.Node node : cluster.getNodes()) {
 			clusterNodes.add(node.host() + ":" + node.port());
 		}
 		return clusterNodes;

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryConnectionDetails.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryConnectionDetails.java
@@ -15,8 +15,6 @@
  */
 package com.alibaba.cloud.ai.autoconfigure.memory.redis;
 
-import org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails;
-
 import java.util.List;
 
 /**
@@ -25,7 +23,7 @@ import java.util.List;
  * @author benym
  * @date 2025/7/30 20:39
  */
-public class RedisChatMemoryConnectionDetails implements RedisConnectionDetails {
+public class RedisChatMemoryConnectionDetails implements RedisMemoryConnectionDetails {
 
 	private final RedisChatMemoryProperties properties;
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisMemoryConnectionDetails.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisMemoryConnectionDetails.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.autoconfigure.memory.redis;
+
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+/**
+ * Details required to establish a chat memory connection to a Redis service.
+ *
+ * @author benym
+ * @since 2025/8/21 16:20
+ */
+public interface RedisMemoryConnectionDetails {
+
+	/**
+	 * Login username of the redis server.
+	 * @return the login username of the redis server
+	 */
+	default String getUsername() {
+		return null;
+	}
+
+	/**
+	 * Login password of the redis server.
+	 * @return the login password of the redis server
+	 */
+	default String getPassword() {
+		return null;
+	}
+
+	/**
+	 * Redis standalone configuration. Mutually exclusive with {@link #getSentinel()} and
+	 * {@link #getCluster()}.
+	 * @return the Redis standalone configuration
+	 */
+	default Standalone getStandalone() {
+		return null;
+	}
+
+	/**
+	 * Redis sentinel configuration. Mutually exclusive with {@link #getStandalone()} and
+	 * {@link #getCluster()}.
+	 * @return the Redis sentinel configuration
+	 */
+	default Sentinel getSentinel() {
+		return null;
+	}
+
+	/**
+	 * Redis cluster configuration. Mutually exclusive with {@link #getStandalone()} and
+	 * {@link #getSentinel()}.
+	 * @return the Redis cluster configuration
+	 */
+	default Cluster getCluster() {
+		return null;
+	}
+
+	/**
+	 * Redis standalone configuration.
+	 */
+	interface Standalone {
+
+		/**
+		 * Redis server host.
+		 * @return the redis server host
+		 */
+		String getHost();
+
+		/**
+		 * Redis server port.
+		 * @return the redis server port
+		 */
+		int getPort();
+
+		/**
+		 * Database index used by the connection factory.
+		 * @return the database index used by the connection factory
+		 */
+		default int getDatabase() {
+			return 0;
+		}
+
+		static RedisMemoryConnectionDetails.Standalone of(String host, int port) {
+			return of(host, port, 0);
+		}
+
+		static RedisMemoryConnectionDetails.Standalone of(String host, int port, int database) {
+			Assert.hasLength(host, "Host must not be empty");
+			return new RedisMemoryConnectionDetails.Standalone() {
+
+				@Override
+				public String getHost() {
+					return host;
+				}
+
+				@Override
+				public int getPort() {
+					return port;
+				}
+
+				@Override
+				public int getDatabase() {
+					return database;
+				}
+
+			};
+		}
+
+	}
+
+	/**
+	 * Redis sentinel configuration.
+	 */
+	interface Sentinel {
+
+		/**
+		 * Database index used by the connection factory.
+		 * @return the database index used by the connection factory
+		 */
+		int getDatabase();
+
+		/**
+		 * Name of the Redis server.
+		 * @return the name of the Redis server
+		 */
+		String getMaster();
+
+		/**
+		 * List of nodes.
+		 * @return the list of nodes
+		 */
+		List<RedisMemoryConnectionDetails.Node> getNodes();
+
+		/**
+		 * Login username for authenticating with sentinel(s).
+		 * @return the login username for authenticating with sentinel(s) or {@code null}
+		 */
+		String getUsername();
+
+		/**
+		 * Password for authenticating with sentinel(s).
+		 * @return the password for authenticating with sentinel(s) or {@code null}
+		 */
+		String getPassword();
+
+	}
+
+	/**
+	 * Redis cluster configuration.
+	 */
+	interface Cluster {
+
+		/**
+		 * Nodes to bootstrap from. This represents an "initial" list of cluster nodes and
+		 * is required to have at least one entry.
+		 * @return nodes to bootstrap from
+		 */
+		List<Node> getNodes();
+
+	}
+
+	/**
+	 * A node in a sentinel or cluster configuration.
+	 *
+	 * @param host the hostname of the node
+	 * @param port the port of the node
+	 */
+	record Node(String host, int port) {
+
+	}
+
+}


### PR DESCRIPTION
fix the compatibility issue between redis chat memory and spring-boot-starter-data-redis (#2188)


### Describe what this PR does / why we need it
When using `spring-ai-alibaba-autoconfigure-memory`, the original `RedisChatMemoryConnectionDetails` is implemented by `org.springframework.boot.autoconfigure.data.redis.RedisConnectionDetails` in `spring-data-redis`, and the injection condition of `RedisChatMemoryConnectionDetails` is `@ConditionalOnMissingBean(RedisConnectionDetails.class)`. When `spring-boot-starter-data-redis` is used in the project at the same time, `com.alibaba.cloud.ai.autoconfigure.memory.redis.RedisChatMemoryAutoConfiguration` will be loaded before `org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration`, which means that the bean of type `RedisConnectionDetails` will be injected first, resulting in the failure of `PropertiesRedisConnectionDetails` in `org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration` to be injected, resulting in the `RedisConnectionDetails` based on `spring-boot-starter-data-redis` becoming `RedisChatMemoryConnectionDetails`

### Does this pull request fix one issue?

#2188 

### Describe how you did it

Considering that the same `RedisConnectionDetails` implementation class cannot coexist without specifying `@Qualifier`, and we cannot modify the `spring-data-redis` code at will, I created a connection interface `RedisMemoryConnectionDetails` that is unique to redis chat memory to isolate the connection management of redis memory from the `RedisConnectionDetails` of `spring-data-redis`.