### PR TITLE
feat(core): add Partial Mode support for code completion

### DIFF
--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelper.java
@@ -139,7 +139,7 @@ public class DashScopeAiStreamFunctionCallingHelper {
 				toolCalls.add(lastPreviousTooCall);
 			}
 		}
-		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, reasoningContent);
+		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, reasoningContent, null);
 	}
 
 	private ToolCall merge(ToolCall previous, ToolCall current) {

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/api/DashScopeApi.java
@@ -1270,6 +1270,9 @@ public class DashScopeApi {
 	 * "https://help.aliyun.com/zh/model-studio/developer-reference/deepseek">DeepSeek
 	 * ReasoningContent</a> Applicable only for {@link Role#ASSISTANT} role and null
 	 * otherwise.
+	 * @param partial Indicates whether this message is a partial prefix for code completion.
+	 * When set to true, the model will continue generating from the provided content.
+	 * Applicable only for {@link Role#ASSISTANT} role and null otherwise.
 	 */
 	// format: off
 	@JsonInclude(JsonInclude.Include.NON_NULL)
@@ -1277,7 +1280,8 @@ public class DashScopeApi {
 	public record ChatCompletionMessage(@JsonProperty("content") Object rawContent, @JsonProperty("role") Role role,
 			@JsonProperty("name") String name, @JsonProperty("tool_call_id") String toolCallId,
 			@JsonProperty("tool_calls") List<ToolCall> toolCalls,
-			@JsonProperty("reasoning_content") String reasoningContent) {
+			@JsonProperty("reasoning_content") String reasoningContent,
+			@JsonProperty("partial") Boolean partial) {
 
 		/**
 		 * Get message content as String.
@@ -1316,7 +1320,7 @@ public class DashScopeApi {
 		 */
 		public ChatCompletionMessage(Object content, Role role) {
 
-			this(content, role, null, null, null, null);
+			this(content, role, null, null, null, null, null);
 		}
 		// format: on
 

--- a/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
+++ b/spring-ai-alibaba-core/src/main/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModel.java
@@ -482,17 +482,28 @@ public class DashScopeChatModel implements ChatModel {
 						ChatCompletionMessage.Role.valueOf(message.getMessageType().name())));
 			}
 			else if (message.getMessageType() == MessageType.ASSISTANT) {
-				var assistantMessage = (AssistantMessage) message;
-				List<ToolCall> toolCalls = null;
-				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
-					toolCalls = assistantMessage.getToolCalls().stream().map(toolCall -> {
-						var function = new ChatCompletionFunction(toolCall.name(), toolCall.arguments());
-						return new ToolCall(toolCall.id(), toolCall.type(), function);
-					}).toList();
-				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
-						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null));
+			var assistantMessage = (AssistantMessage) message;
+			List<ToolCall> toolCalls = null;
+			if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
+				toolCalls = assistantMessage.getToolCalls().stream().map(toolCall -> {
+					var function = new ChatCompletionFunction(toolCall.name(), toolCall.arguments());
+					return new ToolCall(toolCall.id(), toolCall.type(), function);
+				}).toList();
 			}
+			// Extract partial flag from metadata
+			Boolean partial = null;
+			if (assistantMessage.getMetadata() != null) {
+				Object partialValue = assistantMessage.getMetadata().get("partial");
+				if (partialValue instanceof Boolean) {
+					partial = (Boolean) partialValue;
+				}
+				else if (partialValue instanceof String) {
+					partial = Boolean.parseBoolean((String) partialValue);
+				}
+			}
+			return List.of(new ChatCompletionMessage(assistantMessage.getText(),
+					ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null, partial));
+		}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;
 
@@ -501,11 +512,11 @@ public class DashScopeChatModel implements ChatModel {
 					Assert.isTrue(response.name() != null, "ToolResponseMessage must have a name");
 				});
 
-				return toolMessage.getResponses()
-					.stream()
-					.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
-							tr.id(), null, null))
-					.toList();
+			return toolMessage.getResponses()
+				.stream()
+				.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
+						tr.id(), null, null, null))
+				.toList();
 			}
 			else {
 				throw new IllegalArgumentException("Unsupported message type: " + message.getMessageType());

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/api/DashScopeAiStreamFunctionCallingHelperTests.java
@@ -234,7 +234,7 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 		ChatCompletionFunction function = new ChatCompletionFunction(functionName, arguments);
 		ToolCall toolCall = new ToolCall(toolId, "function", function);
 		ChatCompletionMessage message = new ChatCompletionMessage("", Role.ASSISTANT, null, null, List.of(toolCall),
-				null);
+				null, null);
 		Choice choice = new Choice(finishReason, message, null);
 		ChatCompletionOutput output = new ChatCompletionOutput(null, List.of(choice), null);
 		TokenUsage usage = new TokenUsage(10, 5, 15, null, null, null, null, null, null);
@@ -248,7 +248,7 @@ public class DashScopeAiStreamFunctionCallingHelperTests {
 		ChatCompletionFunction function2 = new ChatCompletionFunction("function-2", "{\"param2\":\"value2\"}");
 		ToolCall toolCall2 = new ToolCall("tool-2", "function", function2);
 		ChatCompletionMessage message = new ChatCompletionMessage("", Role.ASSISTANT, null, null,
-				List.of(toolCall1, toolCall2), null);
+				List.of(toolCall1, toolCall2), null, null);
 		Choice choice = new Choice(null, message, null);
 		ChatCompletionOutput output = new ChatCompletionOutput(null, List.of(choice), null);
 		TokenUsage usage = new TokenUsage(10, 5, 15, null, null, null, null, null, null);

