### PR TITLE
feat(mcp): add ouath properties for mcp-router

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-router/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/gateway/nacos/NacosMcpGatewayAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-router/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/gateway/nacos/NacosMcpGatewayAutoConfiguration.java
@@ -17,6 +17,7 @@
 package com.alibaba.cloud.ai.autoconfigure.mcp.gateway.nacos;
 
 import com.alibaba.cloud.ai.autoconfigure.mcp.gateway.core.McpGatewayServerAutoConfiguration;
+import com.alibaba.cloud.ai.autoconfigure.mcp.gateway.security.McpGatewayOAuthAutoConfiguration;
 import com.alibaba.cloud.ai.mcp.gateway.core.McpGatewayToolManager;
 import com.alibaba.cloud.ai.mcp.gateway.core.McpGatewayToolsInitializer;
 import com.alibaba.cloud.ai.mcp.gateway.nacos.properties.NacosMcpGatewayProperties;
@@ -45,7 +46,7 @@ import java.util.Properties;
  * @author aias00
  */
 @EnableConfigurationProperties({ NacosMcpGatewayProperties.class, NacosMcpProperties.class, McpServerProperties.class })
-@AutoConfiguration(after = { McpGatewayServerAutoConfiguration.class })
+@AutoConfiguration(after = { McpGatewayServerAutoConfiguration.class, McpGatewayOAuthAutoConfiguration.class })
 @ConditionalOnProperty(prefix = "spring.ai.alibaba.mcp.gateway", name = "registry", havingValue = "nacos",
 		matchIfMissing = true)
 public class NacosMcpGatewayAutoConfiguration {

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-router/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/gateway/security/McpGatewayOAuthAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-mcp-router/src/main/java/com/alibaba/cloud/ai/autoconfigure/mcp/gateway/security/McpGatewayOAuthAutoConfiguration.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.autoconfigure.mcp.gateway.security;
+
+import com.alibaba.cloud.ai.mcp.gateway.core.security.McpGatewayOAuthConfigValidator;
+import com.alibaba.cloud.ai.mcp.gateway.core.security.McpGatewayOAuthInterceptor;
+import com.alibaba.cloud.ai.mcp.gateway.core.security.McpGatewayOAuthProperties;
+import com.alibaba.cloud.ai.mcp.gateway.core.security.McpGatewayOAuthTokenManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.EventListener;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@AutoConfiguration
+@EnableConfigurationProperties(McpGatewayOAuthProperties.class)
+@ConditionalOnProperty(prefix = "spring.ai.alibaba.mcp.gateway.oauth", name = "enabled", havingValue = "true",
+		matchIfMissing = false)
+@ConditionalOnClass(WebClient.class)
+public class McpGatewayOAuthAutoConfiguration {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpGatewayOAuthAutoConfiguration.class);
+
+	@Bean
+	@ConditionalOnBean(WebClient.Builder.class)
+	@ConditionalOnMissingBean(McpGatewayOAuthTokenManager.class)
+	public McpGatewayOAuthTokenManager mcpGatewayOAuthTokenManager(WebClient.Builder webClientBuilder,
+			McpGatewayOAuthProperties oauthProperties) {
+
+		McpGatewayOAuthConfigValidator.ValidationResult validation = McpGatewayOAuthConfigValidator
+			.validateOAuthProperties(oauthProperties);
+
+		if (!validation.isValid()) {
+			validation.logResults();
+			throw new IllegalStateException("OAuth configuration is invalid");
+		}
+		else if (validation.hasWarnings()) {
+			validation.logResults();
+		}
+
+		return new McpGatewayOAuthTokenManager(webClientBuilder, oauthProperties);
+	}
+
+	@Bean
+	@ConditionalOnBean(McpGatewayOAuthTokenManager.class)
+	@ConditionalOnMissingBean(McpGatewayOAuthInterceptor.class)
+	public McpGatewayOAuthInterceptor mcpGatewayOAuthInterceptor(McpGatewayOAuthTokenManager tokenManager,
+			McpGatewayOAuthProperties oauthProperties) {
+
+		return new McpGatewayOAuthInterceptor(tokenManager, oauthProperties);
+	}
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void validateOAuthConfigurationOnStartup(ApplicationReadyEvent event) {
+		try {
+			McpGatewayOAuthProperties oauthProperties = event.getApplicationContext()
+				.getBean(McpGatewayOAuthProperties.class);
+
+			if (oauthProperties.isEnabled()) {
+
+				McpGatewayOAuthConfigValidator.ValidationResult validation = McpGatewayOAuthConfigValidator
+					.validateOAuthProperties(oauthProperties);
+
+				validation.logResults();
+			}
+		}
+		catch (Exception e) {
+			logger.debug("OAuth配置验证已跳过: {}", e.getMessage());
+		}
+	}
+
+}

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/README.md
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/README.md
@@ -133,6 +133,32 @@ spring:
         router:
           enabled: true
           service-names: ["echo-server", "weather-server"]
