### PR TITLE
fix(core): remove redundant baseUrl initialization in Properties constructors to support configuration inheritance

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechSynthesisProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioSpeechSynthesisProperties.java
@@ -21,8 +21,6 @@ import com.alibaba.cloud.ai.dashscope.audio.DashScopeAudioSpeechOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DEFAULT_BASE_URL;
-
 /**
  * @author kevinlin09
  */
@@ -58,9 +56,5 @@ public class DashScopeAudioSpeechSynthesisProperties extends DashScopeParentProp
 		.speed(SPEED)
 		.responseFormat(DEFAULT_RESPONSE_FORMAT)
 		.build();
-
-	public DashScopeAudioSpeechSynthesisProperties() {
-		super.setBaseUrl(DEFAULT_BASE_URL);
-	}
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeAudioTranscriptionProperties.java
@@ -19,8 +19,6 @@ import com.alibaba.cloud.ai.dashscope.audio.DashScopeAudioTranscriptionOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DEFAULT_BASE_URL;
-
 /**
  * @author xYLiu
  * @author yuluo
@@ -37,10 +35,6 @@ public class DashScopeAudioTranscriptionProperties extends DashScopeParentProper
 
 	@NestedConfigurationProperty
 	private DashScopeAudioTranscriptionOptions options = DashScopeAudioTranscriptionOptions.builder().build();
-
-	public DashScopeAudioTranscriptionProperties() {
-		super.setBaseUrl(DEFAULT_BASE_URL);
-	}
 
 	public DashScopeAudioTranscriptionOptions getOptions() {
 		return this.options;

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/main/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopeChatProperties.java
@@ -20,8 +20,6 @@ import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DEFAULT_BASE_URL;
-
 /**
  * @author yuluo
  * @author <a href="mailto:yuluo08290126@gmail.com">yuluo</a>
@@ -56,10 +54,6 @@ public class DashScopeChatProperties extends DashScopeParentProperties {
 		.withModel(DEFAULT_DEPLOYMENT_NAME)
 		.withTemperature(DEFAULT_TEMPERATURE)
 		.build();
-
-	public DashScopeChatProperties() {
-		super.setBaseUrl(DEFAULT_BASE_URL);
-	}
 
 	public DashScopeChatOptions getOptions() {
 

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopePropertiesTests.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-dashscope/src/test/java/com/alibaba/cloud/ai/autoconfigure/dashscope/DashScopePropertiesTests.java
@@ -33,7 +33,6 @@ import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-import static com.alibaba.cloud.ai.dashscope.common.DashScopeApiConstants.DEFAULT_BASE_URL;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -63,7 +62,7 @@ public class DashScopePropertiesTests {
 				assertThat(connectionProperties.getBaseUrl()).isEqualTo("TEST_BASE_URL");
 
 				assertThat(chatProperties.getApiKey()).isNull();
-				assertThat(chatProperties.getBaseUrl()).isEqualTo(DEFAULT_BASE_URL);
+				assertThat(chatProperties.getBaseUrl()).isNull();
 
 				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_CUSTOM");
 				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.80);
@@ -88,7 +87,7 @@ public class DashScopePropertiesTests {
 				assertThat(connectionProperties.getBaseUrl()).isEqualTo("TEST_BASE_URL");
 
 				assertThat(transcriptionProperties.getApiKey()).isNull();
-				assertThat(transcriptionProperties.getBaseUrl()).isEqualTo(DEFAULT_BASE_URL);
+				assertThat(transcriptionProperties.getBaseUrl()).isNull();
 
 				assertThat(transcriptionProperties.getOptions().getModel()).isEqualTo("MODEL_CUSTOM");
 			});
@@ -169,7 +168,7 @@ public class DashScopePropertiesTests {
 				assertThat(connectionProperties.getBaseUrl()).isEqualTo("TEST_BASE_URL");
 
 				assertThat(speechProperties.getApiKey()).isNull();
-				assertThat(speechProperties.getBaseUrl()).isEqualTo(DEFAULT_BASE_URL);
+				assertThat(speechProperties.getBaseUrl()).isNull();
 
 				assertThat(speechProperties.getOptions().getModel()).isEqualTo("TTS_1");
 				assertThat(speechProperties.getOptions().getVoice()).isEqualTo("longhua_test");


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes the configuration inheritance issue where `spring.ai.dashscope.base-url` cannot be inherited by sub-configurations (Chat, AudioTranscription, AudioSynthesis).

**Problem:** Users with private deployments had to configure `base-url` for each model type separately, even though they wanted to use the same URL for all.

**Solution:** Remove redundant `DEFAULT_BASE_URL` initialization in sub-configuration constructors, allowing proper inheritance from top-level configuration.

### Does this pull request fix one issue?

Fixes #2591

### Describe how you did it

Removed constructors that set `DEFAULT_BASE_URL` in:
- `DashScopeChatProperties`
- `DashScopeAudioTranscriptionProperties`  
- `DashScopeAudioSpeechSynthesisProperties`

Updated corresponding tests to expect `null` instead of `DEFAULT_BASE_URL` for sub-configurations.

The existing fallback logic in `DashScopeConnectionUtils.resolveConnectionProperties()` now works correctly:
- If sub-config `baseUrl` is `null` → inherit from top-level
- If sub-config `baseUrl` is set → use sub-config value (override)

### Describe how to verify it

**Before fix:**
```yaml
spring:
  ai:
    dashscope:
      base-url: https://my-private.com  
      chat:
        base-url: https://my-private.com  
```

**After fix:**
```yaml
spring:
  ai:
    dashscope:
      base-url: https://my-private.com  
```

### Special notes for reviews

- **No Breaking Changes:** Existing configurations continue to work
- **Consistency:** Aligns with other config classes (Image, Embedding, Video, etc.) that don't have constructors
- **Code Quality:** Reduces redundancy, follows Spring Boot best practices
- **All checks pass:** Compilation, checkstyle, tests