### PR TITLE
fix(core): 修复audio请求头

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAudioTranscriptionApi.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAudioTranscriptionApi.java
@@ -109,11 +109,6 @@ public class DashScopeAudioTranscriptionApi {
 				.baseUrl(baseUrl)
 				.defaultHeaders(authHeaders)
 				.defaultStatusHandler(responseErrorHandler)
-				.defaultRequest(requestHeadersSpec -> {
-					if (!(apiKey instanceof NoopApiKey)) {
-						requestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.getValue());
-					}
-				})
 				.build();
 
 		this.webSocketClient = new DashScopeWebSocketClient(DashScopeWebSocketClientOptions.builder()


### PR DESCRIPTION
restClientBuilder的defaultRequest方法，如果初始时没有值，那么再进行赋值是不会走函数的，源码实现如下：
<img width="1055" height="119" alt="image" src="https://github.com/user-attachments/assets/f1f811a0-6375-4919-9997-4030711a7183" />

所以请求audio的api时，请求头并未设置成功。直接导致报错。我这里直接将函数提前写到了前面，写到了请求头了，运行成功。并且原api请求新增加了一个请求头【X-DashScope-Async】，如图：
<img width="1247" height="168" alt="image" src="https://github.com/user-attachments/assets/e96cb96e-b595-4ae1-8570-301bfc353ade" />
