### PR TITLE
fix(deepresearch): 修复背景调查节点的查询结果

### DIFF
--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationNode.java
@@ -96,9 +96,9 @@ public class BackgroundInvestigationNode implements NodeAction {
 			// 使用支持工具调用的搜索方法
 			results = searchInfoService.searchInfo(StateUtil.isSearchFilter(state), searchSelection.getSearchEnum(),
 					query, searchSelection.getSearchPlatform());
-			resultMap.put("site_information", results);
 			resultsList.add(results);
 		}
+		resultMap.put("site_information", resultsList);
 
 		List<String> backgroundResults = new ArrayList<>();
 		assert resultsList.size() != queries.size();

--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationNode.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/node/BackgroundInvestigationNode.java
@@ -101,7 +101,7 @@ public class BackgroundInvestigationNode implements NodeAction {
 		resultMap.put("site_information", resultsList);
 
 		List<String> backgroundResults = new ArrayList<>();
-		assert resultsList.size() != queries.size();
+		assert resultsList.size() == queries.size();
 
 		for (int i = 0; i < resultsList.size(); i++) {
 			List<Map<String, String>> searchResults = resultsList.get(i);


### PR DESCRIPTION

### Describe what this PR does / why we need it
- 原实现会不断覆盖前一个查询的查询结果
- 修改结果的保存方式，确保所有查询结果都被正确保存

- 修复背景调查节点的结果列表大小比较逻辑
- 将不等修正为相等
- 确保结果列表与查询列表的大小一致，避免潜在的索引越界问题

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
