### PR TITLE
fix(graph): fix Spring AI Document type serialization

### DIFF
--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/serializer/SpringAIDocumentDeserializerTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/serializer/SpringAIDocumentDeserializerTest.java
@@ -29,406 +29,358 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class SpringAIDocumentDeserializerTest {
 
-    private JacksonStateSerializer.SpringAIDocumentDeserializer deserializer;
-    private ObjectMapper objectMapper;
+	private JacksonStateSerializer.SpringAIDocumentDeserializer deserializer;
 
-    @BeforeEach
-    void setUp() {
-        objectMapper = new ObjectMapper();
-        deserializer = new JacksonStateSerializer.SpringAIDocumentDeserializer();
-    }
+	private ObjectMapper objectMapper;
 
-    @Test
-    void testDeserializeDocumentWithAllFields() throws Exception {
-        // Arrange
-        String json = """
-        {
-            "id": "doc-123",
-            "content": "This is a test document content",
-            "metadata": {
-                "source": "test-source",
-                "author": "test-author",
-                "score": 0.95
-            }
-        }
-        """;
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+		deserializer = new JacksonStateSerializer.SpringAIDocumentDeserializer();
+	}
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+	@Test
+	void testDeserializeDocumentWithAllFields() throws Exception {
+		// Arrange
+		String json = """
+				{
+				    "id": "doc-123",
+				    "content": "This is a test document content",
+				    "metadata": {
+				        "source": "test-source",
+				        "author": "test-author",
+				        "score": 0.95
+				    }
+				}
+				""";
 
-        // Assert
-        assertNotNull(result);
-        assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
-        
-        // Verify content through reflection
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("This is a test document content", content);
-        
-        // Verify ID through reflection
-        String id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertEquals("doc-123", id);
-        
-        // Verify metadata through reflection
-        Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
-        assertNotNull(metadata);
-        assertEquals("test-source", metadata.get("source"));
-        assertEquals("test-author", metadata.get("author"));
-        assertEquals(0.95, metadata.get("score"));
-    }
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
 
-    @Test
-    void testDeserializeDocumentWithAlternativeFieldNames() throws Exception {
-        // Arrange
-        String json = """
-        {
-            "docId": "doc-456",
-            "text": "Alternative content field",
-            "pageContent": "Page content field",
-            "properties": {
-                "category": "test",
-                "priority": 1
-            }
-        }
-        """;
+		// Assert
+		assertNotNull(result);
+		assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+		// Verify content through reflection
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("This is a test document content", content);
 
-        // Assert
-        assertNotNull(result);
-        assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
-        
-        // Should prefer "text" over "pageContent" for content
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("Alternative content field", content);
-        
-        // Should use "docId" as ID
-        String id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertEquals("doc-456", id);
-    }
+		// Verify ID through reflection
+		String id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertEquals("doc-123", id);
 
-    @Test
-    void testDeserializeDocumentWithMinimalFields() throws Exception {
-        // Arrange
-        String json = """
-        {
-            "content": "Minimal document"
-        }
-        """;
+		// Verify metadata through reflection
+		Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
+		assertNotNull(metadata);
+		assertEquals("test-source", metadata.get("source"));
+		assertEquals("test-author", metadata.get("author"));
+		assertEquals(0.95, metadata.get("score"));
+	}
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+	@Test
+	void testDeserializeDocumentWithAlternativeFieldNames() throws Exception {
+		// Arrange
+		String json = """
+				{
+				    "docId": "doc-456",
+				    "text": "Alternative content field",
+				    "pageContent": "Page content field",
+				    "properties": {
+				        "category": "test",
+				        "priority": 1
+				    }
+				}
+				""";
 
-        // Assert
-        assertNotNull(result);
-        assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
-        
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("Minimal document", content);
-        
-        String id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertNotNull(id);
-        
-        // Metadata should be empty
-        Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
-        assertTrue(metadata.isEmpty());
-    }
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
 
-    @Test
-    void testDeserializeDocumentWithComplexMetadata() throws Exception {
-        // Arrange
-        String json = """
-        {
-            "id": "complex-doc",
-            "content": "Document with complex metadata",
-            "metadata": {
-                "nested": {
-                    "level1": "value1",
-                    "level2": {
-                        "final": "value2"
-                    }
-                },
-                "array": [1, 2, 3],
-                "boolean": true,
-                "number": 42
-            }
-        }
-        """;
+		// Assert
+		assertNotNull(result);
+		assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+		// Should prefer "text" over "pageContent" for content
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("Alternative content field", content);
 
-        // Assert
-        assertNotNull(result);
-        
-        Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
-        assertNotNull(metadata);
-        
-        // Verify complex nested structure
-        Map<?, ?> nested = (Map<?, ?>) metadata.get("nested");
-        assertEquals("value1", nested.get("level1"));
-        
-        Map<?, ?> level2 = (Map<?, ?>) nested.get("level2");
-        assertEquals("value2", level2.get("final"));
-        
-        // Verify array
-        assertTrue(metadata.get("array") instanceof java.util.List);
-        assertEquals(true, metadata.get("boolean"));
-        assertEquals(42, metadata.get("number"));
-    }
+		// Should use "docId" as ID
+		String id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertEquals("doc-456", id);
+	}
 
