### PR TITLE
fix(mcp): fix response template with root placeholder not returning actual HTTP response

### DIFF
--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallback.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/main/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallback.java
@@ -73,7 +73,7 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
     
     private static final Logger logger = LoggerFactory.getLogger(NacosMcpGatewayToolCallback.class);
     
-    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{\\s*(\\.[\\w]+(?:\\.[\\w]+)*)\\s*\\}\\}");
+    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{\\s*(\\.(?:[\\w]+(?:\\.[\\w]+)*)?)\\s*\\}\\}");
     
     // 匹配 {{ ${nacos.dataId/group} }} 或 {{ ${nacos.dataId/group}.key1.key2 }}
     private static final Pattern NACOS_TEMPLATE_PATTERN = Pattern
@@ -532,14 +532,19 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
      * @return 解析后的值
      */
     private String resolvePathValue(String fullPath, Map<String, Object> args, String extendedData) {
-        if (StringUtils.isBlank(fullPath)) {
-            return "";
+        if (fullPath == null) {
+            return extendedData != null ? extendedData : "";
         }
+
         // 移除开头的点号
         if (fullPath.startsWith(".")) {
             fullPath = fullPath.substring(1);
         }
-        
+
+        if (StringUtils.isBlank(fullPath)) {
+            return extendedData != null ? extendedData : "";
+        }
+
         String[] pathParts = fullPath.split("\\.");
         if (pathParts.length == 0) {
             return "";

--- a/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/test/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallbackResponseTemplateTests.java
+++ b/spring-ai-alibaba-mcp/spring-ai-alibaba-mcp-router/src/test/java/com/alibaba/cloud/ai/mcp/gateway/nacos/callback/NacosMcpGatewayToolCallbackResponseTemplateTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.mcp.gateway.nacos.callback;
+
+import com.alibaba.cloud.ai.mcp.gateway.core.utils.SpringBeanUtils;
+import com.alibaba.cloud.ai.mcp.gateway.nacos.definition.NacosMcpGatewayToolDefinition;
+import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerRemoteServiceConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for NacosMcpGatewayToolCallback response template processing
+ * @author saladday
+ */
+class NacosMcpGatewayToolCallbackResponseTemplateTests {
+
+	private GenericApplicationContext applicationContext;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+		applicationContext = new GenericApplicationContext();
+		applicationContext.registerBean(WebClient.Builder.class, WebClient::builder);
+		applicationContext.registerBean(NacosMcpOperationService.class, () -> Mockito.mock(NacosMcpOperationService.class));
+		applicationContext.refresh();
+		SpringBeanUtils.getInstance().setApplicationContext(applicationContext);
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (applicationContext != null) {
+			applicationContext.close();
+		}
+		SpringBeanUtils.getInstance().setApplicationContext(null);
+	}
+
+	@Test
+	void bodyTemplateWithRootPlaceholderReturnsRawResponse() throws Exception {
+		NacosMcpGatewayToolDefinition definition = new NacosMcpGatewayToolDefinition();
+		definition.setName("test-tool");
+		definition.setDescription("test tool");
+		definition.setProtocol("http");
+		definition.setRemoteServerConfig(new McpServerRemoteServiceConfig());
+
+		NacosMcpGatewayToolCallback callback = new NacosMcpGatewayToolCallback(definition);
+
+		ObjectNode responseTemplate = objectMapper.createObjectNode();
+		responseTemplate.put("body", "{{.}}");
+
+		JsonNode templateNode = responseTemplate;
+
+		Method processResponse = NacosMcpGatewayToolCallback.class
+			.getDeclaredMethod("processResponse", String.class, JsonNode.class, Map.class);
+		processResponse.setAccessible(true);
+
+		String response = "20.5";
+		String result = (String) processResponse.invoke(callback, response, templateNode, Collections.emptyMap());
+
+		assertEquals(response, result);
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

修复了HTTP服务转换为MCP工具时，响应模板配置为 `{{.}}` 时无法正确返回HTTP服务实际响应值的问题。

在1.0.0.4版本中，当使用如下响应模板配置时：
```json
{
  "responseTemplate": {
    "body": "{{.}}"
  }
}
```

使用inspector测试时会返回字符串 `"{{.}}"`，而不是HTTP服务返回的实际值（如 `"20.5"`）。

### Does this pull request fix one issue?

Fixes #2538


### Describe how to verify it

```
mvn test -Dtest=NacosMcpGatewayToolCallbackResponseTemplateTests
```


