### PR TITLE
feat(studio): support dsl2saa only Application

### DIFF
--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/pom.xml
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/pom.xml
@@ -125,6 +125,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring-boot.version}</version>
+                <configuration>
+                    <mainClass>com.alibaba.cloud.ai.studio.admin.SaaStudioApplication</mainClass>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/SaaStudioApplication.java
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/SaaStudioApplication.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.ai.studio.admin;
 
+import com.alibaba.cloud.ai.studio.admin.generator.GeneratorApplication;
 import com.alibaba.cloud.ai.studio.admin.generator.config.GraphProjectGenerationConfiguration;
 import com.alibaba.cloud.ai.studio.core.config.StudioProperties;
 import org.springframework.boot.SpringApplication;
@@ -36,11 +37,14 @@ import org.springframework.context.annotation.FilterType;
  *
  * @since 1.0.0.3
  */
-// @SpringBootApplication(scanBasePackages = "com.alibaba.cloud.ai.studio")
 @SpringBootApplication
 @ComponentScan(basePackages = { "com.alibaba.cloud.ai.studio" },
-		excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
-				classes = GraphProjectGenerationConfiguration.class))
+		excludeFilters = {
+				@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+						classes = GraphProjectGenerationConfiguration.class),
+				@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = GeneratorApplication.class),
+				@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+						classes = GeneratorApplication.MockLoginController.class) })
 @EnableConfigurationProperties(StudioProperties.class)
 public class SaaStudioApplication {
 

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/generator/GeneratorApplication.java
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/generator/GeneratorApplication.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.admin.generator;
+
+import com.alibaba.cloud.ai.studio.admin.controller.SystemController;
+import com.alibaba.cloud.ai.studio.admin.generator.config.GraphProjectGenerationConfiguration;
+import com.alibaba.cloud.ai.studio.runtime.domain.Result;
+import com.alibaba.cloud.ai.studio.runtime.domain.account.Account;
+import com.alibaba.cloud.ai.studio.runtime.domain.account.LoginRequest;
+import com.alibaba.cloud.ai.studio.runtime.domain.account.RefreshTokenRequest;
+import com.alibaba.cloud.ai.studio.runtime.domain.account.TokenResponse;
+import org.redisson.spring.starter.RedissonAutoConfigurationV2;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 仅用来启动DSL转换SAA服务的启动类（可以不启动studio-admin所需要的中间件）
+ */
+// TODO: 将Studio的低代码平台也引入本启动类中
+@SpringBootApplication(exclude = { RedissonAutoConfigurationV2.class, ElasticsearchDataAutoConfiguration.class,
+		ElasticsearchRepositoriesAutoConfiguration.class, ElasticsearchRestClientAutoConfiguration.class,
+		DataSourceAutoConfiguration.class })
+@ComponentScan(excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
+		classes = GraphProjectGenerationConfiguration.class))
+public class GeneratorApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(GeneratorApplication.class, args);
+	}
+
+	// TODO: 前端适配无登陆进入DSL转换页面，去掉这个MockLoginController
+	@RestController
+	@CrossOrigin
+	public static class MockLoginController {
+
+		@PostMapping("/console/v1/auth/login")
+		public Result<TokenResponse> login(@RequestBody LoginRequest loginRequest) {
+			return Result.success(new TokenResponse("token", "refreshToken", 1000L));
+		}
+
+		@PostMapping("/console/v1/auth/refresh-token")
+		public Result<TokenResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
+			return Result.success(new TokenResponse("token", "refreshToken", 1000L));
+		}
+
+		@GetMapping("/console/v1/system/global-config")
+		public Result<SystemController.GlobalConfig> globalConfig() {
+			SystemController.GlobalConfig globalConfig = new SystemController.GlobalConfig();
+			globalConfig.setLoginMethod("preset_account");
+			globalConfig.setUploadMethod("file");
+			return Result.success(globalConfig);
+		}
+
+		@GetMapping("/console/v1/accounts/profile")
+		public Result<Account> getAccountProfile() {
+			Account account = new Account();
+			account.setUsername("admin");
+			return Result.success(account);
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/generator/controller/GeneratorController.java
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/generator/controller/GeneratorController.java
@@ -23,7 +23,9 @@ import io.spring.initializr.web.controller.ProjectGenerationController;
 import io.spring.initializr.web.project.ProjectGenerationInvoker;
 
 import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
+@CrossOrigin
 public class GeneratorController extends ProjectGenerationController<GraphProjectRequest> {
 
 	public GeneratorController(InitializrMetadataProvider metadataProvider,

--- a/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/generator/service/generator/workflow/sections/KnowledgeRetrievalNodeSection.java
+++ b/spring-ai-alibaba-studio/spring-ai-alibaba-studio-server/spring-ai-alibaba-studio-server-admin/src/main/java/com/alibaba/cloud/ai/studio/admin/generator/service/generator/workflow/sections/KnowledgeRetrievalNodeSection.java
@@ -29,6 +29,7 @@ import com.alibaba.cloud.ai.studio.runtime.domain.PagingList;
 import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.Document;
 import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.DocumentQuery;
 import com.alibaba.cloud.ai.studio.runtime.enums.DocumentType;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -54,9 +55,10 @@ public class KnowledgeRetrievalNodeSection implements NodeSection<KnowledgeRetri
 
 	private final String studioStoragePath;
 
-	public KnowledgeRetrievalNodeSection(DocumentService studioDocumentService, StudioProperties properties) {
+	public KnowledgeRetrievalNodeSection(@Autowired(required = false) DocumentService studioDocumentService,
+			@Autowired(required = false) StudioProperties properties) {
 		this.studioDocumentService = studioDocumentService;
-		this.studioStoragePath = properties.getStoragePath();
+		this.studioStoragePath = properties != null ? properties.getStoragePath() : null;
 	}
 
 	@Override
@@ -64,6 +66,10 @@ public class KnowledgeRetrievalNodeSection implements NodeSection<KnowledgeRetri
 		KnowledgeRetrievalNodeData nodeData = (KnowledgeRetrievalNodeData) node.getData();
 
 		if (DSLDialectType.STUDIO.equals(nodeData.getDialectType())) {
+			if (this.studioDocumentService == null || this.studioStoragePath == null) {
+				throw new IllegalArgumentException(
+						"The current mode does not support Studio's knowledge retrieval node code generation. Please start the complete StudioApplication class");
+			}
 			// 根据knowledgeBaseIds获取对应的资源文件
 			List<ResourceFile> resourceFiles = Optional.ofNullable(nodeData.getKnowledgeBaseIds())
 				.orElse(List.of())


### PR DESCRIPTION
### Describe what this PR does / why we need it

Based on user feedback, a new startup class has been added that only provides low-code generation. This startup class solely activates the DSL-to-code conversion feature of the Studio and does not support other Studio functionalities. There is no need to start middleware such as rocketMQ. Both startup classes have been tested.

### Does this pull request fix one issue?

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

This solution is only a temporary measure. It can be modified later to activate specific functions based on the user's configuration needs.
