### PR TITLE
fix(studio): fix WorkflowStatus equals bug

### DIFF
--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/impl/WorkflowServiceImpl.java
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/impl/WorkflowServiceImpl.java
@@ -103,8 +103,8 @@ public class WorkflowServiceImpl implements WorkflowService {
 		List<WorkflowResponse> allResponses = streamCall(Flux.just(request)).collectList().block();
 
 		Optional<WorkflowResponse> any = allResponses.stream()
-			.filter(workflowResponse -> workflowResponse.getStatus().equals(WorkflowStatus.FAILED.getValue())
-					|| workflowResponse.getStatus().equals(WorkflowStatus.PAUSE.getValue()))
+			.filter(workflowResponse -> workflowResponse.getStatus().equals(WorkflowStatus.FAILED)
+					|| workflowResponse.getStatus().equals(WorkflowStatus.PAUSE))
 			.findAny();
 		if (any.isPresent()) {
 			return any.get();


### PR DESCRIPTION
### Describe what this PR does / why we need it

fix the following equals bug, `WorkflowStatus` is compared against `String` 

`workflowResponse.getStatus().equals(WorkflowStatus.FAILED.getValue())`

### Describe how you did it

change it to `workflowResponse.getStatus().equals(WorkflowStatus.FAILED)`

