### PR TITLE
feat(memories): add Redis database index support

### DIFF
--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/JedisRedisChatMemoryConnectionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/JedisRedisChatMemoryConnectionAutoConfiguration.java
@@ -67,6 +67,7 @@ public class JedisRedisChatMemoryConnectionAutoConfiguration
 			.username(standaloneConfiguration.username())
 			.password(standaloneConfiguration.password())
 			.timeout(standaloneConfiguration.timeout())
+			.database(standaloneConfiguration.database())
 			.sslBundles(standaloneConfiguration.sslBundles())
 			.useSsl(standaloneConfiguration.ssl().isEnabled())
 			.bundle(standaloneConfiguration.ssl().getBundle())

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/LettuceRedisChatMemoryConnectionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/LettuceRedisChatMemoryConnectionAutoConfiguration.java
@@ -67,6 +67,7 @@ public class LettuceRedisChatMemoryConnectionAutoConfiguration
 			.username(standaloneConfiguration.username())
 			.password(standaloneConfiguration.password())
 			.timeout(standaloneConfiguration.timeout())
+			.database(standaloneConfiguration.database())
 			.sslBundles(standaloneConfiguration.sslBundles())
 			.useSsl(standaloneConfiguration.ssl().isEnabled())
 			.bundle(standaloneConfiguration.ssl().getBundle())

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryConnectionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryConnectionAutoConfiguration.java
@@ -108,7 +108,7 @@ public abstract class RedisChatMemoryConnectionAutoConfiguration<T extends ChatM
 		RedisMemoryConnectionDetails.Standalone standalone = connectionDetails.getStandalone();
 		return new RedisChatMemoryStandaloneConfiguration(standalone.getHost(), standalone.getPort(),
 				connectionDetails.getUsername(), connectionDetails.getPassword(), properties.getTimeout(),
-				properties.getSsl(), sslBundles);
+				properties.getDatabase(), properties.getSsl(), sslBundles);
 	}
 
 	/**

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryProperties.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryProperties.java
@@ -55,6 +55,11 @@ public class RedisChatMemoryProperties {
 	private int timeout = 2000;
 
 	/**
+	 * Redis database index.
+	 */
+	private int database = 0;
+
+	/**
 	 * Type of client to use. By default, auto-detected according to the classpath.
 	 */
 	private ClientType clientType;
