### PR TITLE
fix(core): image gen retry

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/image/DashScopeImageModel.java
@@ -37,6 +37,7 @@ import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.image.observation.ImageModelObservationDocumentation;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.retry.TransientAiException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
@@ -168,7 +169,7 @@ public class DashScopeImageModel implements ImageModel {
 					}
 				}
 			}
-			throw new RuntimeException("Image generation still pending");
+			throw new TransientAiException("Image generation still pending");
 		}, context -> {
 			observation.lowCardinalityKeyValue("timeout", "true");
 			return new ImageResponse(List.of(), toMetadataTimeout(taskId));


### PR DESCRIPTION
### Describe what this PR does / why we need it

The bailian image generation result retrieval is currently asynchronous. The intended design is to achieve polling via retryTemplate retry mechanism.

The injected retryTemplate bean (org.springframework.ai.retry.RetryUtils#DEFAULT_RETRY_TEMPLATE) only retries on org.springframework.ai.retry.TransientAiException
In the current implementation, thrown RuntimeException is not properly handled
This prevents the polling functionality from working as designed

### Describe how you did it
Changing the thrown exception type to TransientAiException has been verified to deliver the expected polling behavior during testing.




百炼生图结果获取是异步轮询的， retryTemplate只能对TransientAiException进行重试处理， 目前的实现只能获取一次生图结果， 并不会进行重试， 将抛错修改TransientAiException， 经验证符合预期