### PR TITLE
fix(memories): handle Media serialization in JedisRedisChatMemoryRepository

### DIFF
--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/BaseRedisChatMemoryRepository.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/BaseRedisChatMemoryRepository.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.memory.redis;
 
+import com.alibaba.cloud.ai.memory.redis.serializer.MediaSerializer;
 import com.alibaba.cloud.ai.memory.redis.serializer.MessageDeserializer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +43,7 @@ public abstract class BaseRedisChatMemoryRepository implements ChatMemoryReposit
 		this.objectMapper = new ObjectMapper();
 		SimpleModule module = new SimpleModule();
 		module.addDeserializer(Message.class, new MessageDeserializer());
+        module.addSerializer(org.springframework.ai.content.Media.class, new MediaSerializer());
 		this.objectMapper.registerModule(module);
 	}
 

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/serializer/MediaSerializer.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/serializer/MediaSerializer.java
@@ -1,0 +1,36 @@
+package com.alibaba.cloud.ai.memory.redis.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.ai.content.Media;
+
+import java.io.IOException;
+import java.util.Base64;
+
+/**
+ * Robust serializer for Spring AI Media:
+ * - byte[] -> dataBase64
+ * - URI / String -> uri
+ */
+public class MediaSerializer extends JsonSerializer<Media> {
+    @Override
+    public void serialize(Media v, JsonGenerator g, SerializerProvider p) throws IOException {
+        g.writeStartObject();
+
+        if (v.getMimeType() != null) {
+            g.writeStringField("mimeType", v.getMimeType().toString());
+        }
+
+        Object data = v.getData();
+        if (data instanceof byte[] bytes) {
+            g.writeStringField("dataBase64", Base64.getEncoder().encodeToString(bytes));
+        } else if (data != null) {
+            g.writeStringField("uri", data.toString());
+        } else {
+            g.writeNullField("uri");
+        }
+
+        g.writeEndObject();
+    }
+}

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepositoryIT.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepositoryIT.java
@@ -20,17 +20,20 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.content.Media;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.util.MimeTypeUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
@@ -174,6 +177,47 @@ class JedisRedisChatMemoryRepositoryIT {
 		assertThat(savedMessages.get(1).getText()).isEqualTo(messages.get(3).getText());
 		assertThat(savedMessages.get(2).getText()).isEqualTo(messages.get(4).getText());
 	}
