### PR TITLE
fix(vector-stores): avoid NPE by returning non-null observation context builder in TairVectorStore (fixes #2162)

### DIFF
--- a/community/vector-stores/spring-ai-alibaba-starter-tair-store/pom.xml
+++ b/community/vector-stores/spring-ai-alibaba-starter-tair-store/pom.xml
@@ -48,6 +48,57 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-vector-store</artifactId>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-XX:+EnableDynamicAgentLoading
+                        -Djdk.instrument.traceUsage=false</argLine>
+                    <systemPropertyVariables>
+                        <mockito.inline.mockmaker>true</mockito.inline.mockmaker>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/community/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStore.java
+++ b/community/vector-stores/spring-ai-alibaba-starter-tair-store/src/main/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStore.java
@@ -220,9 +220,17 @@ public class TairVectorStore extends AbstractObservationVectorStore {
 		return this.embeddingModel.embed(query);
 	}
 
+	/**
+	 * Creates a VectorStoreObservationContext.Builder for Tair vector operations.
+	 * @param operationName The operation name (e.g., "add", "search", "delete")
+	 * @return A configured VectorStoreObservationContext.Builder instance
+	 */
 	@Override
 	public VectorStoreObservationContext.Builder createObservationContextBuilder(String operationName) {
-		return null;
+		return VectorStoreObservationContext.builder("tair", operationName)
+			.collectionName(this.options.getIndexName())
+			.dimensions(this.options.getDimensions())
+			.similarityMetric(this.options.getDistanceMethod().name());
 	}
 
 	/**

--- a/community/vector-stores/spring-ai-alibaba-starter-tair-store/src/test/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStoreTest.java
+++ b/community/vector-stores/spring-ai-alibaba-starter-tair-store/src/test/java/com/alibaba/cloud/ai/vectorstore/tair/TairVectorStoreTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.vectorstore.tair;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test class for TairVectorStore to verify the fix for createObservationContextBuilder
+ * method.
+ *
+ * @author tfh-yqr
+ * @since 1.0.0-M3
+ */
+class TairVectorStoreTest {
+
+	@Test
+	void testCreateObservationContextBuilder() {
+		// Create mock dependencies
+		TairVectorApi mockTairVectorApi = mock(TairVectorApi.class);
+		EmbeddingModel mockEmbeddingModel = mock(EmbeddingModel.class);
+
+		// Create TairVectorStore instance
+		TairVectorStore vectorStore = TairVectorStore.builder(mockTairVectorApi, mockEmbeddingModel).build();
+
+		// Test that createObservationContextBuilder no longer returns null
+		VectorStoreObservationContext.Builder builder = vectorStore.createObservationContextBuilder("test_operation");
+
+		// Verify the builder is not null
+		assertThat(builder).isNotNull();
+
+		// Verify the builder has the correct properties
+		VectorStoreObservationContext context = builder.build();
+		assertThat(context.getDatabaseSystem()).isEqualTo("tair");
+		assertThat(context.getOperationName()).isEqualTo("test_operation");
+		assertThat(context.getCollectionName()).isEqualTo("spring_ai_tair_vector_store"); // default
+																							// value
+		assertThat(context.getDimensions()).isEqualTo(1536); // default value
+		assertThat(context.getSimilarityMetric()).isEqualTo("L2"); // default value
+	}
+
+	@Test
+	void testCreateObservationContextBuilderWithCustomOptions() {
+		// Create mock dependencies
+		TairVectorApi mockTairVectorApi = mock(TairVectorApi.class);
+		EmbeddingModel mockEmbeddingModel = mock(EmbeddingModel.class);
+
+		// Create custom options
+		TairVectorStoreOptions customOptions = new TairVectorStoreOptions();
+		customOptions.setIndexName("custom_index");
+		customOptions.setDimensions(512);
+		customOptions.setDistanceMethod(com.aliyun.tair.tairvector.params.DistanceMethod.IP);
+
+		// Create TairVectorStore instance with custom options
+		TairVectorStore vectorStore = TairVectorStore.builder(mockTairVectorApi, mockEmbeddingModel)
+			.options(customOptions)
+			.build();
+
+		// Test createObservationContextBuilder with custom options
+		VectorStoreObservationContext.Builder builder = vectorStore.createObservationContextBuilder("custom_operation");
+
+		// Verify the builder is not null
+		assertThat(builder).isNotNull();
+
+		// Verify the builder has the correct custom properties
+		VectorStoreObservationContext context = builder.build();
+		assertThat(context.getDatabaseSystem()).isEqualTo("tair");
+		assertThat(context.getOperationName()).isEqualTo("custom_operation");
+		assertThat(context.getCollectionName()).isEqualTo("custom_index");
+		assertThat(context.getDimensions()).isEqualTo(512);
+		assertThat(context.getSimilarityMetric()).isEqualTo("IP");
+	}
+
+}


### PR DESCRIPTION
## Fix: TairVectorStore createObservationContextBuilder returns null causing NPE

### Problem
`TairVectorStore.createObservationContextBuilder()` method was returning `null`, causing `NullPointerException` during vector store operations.

### Solution
Implemented the method to return a properly configured `VectorStoreObservationContext.Builder` with Tair-specific context information.

### Changes
- Fixed `createObservationContextBuilder` method implementation
- Added comprehensive unit tests
- Added necessary test dependencies

### Testing
- ✅ Added unit tests covering default and custom configurations
- ✅ Verified method no longer returns `null`
- ✅ All tests pass

Fixes #2162