### PR TITLE
fix(graph): add custom object serialization example

### DIFF
--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/custom_serialization/Product.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/custom_serialization/Product.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.custom_serialization;
+
+/**
+ * Example Product entity for custom serialization demonstration
+ *
+ * @author Libres-coder
+ */
+public class Product {
+
+	private String id;
+
+	private String name;
+
+	private Double price;
+
+	private String category;
+
+	public Product() {
+	}
+
+	public Product(String id, String name, Double price, String category) {
+		this.id = id;
+		this.name = name;
+		this.price = price;
+		this.category = category;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Double getPrice() {
+		return price;
+	}
+
+	public void setPrice(Double price) {
+		this.price = price;
+	}
+
+	public String getCategory() {
+		return category;
+	}
+
+	public void setCategory(String category) {
+		this.category = category;
+	}
+
+	@Override
+	public String toString() {
+		return "Product{" + "id='" + id + '\'' + ", name='" + name + '\'' + ", price=" + price + ", category='"
+				+ category + '\'' + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		Product product = (Product) o;
+
+		if (id != null ? !id.equals(product.id) : product.id != null) {
+			return false;
+		}
+		if (name != null ? !name.equals(product.name) : product.name != null) {
+			return false;
+		}
+		if (price != null ? !price.equals(product.price) : product.price != null) {
+			return false;
+		}
+		return category != null ? category.equals(product.category) : product.category == null;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = id != null ? id.hashCode() : 0;
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		result = 31 * result + (price != null ? price.hashCode() : 0);
+		result = 31 * result + (category != null ? category.hashCode() : 0);
+		return result;
+	}
+
+}
+

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/custom_serialization/ProductSerializationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/custom_serialization/ProductSerializationTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.custom_serialization;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test custom object serialization in Graph Workflow
+ *
+ * @author Libres-coder
+ */
+class ProductSerializationTest {
+
+	private ProductStateSerializer serializer;
+
+	@BeforeEach
+	void setUp() {
+		serializer = new ProductStateSerializer(OverAllState::new);
+	}
+
+	@Test
+	void testSingleProductSerialization() throws Exception {
+		Product product = new Product("P001", "Laptop", 999.99, "Electronics");
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("product", product);
+		data.put("timestamp", System.currentTimeMillis());
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		serializer.writeData(data, oos);
+		oos.flush();
+
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		Map<String, Object> deserializedData = serializer.readData(ois);
+
+		assertNotNull(deserializedData);
+		assertTrue(deserializedData.containsKey("product"));
+
+		Object deserializedProduct = deserializedData.get("product");
+		assertInstanceOf(Product.class, deserializedProduct,
+				"Expected Product instance, but got " + deserializedProduct.getClass().getName());
+
+		Product resultProduct = (Product) deserializedProduct;
+		assertEquals("P001", resultProduct.getId());
+		assertEquals("Laptop", resultProduct.getName());
+		assertEquals(999.99, resultProduct.getPrice());
+		assertEquals("Electronics", resultProduct.getCategory());
+	}
+
+	@Test
+	void testProductListSerialization() throws Exception {
+		Product product1 = new Product("P001", "Laptop", 999.99, "Electronics");
+		Product product2 = new Product("P002", "Mouse", 29.99, "Accessories");
+		Product product3 = new Product("P003", "Keyboard", 79.99, "Accessories");
+
+		List<Product> products = List.of(product1, product2, product3);
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("products", products);
+		data.put("total_count", products.size());
+
+		Map<String, Object> deserializedData = serializeAndDeserialize(data);
+
+		assertNotNull(deserializedData);
+		assertTrue(deserializedData.containsKey("products"));
+
+		@SuppressWarnings("unchecked")
+		List<Object> deserializedProducts = (List<Object>) deserializedData.get("products");
+		assertEquals(3, deserializedProducts.size());
+
+		for (int i = 0; i < deserializedProducts.size(); i++) {
+			Object item = deserializedProducts.get(i);
+			assertInstanceOf(Product.class, item, "List item " + i + " should be Product instance");
+		}
+
+		Product firstProduct = (Product) deserializedProducts.get(0);
+		assertEquals("P001", firstProduct.getId());
+		assertEquals("Laptop", firstProduct.getName());
+	}
+
+	@Test
+	void testComplexStateSerialization() throws Exception {
+		Product product = new Product("P001", "Laptop", 999.99, "Electronics");
+
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("source", "web");
+		metadata.put("user_id", "user123");
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("product", product);
+		data.put("metadata", metadata);
+		data.put("score", 0.95);
+		data.put("tags", List.of("featured", "bestseller", "new"));
+
+		Map<String, Object> deserializedData = serializeAndDeserialize(data);
+
+		assertInstanceOf(Product.class, deserializedData.get("product"));
+		Product deserializedProduct = (Product) deserializedData.get("product");
+		assertEquals(product.getId(), deserializedProduct.getId());
+		assertEquals(product.getName(), deserializedProduct.getName());
+
+		assertEquals(0.95, deserializedData.get("score"));
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> deserializedMetadata = (Map<String, Object>) deserializedData.get("metadata");
+		assertEquals("web", deserializedMetadata.get("source"));
+		assertEquals("user123", deserializedMetadata.get("user_id"));
+	}
+
+	@Test
+	void testProductWithNullValues() throws Exception {
+		Product product = new Product("P001", "Laptop", null, null);
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("product", product);
+
+		Map<String, Object> deserializedData = serializeAndDeserialize(data);
+
+		assertInstanceOf(Product.class, deserializedData.get("product"));
+		Product deserializedProduct = (Product) deserializedData.get("product");
+		assertEquals("P001", deserializedProduct.getId());
+		assertEquals("Laptop", deserializedProduct.getName());
+		assertEquals(null, deserializedProduct.getPrice());
+		assertEquals(null, deserializedProduct.getCategory());
+	}
+
+	private Map<String, Object> serializeAndDeserialize(Map<String, Object> data) throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		serializer.writeData(data, oos);
+		oos.flush();
+
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		return serializer.readData(ois);
+	}
+
+}
+

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/custom_serialization/ProductStateSerializer.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/custom_serialization/ProductStateSerializer.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.custom_serialization;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
+import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.TypeMapper;
+import com.alibaba.cloud.ai.graph.state.AgentStateFactory;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Custom StateSerializer for Product object serialization
+ *
+ * @author Libres-coder
+ */
+public class ProductStateSerializer extends SpringAIJacksonStateSerializer {
+
+	public ProductStateSerializer(AgentStateFactory<OverAllState> stateFactory) {
+		super(stateFactory);
+
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(Product.class, new ProductSerializer());
+		module.addDeserializer(Product.class, new ProductDeserializer());
+
+		objectMapper.registerModule(module);
+		typeMapper.register(new TypeMapper.Reference<Product>("PRODUCT") {
+		});
+	}
+
+	static class ProductSerializer extends StdSerializer<Product> {
+
+		public ProductSerializer() {
+			super(Product.class);
+		}
+
+		@Override
+		public void serialize(Product product, JsonGenerator gen, SerializerProvider provider) throws IOException {
+			gen.writeStartObject();
+			gen.writeStringField("@type", "PRODUCT");
+			gen.writeStringField("id", product.getId());
+			gen.writeStringField("name", product.getName());
+
+			if (product.getPrice() != null) {
+				gen.writeNumberField("price", product.getPrice());
+			}
+
+			if (product.getCategory() != null) {
+				gen.writeStringField("category", product.getCategory());
+			}
+
+			gen.writeEndObject();
+		}
+
+	}
+
+	static class ProductDeserializer extends StdDeserializer<Product> {
+
+		public ProductDeserializer() {
+			super(Product.class);
+		}
+
+		@Override
+		public Product deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+			ObjectMapper mapper = (ObjectMapper) jsonParser.getCodec();
+			ObjectNode node = mapper.readTree(jsonParser);
+
+			String id = node.has("id") ? node.get("id").asText() : null;
+			String name = node.has("name") ? node.get("name").asText() : null;
+			Double price = node.has("price") && !node.get("price").isNull() ? node.get("price").asDouble() : null;
+			String category = node.has("category") ? node.get("category").asText() : null;
+
+			return new Product(id, name, price, category);
+		}
+
+	}
+
+}
+


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes `ClassCastException: HashMap cannot be cast to Product` when using custom objects in Graph Workflow.