+
+    @Test
+    void saveAndLoadUserMessageWithUriMedia() {
+        var conversationId = UUID.randomUUID().toString();
+        var userMessage = UserMessage.builder()
+                .text("Explain what do you see on this picture?")
+                .media(List.of(Media.builder()
+                        .mimeType(MimeTypeUtils.IMAGE_PNG)
+                        .data(URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png"))
+                        .build()))
+                .build();
+
+        chatMemoryRepository.saveAll(conversationId, List.of(userMessage));
+        var loaded = chatMemoryRepository.findByConversationId(conversationId);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getMessageType()).isEqualTo(MessageType.USER);
+        assertThat(loaded.get(0).getText()).isEqualTo(userMessage.getText());
+    }
+
+    @Test
+    void saveAndLoadUserMessageWithBytesMedia() {
+        var conversationId = UUID.randomUUID().toString();
+        byte[] bytes = new byte[] { 1, 2, 3 };
+        var userMessage = UserMessage.builder()
+                .text("Here is an inline image")
+                .media(List.of(Media.builder()
+                        .mimeType(MimeTypeUtils.IMAGE_PNG)
+                        .data(bytes)
+                        .build()))
+                .build();
+
+        chatMemoryRepository.saveAll(conversationId, List.of(userMessage));
+        var loaded = chatMemoryRepository.findByConversationId(conversationId);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getMessageType()).isEqualTo(MessageType.USER);
+        assertThat(loaded.get(0).getText()).isEqualTo(userMessage.getText());
+    }
 
 	@SpringBootConfiguration
 	static class TestConfiguration {

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepositoryIT.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepositoryIT.java
@@ -20,17 +20,20 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.content.Media;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.util.MimeTypeUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
@@ -177,6 +180,47 @@ public class LettuceRedisChatMemoryRepositoryIT {
 		assertThat(savedMessages.get(1).getText()).isEqualTo(messages.get(3).getText());
 		assertThat(savedMessages.get(2).getText()).isEqualTo(messages.get(4).getText());
 	}
+
+    @Test
+    void saveAndLoadUserMessageWithUriMedia() {
+        var conversationId = UUID.randomUUID().toString();
+        var userMessage = UserMessage.builder()
+                .text("Explain what do you see on this picture?")
+                .media(List.of(Media.builder()
+                        .mimeType(MimeTypeUtils.IMAGE_PNG)
+                        .data(URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png"))
+                        .build()))
+                .build();
+
+        chatMemoryRepository.saveAll(conversationId, List.of(userMessage));
+        var loaded = chatMemoryRepository.findByConversationId(conversationId);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getMessageType()).isEqualTo(MessageType.USER);
+        assertThat(loaded.get(0).getText()).isEqualTo(userMessage.getText());
+    }
+
+    @Test
+    void saveAndLoadUserMessageWithBytesMedia() {
+        var conversationId = UUID.randomUUID().toString();
+        byte[] bytes = new byte[] { 1, 2, 3 };
+        var userMessage = UserMessage.builder()
+                .text("Here is an inline image")
+                .media(List.of(Media.builder()
+                        .mimeType(MimeTypeUtils.IMAGE_PNG)
+                        .data(bytes)
+                        .build()))
+                .build();
+
+        chatMemoryRepository.saveAll(conversationId, List.of(userMessage));
+        var loaded = chatMemoryRepository.findByConversationId(conversationId);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getMessageType()).isEqualTo(MessageType.USER);
+        assertThat(loaded.get(0).getText()).isEqualTo(userMessage.getText());
+    }
 
 	@SpringBootConfiguration
 	static class TestConfiguration {

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/RedissonRedisChatMemoryRepositoryIT.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/RedissonRedisChatMemoryRepositoryIT.java
@@ -20,17 +20,20 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.content.Media;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.util.MimeTypeUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
@@ -177,6 +180,47 @@ public class RedissonRedisChatMemoryRepositoryIT {
 		assertThat(savedMessages.get(1).getText()).isEqualTo(messages.get(3).getText());
 		assertThat(savedMessages.get(2).getText()).isEqualTo(messages.get(4).getText());
 	}
+
+    @Test
+    void saveAndLoadUserMessageWithUriMedia() {
+        var conversationId = UUID.randomUUID().toString();
+        var userMessage = UserMessage.builder()
+                .text("Explain what do you see on this picture?")
+                .media(List.of(Media.builder()
+                        .mimeType(MimeTypeUtils.IMAGE_PNG)
+                        .data(URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png"))
+                        .build()))
+                .build();
+
+        chatMemoryRepository.saveAll(conversationId, List.of(userMessage));
+        var loaded = chatMemoryRepository.findByConversationId(conversationId);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getMessageType()).isEqualTo(MessageType.USER);
+        assertThat(loaded.get(0).getText()).isEqualTo(userMessage.getText());
+    }
+
+    @Test
+    void saveAndLoadUserMessageWithBytesMedia() {
+        var conversationId = UUID.randomUUID().toString();
+        byte[] bytes = new byte[] { 1, 2, 3 };
+        var userMessage = UserMessage.builder()
+                .text("Here is an inline image")
+                .media(List.of(Media.builder()
+                        .mimeType(MimeTypeUtils.IMAGE_PNG)
+                        .data(bytes)
+                        .build()))
+                .build();
+
+        chatMemoryRepository.saveAll(conversationId, List.of(userMessage));
+        var loaded = chatMemoryRepository.findByConversationId(conversationId);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded).hasSize(1);
+        assertThat(loaded.get(0).getMessageType()).isEqualTo(MessageType.USER);
+        assertThat(loaded.get(0).getText()).isEqualTo(userMessage.getText());
+    }
 
 	@SpringBootConfiguration
 	static class TestConfiguration {


### PR DESCRIPTION
### Describe what this PR does / why we need it
JedisRedisChatMemoryRepository failed to serialize ChatMessage objects containing org.springframework.ai.content.Media with byte[] data.
By default, Jackson serialized byte[] as [B@xxxx strings, which caused errors when storing messages into Redis.
### Does this pull request fix one issue?
Fixes #2305 
### Describe how you did it
Implemented MediaSerializer under com.alibaba.cloud.ai.memory.redis.serializer
Registered the serializer with a SimpleModule in BaseRedisChatMemoryRepository
### Describe how to verify it
I have added test cases to verify serialization works for both byte[] and URI/String media data.
### Special notes for reviews
