### PR TITLE
fix(jmanus): 修复 #2363 jmanus启动报错问题

### DIFF
--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/DefaultLlmConfiguration.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/config/DefaultLlmConfiguration.java
@@ -30,6 +30,8 @@ public class DefaultLlmConfiguration {
 
 	public static final String DEFAULT_DESCRIPTION = "Alibaba Cloud DashScope Qwen Plus Model";
 
+	public static final String DEFAULT_COMPLETIONS_PATH = "/v1/chat/completions";
+
 	public String getDefaultModelName() {
 		return DEFAULT_MODEL_NAME;
 	}
@@ -40,6 +42,10 @@ public class DefaultLlmConfiguration {
 
 	public String getDefaultDescription() {
 		return DEFAULT_DESCRIPTION;
+	}
+
+	public String getDefaultCompletionsPath() {
+		return DEFAULT_COMPLETIONS_PATH;
 	}
 
 }

--- a/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/model/service/ModelDataInitialization.java
+++ b/spring-ai-alibaba-jmanus/src/main/java/com/alibaba/cloud/ai/example/manus/dynamic/model/service/ModelDataInitialization.java
@@ -146,6 +146,7 @@ public class ModelDataInitialization implements IModelDataInitialization {
 						defaultLlmConfig.getDefaultDescription() + " - Auto-created from environment variables");
 				dynamicModelEntity.setType(ModelType.GENERAL.name());
 				dynamicModelEntity.setIsDefault(true);
+				dynamicModelEntity.setCompletionsPath(defaultLlmConfig.getDefaultCompletionsPath());
 
 				DynamicModelEntity save = repository.save(dynamicModelEntity);
 				jmanusEventPublisher.publish(new ModelChangeEvent(save));


### PR DESCRIPTION



### Describe what this PR does / why we need it
为模型添加默认 completions 路径配置

### Does this pull request fix one issue?
Fixes #2363
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
- 在 DefaultLlmConfiguration 中添加 DEFAULT_COMPLETIONS_PATH 常量
- 在 ModelDataInitialization 中使用该路径初始化动态模型实体

### Describe how to verify it


### Special notes for reviews