-    @Test
-    void testDeserializeDocumentWithEmptyContent() throws Exception {
-        // Arrange
-        String json = """
-        {
-            "text": "",
-            "metadata": {}
-        }
-        """;
+	@Test
+	void testDeserializeDocumentWithMinimalFields() throws Exception {
+		// Arrange
+		String json = """
+				{
+				    "content": "Minimal document"
+				}
+				""";
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
 
-        // Assert
-        assertNotNull(result);
-        
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("", content);
-    }
+		// Assert
+		assertNotNull(result);
+		assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
 
-    @Test
-    void testDeserializeDocumentWithNullContent() throws Exception {
-        // Arrange
-        String json = """
-        {
-            "content": null
-        }
-        """;
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("Minimal document", content);
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+		String id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertNotNull(id);
 
-        // Assert
-        assertNotNull(result);
-        
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("", content); // Should fallback to empty string
-    }
+		// Metadata should be empty
+		Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
+		assertTrue(metadata.isEmpty());
+	}
 
-    @Test
-    void testDeserializeDocumentWithMissingContent() throws Exception {
-        // Arrange
-        String json = """
-        {
-            "id": "no-content-doc"
-        }
-        """;
+	@Test
+	void testDeserializeDocumentWithComplexMetadata() throws Exception {
+		// Arrange
+		String json = """
+				{
+				    "id": "complex-doc",
+				    "content": "Document with complex metadata",
+				    "metadata": {
+				        "nested": {
+				            "level1": "value1",
+				            "level2": {
+				                "final": "value2"
+				            }
+				        },
+				        "array": [1, 2, 3],
+				        "boolean": true,
+				        "number": 42
+				    }
+				}
+				""";
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
 
-        // Assert
-        assertNotNull(result);
-        
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("", content); // Should fallback to empty string
-        
-        String id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertEquals("no-content-doc", id);
-    }
+		// Assert
+		assertNotNull(result);
 
+		Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
+		assertNotNull(metadata);
 
-    @Test
-    void testDeserializeDocumentWithTextualNode() throws Exception {
-        // Arrange
-        String json = "\"Simple text content\"";
+		// Verify complex nested structure
+		Map<?, ?> nested = (Map<?, ?>) metadata.get("nested");
+		assertEquals("value1", nested.get("level1"));
 
-        // Act
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(json),
-            objectMapper.getDeserializationContext()
-        );
+		Map<?, ?> level2 = (Map<?, ?>) nested.get("level2");
+		assertEquals("value2", level2.get("final"));
 
-        // Assert
-        assertNotNull(result);
-        assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
-        
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("Simple text content", content);
-    }
+		// Verify array
+		assertTrue(metadata.get("array") instanceof java.util.List);
+		assertEquals(true, metadata.get("boolean"));
+		assertEquals(42, metadata.get("number"));
+	}
 
-    @Test
-    void testDeserializeDocumentWithInvalidJson() throws Exception {
-        // Arrange
-        String json = "{invalid json";
+	@Test
+	void testDeserializeDocumentWithEmptyContent() throws Exception {
+		// Arrange
+		String json = """
+				{
+				    "text": "",
+				    "metadata": {}
+				}
+				""";
 
-        // Act & Assert
-        assertThrows(Exception.class, () -> {
-            deserializer.deserialize(
-                objectMapper.createParser(json),
-                objectMapper.getDeserializationContext()
-            );
-        });
-    }
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
 
-    @Test
-    void testDeserializeDocumentWithVariousIdFieldNames() throws Exception {
-        // Test with "id" field
-        String jsonWithId = "{\"id\":\"test-id\",\"content\":\"test\"}";
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithId),
-            objectMapper.getDeserializationContext()
-        );
-        String id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertEquals("test-id", id);
-        
-        // Test with "docId" field
-        String jsonWithDocId = "{\"docId\":\"test-docid\",\"content\":\"test\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithDocId),
-            objectMapper.getDeserializationContext()
-        );
-        id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertEquals("test-docid", id);
-        
-        // Test with "documentId" field
-        String jsonWithDocumentId = "{\"documentId\":\"test-documentid\",\"content\":\"test\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithDocumentId),
-            objectMapper.getDeserializationContext()
-        );
-        id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertEquals("test-documentid", id);
-        
-        // Test with no ID field
-        String jsonWithoutId = "{\"content\":\"test\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithoutId),
-            objectMapper.getDeserializationContext()
-        );
-        id = (String) result.getClass().getMethod("getId").invoke(result);
-        assertNotNull(id);
-    }
+		// Assert
+		assertNotNull(result);
 
