### PR TITLE
refactor(nl2sql): 优化 SqlExecuteNode 以支持默认数据源配置

### DIFF
--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/config/Nl2sqlConfiguration.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/config/Nl2sqlConfiguration.java
@@ -232,7 +232,7 @@ public class Nl2sqlConfiguration {
 			.addNode(SQL_GENERATE_NODE, node_async(new SqlGenerateNode(chatClientBuilder, nl2SqlService)))
 			.addNode(PLANNER_NODE, node_async(new PlannerNode(chatClientBuilder)))
 			.addNode(PLAN_EXECUTOR_NODE, node_async(new PlanExecutorNode()))
-			.addNode(SQL_EXECUTE_NODE, node_async(new SqlExecuteNode(dbAccessor, datasourceService)))
+			.addNode(SQL_EXECUTE_NODE, node_async(new SqlExecuteNode(dbAccessor, datasourceService, dbConfig)))
 			.addNode(PYTHON_GENERATE_NODE,
 					node_async(new PythonGenerateNode(codeExecutorProperties, chatClientBuilder)))
 			.addNode(PYTHON_EXECUTE_NODE, node_async(new PythonExecuteNode(codePoolExecutor)))

--- a/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/node/SqlExecuteNode.java
+++ b/spring-ai-alibaba-nl2sql/spring-ai-alibaba-nl2sql-chat/src/main/java/com/alibaba/cloud/ai/node/SqlExecuteNode.java
@@ -61,10 +61,13 @@ public class SqlExecuteNode extends AbstractPlanBasedNode {
 
 	private final DatasourceService datasourceService;
 
-	public SqlExecuteNode(Accessor dbAccessor, DatasourceService datasourceService) {
+	private final DbConfig dbConfig;
+
+	public SqlExecuteNode(Accessor dbAccessor, DatasourceService datasourceService, DbConfig dbConfig) {
 		super();
 		this.dbAccessor = dbAccessor;
 		this.datasourceService = datasourceService;
+		this.dbConfig = dbConfig;
 	}
 
 	@Override
@@ -97,7 +100,8 @@ public class SqlExecuteNode extends AbstractPlanBasedNode {
 			// Get the agent ID from the state
 			String agentIdStr = StateUtils.getStringValue(state, Constant.AGENT_ID);
 			if (agentIdStr == null || agentIdStr.trim().isEmpty()) {
-				throw new RuntimeException("未找到智能体ID，无法获取数据源配置");
+				// 返回默认数据源
+				return dbConfig;
 			}
 
 			Integer agentId = Integer.valueOf(agentIdStr);


### PR DESCRIPTION



### Describe what this PR does / why we need it
当 agentId 为空时，前序节点都没问题，但是SqlExecuteNode 会抛异常，导致流程卡在最后一步

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- 在 SqlExecuteNode 构造函数中添加 DbConfig 参数
- 当无法找到智能体 ID 时，返回默认数据源配置
- 更新 Nl2sqlConfiguration 以传递 dbConfig 到 SqlExecuteNode

### Describe how to verify it


### Special notes for reviews
