### PR TITLE
fix(agent): llmRoutingAgent fails with Ollama and other ChatModel implementations

### DIFF
--- a/spring-ai-alibaba-agent-framework/pom.xml
+++ b/spring-ai-alibaba-agent-framework/pom.xml
@@ -113,6 +113,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-ollama</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <reporting>


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes an issue where `LlmRoutingAgent` fails with "cannot find edge mapping" error when using Ollama or other ChatModel implementations that return non-exact agent names. The fix improves prompt clarity and adds intelligent response parsing with fallback strategies to handle various ChatModel output formats.

### Does this pull request fix one issue?

Fixes #2731 

### Describe how you did it

1. Enhanced prompt construction in `RoutingEdgeAction.java` to explicitly guide ChatModel to return exact agent names
2. Implemented `parseAgentName()` method with 3-tier fallback strategies:
   - Exact match (most common case)
   - Case-insensitive match (handles case variations)
   - Substring match with length-based sorting (handles extra text and avoids partial matches like "writer_agent" vs "poem_writer_agent")
3. Added SLF4J logging for routing decisions (debug, info, warn levels)
4. Added `spring-ai-starter-model-ollama` test dependency in pom.xml

### Describe how to verify it

Run test: `mvn test -pl spring-ai-alibaba-agent-framework -Dtest=LlmRoutingAgentTest`

With environment variable `AI_DASHSCOPE_API_KEY` set, the test should pass. The routing logic now correctly handles ChatModel responses even when they include extra text or incorrect case.

Manual verification with Ollama:
```java
OllamaApi ollamaApi = OllamaApi.builder().baseUrl("http://localhost:11434").build();
OllamaOptions options = OllamaOptions.builder().model("qwen3:32b").temperature(0.1).build();
ChatModel chatModel = OllamaChatModel.builder()
    .ollamaApi(ollamaApi)
    .defaultOptions(options)
    .build();

LlmRoutingAgent agent = LlmRoutingAgent.builder()
    .model(chatModel)  // Now works with Ollama
    .subAgents(...)
    .build();
```

### Special notes for reviews

- No breaking changes - fully backward compatible
- Minimal code changes (2 files modified: pom.xml + RoutingEdgeAction.java)
- Code follows project style (simplified comments, concise prompt)
- All Checkstyle and Spotless checks pass (0 violations)
- Fixed potential bug: length-sorted substring matching prevents "poem_writer_agent" from matching "writer_agent"
- Logging added for debugging ChatModel responses