### PR TITLE
feat(core): support dashscope search metadata streaming

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -1486,11 +1486,21 @@ public class DashScopeApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	public record SearchInfo(@JsonProperty("search_results") List<SearchResult> searchResults) {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record SearchInfo(@JsonProperty("search_results") List<SearchResult> searchResults,
+			@JsonProperty("extra_tool_info") List<ExtraToolInfo> extraToolInfo) {
+
 		@JsonInclude(JsonInclude.Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record SearchResult(@JsonProperty("site_name") String siteName, @JsonProperty("icon") String icon,
 				@JsonProperty("index") Integer index, @JsonProperty("title") String title,
-				@JsonProperty("url") String url) {
+				@JsonProperty("url") String url, @JsonProperty("description") String description,
+				@JsonProperty("summary") String summary) {
+		}
+
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		public record ExtraToolInfo(@JsonProperty("result") String result, @JsonProperty("tool") String tool) {
 		}
 	}
 
@@ -1764,7 +1774,8 @@ public class DashScopeApi {
 	public record SearchOptions(@JsonProperty("enable_source") Boolean enableSource,
 			@JsonProperty("enable_citation") Boolean enableCitation,
 			@JsonProperty("citation_format") String citationFormat, @JsonProperty("forced_search") Boolean forcedSearch,
-			@JsonProperty("search_strategy") String searchStrategy) {
+			@JsonProperty("search_strategy") String searchStrategy,
+			@JsonProperty("prepend_search_result") Boolean prependSearchResult) {
 
 		public static Builder builder() {
 			return new Builder();
@@ -1781,6 +1792,8 @@ public class DashScopeApi {
 			private Boolean forcedSearch;
 
 			private String searchStrategy;
+
+			private Boolean prependSearchResult;
 
 			public Builder enableSource(Boolean enableSource) {
 				this.enableSource = enableSource;
@@ -1807,8 +1820,14 @@ public class DashScopeApi {
 				return this;
 			}
 
+			public Builder prependSearchResult(Boolean prependSearchResult) {
+				this.prependSearchResult = prependSearchResult;
+				return this;
+			}
+
 			public SearchOptions build() {
-				return new SearchOptions(enableSource, enableCitation, citationFormat, forcedSearch, searchStrategy);
+				return new SearchOptions(enableSource, enableCitation, citationFormat, forcedSearch, searchStrategy,
+						prependSearchResult);
 			}
 
 		}


### PR DESCRIPTION
### Describe what this PR does / why we need it

1. add the missing prepend_search_result flag to DashScope chat search options so callers can request a metadata-only first SSE packet when enable_source=true
2. extend the stored search metadata (search_info) to surface per-result description / summary fields and optional extra_tool_info, matching the latest DashScope documentation
3. keep search_info attached while streaming chunks are merged so that the consumer can always read the search provenance



### Does this pull request fix one issue?

Fixes #2521

### Describe how you did it

1. updated DashScopeApi.SearchOptions to expose prepend_search_result, keeping the fluent builder in sync
2. relaxed DashScopeApi.SearchInfo/SearchResult with @JsonIgnoreProperties and mapped the new metadata fields
3. taught DashScopeAiStreamFunctionCallingHelper to carry forward the newest search_info when merging streaming chunks
4. added a regression test (testMergePreservesSearchInfo) that asserts the helper preserves the expanded metadata

### Describe how to verify it
```
mvn -pl spring-ai-alibaba-core test -Dtest=DashScopeAiStreamFunctionCallingHelperTests -DskipITs -Dspotless.skip=true
```

### Special notes for reviews
the new fields are all optional and unknown JSON keys are ignored to stay compatible with upstream API evolutions