### PR TITLE
fix(nl2sql): 修正实体类字段映射与数据库schema不一致

### DIFF
--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/entity/BusinessKnowledge.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/entity/BusinessKnowledge.java
@@ -36,10 +36,10 @@ public class BusinessKnowledge {
 	@TableField("synonyms")
 	private String synonyms; // Synonyms, comma-separated
 
-	@TableField("default_recall")
+	@TableField("is_recall")
 	private Boolean defaultRecall; // Default recall
 
-	@TableField("dataset_id")
+	@TableField("data_set_id")
 	private String datasetId; // Associated dataset ID
 
 	@TableField("agent_id")

--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/entity/SemanticModel.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/entity/SemanticModel.java
@@ -30,28 +30,28 @@ public class SemanticModel {
 	@TableField("agent_id")
 	private Long agentId; // Agent ID
 
-	@TableField("original_field_name")
+	@TableField("origin_name")
 	private String originalFieldName; // Original field name
 
-	@TableField("agent_field_name")
+	@TableField("field_name")
 	private String agentFieldName; // Agent field name
 
-	@TableField("field_synonyms")
+	@TableField("synonyms")
 	private String fieldSynonyms; // Field name synonyms, comma-separated
 
-	@TableField("field_description")
+	@TableField("description")
 	private String fieldDescription; // Field description
 
-	@TableField("field_type")
+	@TableField("type")
 	private String fieldType; // Field type
 
-	@TableField("original_description")
+	@TableField("origin_description")
 	private String originalDescription; // Original field description
 
-	@TableField("default_recall")
+	@TableField("is_recall")
 	private Boolean defaultRecall; // Default recall
 
-	@TableField("enabled")
+	@TableField("status")
 	private Boolean enabled; // Whether enabled
 
 	@TableField(value = "created_time", fill = FieldFill.INSERT)

--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/mapper/BusinessKnowledgeMapper.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/mapper/BusinessKnowledgeMapper.java
@@ -35,13 +35,13 @@ public interface BusinessKnowledgeMapper extends BaseMapper<BusinessKnowledge> {
 	/**
 	 * Query business knowledge list by dataset ID
 	 */
-	@Select("SELECT * FROM business_knowledge WHERE dataset_id = #{datasetId} ORDER BY created_time DESC")
+	@Select("SELECT * FROM business_knowledge WHERE data_set_id = #{datasetId} ORDER BY created_time DESC")
 	List<BusinessKnowledge> selectByDatasetId(@Param("datasetId") String datasetId);
 
 	/**
 	 * Get all dataset ID list
 	 */
-	@Select("SELECT DISTINCT dataset_id FROM business_knowledge WHERE dataset_id IS NOT NULL ORDER BY dataset_id")
+	@Select("SELECT DISTINCT data_set_id FROM business_knowledge WHERE data_set_id IS NOT NULL ORDER BY data_set_id")
 	List<String> selectDistinctDatasetIds();
 
 	/**
@@ -61,7 +61,7 @@ public interface BusinessKnowledgeMapper extends BaseMapper<BusinessKnowledge> {
 	/**
 	 * Query business knowledge by dataset ID and default recall status
 	 */
-	@Select("SELECT * FROM business_knowledge WHERE dataset_id = #{datasetId} AND default_recall = #{defaultRecall} ORDER BY created_time DESC")
+	@Select("SELECT * FROM business_knowledge WHERE data_set_id = #{datasetId} AND is_recall = #{defaultRecall} ORDER BY created_time DESC")
 	List<BusinessKnowledge> selectByDatasetIdAndDefaultRecall(@Param("datasetId") String datasetId,
 			@Param("defaultRecall") Boolean defaultRecall);
 

--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/mapper/SemanticModelMapper.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-management/src/main/java/com/alibaba/cloud/ai/mapper/SemanticModelMapper.java
@@ -42,27 +42,27 @@ public interface SemanticModelMapper extends BaseMapper<SemanticModel> {
 	/**
 	 * Search semantic models by keyword
 	 */
-	@Select("SELECT * FROM semantic_model WHERE " + "agent_field_name LIKE CONCAT('%', #{keyword}, '%') OR "
-			+ "field_description LIKE CONCAT('%', #{keyword}, '%') OR "
-			+ "field_synonyms LIKE CONCAT('%', #{keyword}, '%') " + "ORDER BY created_time DESC")
+	@Select("SELECT * FROM semantic_model WHERE " + "field_name LIKE CONCAT('%', #{keyword}, '%') OR "
+			+ "description LIKE CONCAT('%', #{keyword}, '%') OR " + "synonyms LIKE CONCAT('%', #{keyword}, '%') "
+			+ "ORDER BY created_time DESC")
 	List<SemanticModel> searchByKeyword(@Param("keyword") String keyword);
 
 	/**
 	 * Batch enable fields
 	 */
-	@Update("UPDATE semantic_model SET enabled = 1 WHERE id = #{id}")
+	@Update("UPDATE semantic_model SET status = 1 WHERE id = #{id}")
 	int enableById(@Param("id") Long id);
 
 	/**
 	 * Batch disable fields
 	 */
-	@Update("UPDATE semantic_model SET enabled = 0 WHERE id = #{id}")
+	@Update("UPDATE semantic_model SET status = 0 WHERE id = #{id}")
 	int disableById(@Param("id") Long id);
 
 	/**
 	 * Query semantic models by agent ID and enabled status
 	 */
-	@Select("SELECT * FROM semantic_model WHERE agent_id = #{agentId} AND enabled = #{enabled} ORDER BY created_time DESC")
+	@Select("SELECT * FROM semantic_model WHERE agent_id = #{agentId} AND status = #{enabled} ORDER BY created_time DESC")
 	List<SemanticModel> selectByAgentIdAndEnabled(@Param("agentId") Long agentId, @Param("enabled") Boolean enabled);
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
修正nl2sql模块中实体类字段映射与数据库schema不一致的问题。
当前BusinessKnowledge和SemanticModel实体类的@TableField注解与实际数据库表字段名不匹配，导致保存语义模型实体时出错。
为保持向前兼容，以及确保现有sql查询正常运行，我选择修改映射字段。


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2171 
### Describe how you did it
调整实体类的@TableField注解，使其与数据库schema完全匹配

### Describe how to verify it
确认实体类@TableField注解与数据库schema.sql中的字段名一致

### Special notes for reviews 
  这是一个字段映射的修复，没有改变业务逻辑，只是确保ORM映射的正确性。
  修改后的字段映射与现有的硬编码SQL查询保持一致。
