### PR TITLE
fix(graph): duplicated messages in state

### DIFF
--- a/spring-ai-alibaba-graph-core/pom.xml
+++ b/spring-ai-alibaba-graph-core/pom.xml
@@ -117,6 +117,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
             <exclusions>

--- a/spring-ai-alibaba-graph-core/pom.xml
+++ b/spring-ai-alibaba-graph-core/pom.xml
@@ -41,6 +41,7 @@
         <testcontainers.version>1.19.3</testcontainers.version>
         <httpclient.version>4.5.14</httpclient.version>
         <community.components.version>1.0.0.3</community.components.version>
+        <jackson.version>2.18.4</jackson.version>
     </properties>
 
     <dependencies>
@@ -119,6 +120,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -286,8 +286,20 @@ public class GraphRunnerContext {
 	// State Management Methods
 	// ================================================================================================================
 
-	public void updateCurrentState(Map<String, Object> state) {
-		this.currentStateData = OverAllState.updateState(this.currentStateData, state, getKeyStrategyMap());
+	public void setCurrentStatData(Map<String, Object> state) {
+		this.currentStateData = state;
+	}
+
+	/**
+	 * Updates the intermediate state with the provided state updates.
+	 * This method updates both the current state data and the overall state.
+	 *
+	 * @param updateState the state updates to apply
+	 */
+	public void updateState(Map<String, Object> updateState) {
+		this.currentStateData = OverAllState.updateState(this.currentStateData,
+				updateState, getKeyStrategyMap());
+		this.overallState.updateState(updateState);
 	}
 
 	// ================================================================================================================

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -291,7 +291,6 @@ public class GraphRunnerContext {
 	}
 
 	/**
-	 * Updates the intermediate state with the provided state updates.
 	 * This method updates both the current state data and the overall state.
 	 *
 	 * @param updateState the state updates to apply

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllStateBuilder.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllStateBuilder.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph;
 
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import com.alibaba.cloud.ai.graph.store.Store;
+import com.alibaba.cloud.ai.graph.utils.SerializationUtils;
 import org.springframework.util.CollectionUtils;
 
 import java.util.HashMap;
@@ -64,9 +65,9 @@ import java.util.Map;
  */
 public class OverAllStateBuilder {
 
-	private Map<String, Object> data = new HashMap<>();
+	private final Map<String, Object> data = new HashMap<>();
 
-	private Map<String, KeyStrategy> keyStrategies = new HashMap<>();
+	private final Map<String, KeyStrategy> keyStrategies = new HashMap<>();
 
 	private Boolean resume = false;
 
@@ -109,7 +110,9 @@ public class OverAllStateBuilder {
 			return this;
 		}
 
-		data.putAll(dataMap);
+		// deep copy to avoid side effects
+		Map<String, Object> deepCopiedData = SerializationUtils.deepCopyMap(dataMap);
+		data.putAll(deepCopiedData);
 		return this;
 	}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/MainGraphExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/MainGraphExecutor.java
@@ -88,7 +88,7 @@ public class MainGraphExecutor extends BaseGraphExecutor {
 						&& java.util.Objects.equals(context.getNextNodeId(), INTERRUPT_AFTER)) {
 					var nextNodeCommand = context.nextNodeId(resumeFrom.get(), context.getCurrentStateData());
 					context.setNextNodeId(nextNodeCommand.gotoNode());
-					context.updateCurrentState(nextNodeCommand.update());
+					context.setCurrentStatData(nextNodeCommand.update());
 					context.setCurrentNodeId(null);
 				}
 			}
@@ -125,7 +125,7 @@ public class MainGraphExecutor extends BaseGraphExecutor {
 			context.doListeners(START, null);
 			Command nextCommand = context.getEntryPoint();
 			context.setNextNodeId(nextCommand.gotoNode());
-			context.updateCurrentState(nextCommand.update());
+			context.setCurrentStatData(nextCommand.update());
 
 			Optional<Checkpoint> cp = context.addCheckpoint(START, context.getNextNodeId());
 			NodeOutput output = context.buildOutput(START, cp);

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -133,8 +133,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 				return handleEmbeddedGenerator(context, embedGenerator.get(), updateState, resultValue);
 			}
 
-			context.updateCurrentState(updateState);
-			context.getOverallState().updateState(updateState);
+			context.updateState(updateState);
 
 			if (context.getCompiledGraph().compileConfig.interruptBeforeEdge()
 					&& context.getCompiledGraph().compileConfig.interruptsAfter()
@@ -144,7 +143,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 			else {
 				Command nextCommand = context.nextNodeId(context.getCurrentNodeId(), context.getCurrentStateData());
 				context.setNextNodeId(nextCommand.gotoNode());
-				context.updateCurrentState(nextCommand.update());
+				context.setCurrentStatData(nextCommand.update());
 			}
 
 			NodeOutput output = context.buildCurrentNodeOutput();
@@ -294,20 +293,17 @@ public class NodeExecutor extends BaseGraphExecutor {
 				return;
 			}
 
+			Map<String, Object> partialStateWithoutFlux = partialState.entrySet()
+					.stream()
+					.filter(e -> !(e.getValue() instanceof Flux))
+					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+			context.updateState(partialStateWithoutFlux);
+
 			if (nodeResultValue.isPresent()) {
 				Object value = nodeResultValue.get();
 				if (value instanceof Map<?, ?>) {
-					Map<String, Object> partialStateWithoutFlux = partialState.entrySet()
-						.stream()
-						.filter(e -> !(e.getValue() instanceof Flux))
-						.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-					Map<String, Object> intermediateState = OverAllState.updateState(context.getCurrentStateData(),
-							partialStateWithoutFlux, context.getKeyStrategyMap());
-					var currentState = OverAllState.updateState(intermediateState, (Map<String, Object>) value,
-							context.getKeyStrategyMap());
-					context.updateCurrentState(currentState);
-					context.getOverallState().updateState(currentState);
+					context.updateState((Map<String, Object>) value);
 				}
 				else {
 					throw new IllegalArgumentException("Node stream must return Map result using Data.done(),");
@@ -317,7 +313,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 			try {
 				Command nextCommand = context.nextNodeId(context.getCurrentNodeId(), context.getCurrentStateData());
 				context.setNextNodeId(nextCommand.gotoNode());
-				context.updateCurrentState(nextCommand.update());
+				context.setCurrentStatData(nextCommand.update());
 
 				// save checkpoint after embedded flux completes
 				context.buildCurrentNodeOutput();
@@ -387,7 +383,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 									partialStateWithoutFlux, context.getKeyStrategyMap());
 							var currentState = OverAllState.updateState(intermediateState,
 									(Map<String, Object>) nodeResultValue, context.getKeyStrategyMap());
-							context.updateCurrentState(currentState);
+							context.setCurrentStatData(currentState);
 							context.getOverallState().updateState(currentState);
 						}
 						else {
@@ -404,7 +400,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 			try {
 				Command nextCommand = context.nextNodeId(context.getCurrentNodeId(), context.getCurrentStateData());
 				context.setNextNodeId(nextCommand.gotoNode());
-				context.updateCurrentState(nextCommand.update());
+				context.setCurrentStatData(nextCommand.update());
 
 				return mainGraphExecutor.execute(context, resultValue);
 			}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2024-2025 the original author or authors.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +14,6 @@
  * limitations under the License.
  */
 package com.alibaba.cloud.ai.graph.utils;
-
-import com.alibaba.cloud.ai.graph.CompiledGraph;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.utils;
+
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for object serialization and deep copying operations.
+ */
+public class SerializationUtils {
+	private static final Logger log = LoggerFactory.getLogger(SerializationUtils.class);
+
+	// Jackson ObjectMapper for serialization
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	private SerializationUtils() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Deep copy a Map, recursively handling all nested collections and Maps
+	 *
+	 * @param original the original Map object
+	 * @return the deep copied Map object, returns null if the original object is null
+	 */
+	public static Map<String, Object> deepCopyMap(Map<String, Object> original) {
+		if (original == null) {
+			return null;
+		}
+
+		Map<String, Object> copy = new HashMap<>();
+		for (Map.Entry<String, Object> entry : original.entrySet()) {
+			copy.put(entry.getKey(), deepCopyValue(entry.getValue()));
+		}
+		return copy;
+	}
+
+	/**
+	 * Recursively deep copy values of any type
+	 *
+	 * @param value the value that needs to be deep copied
+	 * @return the deep copied value
+	 */
+	@SuppressWarnings("unchecked")
+	public static Object deepCopyValue(Object value) {
+		if (value == null) {
+			return null;
+		}
+
+		// Handle primitive types and immutable objects
+		if (value instanceof String || value instanceof Number ||
+			value instanceof Boolean || value instanceof Character) {
+			return value;
+		}
+
+		// Handle Map
+		if (value instanceof Map) {
+			return deepCopyMap((Map<String, Object>) value);
+		}
+
+		// Handle List
+		if (value instanceof java.util.List) {
+			java.util.List<Object> originalList = (java.util.List<Object>) value;
+			java.util.List<Object> copyList = new java.util.ArrayList<>();
+			for (Object item : originalList) {
+				copyList.add(deepCopyValue(item));
+			}
+			return copyList;
+		}
+
+		// Handle Set
+		if (value instanceof java.util.Set) {
+			java.util.Set<Object> originalSet = (java.util.Set<Object>) value;
+			java.util.Set<Object> copySet = new java.util.HashSet<>();
+			for (Object item : originalSet) {
+				copySet.add(deepCopyValue(item));
+			}
+			return copySet;
+		}
+
+		// Handle arrays
+		if (value.getClass().isArray()) {
+			Object[] originalArray = (Object[]) value;
+			Object[] copyArray = new Object[originalArray.length];
+			for (int i = 0; i < originalArray.length; i++) {
+				copyArray[i] = deepCopyValue(originalArray[i]);
+			}
+			return copyArray;
+		}
+
+		// For other complex objects, try using Jackson serialization
+		// If it fails, return the original object (shallow copy)
+		try {
+			String json = objectMapper.writeValueAsString(value);
+			return objectMapper.readValue(json, value.getClass());
+		} catch (Exception e) {
+			// If serialization fails, log a warning and return the original object (shallow copy)
+			log.info("Could not deep copy object of type " +
+				value.getClass().getName() + ", using shallow copy instead: " + e.getMessage());
+			return value;
+		}
+	}
+}


### PR DESCRIPTION
1. deepcopy `input data` used to initialize state.
2. fix state update after node execution.