### PR TITLE
fix(core): fix DashScopeChatModel 实例化时参数判空bug

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -140,7 +140,8 @@ public class DashScopeChatModel implements ChatModel {
 			ToolCallingManager toolCallingManager, RetryTemplate retryTemplate,
 			ObservationRegistry observationRegistry) {
 
-		this(dashscopeApi, defaultOptions, toolCallingManager, retryTemplate, observationRegistry, null);
+		this(dashscopeApi, defaultOptions, toolCallingManager, retryTemplate, observationRegistry,
+				new DefaultToolExecutionEligibilityPredicate());
 	}
 
 	public DashScopeChatModel(DashScopeApi dashscopeApi, DashScopeChatOptions defaultOptions,
@@ -159,7 +160,7 @@ public class DashScopeChatModel implements ChatModel {
 		this.toolCallingManager = toolCallingManager;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-		this.toolExecutionEligibilityPredicate = new DefaultToolExecutionEligibilityPredicate();
+		this.toolExecutionEligibilityPredicate = toolExecutionEligibilityPredicate;
 	}
 
 	@Override


### PR DESCRIPTION
### Describe what this PR does / why we need it
DashScopeChatModel 实例化时，toolExecutionEligibilityPredicate参数判空bug
<img width="972" height="404" alt="image" src="https://github.com/user-attachments/assets/caf743ae-f881-4541-9ff4-4d7f0c33bb80" />


### Does this pull request fix one issue?
无

### Describe how you did it

移除toolExecutionEligibilityPredicate判空，在this.toolExecutionEligibilityPredicate赋值时对空值给默认值


### Describe how to verify it
### Special notes for reviews