+# 开启 OAuth 验证配置
+spring:
+  ai:
+    alibaba:
+      mcp:
+        gateway:
+          oauth:
+            enabled: true
+            # OAuth 配置
+            provider:
+              client-id: your-client-id
+              client-secret: your-client-secret
+              token-uri: https://your-oauth-server.com/oauth/token
+              authorization-uri: https://your-oauth-server.com/oauth/authorize
+              user-info-uri: https://your-oauth-server.com/userinfo
+              grant-type: client_credentials
+              scope: read,write
+              # token 缓存配置
+            token-cache:
+              enabled: true 
+              max-size: 1000
+              refresh-before-expiry: PT5M # 在过期多久前刷新缓存
+              # 重试配置，最大重试次数和间隔           
+            retry:
+              max-attempts: 3
+              backoff: PT1S
 ```
 
 ### 3. 使用示例

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthConfigValidator.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthConfigValidator.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.gateway.core.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class McpGatewayOAuthConfigValidator {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpGatewayOAuthConfigValidator.class);
+
+	/**
+	 * 验证OAuth配置的完整性
+	 */
+	public static ValidationResult validateOAuthProperties(McpGatewayOAuthProperties properties) {
+		List<String> errors = new ArrayList<>();
+		List<String> warnings = new ArrayList<>();
+
+		if (properties == null) {
+			errors.add("OAuth 属性为空");
+			return new ValidationResult(false, errors, warnings);
+		}
+
+		if (!properties.isEnabled()) {
+			logger.debug("OAuth 配置未开启");
+			return new ValidationResult(true, errors, warnings);
+		}
+
+		McpGatewayOAuthProperties.OAuthProvider provider = properties.getProvider();
+		if (provider == null) {
+			errors.add("OAuth配置为空");
+		}
+		else {
+			List<String> providerErrors = validateProvider(provider);
+			errors.addAll(providerErrors);
+		}
+
+		if (properties.getTokenCache() != null) {
+			validateTokenCacheConfig(properties.getTokenCache(), warnings);
+		}
+
+		if (properties.getRetry() != null) {
+			validateRetryConfig(properties.getRetry(), warnings);
+		}
+
+		boolean isValid = errors.isEmpty();
+		return new ValidationResult(isValid, errors, warnings);
+	}
+
+	/**
+	 * 验证OAuth提供商配置
+	 */
+	private static List<String> validateProvider(McpGatewayOAuthProperties.OAuthProvider provider) {
+		List<String> errors = new ArrayList<>();
+
+		if (provider == null) {
+			errors.add("提供商配置为空");
+			return errors;
+		}
+
+		// 进行字段的验证
+		if (!StringUtils.hasText(provider.getClientId())) {
+			errors.add("clientId是必需的");
+		}
+
+		if (!StringUtils.hasText(provider.getClientSecret())) {
+			errors.add("clientSecret是必需的");
+		}
+
+		if (!StringUtils.hasText(provider.getTokenUri())) {
+			errors.add("tokenUri是必需的");
+		}
+		else {
+			// 验证tokenUri格式
+			try {
+				URI.create(provider.getTokenUri());
+			}
+			catch (Exception e) {
+				errors.add("tokenUri格式无效 - " + e.getMessage());
+			}
+		}
+
+		String grantType = provider.getGrantType();
+		if (StringUtils.hasText(grantType)) {
+			if (!"client_credentials".equals(grantType) && !"authorization_code".equals(grantType)
+					&& !"password".equals(grantType) && !"refresh_token".equals(grantType)) {
+				errors.add("不支持的授权类型 '" + grantType + "'");
+			}
+		}
+
+		if (StringUtils.hasText(provider.getAuthorizationUri())) {
+			try {
+				URI.create(provider.getAuthorizationUri());
+			}
+			catch (Exception e) {
+				errors.add("authorizationUri格式无效 - " + e.getMessage());
+			}
+		}
+
+		if (StringUtils.hasText(provider.getUserInfoUri())) {
+			try {
+				URI.create(provider.getUserInfoUri());
+			}
+			catch (Exception e) {
+				errors.add("userInfoUri格式无效 - " + e.getMessage());
+			}
+		}
+
+		return errors;
+	}
+
+	/**
+	 * 验证Token缓存配置
+	 */
+	private static void validateTokenCacheConfig(McpGatewayOAuthProperties.TokenCache cacheConfig,
+			List<String> warnings) {
+		if (cacheConfig.getMaxSize() <= 0) {
+			warnings.add("Token缓存最大大小应该是正数，当前值: " + cacheConfig.getMaxSize());
+		}
+
+		if (cacheConfig.getRefreshBeforeExpiry() != null) {
+			long refreshSeconds = cacheConfig.getRefreshBeforeExpiry().getSeconds();
+			if (refreshSeconds < 0) {
+				warnings.add("Token缓存刷新时间不应为负数");
+			}
+			else if (refreshSeconds > 3600) {
+				warnings.add("Token缓存刷新时间过大(> 1小时)，建议减小该值");
+			}
+		}
+	}
+
+	/**
+	 * 验证重试配置
+	 */
+	private static void validateRetryConfig(McpGatewayOAuthProperties.Retry retryConfig, List<String> warnings) {
+		if (retryConfig.getMaxAttempts() < 1) {
+			warnings.add("重试最大尝试次数应至少为1，当前值: " + retryConfig.getMaxAttempts());
+		}
+
+		if (retryConfig.getBackoff() != null) {
+			long backoffMillis = retryConfig.getBackoff().toMillis();
+			if (backoffMillis < 0) {
+				warnings.add("重试退避时间不应为负数");
+			}
+			else if (backoffMillis > 30000) {
+				warnings.add("重试退避时间过大，建议减小该值");
+			}
+		}
+	}
+
+	/**
+	 * 验证结果类
+	 */
+	public static class ValidationResult {
+
+		private final boolean valid;
+
+		private final List<String> errors;
+
+		private final List<String> warnings;
+
+		public ValidationResult(boolean valid, List<String> errors, List<String> warnings) {
+			this.valid = valid;
+			this.errors = errors != null ? errors : new ArrayList<>();
+			this.warnings = warnings != null ? warnings : new ArrayList<>();
+		}
+
+		public boolean isValid() {
+			return valid;
+		}
+
+		public List<String> getErrors() {
+			return errors;
+		}
+
+		public List<String> getWarnings() {
+			return warnings;
+		}
+
+		public boolean hasWarnings() {
+			return !warnings.isEmpty();
+		}
+
+		public void logResults() {
+			if (!valid) {
+				logger.error("OAuth configuration validation failed with {} errors", errors.size());
+				for (int i = 0; i < errors.size(); i++) {
+					logger.error("Error {}: {}", (i + 1), errors.get(i));
+				}
+			}
+			else {
+				logger.info("OAuth configuration validation passed");
+			}
+
+			if (hasWarnings()) {
+				logger.warn("OAuth configuration has {} warnings", warnings.size());
+				for (int i = 0; i < warnings.size(); i++) {
+					logger.warn("Warning {}: {}", (i + 1), warnings.get(i));
+				}
+			}
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthInterceptor.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.gateway.core.security;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+/**
+ * OAuth认证拦截器 自动为MCP Gateway的HTTP请求添加OAuth认证头
+ */
+public class McpGatewayOAuthInterceptor implements ExchangeFilterFunction {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpGatewayOAuthInterceptor.class);
+
+	private final McpGatewayOAuthTokenManager tokenManager;
+
+	private final McpGatewayOAuthProperties oauthProperties;
+
+	public McpGatewayOAuthInterceptor(McpGatewayOAuthTokenManager tokenManager,
+			McpGatewayOAuthProperties oauthProperties) {
+		this.tokenManager = tokenManager;
+		this.oauthProperties = oauthProperties;
+	}
+
+	@NotNull
+	@Override
+	public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
+		if (!oauthProperties.isEnabled()) {
+			logger.debug("OAuth 身份验证未开启");
+			return next.exchange(request);
+		}
+
+		logger.debug("OAuth 认证 URL: {}", request.url());
+
+		return tokenManager.getAccessToken().flatMap(accessToken -> {
+			ClientRequest authenticatedRequest = ClientRequest.from(request)
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+				.build();
+
+			logger.debug("成功添加 OAuth 认证");
+			return next.exchange(authenticatedRequest);
+		}).switchIfEmpty(Mono.defer(() -> {
+			logger.warn("没有可用的OAuth token，继续执行无认证请求");
+			return next.exchange(request);
+		})).onErrorResume(throwable -> {
+			logger.error("OAuth认证失败，error: {}", throwable.getMessage(), throwable);
+			return next.exchange(request);
+		}).doOnNext(response -> {
+			if (response.statusCode().is4xxClientError() && response.statusCode().value() == 401) {
+				logger.warn("收到401未授权响应，OAuth token 无效");
+				try {
+					tokenManager.clearCachedToken();
+					logger.info("已清除无效的缓存token");
+				}
+				catch (Exception e) {
+					logger.debug("清除缓存token失败", e);
+				}
+			}
+		});
+	}
+
+}

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthProperties.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthProperties.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.gateway.core.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * MCP Gateway OAuth认证配置属性
+ */
+@ConfigurationProperties(prefix = "spring.ai.alibaba.mcp.gateway.oauth")
+public class McpGatewayOAuthProperties {
+
+	/**
+	 * 是否启用OAuth认证
+	 */
+	private boolean enabled = false;
+
+	/**
+	 * OAuth提供商配置
+	 */
+	private OAuthProvider provider = new OAuthProvider();
+
+	/**
+	 * Token缓存配置
+	 */
+	private TokenCache tokenCache = new TokenCache();
+
+	/**
+	 * 重试配置
+	 */
+	private Retry retry = new Retry();
+
+	public static class OAuthProvider {
+
+		/**
+		 * 客户端ID
+		 */
+		private String clientId;
+
+		/**
+		 * 客户端密钥
+		 */
+		private String clientSecret;
+
+		/**
+		 * 授权URL
+		 */
+		private String authorizationUri;
+
+		/**
+		 * Token获取URL
+		 */
+		private String tokenUri;
+
+		/**
+		 * 用户信息URL
+		 */
+		private String userInfoUri;
+
+		/**
+		 * 授权范围
+		 */
+		private String scope = "read";
+
+		/**
+		 * 重定向URI
+		 */
+		private String redirectUri;
+
+		/**
+		 * 授权类型
+		 */
+		private String grantType = "client_credentials";
+
+		/**
+		 * 额外的请求参数
+		 */
+		private Map<String, String> additionalParameters;
+
+		public String getClientId() {
+			return clientId;
+		}
+
+		public void setClientId(String clientId) {
+			this.clientId = clientId;
+		}
+
+		public String getClientSecret() {
+			return clientSecret;
+		}
+
+		public void setClientSecret(String clientSecret) {
+			this.clientSecret = clientSecret;
+		}
+
+		public String getAuthorizationUri() {
+			return authorizationUri;
+		}
+
+		public void setAuthorizationUri(String authorizationUri) {
+			this.authorizationUri = authorizationUri;
+		}
+
+		public String getTokenUri() {
+			return tokenUri;
+		}
+
+		public void setTokenUri(String tokenUri) {
+			this.tokenUri = tokenUri;
+		}
+
+		public String getUserInfoUri() {
+			return userInfoUri;
+		}
+
+		public void setUserInfoUri(String userInfoUri) {
+			this.userInfoUri = userInfoUri;
+		}
+
+		public String getScope() {
+			return scope;
+		}
+
+		public void setScope(String scope) {
+			this.scope = scope;
+		}
+
+		public String getRedirectUri() {
+			return redirectUri;
+		}
+
+		public void setRedirectUri(String redirectUri) {
+			this.redirectUri = redirectUri;
+		}
+
+		public String getGrantType() {
+			return grantType;
+		}
+
+		public void setGrantType(String grantType) {
+			this.grantType = grantType;
+		}
+
+		public Map<String, String> getAdditionalParameters() {
+			return additionalParameters;
+		}
+
+		public void setAdditionalParameters(Map<String, String> additionalParameters) {
+			this.additionalParameters = additionalParameters;
+		}
+
+	}
+
+	public static class TokenCache {
+
+		/**
+		 * 是否启用Token缓存
+		 */
+		private boolean enabled = true;
+
+		/**
+		 * Token提前刷新时间
+		 */
+		private Duration refreshBeforeExpiry = Duration.ofMinutes(5);
+
+		/**
+		 * 最大缓存大小
+		 */
+		private int maxSize = 1000;
+
+		// Getters and Setters
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Duration getRefreshBeforeExpiry() {
+			return refreshBeforeExpiry;
+		}
+
+		public void setRefreshBeforeExpiry(Duration refreshBeforeExpiry) {
+			this.refreshBeforeExpiry = refreshBeforeExpiry;
+		}
+
+		public int getMaxSize() {
+			return maxSize;
+		}
+
+		public void setMaxSize(int maxSize) {
+			this.maxSize = maxSize;
+		}
+
+	}
+
+	public static class Retry {
+
+		/**
+		 * 最大重试次数
+		 */
+		private int maxAttempts = 3;
+
+		/**
+		 * 重试间隔
+		 */
+		private Duration backoff = Duration.ofSeconds(1);
+
+		// Getters and Setters
+		public int getMaxAttempts() {
+			return maxAttempts;
+		}
+
+		public void setMaxAttempts(int maxAttempts) {
+			this.maxAttempts = maxAttempts;
+		}
+
+		public Duration getBackoff() {
+			return backoff;
+		}
+
+		public void setBackoff(Duration backoff) {
+			this.backoff = backoff;
+		}
+
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public OAuthProvider getProvider() {
+		return provider;
+	}
+
+	public void setProvider(OAuthProvider provider) {
+		this.provider = provider;
+	}
+
+	public TokenCache getTokenCache() {
+		return tokenCache;
+	}
+
+	public void setTokenCache(TokenCache tokenCache) {
+		this.tokenCache = tokenCache;
+	}
+
+	public Retry getRetry() {
+		return retry;
+	}
+
+	public void setRetry(Retry retry) {
+		this.retry = retry;
+	}
+
+}

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthTokenManager.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/core/security/McpGatewayOAuthTokenManager.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.gateway.core.security;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+
+/**
+ * OAuth Token管理器 负责Token的获取、缓存和刷新
+ */
+public class McpGatewayOAuthTokenManager {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpGatewayOAuthTokenManager.class);
+
+	private final WebClient webClient;
+
+	private final McpGatewayOAuthProperties oauthProperties;
+
+	private final ObjectMapper objectMapper;
+
+	private volatile CachedToken cachedToken;
+
+	public McpGatewayOAuthTokenManager(WebClient.Builder webClientBuilder, McpGatewayOAuthProperties oauthProperties) {
+		this.webClient = webClientBuilder.build();
+		this.oauthProperties = oauthProperties;
+		this.objectMapper = new ObjectMapper();
+		this.cachedToken = null;
+	}
+
+	/**
+	 * 获取访问Token
+	 */
+	public Mono<String> getAccessToken() {
+		if (!oauthProperties.isEnabled()) {
+			return Mono.empty();
+		}
+
+		return Mono.fromCallable(() -> {
+			// 检查缓存
+			if (oauthProperties.getTokenCache().isEnabled()) {
+				if (cachedToken != null && !isTokenExpiring(cachedToken)) {
+					logger.debug("使用缓存的token");
+					return cachedToken.getAccessToken();
+				}
+			}
+			return null;
+		}).switchIfEmpty(fetchNewToken()).onErrorResume(throwable -> {
+			logger.error("获取访问token失败", throwable);
+			return Mono.empty();
+		});
+	}
+
+	/**
+	 * 获取新的访问Token
+	 */
+	private Mono<String> fetchNewToken() {
+		McpGatewayOAuthProperties.OAuthProvider provider = oauthProperties.getProvider();
+		if (provider == null) {
+			return Mono.error(new IllegalArgumentException("OAuth 未配置"));
+		}
+
+		logger.info("获取新的访问token");
+
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+		formData.add("grant_type", provider.getGrantType());
+		formData.add("client_id", provider.getClientId());
+		formData.add("client_secret", provider.getClientSecret());
+
+		if (StringUtils.hasText(provider.getScope())) {
+			formData.add("scope", provider.getScope());
+		}
+
+		return webClient.post()
+			.uri(provider.getTokenUri())
+			.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+			.body(BodyInserters.fromFormData(formData))
+			.retrieve()
+			.bodyToMono(String.class)
+			.map(responseBody -> parseTokenResponse(responseBody))
+			.doOnNext(token -> logger.info("成功获取访问token"))
+			.retry(oauthProperties.getRetry().getMaxAttempts())
+			.onErrorMap(throwable -> {
+				logger.error("获取访问token失败", throwable);
+				return new RuntimeException("OAuth token获取失败", throwable);
+			});
+	}
+
+	/**
+	 * 解析Token响应
+	 */
+	private String parseTokenResponse(String responseBody) {
+		try {
+			TokenResponse tokenResponse = objectMapper.readValue(responseBody, TokenResponse.class);
+
+			if (!StringUtils.hasText(tokenResponse.getAccessToken())) {
+				throw new RuntimeException("响应中未找到访问token");
+			}
+
+			// 缓存Token
+			if (oauthProperties.getTokenCache().isEnabled()) {
+				cachedToken = new CachedToken(tokenResponse.getAccessToken(), tokenResponse.getRefreshToken(),
+						Instant.now()
+							.plusSeconds(tokenResponse.getExpiresIn() != null ? tokenResponse.getExpiresIn() : 3600),
+						tokenResponse.getTokenType());
+				logger.debug("缓存访问token");
+			}
+
+			return tokenResponse.getAccessToken();
+		}
+		catch (Exception e) {
+			logger.error("解析token响应失败，响应内容: {}", responseBody, e);
+			throw new RuntimeException("解析OAuth token响应失败", e);
+		}
+	}
+
+	/**
+	 * 检查Token是否即将过期
+	 */
+	private boolean isTokenExpiring(CachedToken cachedToken) {
+		if (cachedToken.getExpiresAt() == null) {
+			return false;
+		}
+
+		Instant refreshThreshold = cachedToken.getExpiresAt()
+			.minus(oauthProperties.getTokenCache().getRefreshBeforeExpiry());
+
+		return Instant.now().isAfter(refreshThreshold);
+	}
+
+	/**
+	 * 强制刷新访问Token
+	 */
+	public Mono<String> refreshAccessToken() {
+		if (!oauthProperties.isEnabled()) {
+			return Mono.empty();
+		}
+
+		logger.info("强制刷新访问token");
+
+		// 清除缓存的token
+		clearCachedToken();
+
+		// 获取新的token
+		return fetchNewToken();
+	}
+
+	/**
+	 * 清除缓存Token
+	 */
+	public void clearCachedToken() {
+		if (cachedToken != null) {
+			logger.info("清除缓存的token ");
+			cachedToken = null;
+		}
+		else {
+			logger.debug("没有找到要清除的缓存token");
+		}
+	}
+
+	/**
+	 * Token响应信息
+	 */
+	public static class TokenResponse {
+
+		@JsonProperty("access_token")
+		private String accessToken;
+
+		@JsonProperty("refresh_token")
+		private String refreshToken;
+
+		@JsonProperty("expires_in")
+		private Long expiresIn;
+
+		@JsonProperty("token_type")
+		private String tokenType;
+
+		@JsonProperty("scope")
+		private String scope;
+
+		public String getAccessToken() {
+			return accessToken;
+		}
+
+		public void setAccessToken(String accessToken) {
+			this.accessToken = accessToken;
+		}
+
+		public String getRefreshToken() {
+			return refreshToken;
+		}
+
+		public void setRefreshToken(String refreshToken) {
+			this.refreshToken = refreshToken;
+		}
+
+		public Long getExpiresIn() {
+			return expiresIn;
+		}
+
+		public void setExpiresIn(Long expiresIn) {
+			this.expiresIn = expiresIn;
+		}
+
+		public String getTokenType() {
+			return tokenType;
+		}
+
+		public void setTokenType(String tokenType) {
+			this.tokenType = tokenType;
+		}
+
+		public String getScope() {
+			return scope;
+		}
+
+		public void setScope(String scope) {
+			this.scope = scope;
+		}
+
+	}
+
+	/**
+	 * 缓存的Token信息
+	 */
+	public static class CachedToken {
+
+		private final String accessToken;
+
+		private final String refreshToken;
+
+		private final Instant expiresAt;
+
+		private final String tokenType;
+
+		public CachedToken(String accessToken, String refreshToken, Instant expiresAt, String tokenType) {
+			this.accessToken = accessToken;
+			this.refreshToken = refreshToken;
+			this.expiresAt = expiresAt;
+			this.tokenType = tokenType;
+		}
+
+		public String getAccessToken() {
+			return accessToken;
+		}
+
+		public String getRefreshToken() {
+			return refreshToken;
+		}
+
+		public Instant getExpiresAt() {
+			return expiresAt;
+		}
+
+		public String getTokenType() {
+			return tokenType;
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-spring-boot-starters/spring-ai-alibaba-starter-mcp-router/pom.xml
+++ b/spring-ai-alibaba-spring-boot-starters/spring-ai-alibaba-starter-mcp-router/pom.xml
@@ -65,6 +65,18 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
### Describe what this PR does / why we need it
给 mcp-router 添加 OAuth 配置，开启配置后，需要经过验证才可以访问 mcp-router 代理的 mcp 服务

### Does this pull request fix one issue?

### Describe how you did it
添加了 OAuth 相关的配置类 McpGatewayOAuthProperties，包含基础的配置信息（提供 OAuth 认证的服务），token的管理，连接重试次数的配置
在 NacosMcpGatewayToolCallback 中为请求添加 OAuth 的认证头

### Describe how to verify it


### Special notes for reviews
