### PR TITLE
fix(core): incorrect method naming causing bean resolution issues in multi-model configurations

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatAutoConfiguration.java
@@ -76,7 +76,7 @@ public class DashScopeChatAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		public DashScopeChatModel dashscopeChatModel(
+		public DashScopeChatModel dashScopeChatModel(
 				RetryTemplate retryTemplate,
 				ToolCallingManager toolCallingManager,
 				DashScopeChatProperties chatProperties,


### PR DESCRIPTION
## Description
This PR fixes the incorrect method naming in `DashScopeChatAutoConfiguration` that can cause bean resolution issues when integrating multiple chat model implementations.

## Problem
When integrating multiple chat model implementations in the system and trying to use different models under different circumstances, we encountered bean resolution failures. The issue was traced to the inconsistent bean naming in the auto-configuration:

- The method name `dashscopeChatModel()` generates a bean name that doesn't match the expected pattern
- This inconsistency causes problems when Spring tries to resolve the correct bean in multi-model configurations
- The bean name generation follows the method name pattern, leading to `dashscopeChatModel` instead of the expected `dashScopeChatModel`

## Solution
Renamed the method from `dashscopeChatModel()` to `dashScopeChatModel()` to:
1. Maintain consistency with other DashScope auto-configuration classes
2. Ensure proper bean name generation that matches the expected pattern
3. Fix bean resolution issues in multi-model configurations

## Impact
This change ensures that:
- Bean names are consistent across all DashScope model configurations
- Multi-model configurations work properly without manual bean name overrides
- The naming follows Spring Boot's auto-configuration conventions

## Testing
Verified that the bean is now properly resolved in multi-model scenarios and maintains backward compatibility with existing configurations.