### PR TITLE
fix(agent): fix bugs when use PromptTemplate in SequentialAgent with ReactAgent

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
@@ -197,7 +197,9 @@ public class AgentLlmNode implements NodeActionWithConfig {
 				break;
 			}
 			if (message instanceof AgentInstructionMessage templatedUserMessage) {
-				messages.set(i, templatedUserMessage.mutate().text(templatedUserMessage.getText() + System.lineSeparator() + outputSchema).build());
+                // 将outputSchema进行转义，避免PromptTemplate渲染时报错
+                String newOutputSchema = outputSchema.replace("{", "\\{").replace("}", "\\}");
+                messages.set(i, templatedUserMessage.mutate().text(templatedUserMessage.getText() + System.lineSeparator() + newOutputSchema).build());
 				break;
 			}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LoopAgentTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LoopAgentTest.java
@@ -83,10 +83,10 @@ public class LoopAgentTest {
                 .description("可以根据用户的自然语言生成MySQL的SQL代码。")
                 .instruction("你是一个熟悉MySQL数据库的小助手，请你根据用户的自然语言，输出对应的SQL。")
                 .outputSchema("""
-                        \\{
-                            "query": 用户的请求,
-                            "output": 生成SQL结果
-                        \\}
+                        {
+                           "query": 用户的请求,
+                           "output": 生成SQL结果
+                        }
                         """)
                 .outputKey("sql")
                 .build();


### PR DESCRIPTION
### Describe what this PR does / why we need it

当把`ReactAgent`作为`SequentialAgent`的子智能体时，使用`outputType`或`outputSchema`会报错，因为JSON格式的花括号与`PromptTemplate`的占位符号冲突。而单独使用`ReactAgent`时，代码是把`outputSchema`贴在`UserMessage`后而不是`AgentInstructionMessage`后面，没有触发这个bug

解决办法是进行转义。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