-    @Test
-    void testDeserializeDocumentWithVariousContentFieldNames() throws Exception {
-        // Test with "content" field
-        String jsonWithContent = "{\"content\":\"test-content\"}";
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithContent),
-            objectMapper.getDeserializationContext()
-        );
-        String content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("test-content", content);
-        
-        // Test with "text" field
-        String jsonWithText = "{\"text\":\"test-text\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithText),
-            objectMapper.getDeserializationContext()
-        );
-        content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("test-text", content);
-        
-        // Test with "pageContent" field
-        String jsonWithPageContent = "{\"pageContent\":\"test-pagecontent\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithPageContent),
-            objectMapper.getDeserializationContext()
-        );
-        content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("test-pagecontent", content);
-        
-        // Test preference order: content > text > pageContent
-        String jsonWithAll = "{\"content\":\"content-value\",\"text\":\"text-value\",\"pageContent\":\"pagecontent-value\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithAll),
-            objectMapper.getDeserializationContext()
-        );
-        content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("content-value", content);
-        
-        // Test with textual node
-        String textualJson = "\"simple text\"";
-        result = deserializer.deserialize(
-            objectMapper.createParser(textualJson),
-            objectMapper.getDeserializationContext()
-        );
-        content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("simple text", content);
-        
-        // Test with no content field
-        String jsonWithoutContent = "{\"id\":\"test\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithoutContent),
-            objectMapper.getDeserializationContext()
-        );
-        content = (String) result.getClass().getMethod("getText").invoke(result);
-        assertEquals("", content);
-    }
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("", content);
+	}
 
