### PR TITLE
fix(deepresearch): fix #2217

### DIFF
--- a/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
+++ b/spring-ai-alibaba-deepresearch/src/main/java/com/alibaba/cloud/ai/example/deepresearch/config/DeepResearchConfiguration.java
@@ -24,7 +24,6 @@ import com.alibaba.cloud.ai.example.deepresearch.dispatcher.InformationDispatche
 import com.alibaba.cloud.ai.example.deepresearch.dispatcher.ProfessionalKbDispatcher;
 import com.alibaba.cloud.ai.example.deepresearch.dispatcher.ResearchTeamDispatcher;
 import com.alibaba.cloud.ai.example.deepresearch.dispatcher.RewriteAndMultiQueryDispatcher;
-import com.alibaba.cloud.ai.example.deepresearch.dispatcher.UserFileRagDispatcher;
 import com.alibaba.cloud.ai.example.deepresearch.model.enums.ParallelEnum;
 
 import com.alibaba.cloud.ai.example.deepresearch.node.BackgroundInvestigationNode;
@@ -252,8 +251,7 @@ public class DeepResearchConfiguration {
 							END))
 			.addConditionalEdges("background_investigator", edge_async(new BackgroundInvestigationDispatcher()),
 					Map.of("reporter", "reporter", "planner", "planner", END, END))
-			.addConditionalEdges("user_file_rag", edge_async(new UserFileRagDispatcher()),
-					Map.of("background_investigator", "background_investigator", END, END))
+			.addEdge("user_file_rag", "background_investigator")
 			.addEdge("planner", "information")
 			.addConditionalEdges("information", edge_async(new InformationDispatcher()),
 					Map.of("reporter", "reporter", "human_feedback", "human_feedback", "planner", "planner",


### PR DESCRIPTION


### Describe what this PR does / why we need it

rewrite_multi_query 会在 user_upload_file 标识为 true 时转入 user_file_rag 节点，为 false 时转入 background_investigator 节点；
而目前 user_file_rag 节点会在 user_upload_file 标识为 true 时再次转入 user_file_rag 节点，为 false 时转入background_investigator 节点， 这里明显不合理；
我理解 user_file_rag 只是 user_upload_file 标识为 true 时引入的额外流程，执行完直接回归正常流程也就是 background_investigator 节点即可，无需引入条件边；

### Does this pull request fix one issue?
Fixes #2217 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
优化用户文件 RAG 节点配置
- 移除 user_file_rag 节点的条件边
- 直接将 user_file_rag 节点连接到 background_investigator 节点


### Describe how to verify it


### Special notes for reviews
