### PR TITLE
fix(graph): filter ChatResponse.getResult() is null event

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -170,13 +170,13 @@ public class NodeExecutor extends BaseGraphExecutor {
 			var lastChatResponseRef = new AtomicReference<org.springframework.ai.chat.model.ChatResponse>(null);
 			var lastGraphResponseRef = new AtomicReference<GraphResponse<NodeOutput>>(null);
 
-			return chatFlux.filter(element -> {
-				// skip ChatResponse.getResult() == null 
-				if (element instanceof org.springframework.ai.chat.model.ChatResponse response) {
-					return response.getResult() != null;
-				}
-				return true;
-			}).map(element -> {
+            return chatFlux.filter(element -> {
+                // skip ChatResponse.getResult() == null
+                if (element instanceof org.springframework.ai.chat.model.ChatResponse response) {
+                    return response.getResult() != null;
+                }
+                return true;
+            }).map(element -> {
 				if (element instanceof org.springframework.ai.chat.model.ChatResponse response) {
 					org.springframework.ai.chat.model.ChatResponse lastResponse = lastChatResponseRef.get();
 					if (lastResponse == null) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
 使用graph时出现了NPE。 错误详情： java.lang.NullPointerException: Cannot invoke "org.springframework.ai.chat.model.Generation.getOutput()" because the return value of "org.springframework.ai.chat.model.ChatResponse.getResult()" is null
<img width="1515" height="538" alt="image" src="https://github.com/user-attachments/assets/0fb43ebf-0ca8-4d70-b572-0fe7fa9945bb" />

已经有多个提交试图修复这个问题，他们添加了非空判断，但是没有完全覆盖所有的逻辑分支。比如：fix: result empty (#2464)

### Does this pull request fix one issue?


### Describe how you did it
    在org.springframework.ai.chat.model.ChatResponse的方法定义，getResult()方法是会存在返回为null的场景。在spring ai alibaba中应该正确的处理返回值为null的场景
    ```
    	public Generation getResult() {
		if (CollectionUtils.isEmpty(this.generations)) {
			return null;
		}
		return this.generations.get(0);
	}
    ```

### Describe how to verify it
使用graph时，开开启流式响应，使用qwen-max 模型当前ChatResponse.getResult()=null的某个chunk 时会出现npe


### Special notes for reviews

