### PR TITLE
fix(agent): ModelFallbackInterceptor incorrectly invokes fallback when primary model succeeds

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelfallback/ModelFallbackInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelfallback/ModelFallbackInterceptor.java
@@ -66,9 +66,14 @@ public class ModelFallbackInterceptor extends ModelInterceptor {
 		try {
 			ModelResponse modelResponse = handler.call(request);
 			Message message = (Message) modelResponse.getMessage();
+			
+			// Check if response contains error indicator
 			if (message.getText() != null && message.getText().contains("Exception:")) {
 				throw new RuntimeException(message.getText());
 			}
+			
+			// Return successful response
+			return modelResponse;
 		}
 		catch (Exception e) {
 			log.warn("Primary model failed: {}", e.getMessage());

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelfallbackTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelfallbackTest.java
@@ -98,8 +98,9 @@ class ModelfallbackTest {
 			System.out.println("Fallback model (DashScope) call count: " + fallbackModelCalls);
 
 			// Verify the models were called as expected
-			assertEquals(1, chatModel.getCallCount());
-			assertEquals(1, fallbackModel.getCallCount());
+			// Bug fix: Primary model succeeded, so fallback should NOT be called
+			assertEquals(1, chatModel.getCallCount(), "Primary model should be called once");
+			assertEquals(0, fallbackModel.getCallCount(), "Fallback should not be called when primary succeeds");
 
 		}
 		catch (java.util.concurrent.CompletionException e) {


### PR DESCRIPTION

### Describe what this PR does / why we need it

This PR fixes a critical bug in `ModelFallbackInterceptor` where the primary model's successful response is ignored, and the fallback model is incorrectly invoked.

**Root cause:** A `return` statement was accidentally omitted during code refactoring (commit 53bb95a7a), causing the interceptor to continue executing the fallback logic even when the primary model succeeds.

**Why this matters:**
- **Cost waste**: Unnecessary API calls to fallback models (e.g., calling GPT-3.5 after GPT-4 already succeeded)
- **Performance degradation**: Added latency from redundant model invocations
- **Incorrect semantics**: Violates the standard fallback pattern - fallback should only be triggered on errors
- **Documentation mismatch**: Class javadoc states "Automatic fallback to alternative models **on errors**", but current implementation always calls fallback

### Does this pull request fix one issue?

NONE

### Describe how you did it

**Core fix:**
Added the missing `return modelResponse;` statement in `ModelFallbackInterceptor.java` after the primary model succeeds:

```java
try {
    ModelResponse modelResponse = handler.call(request);
    Message message = (Message) modelResponse.getMessage();
    
    // Check if response contains error indicator
    if (message.getText() != null && message.getText().contains("Exception:")) {
        throw new RuntimeException(message.getText());
    }
    
+   // Return successful response
+   return modelResponse;  // This line was missing!
}
catch (Exception e) {
    log.warn("Primary model failed: {}", e.getMessage());
    lastException = e;
}
// Now fallback is only called when primary fails
```

**Test update:**
Fixed incorrect test assertion in `ModelfallbackTest.java`:
- Before: Expected fallback to be called even when primary succeeds ❌
- After: Expects fallback NOT to be called when primary succeeds ✅

### Describe how to verify it

**Method 1: Run existing integration test** (requires API keys)
```bash
export OPENAI_API_KEY=your_openai_key
export AI_DASHSCOPE_API_KEY=your_dashscope_key

cd spring-ai-alibaba-agent-framework
mvn test -Dtest=ModelfallbackTest
```

**Expected result:**
```
✅ Primary model (OpenAI) call count: 1
✅ Fallback model (DashScope) call count: 0  (was 1 before fix)
```

**Method 2: Manual verification**
1. Create a `ModelFallbackInterceptor` with a fallback model
2. Make a successful request through the interceptor
3. Verify only the primary model is called (fallback should have 0 invocations)

**Method 3: Code review**
Review the execution flow:
- **Before**: Primary succeeds → continues to fallback → returns fallback result ❌
- **After**: Primary succeeds → returns immediately → no fallback ✅

### Special notes for reviews

1. **This is a regression bug**
   - Introduced in refactoring commit 53bb95a7a
   - Original code had the `return` statement
   - Accidentally removed when splitting code into multiple lines

2. **Minimal but critical change**
   - Only 2 files changed, 8 insertions, 2 deletions
   - Core fix is literally 1 line: `return modelResponse;`
   - High impact: prevents cost waste and improves performance

3. **Test expectations were based on buggy behavior**
   - The existing `ModelfallbackTest` expected both models to be called
   - This expectation was incorrect - contradicts fallback semantics
   - Test now verifies correct behavior: fallback only on failure

4. **No breaking changes**
   - Fallback behavior on errors is fully preserved
   - Only fixes the incorrect behavior when primary succeeds
   - All existing error handling remains unchanged

5. **Documentation alignment**
   - Fix aligns code with class javadoc
   - Javadoc states "on errors" - now code actually does this
