### PR TITLE
fix(mcp): 修复发现注册到 nacos 上的 mcp server 时， 无法正确发现 https 协议的 mcp server 的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 
         <!-- Nacos -->
         <nacos2.version>2.5.1</nacos2.version>
-        <nacos3.version>3.0.2</nacos3.version>
+        <nacos3.version>3.0.3</nacos3.version>
         <nacos-client-mse-extension.version>1.0.4</nacos-client-mse-extension.version>
         <spring-alibaba-nacos-config.version>2023.0.1.3</spring-alibaba-nacos-config.version>
 

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-common/src/main/java/com/alibaba/cloud/ai/mcp/nacos/service/NacosMcpOperationService.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-common/src/main/java/com/alibaba/cloud/ai/mcp/nacos/service/NacosMcpOperationService.java
@@ -174,7 +174,7 @@ public class NacosMcpOperationService {
 		return mcpEndpointInfo;
 	}
 
-	public boolean createMcpServer(String mcpName, McpServerBasicInfo serverSpec, McpToolSpecification toolSpec,
+	public String createMcpServer(String mcpName, McpServerBasicInfo serverSpec, McpToolSpecification toolSpec,
 			McpEndpointSpec endpointSpec) throws NacosException {
 		endpointSpec.getData().put("namespaceId", this.namespace);
 		return aiMaintainerService.createMcpServer(this.namespace, mcpName, serverSpec, toolSpec, endpointSpec);

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpAsyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpAsyncClient.java
@@ -354,16 +354,7 @@ public class LoadbalancedMcpAsyncClient {
 
 	private McpAsyncClient clientByEndpoint(McpEndpointInfo mcpEndpointInfo, String exportPath) {
 		McpAsyncClient asyncClient;
-
-		String protocol = mcpEndpointInfo.getProtocol();
-		if (protocol == null || !"http".equals(protocol) && !"https".equals(protocol)) {
-			if (mcpEndpointInfo.getPort() == 443 || mcpEndpointInfo.getPort() == 8443) {
-				protocol = "https";
-			}
-			else {
-				protocol = "http";
-			}
-		}
+		String protocol = NacosMcpClientUtils.checkProtocol(mcpEndpointInfo);
 		String baseUrl = protocol + "://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
 		WebClient.Builder webClientBuilder = webClientBuilderTemplate.clone().baseUrl(baseUrl);
 

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpAsyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpAsyncClient.java
@@ -357,7 +357,7 @@ public class LoadbalancedMcpAsyncClient {
 
 		String protocol = mcpEndpointInfo.getProtocol();
 		if (protocol == null || !"http".equals(protocol) && !"https".equals(protocol)) {
-			if (mcpEndpointInfo.getPort() == 443) {
+			if (mcpEndpointInfo.getPort() == 443 || mcpEndpointInfo.getPort() == 8443) {
 				protocol = "https";
 			}
 			else {

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpAsyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpAsyncClient.java
@@ -355,7 +355,16 @@ public class LoadbalancedMcpAsyncClient {
 	private McpAsyncClient clientByEndpoint(McpEndpointInfo mcpEndpointInfo, String exportPath) {
 		McpAsyncClient asyncClient;
 
-		String baseUrl = "http://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
+		String protocol = mcpEndpointInfo.getProtocol();
+		if (protocol == null || !"http".equals(protocol) && !"https".equals(protocol)) {
+			if (mcpEndpointInfo.getPort() == 443) {
+				protocol = "https";
+			}
+			else {
+				protocol = "http";
+			}
+		}
+		String baseUrl = protocol + "://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
 		WebClient.Builder webClientBuilder = webClientBuilderTemplate.clone().baseUrl(baseUrl);
 
 		WebFluxSseClientTransport transport;

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
@@ -46,6 +46,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.alibaba.cloud.ai.mcp.discovery.client.utils.NacosMcpClientUtils.checkProtocol;
+
 /**
  * @author yingzi
  * @since 2025/4/29:13:00
@@ -294,15 +296,7 @@ public class LoadbalancedMcpSyncClient {
 
 	private McpSyncClient clientByEndpoint(McpEndpointInfo mcpEndpointInfo, String exportPath) {
 		McpSyncClient syncClient;
-		String protocol = mcpEndpointInfo.getProtocol();
-		if (protocol == null || !"http".equals(protocol) && !"https".equals(protocol)) {
-			if (mcpEndpointInfo.getPort() == 443 || mcpEndpointInfo.getPort() == 8443) {
-				protocol = "https";
-			}
-			else {
-				protocol = "http";
-			}
-		}
+		String protocol = NacosMcpClientUtils.checkProtocol(mcpEndpointInfo);
 		String baseUrl = protocol + "://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
 		WebClient.Builder webClientBuilder = webClientBuilderTemplate.clone().baseUrl(baseUrl);
 

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
@@ -294,7 +294,16 @@ public class LoadbalancedMcpSyncClient {
 
 	private McpSyncClient clientByEndpoint(McpEndpointInfo mcpEndpointInfo, String exportPath) {
 		McpSyncClient syncClient;
-		String baseUrl = "http://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
+		String protocol = mcpEndpointInfo.getProtocol();
+		if (protocol == null || !"http".equals(protocol) && !"https".equals(protocol)) {
+			if (mcpEndpointInfo.getPort() == 443) {
+				protocol = "https";
+			}
+			else {
+				protocol = "http";
+			}
+		}
+		String baseUrl = protocol + "://" + mcpEndpointInfo.getAddress() + ":" + mcpEndpointInfo.getPort();
 		WebClient.Builder webClientBuilder = webClientBuilderTemplate.clone().baseUrl(baseUrl);
 
 		// Using the build method with link tracking

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.alibaba.cloud.ai.mcp.discovery.client.utils.NacosMcpClientUtils.checkProtocol;
 
 /**
  * @author yingzi

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
@@ -296,7 +296,7 @@ public class LoadbalancedMcpSyncClient {
 		McpSyncClient syncClient;
 		String protocol = mcpEndpointInfo.getProtocol();
 		if (protocol == null || !"http".equals(protocol) && !"https".equals(protocol)) {
-			if (mcpEndpointInfo.getPort() == 443) {
+			if (mcpEndpointInfo.getPort() == 443 || mcpEndpointInfo.getPort() == 8443) {
 				protocol = "https";
 			}
 			else {

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/transport/LoadbalancedMcpSyncClient.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-
 /**
  * @author yingzi
  * @since 2025/4/29:13:00

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/utils/NacosMcpClientUtils.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-registry/src/main/java/com/alibaba/cloud/ai/mcp/discovery/client/utils/NacosMcpClientUtils.java
@@ -27,4 +27,17 @@ public class NacosMcpClientUtils {
 		return mcpEndpointInfo.getAddress() + "@@" + mcpEndpointInfo.getPort() + "@@" + exportPath;
 	}
 
+	public static String checkProtocol(McpEndpointInfo mcpEndpointInfo) {
+		String protocol = mcpEndpointInfo.getProtocol();
+		if (protocol == null || !"http".equals(protocol) && !"https".equals(protocol)) {
+			if (mcpEndpointInfo.getPort() == 443 || mcpEndpointInfo.getPort() == 8443) {
+				protocol = "https";
+			}
+			else {
+				protocol = "http";
+			}
+		}
+		return protocol;
+	}
+
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

目前发现 mcp 时， protocol字段是写死的http，导致无法正确发现 https 的 mcp server, 修复这个问题
<img width="1916" height="262" alt="image" src="https://github.com/user-attachments/assets/e03f2c16-11df-407c-b08c-fbd73c497332" />

### Does this pull request fix one issue?

fix #2407 

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
