### PR TITLE
feat(mcp): A simple implementation of tool calls for supplementing StreamableHTTP

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/vo/McpServersVO.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/vo/McpServersVO.java
@@ -34,6 +34,8 @@ public class McpServersVO {
 
 		String version;
 
+        String host;
+
 		Set<String> whiteTools;
 
 		Map<String, String> headers;


### PR DESCRIPTION
### Describe what this PR does / why we need it

Supplement the Streamable http implementation of toolcall in NacosMcpGatewayToolCallback


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

I believe that in the Nacos config starter package, Nacos should be used as a configuration center, not a registry center (similar to namingService used in the SSE protocol, which should be placed in the A2A starter package?). Therefore, I added the McpServerVo host field for Nacos as the configuration center and a Streamable HTTP implementation.

### Describe how to verify it


### Special notes for reviews
