### PR TITLE
fix(jmanus): 修复agent配置初始化时由于没有指定语言导致失败的问题

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/OpenManusSpringBootApplication.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/OpenManusSpringBootApplication.java
@@ -17,6 +17,8 @@
 package com.alibaba.cloud.ai.example.manus;
 
 import com.microsoft.playwright.Playwright;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -27,7 +29,9 @@ import java.io.IOException;
 @EnableScheduling
 public class OpenManusSpringBootApplication {
 
-	public static void main(String[] args) throws IOException, InterruptedException {
+    private static final Logger log = LoggerFactory.getLogger(OpenManusSpringBootApplication.class);
+
+    public static void main(String[] args) throws IOException, InterruptedException {
 		if (args != null && args.length >= 1 && args[0].equals("playwright-init")) {
 			Playwright.create();
 			System.out.println("Playwright init finished");
@@ -36,6 +40,7 @@ public class OpenManusSpringBootApplication {
 		else {
 			SpringApplication.run(OpenManusSpringBootApplication.class, args);
 		}
+        log.info("OpenManus Spring Boot Application started");
 	}
 
 }

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/OpenManusSpringBootApplication.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/OpenManusSpringBootApplication.java
@@ -29,9 +29,9 @@ import java.io.IOException;
 @EnableScheduling
 public class OpenManusSpringBootApplication {
 
-    private static final Logger log = LoggerFactory.getLogger(OpenManusSpringBootApplication.class);
+	private static final Logger log = LoggerFactory.getLogger(OpenManusSpringBootApplication.class);
 
-    public static void main(String[] args) throws IOException, InterruptedException {
+	public static void main(String[] args) throws IOException, InterruptedException {
 		if (args != null && args.length >= 1 && args[0].equals("playwright-init")) {
 			Playwright.create();
 			System.out.println("Playwright init finished");
@@ -40,7 +40,7 @@ public class OpenManusSpringBootApplication {
 		else {
 			SpringApplication.run(OpenManusSpringBootApplication.class, args);
 		}
-        log.info("OpenManus Spring Boot Application started");
+		log.info("OpenManus Spring Boot Application started");
 	}
 
 }

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/startUp/ConfigAppStartupListener.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/startUp/ConfigAppStartupListener.java
@@ -44,9 +44,9 @@ public class ConfigAppStartupListener implements ApplicationListener<Application
 
 	@Override
 	public void onApplicationEvent(ApplicationStartedEvent event) {
-        String defaultLanguage = "en";
-        initializeConfigs();
-        initializeDynamicAgents(defaultLanguage);
+		String defaultLanguage = "en";
+		initializeConfigs();
+		initializeDynamicAgents(defaultLanguage);
 	}
 
 	private void initializeConfigs() {

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/startUp/ConfigAppStartupListener.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/startUp/ConfigAppStartupListener.java
@@ -44,8 +44,9 @@ public class ConfigAppStartupListener implements ApplicationListener<Application
 
 	@Override
 	public void onApplicationEvent(ApplicationStartedEvent event) {
-		initializeConfigs();
-		initializeDynamicAgents();
+        String defaultLanguage = "en";
+        initializeConfigs();
+        initializeDynamicAgents(defaultLanguage);
 	}
 
 	private void initializeConfigs() {
@@ -73,10 +74,10 @@ public class ConfigAppStartupListener implements ApplicationListener<Application
 		}
 	}
 
-	private void initializeDynamicAgents() {
+	private void initializeDynamicAgents(String language) {
 		try {
 			log.info("Starting to initialize dynamic agents...");
-			dynamicAgentScanner.scanAndSaveAgents();
+			dynamicAgentScanner.scanAndSaveAgents(language);
 			log.info("Dynamic agents initialization completed");
 		}
 		catch (Exception e) {

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/service/DynamicAgentScanner.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/service/DynamicAgentScanner.java
@@ -72,7 +72,8 @@ public class DynamicAgentScanner implements IDynamicAgentScanner {
 		boolean shouldOverrideFromYaml = Boolean.parseBoolean(overrideConfig.getConfigValue());
 
 		if (shouldOverrideFromYaml) {
-			log.info("✅ Force override from YAML enabled - Starting to scan and override agents from YAML configuration files...");
+			log.info(
+					"✅ Force override from YAML enabled - Starting to scan and override agents from YAML configuration files...");
 
 			// Scan and save/override StartupAgent loaded from configuration file
 			scanAndSaveStartupAgents(language);
@@ -186,7 +187,8 @@ public class DynamicAgentScanner implements IDynamicAgentScanner {
 
 		for (String agentDir : agentDirs) {
 			try {
-				StartupAgentConfigLoader.AgentConfig agentConfig = startupAgentConfigLoader.loadAgentConfig(agentDir, language);
+				StartupAgentConfigLoader.AgentConfig agentConfig = startupAgentConfigLoader.loadAgentConfig(agentDir,
+						language);
 				if (agentConfig != null) {
 					// Check if this is an override or new creation
 					DynamicAgentEntity existingEntity = repository.findByAgentName(agentConfig.getAgentName());

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/service/DynamicAgentScanner.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/service/DynamicAgentScanner.java
@@ -60,7 +60,7 @@ public class DynamicAgentScanner implements IDynamicAgentScanner {
 		this.repository = repository;
 	}
 
-	public void scanAndSaveAgents() {
+	public void scanAndSaveAgents(String language) {
 		// Check configuration for YAML-based agent override behavior
 		ConfigEntity overrideConfig = configService.getConfig("manus.agents.forceOverrideFromYaml")
 			.orElseThrow(() -> new IllegalStateException("Cannot find agent override configuration item"));
@@ -72,11 +72,10 @@ public class DynamicAgentScanner implements IDynamicAgentScanner {
 		boolean shouldOverrideFromYaml = Boolean.parseBoolean(overrideConfig.getConfigValue());
 
 		if (shouldOverrideFromYaml) {
-			log.info(
-					"✅ Force override from YAML enabled - Starting to scan and override agents from YAML configuration files...");
+			log.info("✅ Force override from YAML enabled - Starting to scan and override agents from YAML configuration files...");
 
 			// Scan and save/override StartupAgent loaded from configuration file
-			scanAndSaveStartupAgents();
+			scanAndSaveStartupAgents(language);
 
 			log.info("✅ Dynamic agent override from YAML files completed");
 		}
@@ -177,17 +176,17 @@ public class DynamicAgentScanner implements IDynamicAgentScanner {
 	/**
 	 * Scan and save/override StartupAgent loaded from configuration file
 	 */
-	private void scanAndSaveStartupAgents() {
+	private void scanAndSaveStartupAgents(String language) {
 		log.info("🔍 Starting to scan YAML agent configuration files...");
 
-		List<String> agentDirs = startupAgentConfigLoader.scanAvailableAgents();
+		List<String> agentDirs = startupAgentConfigLoader.scanAvailableAgents(language);
 		int processedCount = 0;
 		int overriddenCount = 0;
 		int createdCount = 0;
 
 		for (String agentDir : agentDirs) {
 			try {
-				StartupAgentConfigLoader.AgentConfig agentConfig = startupAgentConfigLoader.loadAgentConfig(agentDir);
+				StartupAgentConfigLoader.AgentConfig agentConfig = startupAgentConfigLoader.loadAgentConfig(agentDir, language);
 				if (agentConfig != null) {
 					// Check if this is an override or new creation
 					DynamicAgentEntity existingEntity = repository.findByAgentName(agentConfig.getAgentName());

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/service/IDynamicAgentScanner.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/service/IDynamicAgentScanner.java
@@ -23,6 +23,6 @@ public interface IDynamicAgentScanner {
 	/**
 	 * Scan And Save Agents
 	 */
-	void scanAndSaveAgents();
+	void scanAndSaveAgents(String language);
 
 }

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/IStartupAgentConfigLoader.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/IStartupAgentConfigLoader.java
@@ -40,6 +40,6 @@ public interface IStartupAgentConfigLoader {
 	/**
 	 * Scan available agents
 	 */
-	List<String> scanAvailableAgents();
+	List<String> scanAvailableAgents(String language);
 
 }

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
@@ -113,16 +113,15 @@ public class StartupAgentConfigLoader implements IStartupAgentConfigLoader {
 			configPath = CONFIG_BASE_PATH + agentName.toLowerCase() + "/agent-config.yml";
 		}
 
-		String configContent = loadConfigContent(configPath);
-
-		if (configContent.isEmpty()) {
-			log.warn("Agent configuration file does not exist or is empty: {}", configPath);
-			return null;
-		}
-
 		try {
+            ClassPathResource resource = new ClassPathResource(configPath);
+            if (!resource.exists()) {
+                log.warn("Configuration file does not exist: {}", configPath);
+                return null;
+            }
+
 			Yaml yaml = new Yaml();
-			Map<String, Object> yamlData = yaml.load(configContent);
+			Map<String, Object> yamlData = yaml.load(resource.getInputStream());
 
 			if (yamlData == null) {
 				log.warn("YAML configuration file parsing result is empty: {}", configPath);

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
@@ -163,7 +163,7 @@ public class StartupAgentConfigLoader implements IStartupAgentConfigLoader {
 	 * Scan all available startup agent configuration directories
 	 * @return agent directory name list
 	 */
-	public List<String> scanAvailableAgents() {
+	public List<String> scanAvailableAgents(String language) {
 		try {
 			ClassPathResource baseResource = new ClassPathResource(CONFIG_BASE_PATH);
 			if (!baseResource.exists()) {
@@ -181,6 +181,10 @@ public class StartupAgentConfigLoader implements IStartupAgentConfigLoader {
 
 			// Scan for all agent-config.yml files in subdirectories
 			String pattern = CONFIG_BASE_PATH + "*/agent-config.yml";
+            if (language != null && !language.trim().isEmpty()) {
+                // Multi-language path: prompts/startup-agents/zh/agent_name/agent-config.yml
+                pattern = CONFIG_BASE_PATH + language + "/*/agent-config.yml";
+            }
 			Resource[] resources = resolver.getResources("classpath:" + pattern);
 
 			for (Resource resource : resources) {

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
@@ -114,11 +114,11 @@ public class StartupAgentConfigLoader implements IStartupAgentConfigLoader {
 		}
 
 		try {
-            ClassPathResource resource = new ClassPathResource(configPath);
-            if (!resource.exists()) {
-                log.warn("Configuration file does not exist: {}", configPath);
-                return null;
-            }
+			ClassPathResource resource = new ClassPathResource(configPath);
+			if (!resource.exists()) {
+				log.warn("Configuration file does not exist: {}", configPath);
+				return null;
+			}
 
 			Yaml yaml = new Yaml();
 			Map<String, Object> yamlData = yaml.load(resource.getInputStream());
@@ -180,10 +180,11 @@ public class StartupAgentConfigLoader implements IStartupAgentConfigLoader {
 
 			// Scan for all agent-config.yml files in subdirectories
 			String pattern = CONFIG_BASE_PATH + "*/agent-config.yml";
-            if (language != null && !language.trim().isEmpty()) {
-                // Multi-language path: prompts/startup-agents/zh/agent_name/agent-config.yml
-                pattern = CONFIG_BASE_PATH + language + "/*/agent-config.yml";
-            }
+			if (language != null && !language.trim().isEmpty()) {
+				// Multi-language path:
+				// prompts/startup-agents/zh/agent_name/agent-config.yml
+				pattern = CONFIG_BASE_PATH + language + "/*/agent-config.yml";
+			}
 			Resource[] resources = resolver.getResources("classpath:" + pattern);
 
 			for (Resource resource : resources) {
@@ -194,7 +195,7 @@ public class StartupAgentConfigLoader implements IStartupAgentConfigLoader {
 					String[] pathParts = path.split("/");
 					for (int i = 0; i < pathParts.length - 1; i++) {
 						if ("startup-agents".equals(pathParts[i]) && i + 1 < pathParts.length) {
-                            String agentDirName = pathParts[i + 2];
+							String agentDirName = pathParts[i + 2];
 							if (!agentList.contains(agentDirName)) {
 								agentList.add(agentDirName);
 								log.debug("Found startup agent: {}", agentDirName);

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/agent/startupAgent/StartupAgentConfigLoader.java
@@ -195,7 +195,7 @@ public class StartupAgentConfigLoader implements IStartupAgentConfigLoader {
 					String[] pathParts = path.split("/");
 					for (int i = 0; i < pathParts.length - 1; i++) {
 						if ("startup-agents".equals(pathParts[i]) && i + 1 < pathParts.length) {
-							String agentDirName = pathParts[i + 1];
+                            String agentDirName = pathParts[i + 2];
 							if (!agentList.contains(agentDirName)) {
 								agentList.add(agentDirName);
 								log.debug("Found startup agent: {}", agentDirName);

--- a/spring-ai-alibaba-jmanus/src/main/resources/application-h2.yml
+++ b/spring-ai-alibaba-jmanus/src/main/resources/application-h2.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:file:./h2-data/openmanus_db;MODE=MYSQL;DATABASE_TO_LOWER=TRUE
+    url: jdbc:h2:file:./h2-data/openmanus_db;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;AUTO_SERVER=TRUE
     driver-class-name: org.h2.Driver
     username: sa
     password: $FSD#@!@#!#$!12341234


### PR DESCRIPTION
### Describe what this PR does / why we need it
某个版本提供了agents多语言的支持，但是项目启动初始化时候没有指定语言，导致了agents初始化失败的问题。
且agent配置加载时，触发了yaml.load方法的bug，也同步修复（加载prompts/startup-agents/zh/file_manager_agent/agent-config.yml文件可以复现该问题）

- 修复agent配置初始化时由于没有指定语言导致失败的问题
- 修复agent配置文件加载方式，规避yml文件加载错误
- 同时修改了h2链接URL，增加;AUTO_SERVER=TRUE，启用自动服务器模式，允许多个进程同时访问同一个数据库文件（类似 TCP 服务模式）。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
