### PR TITLE
fix(deepresearch): resolve UserFileRagDispatcher routing inconsistency issue #2217

### DIFF
--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/dispatcher/UserFileRagDispatcher.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/dispatcher/UserFileRagDispatcher.java
@@ -18,12 +18,25 @@ package com.alibaba.cloud.ai.example.deepresearch.dispatcher;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.EdgeAction;
 
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+
 public class UserFileRagDispatcher implements EdgeAction {
 
 	@Override
 	public String apply(OverAllState state) {
-		Boolean enabled = state.value("user_upload_file", false);
-		return Boolean.TRUE.equals(enabled) ? "user_file_rag" : "background_investigator";
+		// 读取rewrite_multi_query_next_node的状态值，确保与前置节点决策一致
+		// 如果前置节点决定进入user_file_rag，那么这里应该继续到background_investigator
+		// 如果前置节点决定进入background_investigator，那么这里应该结束
+		String previousDecision = state.value("rewrite_multi_query_next_node", END);
+
+		// 如果前置节点决定进入user_file_rag，说明需要用户文件RAG处理
+		// 处理完成后应该进入background_investigator进行后续调查
+		if ("user_file_rag".equals(previousDecision)) {
+			return "background_investigator";
+		}
+
+		// 其他情况直接结束
+		return END;
 	}
 
 }

--- a/spring-ai-alibaba-deepresearch/src/test/java/com/alibaba/cloud/ai/example/deepresearch/dispatcher/UserFileRagDispatcherTest.java
+++ b/spring-ai-alibaba-deepresearch/src/test/java/com/alibaba/cloud/ai/example/deepresearch/dispatcher/UserFileRagDispatcherTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.example.deepresearch.dispatcher;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test cases for UserFileRagDispatcher
+ *
+ * @author tfh-yqf
+ * @since 2025/8/22
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UserFileRagDispatcherTest {
+
+	@Mock
+	private OverAllState mockState;
+
+	private UserFileRagDispatcher dispatcher;
+
+	@BeforeEach
+	void setUp() {
+		dispatcher = new UserFileRagDispatcher();
+	}
+
+	@Test
+	void testApply_WhenPreviousDecisionIsUserFileRag_ShouldReturnBackgroundInvestigator() {
+		// Given: 前置节点决定进入user_file_rag
+		Map<String, Object> stateValues = new HashMap<>();
+		stateValues.put("rewrite_multi_query_next_node", "user_file_rag");
+
+		when(mockState.value("rewrite_multi_query_next_node", END)).thenReturn("user_file_rag");
+
+		// When: 调用dispatcher
+		String result = dispatcher.apply(mockState);
+
+		// Then: 应该返回background_investigator
+		assertEquals("background_investigator", result);
+	}
+
+	@Test
+    void testApply_WhenPreviousDecisionIsBackgroundInvestigator_ShouldReturnEnd() {
+        // Given: 前置节点决定进入background_investigator
+        when(mockState.value("rewrite_multi_query_next_node", END)).thenReturn("background_investigator");
+
+        // When: 调用dispatcher
+        String result = dispatcher.apply(mockState);
+
+        // Then: 应该返回END
+        assertEquals(END, result);
+    }
+
+	@Test
+    void testApply_WhenPreviousDecisionIsEnd_ShouldReturnEnd() {
+        // Given: 前置节点决定结束
+        when(mockState.value("rewrite_multi_query_next_node", END)).thenReturn(END);
+
+        // When: 调用dispatcher
+        String result = dispatcher.apply(mockState);
+
+        // Then: 应该返回END
+        assertEquals(END, result);
+    }
+
+	@Test
+    void testApply_WhenPreviousDecisionIsNull_ShouldReturnEnd() {
+        // Given: 前置节点没有设置决策值
+        when(mockState.value("rewrite_multi_query_next_node", END)).thenReturn(null);
+
+        // When: 调用dispatcher
+        String result = dispatcher.apply(mockState);
+
+        // Then: 应该返回默认值END
+        assertEquals(END, result);
+    }
+
+	@Test
+    void testApply_WhenPreviousDecisionIsUnknown_ShouldReturnEnd() {
+        // Given: 前置节点设置了未知的决策值
+        when(mockState.value("rewrite_multi_query_next_node", END)).thenReturn("unknown_node");
+
+        // When: 调用dispatcher
+        String result = dispatcher.apply(mockState);
+
+        // Then: 应该返回END
+        assertEquals(END, result);
+    }
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

修复了 `UserFileRagDispatcher` 中存在的路由不一致问题。该问题导致 DeepResearch 工作流在处理用户文件RAG操作时，返回值与期望的 `targetId` 不匹配，影响工作流的正常执行。

### Does this pull request fix one issue?

Fixes #2217

### Describe how you did it

1. 分析了问题的根本原因：`UserFileRagDispatcher` 重复检查 `user_upload_file` 状态，与前置节点的决策不一致
2. 修改了 `UserFileRagDispatcher.apply()` 方法，改为读取前置节点的决策结果 `rewrite_multi_query_next_node`
3. 消除了重复的状态检查，确保路由决策的一致性
4. 添加了完整的测试用例 `UserFileRagDispatcherTest`，覆盖各种路由场景

### Describe how to verify it

1. 运行测试：`mvn test -Dtest=UserFileRagDispatcherTest`
2. 验证修复后的逻辑：
   - 当前置节点决定进入 `user_file_rag` 时，`UserFileRagDispatcher` 应返回 `background_investigator`
   - 当前置节点决定进入 `background_investigator` 时，应返回 `END`
   - 其他情况都应返回 `END`
3. 确保整个 DeepResearch 工作流的路由决策保持一致

### Special notes for reviews