### PR TITLE
fix(graph): incorrect GraphRunnerContext `doListeners` call

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -21,6 +21,7 @@ import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
 import com.alibaba.cloud.ai.graph.exception.RunnableErrors;
 import com.alibaba.cloud.ai.graph.internal.node.SubCompiledGraphNodeAction;
 import com.alibaba.cloud.ai.graph.state.StateSnapshot;
+import com.alibaba.cloud.ai.graph.utils.SystemClock;
 import com.alibaba.cloud.ai.graph.utils.TypeRef;
 
 import org.springframework.util.CollectionUtils;
@@ -262,13 +263,13 @@ public class GraphRunnerContext {
 						listener.onStart(getCurrentNodeId(), getCurrentStateData(), config);
 						break;
 					case END:
-						listener.onComplete(getCurrentNodeId(), getCurrentStateData(), config);
+						listener.onComplete(END, getCurrentStateData(), config);
 						break;
 					case NODE_BEFORE:
-						listener.onStart(getCurrentNodeId(), getCurrentStateData(), config);
+						listener.before(getCurrentNodeId(), getCurrentStateData(), config, SystemClock.now());
 						break;
 					case NODE_AFTER:
-						listener.onComplete(getCurrentNodeId(), getCurrentStateData(), config);
+						listener.after(getCurrentNodeId(), getCurrentStateData(), config, SystemClock.now());
 						break;
 					case ERROR:
 						listener.onError(getCurrentNodeId(), getCurrentStateData(), e, config);


### PR DESCRIPTION
Correct `GraphLifecycleListener` method call in case `END`, `NODE_BEFORE` and `NODE_AFTER`


### Describe what this PR does / why we need it
See more in #2525
In short, 
- case `NODE_BEFORE` should call `listener.before`
- case`NODE_AFTER` should call `listener.after`
- case `END` should pass `END` as `nodeId` parameter

### Does this pull request fix one issue?
Fixes #2525 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