-    @Test
-    void testDeserializeDocumentWithVariousMetadataTypes() throws Exception {
-        // Test with simple metadata
-        String jsonWithSimpleMetadata = "{\"content\":\"test\",\"metadata\":{\"key1\":\"value1\",\"key2\":42}}";
-        Object result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithSimpleMetadata),
-            objectMapper.getDeserializationContext()
-        );
-        Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
-        assertEquals("value1", metadata.get("key1"));
-        assertEquals(42, metadata.get("key2"));
-        
-        // Test with nested metadata
-        String jsonWithNestedMetadata = "{\"content\":\"test\",\"metadata\":{\"nested\":{\"inner\":\"value\"}}}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithNestedMetadata),
-            objectMapper.getDeserializationContext()
-        );
-        metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
-        Map<?, ?> nested = (Map<?, ?>) metadata.get("nested");
-        assertEquals("value", nested.get("inner"));
-        
-        // Test with array metadata
-        String jsonWithArrayMetadata = "{\"content\":\"test\",\"metadata\":{\"array\":[1,2,3]}}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithArrayMetadata),
-            objectMapper.getDeserializationContext()
-        );
-        metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
-        assertTrue(metadata.get("array") instanceof java.util.List);
-        
-        // Test with no metadata
-        String jsonWithoutMetadata = "{\"content\":\"test\"}";
-        result = deserializer.deserialize(
-            objectMapper.createParser(jsonWithoutMetadata),
-            objectMapper.getDeserializationContext()
-        );
-        metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
-        assertTrue(metadata.isEmpty());
-    }
+	@Test
+	void testDeserializeDocumentWithNullContent() throws Exception {
+		// Arrange
+		String json = """
+				{
+				    "content": null
+				}
+				""";
 
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
+
+		// Assert
+		assertNotNull(result);
+
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("", content); // Should fallback to empty string
+	}
+
+	@Test
+	void testDeserializeDocumentWithMissingContent() throws Exception {
+		// Arrange
+		String json = """
+				{
+				    "id": "no-content-doc"
+				}
+				""";
+
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
+
+		// Assert
+		assertNotNull(result);
+
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("", content); // Should fallback to empty string
+
+		String id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertEquals("no-content-doc", id);
+	}
+
+	@Test
+	void testDeserializeDocumentWithTextualNode() throws Exception {
+		// Arrange
+		String json = "\"Simple text content\"";
+
+		// Act
+		Object result = deserializer.deserialize(objectMapper.createParser(json),
+				objectMapper.getDeserializationContext());
+
+		// Assert
+		assertNotNull(result);
+		assertEquals("org.springframework.ai.document.Document", result.getClass().getName());
+
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("Simple text content", content);
+	}
+
+	@Test
+	void testDeserializeDocumentWithInvalidJson() throws Exception {
+		// Arrange
+		String json = "{invalid json";
+
+		// Act & Assert
+		assertThrows(Exception.class, () -> {
+			deserializer.deserialize(objectMapper.createParser(json), objectMapper.getDeserializationContext());
+		});
+	}
+
+	@Test
+	void testDeserializeDocumentWithVariousIdFieldNames() throws Exception {
+		// Test with "id" field
+		String jsonWithId = "{\"id\":\"test-id\",\"content\":\"test\"}";
+		Object result = deserializer.deserialize(objectMapper.createParser(jsonWithId),
+				objectMapper.getDeserializationContext());
+		String id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertEquals("test-id", id);
+
+		// Test with "docId" field
+		String jsonWithDocId = "{\"docId\":\"test-docid\",\"content\":\"test\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithDocId),
+				objectMapper.getDeserializationContext());
+		id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertEquals("test-docid", id);
+
+		// Test with "documentId" field
+		String jsonWithDocumentId = "{\"documentId\":\"test-documentid\",\"content\":\"test\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithDocumentId),
+				objectMapper.getDeserializationContext());
+		id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertEquals("test-documentid", id);
+
+		// Test with no ID field
+		String jsonWithoutId = "{\"content\":\"test\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithoutId),
+				objectMapper.getDeserializationContext());
+		id = (String) result.getClass().getMethod("getId").invoke(result);
+		assertNotNull(id);
+	}
+
+	@Test
+	void testDeserializeDocumentWithVariousContentFieldNames() throws Exception {
+		// Test with "content" field
+		String jsonWithContent = "{\"content\":\"test-content\"}";
+		Object result = deserializer.deserialize(objectMapper.createParser(jsonWithContent),
+				objectMapper.getDeserializationContext());
+		String content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("test-content", content);
+
+		// Test with "text" field
+		String jsonWithText = "{\"text\":\"test-text\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithText),
+				objectMapper.getDeserializationContext());
+		content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("test-text", content);
+
+		// Test with "pageContent" field
+		String jsonWithPageContent = "{\"pageContent\":\"test-pagecontent\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithPageContent),
+				objectMapper.getDeserializationContext());
+		content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("test-pagecontent", content);
+
+		// Test preference order: content > text > pageContent
+		String jsonWithAll = "{\"content\":\"content-value\",\"text\":\"text-value\",\"pageContent\":\"pagecontent-value\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithAll),
+				objectMapper.getDeserializationContext());
+		content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("content-value", content);
+
+		// Test with textual node
+		String textualJson = "\"simple text\"";
+		result = deserializer.deserialize(objectMapper.createParser(textualJson),
+				objectMapper.getDeserializationContext());
+		content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("simple text", content);
+
+		// Test with no content field
+		String jsonWithoutContent = "{\"id\":\"test\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithoutContent),
+				objectMapper.getDeserializationContext());
+		content = (String) result.getClass().getMethod("getText").invoke(result);
+		assertEquals("", content);
+	}
+
+	@Test
+	void testDeserializeDocumentWithVariousMetadataTypes() throws Exception {
+		// Test with simple metadata
+		String jsonWithSimpleMetadata = "{\"content\":\"test\",\"metadata\":{\"key1\":\"value1\",\"key2\":42}}";
+		Object result = deserializer.deserialize(objectMapper.createParser(jsonWithSimpleMetadata),
+				objectMapper.getDeserializationContext());
+		Map<?, ?> metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
+		assertEquals("value1", metadata.get("key1"));
+		assertEquals(42, metadata.get("key2"));
+
+		// Test with nested metadata
+		String jsonWithNestedMetadata = "{\"content\":\"test\",\"metadata\":{\"nested\":{\"inner\":\"value\"}}}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithNestedMetadata),
+				objectMapper.getDeserializationContext());
+		metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
+		Map<?, ?> nested = (Map<?, ?>) metadata.get("nested");
+		assertEquals("value", nested.get("inner"));
+
+		// Test with array metadata
+		String jsonWithArrayMetadata = "{\"content\":\"test\",\"metadata\":{\"array\":[1,2,3]}}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithArrayMetadata),
+				objectMapper.getDeserializationContext());
+		metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
+		assertTrue(metadata.get("array") instanceof java.util.List);
+
+		// Test with no metadata
+		String jsonWithoutMetadata = "{\"content\":\"test\"}";
+		result = deserializer.deserialize(objectMapper.createParser(jsonWithoutMetadata),
+				objectMapper.getDeserializationContext());
+		metadata = (Map<?, ?>) result.getClass().getMethod("getMetadata").invoke(result);
+		assertTrue(metadata.isEmpty());
+	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
JacksonStateSerializer 缺少对 org.springframework.ai.document.Document 类型的专门处理，导致在状态克隆过程中反序列化失败。虽然有回退机制，但回退到 HashMap 会破坏类型一致性，导致后续处理失败。
需要在 JacksonStateSerializer 中为 org.springframework.ai.document.Document 类型注册专门的反序列化器。

### Does this pull request fix one issue?
fix #2312

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
