### PR TITLE
feat(core): add sse stream output wrapper, add runnable config param overri…

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/ChatResponse.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/ChatResponse.java
@@ -1,0 +1,39 @@
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.exception.GraphStateException;
+import com.drew.lang.annotations.Nullable;
+
+public class ChatResponse {
+
+	@Nullable
+	private String data;
+
+	private ChatResponse(ChatResponseBuilder builder) {
+		this.data = builder.data;
+	}
+
+    public String getData() {
+        return data;
+    }
+
+	public static ChatResponseBuilder builder() {
+		return new ChatResponseBuilder();
+	}
+
+	public static class ChatResponseBuilder {
+
+		@Nullable
+		private String data;
+
+		public ChatResponseBuilder data(@Nullable String data) {
+			this.data = data;
+			return this;
+		}
+
+		public ChatResponse build() throws GraphStateException {
+			return new ChatResponse(this);
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/BaseAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/BaseAgent.java
@@ -17,17 +17,30 @@ package com.alibaba.cloud.ai.graph.agent;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.AsyncNodeAction;
 import com.alibaba.cloud.ai.graph.async.AsyncGenerator;
 import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
+import com.alibaba.cloud.ai.graph.ChatResponse;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduleConfig;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduledAgentTask;
 
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.scheduling.Trigger;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 
 /**
  * Abstract base class for all agents in the graph system. Contains common properties and
@@ -98,7 +111,12 @@ public abstract class BaseAgent {
 	public abstract AsyncNodeAction asAsyncNodeAction(String inputKeyFromParent, String outputKeyToParent)
 			throws GraphStateException;
 
-	public abstract Optional<OverAllState> invoke(Map<String, Object> input)
+	public Optional<OverAllState> invoke(Map<String, Object> input)
+			throws GraphStateException, GraphRunnerException {
+		return invoke(input, RunnableConfig.builder().build());
+	}
+
+	public abstract Optional<OverAllState> invoke(Map<String, Object> input, RunnableConfig config)
 			throws GraphStateException, GraphRunnerException;
 
 	/**
@@ -121,7 +139,99 @@ public abstract class BaseAgent {
 	public abstract ScheduledAgentTask schedule(ScheduleConfig scheduleConfig)
 			throws GraphStateException, GraphRunnerException;
 
-	public abstract AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
+	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
+			throws GraphStateException, GraphRunnerException {
+		return stream(input, RunnableConfig.builder().build());
+	}
+
+	public abstract AsyncGenerator<NodeOutput> stream(Map<String, Object> input, RunnableConfig config)
 			throws GraphStateException, GraphRunnerException;
+
+    public Flux<ChatResponse> fluxStream(Map<String, Object> input) throws GraphStateException, GraphRunnerException {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Logger logger = LoggerFactory.getLogger(BaseAgent.class);
+        Sinks.Many<ChatResponse> sink = Sinks.many().unicast().onBackpressureBuffer();
+        AsyncGenerator<NodeOutput> generator = stream(input);
+        executor.submit(() -> {
+            generator.forEachAsync(output -> {
+                try {
+                    logger.info("output = {}", output);
+                    String nodeName = output.node();
+                    String content;
+                    if (output instanceof StreamingOutput streamingOutput) {
+                        content = JSON.toJSONString(Map.of(nodeName, streamingOutput.chunk()));
+                    }
+                    else {
+                        JSONObject nodeOutput = new JSONObject();
+                        nodeOutput.put("data", output.state().data());
+                        nodeOutput.put("node", nodeName);
+                        content = JSON.toJSONString(nodeOutput);
+                    }
+                    sink.tryEmitNext(ChatResponse.builder().data(content).build());
+                }
+                catch (Exception e) {
+                    throw new CompletionException(e);
+                }
+            }).thenAccept(v -> {
+                sink.tryEmitComplete();
+                executor.shutdown(); // 关闭线程池
+            }).exceptionally(e -> {
+                sink.tryEmitError(e);
+                executor.shutdown(); // 关闭线程池
+                return null;
+            });
+        });
+        return sink.asFlux().doOnCancel(() -> {
+            logger.info("Client disconnected from stream");
+            executor.shutdown(); // 关闭线程池
+        }).doOnError(e -> {
+            logger.error("Error occurred during streaming", e);
+            executor.shutdown(); // 关闭线程池
+        });
+    }
+
+    public Flux<ServerSentEvent<String>> sseStream(Map<String, Object> input)
+            throws GraphStateException, GraphRunnerException {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Logger logger = LoggerFactory.getLogger(BaseAgent.class);
+        Sinks.Many<ServerSentEvent<String>> sink = Sinks.many().unicast().onBackpressureBuffer();
+        AsyncGenerator<NodeOutput> generator = stream(input);
+        executor.submit(() -> {
+            generator.forEachAsync(output -> {
+                try {
+                    logger.info("output = {}", output);
+                    String nodeName = output.node();
+                    String content;
+                    if (output instanceof StreamingOutput streamingOutput) {
+                        content = JSON.toJSONString(Map.of(nodeName, streamingOutput.chunk()));
+                    }
+                    else {
+                        JSONObject nodeOutput = new JSONObject();
+                        nodeOutput.put("data", output.state().data());
+                        nodeOutput.put("node", nodeName);
+                        content = JSON.toJSONString(nodeOutput);
+                    }
+                    sink.tryEmitNext(ServerSentEvent.builder(content).build());
+                }
+                catch (Exception e) {
+                    throw new CompletionException(e);
+                }
+            }).thenAccept(v -> {
+                sink.tryEmitComplete();
+                executor.shutdown(); // 关闭线程池
+            }).exceptionally(e -> {
+                sink.tryEmitError(e);
+                executor.shutdown(); // 关闭线程池
+                return null;
+            });
+        });
+        return sink.asFlux().doOnCancel(() -> {
+            logger.info("Client disconnected from stream");
+            executor.shutdown(); // 关闭线程池
+        }).doOnError(e -> {
+            logger.error("Error occurred during streaming", e);
+            executor.shutdown(); // 关闭线程池
+        });
+    }
 
 }

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -111,8 +111,24 @@ public class ReactAgent extends BaseAgent {
 		return this.compiledGraph.invoke(input);
 	}
 
+	public Optional<OverAllState> invoke(Map<String, Object> input, RunnableConfig runnableConfig) throws GraphStateException, GraphRunnerException {
+		if (this.compiledGraph == null) {
+			this.compiledGraph = getAndCompileGraph();
+		}
+		return this.compiledGraph.invoke(input);
+	}
+
 	@Override
 	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
+			throws GraphStateException, GraphRunnerException {
+		if (this.compiledGraph == null) {
+			this.compiledGraph = getAndCompileGraph();
+		}
+		return this.compiledGraph.stream(input);
+	}
+
+	@Override
+	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input, RunnableConfig runnableConfig)
 			throws GraphStateException, GraphRunnerException {
 		if (this.compiledGraph == null) {
 			this.compiledGraph = getAndCompileGraph();

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNode.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNode.java
@@ -521,6 +521,11 @@ public class A2aNode implements NodeAction {
 		message.put("parts", List.of(part));
 		message.put("role", "user");
 
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("userId", state.data().containsKey("userId") ? String.valueOf(state.data().get("userId")) : "default_user");
+        metadata.put("sessionId", state.data().containsKey("sessionId") ? String.valueOf(state.data().get("sessionId")) : "default_session");
+        message.put("metadata", metadata);
+
 		Map<String, Object> params = Map.of("message", message);
 
 		Map<String, Object> root = new HashMap<>();
@@ -559,6 +564,11 @@ public class A2aNode implements NodeAction {
 		message.put("messageId", messageId);
 		message.put("parts", List.of(part));
 		message.put("role", "user");
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("userId", state.data().containsKey("userId") ? String.valueOf(state.data().get("userId")) : "default_user");
+        metadata.put("sessionId", state.data().containsKey("sessionId") ? String.valueOf(state.data().get("sessionId")) : "default_session");
+        message.put("metadata", metadata);
 
 		Map<String, Object> params = Map.of("message", message);
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
@@ -88,11 +88,11 @@ public class A2aRemoteAgent extends BaseAgent {
 	}
 
 	@Override
-	public Optional<OverAllState> invoke(Map<String, Object> input) throws GraphStateException, GraphRunnerException {
+	public Optional<OverAllState> invoke(Map<String, Object> input, RunnableConfig runnableConfig) throws GraphStateException, GraphRunnerException {
 		if (this.compiledGraph == null) {
 			this.compiledGraph = getAndCompileGraph();
 		}
-		return this.compiledGraph.invoke(input);
+		return this.compiledGraph.invoke(input, runnableConfig);
 	}
 
 	@Override
@@ -100,7 +100,7 @@ public class A2aRemoteAgent extends BaseAgent {
 		throw new UnsupportedOperationException("A2aRemoteAgent has not support schedule.");
 	}
 
-	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
+	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input, RunnableConfig runnableConfig)
 			throws GraphStateException, GraphRunnerException {
 		if (!streaming) {
 			logger.warning("Streaming is not enabled for this agent.");
@@ -108,7 +108,7 @@ public class A2aRemoteAgent extends BaseAgent {
 		if (this.compiledGraph == null) {
 			this.compiledGraph = getAndCompileGraph();
 		}
-		return this.compiledGraph.stream(input);
+		return this.compiledGraph.stream(input, runnableConfig);
 	}
 
 	public StateGraph getStateGraph() {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/FlowAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/FlowAgent.java
@@ -16,15 +16,22 @@
 package com.alibaba.cloud.ai.graph.agent.flow.agent;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.CompiledGraph;
 import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.action.AsyncNodeAction;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.builder.FlowGraphBuilder;
+import com.alibaba.cloud.ai.graph.async.AsyncGenerator;
+import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduleConfig;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduledAgentTask;
@@ -102,6 +109,21 @@ public abstract class FlowAgent extends BaseAgent {
 			this.compiledGraph = graph.compile(this.compileConfig);
 		}
 		return this.compiledGraph;
+	}
+
+	@Override
+	public Optional<OverAllState> invoke(Map<String, Object> input, RunnableConfig runnableConfig) throws GraphStateException, GraphRunnerException {
+		CompiledGraph compiledGraph = getAndCompileGraph();
+		return compiledGraph.invoke(input, runnableConfig);
+	}
+
+	@Override
+	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input, RunnableConfig runnableConfig)
+			throws GraphStateException, GraphRunnerException {
+		if (this.compiledGraph == null) {
+			this.compiledGraph = getAndCompileGraph();
+		}
+		return this.compiledGraph.stream(input, runnableConfig);
 	}
 
 	public CompileConfig compileConfig() {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/LlmRoutingAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/LlmRoutingAgent.java
@@ -42,21 +42,6 @@ public class LlmRoutingAgent extends FlowAgent {
 	}
 
 	@Override
-	public Optional<OverAllState> invoke(Map<String, Object> input) throws GraphStateException, GraphRunnerException {
-		CompiledGraph compiledGraph = getAndCompileGraph();
-		return compiledGraph.invoke(input);
-	}
-
-	@Override
-	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
-			throws GraphStateException, GraphRunnerException {
-		if (this.compiledGraph == null) {
-			this.compiledGraph = getAndCompileGraph();
-		}
-		return this.compiledGraph.stream(input);
-	}
-
-	@Override
 	protected StateGraph buildSpecificGraph(FlowGraphBuilder.FlowGraphConfig config) throws GraphStateException {
 		config.setChatModel(this.chatModel);
 		return FlowGraphBuilder.buildGraph(FlowAgentEnum.ROUTING.getType(), config);

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/LoopAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/LoopAgent.java
@@ -101,22 +101,13 @@ public class LoopAgent extends FlowAgent {
 	}
 
 	@Override
-	public Optional<OverAllState> invoke(Map<String, Object> input) throws GraphStateException, GraphRunnerException {
+	public Optional<OverAllState> invoke(Map<String, Object> input, RunnableConfig runnableConfig) throws GraphStateException, GraphRunnerException {
 		CompiledGraph compiledGraph = this.getAndCompileGraph();
 		// Initialize outputKey as an empty list to collect loop results
 		return compiledGraph.invoke(Stream.of(input, Map.of(this.outputKey(), new ArrayList<>()))
 			.map(Map::entrySet)
 			.flatMap(Collection::stream)
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> newValue)));
-	}
-
-	@Override
-	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
-			throws GraphStateException, GraphRunnerException {
-		if (this.compiledGraph == null) {
-			this.compiledGraph = getAndCompileGraph();
-		}
-		return this.compiledGraph.stream(input);
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> newValue)), runnableConfig);
 	}
 
 	public static Builder builder() {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/ParallelAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/ParallelAgent.java
@@ -70,21 +70,6 @@ public class ParallelAgent extends FlowAgent {
 	}
 
 	@Override
-	public Optional<OverAllState> invoke(Map<String, Object> input) throws GraphStateException, GraphRunnerException {
-		CompiledGraph compiledGraph = getAndCompileGraph();
-		return compiledGraph.invoke(input);
-	}
-
-	@Override
-	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
-			throws GraphStateException, GraphRunnerException {
-		if (this.compiledGraph == null) {
-			this.compiledGraph = getAndCompileGraph();
-		}
-		return this.compiledGraph.stream(input);
-	}
-
-	@Override
 	protected StateGraph buildSpecificGraph(FlowGraphBuilder.FlowGraphConfig config) throws GraphStateException {
 		// Add parallel-specific properties to config
 		config.customProperty("mergeStrategy", this.mergeStrategy);

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/SequentialAgent.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/SequentialAgent.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.graph.agent.flow.agent;
 import com.alibaba.cloud.ai.graph.CompiledGraph;
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.agent.flow.builder.FlowAgentBuilder;
 import com.alibaba.cloud.ai.graph.agent.flow.builder.FlowGraphBuilder;
@@ -35,21 +36,6 @@ public class SequentialAgent extends FlowAgent {
 		super(builder.name, builder.description, builder.outputKey, builder.inputKey, builder.keyStrategyFactory,
 				builder.compileConfig, builder.subAgents);
 		this.graph = initGraph();
-	}
-
-	@Override
-	public Optional<OverAllState> invoke(Map<String, Object> input) throws GraphStateException, GraphRunnerException {
-		CompiledGraph compiledGraph = getAndCompileGraph();
-		return compiledGraph.invoke(input);
-	}
-
-	@Override
-	public AsyncGenerator<NodeOutput> stream(Map<String, Object> input)
-			throws GraphStateException, GraphRunnerException {
-		if (this.compiledGraph == null) {
-			this.compiledGraph = getAndCompileGraph();
-		}
-		return this.compiledGraph.stream(input);
 	}
 
 	@Override

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/agent/FluxStreamAgentTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/agent/FluxStreamAgentTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
+import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatModel;
+import com.alibaba.cloud.ai.graph.ChatResponse;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.model.ChatModel;
+import reactor.core.publisher.Flux;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+class FluxStreamAgentTest {
+
+	private ChatModel chatModel;
+
+	@BeforeEach
+	void setUp() {
+		// 先创建 DashScopeApi 实例
+		DashScopeApi dashScopeApi = DashScopeApi.builder().apiKey(System.getenv("AI_DASHSCOPE_API_KEY")).build();
+
+		// 创建 DashScope ChatModel 实例
+		this.chatModel = DashScopeChatModel.builder().dashScopeApi(dashScopeApi).build();
+	}
+
+	@Test
+	public void testStreamLlmRoutingAgent() throws Exception {
+		KeyStrategyFactory stateFactory = () -> {
+			HashMap<String, KeyStrategy> keyStrategyHashMap = new HashMap<>();
+			keyStrategyHashMap.put("input", new ReplaceStrategy());
+			keyStrategyHashMap.put("topic", new ReplaceStrategy());
+			keyStrategyHashMap.put("article", new ReplaceStrategy());
+			keyStrategyHashMap.put("reviewed_article", new ReplaceStrategy());
+			return keyStrategyHashMap;
+		};
+
+		ReactAgent proseWriterAgent = ReactAgent.builder()
+			.name("prose_writer_agent")
+			.model(chatModel)
+			.description("可以写散文文章。")
+			.instruction("你是一个知名的作家，擅长写散文。请根据用户的提问进行回答。")
+			.outputKey("messages")
+			.build();
+
+		ReactAgent poemWriterAgent = ReactAgent.builder()
+			.name("poem_writer_agent")
+			.model(chatModel)
+			.description("可以写现代诗。")
+			.instruction("你是一个知名的诗人，擅长写现代诗。请根据用户的提问进行回答。")
+			.outputKey("messages")
+			.build();
+
+		LlmRoutingAgent blogAgent = LlmRoutingAgent.builder()
+			.name("blog_agent")
+			.model(chatModel)
+			.state(stateFactory)
+			.description("可以根据用户给定的主题写文章或作诗。")
+			.inputKey("input")
+			.outputKey("messages")
+			.subAgents(List.of(proseWriterAgent, poemWriterAgent))
+			.build();
+
+		try {
+			Flux<ChatResponse> result = blogAgent.fluxStream(Map.of("input", "帮我写一个100字左右的散文"));
+
+			// 使用blockLast()等待流完成，或者使用CountDownLatch
+			result.doOnNext(response -> {
+				System.out.println("Response: " + response.getData());
+			}).doOnError(e -> {
+				System.err.println("Stream error: " + e.getMessage());
+				e.printStackTrace();
+			}).doOnComplete(() -> {
+				System.out.println("Stream completed");
+			}).blockLast(); // 等待流完成
+		}
+		catch (Exception e) {
+			System.err.println("Test error: " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
…de for the invoke and stream function in agents and add userId&sessionId support for A2A remote agents

Since it can be challenging for new users and developers to understand the AsyncGenerator<NodeOutput> type in streaming responses, I added two new functions—"fluxStream" and "sseStream"—to wrap this type. These functions return responses in standard Flux format, making them more intuitive and easier to use.

Additionally, the Agentic APIs previously did not support passing the RunnableConfig parameter to invoke and stream methods. This issue has been resolved in the this PR, allowing these methods to be used consistently with graph APIs.

To further improve support for remote A2A agents, I have also added userId and sessionId to the metadata. These fields are transmitted to remote agents via the A2A protocol, enabling them to identify the specific message source. This enhancement paves the way for more effective memory management in future implementations.