--- a/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
+++ b/spring-ai-alibaba-core/src/test/java/com/alibaba/cloud/ai/dashscope/chat/DashScopeChatModelTests.java
@@ -491,7 +491,7 @@ class DashScopeChatModelTests {
 		ToolCall nullNameToolCall = new ToolCall("tool-call-id", "function", nullNameFunction);
 
 		ChatCompletionMessage nullNameToolMessage = new ChatCompletionMessage("", ChatCompletionMessage.Role.ASSISTANT,
-				null, null, List.of(nullNameToolCall), null);
+				null, null, List.of(nullNameToolCall), null, null);
 		Choice nullNameChoice = new Choice(ChatCompletionFinishReason.TOOL_CALLS, nullNameToolMessage, null);
 
 		// Add non-null TokenUsage with correct parameters - 9 parameters total
@@ -513,6 +513,79 @@ class DashScopeChatModelTests {
 			// Tool calls with null names should be filtered out
 			assertThat(response.getResults().get(0).getOutput().getToolCalls()).isEmpty();
 		}).doesNotThrowAnyException();
+	}
+
+	@Test
+	void testPartialModeForCodeCompletion() {
+		// Test partial mode support for code completion scenarios
+		// Create a prompt with partial assistant message to continue code generation
+		List<Message> messages = List.of(
+				new SystemMessage("You are a code assistant. Complete the code provided."),
+				new UserMessage("Please complete this Fibonacci function."),
+				new AssistantMessage("def calculate_fibonacci(n):\n    if n <= 1:\n        return n\n    else:\n",
+						java.util.Map.of("partial", true))
+		);
+
+		Prompt prompt = new Prompt(messages, DashScopeChatOptions.builder().build());
+
+		// Create the request to verify partial flag is correctly set
+		ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+		// Verify the request messages
+		List<ChatCompletionMessage> requestMessages = request.input().messages();
+		assertThat(requestMessages).isNotEmpty();
+		assertThat(requestMessages.size()).isEqualTo(3);
+
+		// Verify the last message is an assistant message with partial=true
+		ChatCompletionMessage lastMessage = requestMessages.get(2);
+		assertThat(lastMessage.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(lastMessage.partial()).isNotNull();
+		assertThat(lastMessage.partial()).isTrue();
+		assertThat(lastMessage.content()).contains("def calculate_fibonacci");
+	}
+
+	@Test
+	void testPartialModeWithStringValue() {
+		// Test partial mode when set as string "true" in metadata
+		AssistantMessage assistantMessage = new AssistantMessage(
+				"def calculate_fibonacci(n):\n    if n <= 1:\n        return n\n    else:\n",
+				java.util.Map.of("partial", "true")
+		);
+
+		List<Message> messages = List.of(
+				new UserMessage("Please complete this function."),
+				assistantMessage
+		);
+
+		Prompt prompt = new Prompt(messages, DashScopeChatOptions.builder().build());
+		ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+		List<ChatCompletionMessage> requestMessages = request.input().messages();
+		ChatCompletionMessage lastMessage = requestMessages.get(requestMessages.size() - 1);
+
+		// Verify string "true" is converted to boolean true
+		assertThat(lastMessage.partial()).isNotNull();
+		assertThat(lastMessage.partial()).isTrue();
+	}
+
+	@Test
+	void testWithoutPartialMode() {
+		// Test normal assistant message without partial flag
+		AssistantMessage assistantMessage = new AssistantMessage("This is a normal response");
+
+		List<Message> messages = List.of(
+				new UserMessage("Hello"),
+				assistantMessage
+		);
+
+		Prompt prompt = new Prompt(messages, DashScopeChatOptions.builder().build());
+		ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+		List<ChatCompletionMessage> requestMessages = request.input().messages();
+		ChatCompletionMessage lastMessage = requestMessages.get(requestMessages.size() - 1);
+
+		// Verify partial is null when not set
+		assertThat(lastMessage.partial()).isNull();
 	}
 
 }


### PR DESCRIPTION
## Describe what this PR does / why we need it

Adds Partial Mode support for code completion. Enables AI models to continue generating from a provided code prefix instead of starting from scratch.

## Does this pull request fix one issue?

Fixes #2598

## Describe how you did it

- Added `partial` field to `ChatCompletionMessage` 
- Extract `partial` flag from `AssistantMessage` metadata
- Updated helper classes and added test coverage

## Describe how to verify it

```java
AssistantMessage msg = new AssistantMessage(
    "def fibonacci(n):\n    return n\n    else:\n",
    Map.of("partial", true)
);
```

## Special notes for reviews

- No breaking changes, backward compatible

<img width="805" height="501" alt="image" src="https://github.com/user-attachments/assets/d12f63a1-82f9-4097-8e19-4f3246c34475" />
<img width="823" height="492" alt="image" src="https://github.com/user-attachments/assets/9710756a-06c9-49fb-b3e7-e02fcab80aa5" />