Adds example implementation and documentation showing how to implement custom `StateSerializer` for user-defined objects.

### Does this pull request fix one issue?

Fixes #2558

### Describe how you did it

Added example code in `src/test/java/.../custom_serialization/`:
- `Product.java` - Example entity
- `ProductStateSerializer.java` - Custom serializer extending `SpringAIJacksonStateSerializer`
- `ProductSerializationTest.java` - 4 test cases

**Implementation pattern** (follows `DocumentHandler`, `UserMessageHandler`):
```java
public class ProductStateSerializer extends SpringAIJacksonStateSerializer {
    public ProductStateSerializer(AgentStateFactory<OverAllState> stateFactory) {
        super(stateFactory);
        SimpleModule module = new SimpleModule();
        module.addSerializer(Product.class, new ProductSerializer());
        module.addDeserializer(Product.class, new ProductDeserializer());
        objectMapper.registerModule(module);
        typeMapper.register(new TypeMapper.Reference<Product>("PRODUCT") {});
    }
}

// Usage
StateGraph graph = new StateGraph("Name", OverAllState::new, serializer);
```

### Describe how to verify it

```bash
cd spring-ai-alibaba-graph-core
mvn test -Dtest=ProductSerializationTest
mvn checkstyle:check
```

### Special notes for reviews

- **Zero breaking changes** - No core code modifications
- **Follows project style** - Minimal comments, matches existing serialization handlers
- **Serializer location** - Must pass to `StateGraph` constructor (not `CompileConfig`)