### PR TITLE
fix(graph): register Jdk8Module to support Optional serialization

### DIFF
--- a/spring-ai-alibaba-graph-core/pom.xml
+++ b/spring-ai-alibaba-graph-core/pom.xml
@@ -49,6 +49,10 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/RedisSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/RedisSaver.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.redisson.api.RBucket;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
@@ -31,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
@@ -57,8 +59,7 @@ public class RedisSaver implements BaseCheckpointSaver {
 	 * @param redisson the redisson
 	 */
 	public RedisSaver(RedissonClient redisson) {
-		this.redisson = redisson;
-		this.objectMapper = new ObjectMapper();
+		this(redisson, new ObjectMapper());
 	}
 
 	/**
@@ -67,7 +68,13 @@ public class RedisSaver implements BaseCheckpointSaver {
 	 */
 	public RedisSaver(RedissonClient redisson, ObjectMapper objectMapper) {
 		this.redisson = redisson;
-		this.objectMapper = objectMapper;
+		this.objectMapper = configureObjectMapper(objectMapper);
+	}
+
+	private static ObjectMapper configureObjectMapper(ObjectMapper objectMapper) {
+		ObjectMapper mapper = Objects.requireNonNull(objectMapper, "objectMapper cannot be null");
+		mapper.registerModule(new Jdk8Module());
+		return mapper;
 	}
 
 	@Override

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 /**
  * Base Implementation of {@link PlainTextStateSerializer} using Jackson library. Need to
@@ -53,6 +54,7 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 		super(stateFactory);
 		this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper cannot be null");
 
+		this.objectMapper.registerModule(new Jdk8Module());
 		this.objectMapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.USE_BIG_INTEGER_FOR_INTS,
 				false);
 		this.objectMapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS,


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes the serialization issue with `Optional` type in Graph module's checkpoint and state serialization.

previously, when using `Optional` type in state objects, the serialization would fail because the ObjectMapper in both `RedisSaver` and `JacksonStateSerializer` did not register the `Jdk8Module`

This fix ensure that `Optional` and other Java 8 types can be properly (de)serialized in Graph workflows

### Does this pull request fix one issue?

Fixes #2224


### Describe how to verify it

1. Create a Graph workflow with state containing `Optional` fields
2. Use `RedisSaver` as checkpoint saver
3. Execute the workflow
4. Verify the checkpoint can be saved and restored without serialization error


