### PR TITLE
test(core): fix compile warnings

### DIFF
--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/advisor/RetrievalRerankAdvisorTests.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/advisor/RetrievalRerankAdvisorTests.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -178,7 +179,7 @@ class RetrievalRerankAdvisorTests {
 		assertThat(response.context()).containsKey(RetrievalRerankAdvisor.RETRIEVED_DOCUMENTS);
 		assertThat(response.context().get(RetrievalRerankAdvisor.RETRIEVED_DOCUMENTS)).isNotNull()
 			.isInstanceOf(List.class)
-			.asList()
+			.asInstanceOf(LIST)
 			.hasSize(1)
 			.contains(testDocument);
 	}
@@ -209,7 +210,7 @@ class RetrievalRerankAdvisorTests {
 		assertThat(response.context()).containsKey(RetrievalRerankAdvisor.RETRIEVED_DOCUMENTS);
 		assertThat(response.context().get(RetrievalRerankAdvisor.RETRIEVED_DOCUMENTS)).isNotNull()
 			.isInstanceOf(List.class)
-			.asList()
+			.asInstanceOf(LIST)
 			.isEmpty();
 	}
 
@@ -313,7 +314,7 @@ class RetrievalRerankAdvisorTests {
 		assertThat(response.context()).containsKey(RetrievalRerankAdvisor.RETRIEVED_DOCUMENTS);
 		assertThat(response.context().get(RetrievalRerankAdvisor.RETRIEVED_DOCUMENTS)).isNotNull()
 			.isInstanceOf(List.class)
-			.asList()
+			.asInstanceOf(LIST)
 			.isEmpty();
 	}
 

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/common/RequestIdGeneratorTests.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/common/RequestIdGeneratorTests.java
@@ -94,7 +94,7 @@ class RequestIdGeneratorTests {
 	@Test
 	void testGenerateIdWithNullParameters() {
 		// Test ID generation with null parameters
-		String id1 = generator.generateId(null);
+		String id1 = generator.generateId((Object) null);
 		String id2 = generator.generateId(null, null);
 
 		// Verify IDs generated with null parameters are not null


### PR DESCRIPTION
### Describe what this PR does / why we need it
fix compile warnings

### Does this pull request fix one issue?
no

### Describe how you did it
* cast null to Object type to fix varargs warning in RequestIdGeneratorTests
* replace deprecated method in RetrievalRerankAdvisorTests

### Describe how to verify it
mvn test

### Special notes for reviews
no