@@ -112,6 +117,14 @@ public class RedisChatMemoryProperties {
 
 	public void setTimeout(int timeout) {
 		this.timeout = timeout;
+	}
+
+	public int getDatabase() {
+		return database;
+	}
+
+	public void setDatabase(int database) {
+		this.database = database;
 	}
 
 	public Cluster getCluster() {

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryStandaloneConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedisChatMemoryStandaloneConfiguration.java
@@ -24,6 +24,6 @@ import org.springframework.boot.ssl.SslBundles;
  * @since 2025/7/30 21:32
  */
 public record RedisChatMemoryStandaloneConfiguration(String hostName, int port, String username, String password,
-		int timeout, RedisChatMemoryProperties.Ssl ssl, SslBundles sslBundles) {
+		int timeout, int database, RedisChatMemoryProperties.Ssl ssl, SslBundles sslBundles) {
 
 }

--- a/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedissonRedisChatMemoryConnectionAutoConfiguration.java
+++ b/auto-configurations/spring-ai-alibaba-autoconfigure-memory/src/main/java/com/alibaba/cloud/ai/autoconfigure/memory/redis/RedissonRedisChatMemoryConnectionAutoConfiguration.java
@@ -67,6 +67,7 @@ public class RedissonRedisChatMemoryConnectionAutoConfiguration
 			.username(standaloneConfiguration.username())
 			.password(standaloneConfiguration.password())
 			.timeout(standaloneConfiguration.timeout())
+			.database(standaloneConfiguration.database())
 			.sslBundles(standaloneConfiguration.sslBundles())
 			.useSsl(standaloneConfiguration.ssl().isEnabled())
 			.bundle(standaloneConfiguration.ssl().getBundle())

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepository.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepository.java
@@ -97,6 +97,7 @@ public class JedisRedisChatMemoryRepository extends BaseRedisChatMemoryRepositor
 			}
 			else {
 				RedisStandaloneConfiguration standaloneConfig = new RedisStandaloneConfiguration(host, port);
+				standaloneConfig.setDatabase(database);
 				if (StringUtils.hasText(username)) {
 					standaloneConfig.setUsername(username);
 				}

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepository.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepository.java
@@ -102,6 +102,7 @@ public class LettuceRedisChatMemoryRepository extends BaseRedisChatMemoryReposit
 			}
 			else {
 				RedisStandaloneConfiguration standaloneConfig = new RedisStandaloneConfiguration(host, port);
+				standaloneConfig.setDatabase(database);
 				if (StringUtils.hasText(username)) {
 					standaloneConfig.setUsername(username);
 				}

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/RedissonRedisChatMemoryRepository.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/RedissonRedisChatMemoryRepository.java
@@ -126,7 +126,11 @@ public class RedissonRedisChatMemoryRepository extends BaseRedisChatMemoryReposi
 					config.useSingleServer().setSslTrustManagerFactory(managers.getTrustManagerFactory());
 					nodeUrl = "rediss://" + host + ":" + port;
 				}
-				config.useSingleServer().setAddress(nodeUrl).setConnectionPoolSize(poolSize).setConnectTimeout(timeout);
+				config.useSingleServer()
+					.setAddress(nodeUrl)
+					.setConnectionPoolSize(poolSize)
+					.setConnectTimeout(timeout)
+					.setDatabase(database);
 				if (StringUtils.hasLength(username)) {
 					config.useSingleServer().setUsername(username);
 				}

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/builder/RedisChatMemoryBuilder.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/main/java/com/alibaba/cloud/ai/memory/redis/builder/RedisChatMemoryBuilder.java
@@ -42,6 +42,8 @@ public abstract class RedisChatMemoryBuilder<T extends RedisChatMemoryBuilder<T>
 
 	protected int timeout = 2000;
 
+	protected int database = 0;
+
 	protected boolean useCluster = false;
 
 	protected boolean useSsl = false;
@@ -80,6 +82,11 @@ public abstract class RedisChatMemoryBuilder<T extends RedisChatMemoryBuilder<T>
 
 	public T timeout(int timeout) {
 		this.timeout = timeout;
+		return self();
+	}
+
+	public T database(int database) {
+		this.database = database;
 		return self();
 	}
 

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepositoryTest.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/JedisRedisChatMemoryRepositoryTest.java
@@ -274,6 +274,65 @@ class JedisRedisChatMemoryRepositoryTest {
 			.contains("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png");
 	}
 
+	@Test
+	void testDatabaseIsolation() {
+		var conversationId = UUID.randomUUID().toString();
+
+		var db0Repository = JedisRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.database(0)
+			.build();
+
+		var db1Repository = JedisRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.database(1)
+			.build();
+
+		var db0Messages = List.<Message>of(new UserMessage("Message in DB0 - " + conversationId));
+		var db1Messages = List.<Message>of(new UserMessage("Message in DB1 - " + conversationId));
+
+		db0Repository.saveAll(conversationId, db0Messages);
+		db1Repository.saveAll(conversationId, db1Messages);
+
+		var retrievedDb0 = db0Repository.findByConversationId(conversationId);
+		var retrievedDb1 = db1Repository.findByConversationId(conversationId);
+
+		assertThat(retrievedDb0).hasSize(1);
+		assertThat(retrievedDb1).hasSize(1);
+		assertThat(retrievedDb0.get(0).getText()).contains("DB0");
+		assertThat(retrievedDb1.get(0).getText()).contains("DB1");
+
+		db0Repository.deleteByConversationId(conversationId);
+		db1Repository.deleteByConversationId(conversationId);
+	}
+
+	@Test
+	void testDefaultDatabaseIsZero() {
+		var conversationId = UUID.randomUUID().toString();
+
+		var defaultRepository = JedisRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.build();
+
+		var db0Repository = JedisRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.database(0)
+			.build();
+
+		var messages = List.<Message>of(new UserMessage("Test default database - " + conversationId));
+		defaultRepository.saveAll(conversationId, messages);
+
+		var retrieved = db0Repository.findByConversationId(conversationId);
+		assertThat(retrieved).hasSize(1);
+		assertThat(retrieved.get(0).getText()).isEqualTo(messages.get(0).getText());
+
+		defaultRepository.deleteByConversationId(conversationId);
+	}
+
 	@SpringBootConfiguration
 	static class TestConfiguration {
 

--- a/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepositoryTest.java
+++ b/community/memories/spring-ai-alibaba-starter-memory-redis/src/test/java/com/alibaba/cloud/ai/memory/redis/LettuceRedisChatMemoryRepositoryTest.java
@@ -277,6 +277,65 @@ public class LettuceRedisChatMemoryRepositoryTest {
 			.contains("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png");
 	}
 
+	@Test
+	void testDatabaseIsolation() {
+		var conversationId = UUID.randomUUID().toString();
+
+		var db0Repository = LettuceRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.database(0)
+			.build();
+
+		var db1Repository = LettuceRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.database(1)
+			.build();
+
+		var db0Messages = List.<Message>of(new UserMessage("Message in DB0 - " + conversationId));
+		var db1Messages = List.<Message>of(new UserMessage("Message in DB1 - " + conversationId));
+
+		db0Repository.saveAll(conversationId, db0Messages);
+		db1Repository.saveAll(conversationId, db1Messages);
+
+		var retrievedDb0 = db0Repository.findByConversationId(conversationId);
+		var retrievedDb1 = db1Repository.findByConversationId(conversationId);
+
+		assertThat(retrievedDb0).hasSize(1);
+		assertThat(retrievedDb1).hasSize(1);
+		assertThat(retrievedDb0.get(0).getText()).contains("DB0");
+		assertThat(retrievedDb1.get(0).getText()).contains("DB1");
+
+		db0Repository.deleteByConversationId(conversationId);
+		db1Repository.deleteByConversationId(conversationId);
+	}
+
+	@Test
+	void testDefaultDatabaseIsZero() {
+		var conversationId = UUID.randomUUID().toString();
+
+		var defaultRepository = LettuceRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.build();
+
+		var db0Repository = LettuceRedisChatMemoryRepository.builder()
+			.host(redisContainer.getHost())
+			.port(redisContainer.getMappedPort(REDIS_PORT))
+			.database(0)
+			.build();
+
+		var messages = List.<Message>of(new UserMessage("Test default database - " + conversationId));
+		defaultRepository.saveAll(conversationId, messages);
+
+		var retrieved = db0Repository.findByConversationId(conversationId);
+		assertThat(retrieved).hasSize(1);
+		assertThat(retrieved.get(0).getText()).isEqualTo(messages.get(0).getText());
+
+		defaultRepository.deleteByConversationId(conversationId);
+	}
+
 	@SpringBootConfiguration
 	static class TestConfiguration {
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adds support for specifying Redis database index in `RedisChatMemoryRepository`. Previously, the repository always used database 0 and ignored the `spring.ai.memory.redis.database` configuration, making it impossible to isolate data across different environments or use cases.

This PR enables users to:
- Configure database index via `spring.ai.memory.redis.database` property
- Set database index programmatically using `.database(int)` builder method
- Use different Redis databases for different environments (dev/test/prod)

### Does this pull request fix one issue?

Fixes #2604

### Describe how you did it

1. **Builder layer**: Added `database` field and setter in `RedisChatMemoryBuilder`
2. **Implementation layer**: Updated Jedis, Lettuce, and Redisson to set database in `RedisStandaloneConfiguration`
3. **Configuration layer**: Added `database` property in `RedisChatMemoryProperties` (default: 0)
4. **Autoconfiguration layer**: Pass database parameter through configuration chain
5. **Tests**: Added database isolation and default value tests for all three clients

### Describe how to verify it

**Via configuration file:**
```yaml
spring:
  ai:
    memory:
      redis:
        database: 1
        host: localhost
        port: 6379
```

**Via builder:**
```java
var repository = JedisRedisChatMemoryRepository.builder()
    .host("localhost")
    .port(6379)
    .database(1)
    .build();
```

### Special notes for reviews

- Default database is 0, ensuring backward compatibility
- Only affects standalone mode (cluster mode uses DB0 only by design)
- All three Redis clients (Jedis/Lettuce/Redisson) are supported
- Tests verify database isolation and default behavior