### PR TITLE
fix(nl2sql): 修复数据转换异常

### DIFF
--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/service/business/BusinessKnowledgeRecallService.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/service/business/BusinessKnowledgeRecallService.java
@@ -48,7 +48,7 @@ public class BusinessKnowledgeRecallService {
 			return new BusinessKnowledgeDTO(rs.getString("business_term"), // businessTerm
 					rs.getString("description"), // description
 					rs.getString("synonyms"), // synonyms
-					rs.getObject("is_recall", boolean.class), // defaultRecall (convert to
+					rs.getObject("is_recall", Boolean.class), // defaultRecall (convert to
 																// Boolean)
 					rs.getString("data_set_id") // datasetId
 			);

--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/service/semantic/SemanticModelRecallService.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/service/semantic/SemanticModelRecallService.java
@@ -51,7 +51,7 @@ public class SemanticModelRecallService {
 		return this.jdbcTemplate.query(FIELD_GET_BY_DATASET_IDS, new Object[] { dataSetId }, (rs, rowNum) -> {
 			return new SemanticModelDTO(rs.getString("agent_id"), rs.getString("origin_name"),
 					rs.getString("field_name"), rs.getString("synonyms"), rs.getString("description"),
-					rs.getObject("is_recall", boolean.class), rs.getObject("status", boolean.class),
+					rs.getObject("is_recall", Boolean.class), rs.getObject("status", Boolean.class),
 					rs.getString("type"), rs.getString("origin_description"));
 		});
 	}


### PR DESCRIPTION



### Describe what this PR does / why we need it
测试时报数据转换异常

Caused by: org.springframework.dao.InvalidDataAccessApiUsageException: PreparedStatementCallback; SQL [SELECT
business_term,
description,
synonyms,
is_recall,
data_set_id
FROM business_knowledge WHERE data_set_id = ? AND is_recall = 1
]; Feature not supported: "converting to class boolean" [50100-232]
at org.springframework.jdbc.support.SQLExceptionSubclassTranslator.doTranslate(SQLExceptionSubclassTranslator.java:106) ~[spring-jdbc-6.2.6.jar:6.2.6]

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
- 将数据库查询结果转换类型从 boolean 改为 Boolean

### Describe how to verify it


### Special notes for reviews
