### PR TITLE
chore(autoconf): rename NacosPromptTmplProperties

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateAutoConfiguration.java
@@ -32,8 +32,8 @@ import org.springframework.context.annotation.Conditional;
  */
 
 @AutoConfiguration
-@Conditional(PromptTmplNacosConfigCondition.class)
-@EnableConfigurationProperties(NacosPromptTmplProperties.class)
+@Conditional(PromptTemplateConfigCondition.class)
+@EnableConfigurationProperties(PromptTemplateProperties.class)
 public class PromptTemplateAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateConfigCondition.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateConfigCondition.java
@@ -29,18 +29,18 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * of Nacos log error during startup.
  */
 
-public class PromptTmplNacosConfigCondition implements Condition {
+public class PromptTemplateConfigCondition implements Condition {
 
-	private final Logger logger = LoggerFactory.getLogger(PromptTmplNacosConfigCondition.class);
+	private final Logger logger = LoggerFactory.getLogger(PromptTemplateConfigCondition.class);
 
-	public PromptTmplNacosConfigCondition() {
+	public PromptTemplateConfigCondition() {
 	}
 
 	@Override
 	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
 
 		// @formatter:off
-		String tmplPrefix = NacosPromptTmplProperties.TEMPLATE_PREFIX + ".enabled";
+		String tmplPrefix = PromptTemplateProperties.TEMPLATE_PREFIX + ".enabled";
 
 		// The default value is false, means that the nacos prompt template is not enabled.
 		Boolean enabled = context.getEnvironment().getProperty(tmplPrefix, Boolean.class, false);
@@ -50,7 +50,7 @@ public class PromptTmplNacosConfigCondition implements Condition {
 		if (!enabled) {
 			System.setProperty("spring.nacos.config.enabled", "false");
 		}
-		logger.debug("PromptTmplNacosConfigCondition matches enabled: {}",enabled);
+		logger.debug("PromptTemplateConfigCondition matches enabled: {}",enabled);
 		// @formatter:on
 
 		return enabled;

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/java/com/alibaba/cloud/ai/autoconfigure/prompt/PromptTemplateProperties.java
@@ -22,8 +22,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author <a href="mailto:yuluo08290126@gmail.com">yuluo</a>
  */
 
-@ConfigurationProperties(NacosPromptTmplProperties.TEMPLATE_PREFIX)
-public class NacosPromptTmplProperties {
+@ConfigurationProperties(PromptTemplateProperties.TEMPLATE_PREFIX)
+public class PromptTemplateProperties {
 
 	public final static String TEMPLATE_PREFIX = "spring.ai.nacos.prompt.template";
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -20,8 +20,8 @@
     },
     {
       "name": "spring.ai.nacos.prompt.template",
-      "type": "com.alibaba.cloud.ai.autoconfigure.prompt.NacosPromptTmplProperties",
-      "sourceType": "com.alibaba.cloud.ai.autoconfigure.prompt.NacosPromptTmplProperties",
+      "type": "com.alibaba.cloud.ai.autoconfigure.prompt.PromptTemplateProperties",
+      "sourceType": "com.alibaba.cloud.ai.autoconfigure.prompt.PromptTemplateProperties",
       "description": "Configuration properties for Nacos prompt template integration."
     }
   ],
@@ -161,7 +161,7 @@
       "name": "spring.ai.nacos.prompt.template.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether to enable Nacos prompt template support.",
-      "sourceType": "com.alibaba.cloud.ai.autoconfigure.prompt.NacosPromptTmplProperties",
+      "sourceType": "com.alibaba.cloud.ai.autoconfigure.prompt.PromptTemplateProperties",
       "defaultValue": false
     }
   ],

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/test/java/com/alibaba/cloud/ai/autoconfigure/prompt/NacosPromptTmplPropertiesTests.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-nacos-prompt/src/test/java/com/alibaba/cloud/ai/autoconfigure/prompt/NacosPromptTmplPropertiesTests.java
@@ -26,10 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
-class NacosPromptTmplPropertiesTests {
+class PromptTemplatePropertiesTests {
 
 	@Autowired
-	private NacosPromptTmplProperties properties;
+	private PromptTemplateProperties properties;
 
 	@Test
 	void testDefaultEnabled() {
@@ -43,7 +43,7 @@ class NacosPromptTmplPropertiesTests {
 	}
 
 	@Configuration
-	@EnableConfigurationProperties(NacosPromptTmplProperties.class)
+	@EnableConfigurationProperties(PromptTemplateProperties.class)
 	static class TestConfig {
 
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it
名称 NacosPromptTmplProperties， PromptTemplateAutoConfiguration 名称不一致，都修改为PromptTemplate前缀

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
