### PR TITLE
fix(mcp): NacosMcpGatewayToolCallback log throw com.fasterxml.jackson.databind.exc.InvalidDefinitionException

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
@@ -73,7 +74,8 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 	static {
 		objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 		objectMapper.setSerializationInclusion(Include.NON_NULL);
-	}
+        objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    }
 
 	private final NacosMcpGatewayToolDefinition toolDefinition;
 
@@ -384,7 +386,7 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 	@SuppressWarnings("unchecked")
 	public String call(@NonNull final String input, final ToolContext toolContext) {
 		try {
-			logger.info("[call] input: {} toolContext: {}", input, JacksonUtils.toJson(toolContext));
+			logger.info("[call] input: {} toolContext: {}", input, objectMapper.writeValueAsString(toolContext));
 
 			// 参数验证
 			if (this.toolDefinition == null) {


### PR DESCRIPTION
….InvalidDefinitionException


### Describe what this PR does / why we need it
NacosMcpGatewayToolCallback  used	"logger.info("[call] input: {} toolContext: {}", input, JacksonUtils.toJson(toolContext));" ,but ToolContext#context value cant serialize(such as value is RunnableConfig.class) , so produce Exception:

Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class com.alibaba.cloud.ai.graph.RunnableConfig and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) 
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
use NacosMcpGatewayToolCallback  self jackson

### Describe how to verify it
its easy to see

### Special notes for reviews
