### PR TITLE
graph: support multi-node parallel branches with join; correct state …

### DIFF
--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/ParallelMultiNodeBranchTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/ParallelMultiNodeBranchTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.action.AsyncNodeAction;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ParallelMultiNodeBranchTest {
+
+	private static KeyStrategyFactory createKeyStrategyFactory() {
+		return () -> {
+			HashMap<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		};
+	}
+
+	private AsyncNodeAction makeNode(String id) {
+		return node_async(state -> Map.of("messages", id));
+	}
+
+	@Test
+	void testParallelBranchesWithMultipleNodesAndJoin() throws Exception {
+		StateGraph graph = new StateGraph(createKeyStrategyFactory())
+			.addNode("A", makeNode("A"))
+			.addNode("A1", makeNode("A1"))
+			.addNode("A1b", makeNode("A1b"))
+			.addNode("A2", makeNode("A2"))
+			.addNode("A2b", makeNode("A2b"))
+			.addNode("B", makeNode("B"))
+			.addNode("C", makeNode("C"))
+			.addEdge(START, "A")
+			.addEdge("A", "A1")
+			.addEdge("A", "A2")
+			.addEdge("A1", "A1b")
+			.addEdge("A1b", "B")
+			.addEdge("A2", "A2b")
+			.addEdge("A2b", "B")
+			.addEdge("B", "C")
+			.addEdge("C", END);
+
+		CompiledGraph compiled = graph.compile();
+
+		final OverAllState[] finalState = new OverAllState[1];
+		compiled.stream(Map.of())
+			.map(NodeOutput::state)
+			.doOnNext(s -> finalState[0] = s)
+			.blockLast();
+
+		assertTrue(finalState[0] != null);
+		List<String> messages = (List<String>) finalState[0].value("messages").get();
+		// Must contain all nodes
+		assertTrue(messages.contains("A"));
+		assertTrue(messages.containsAll(List.of("A1", "A1b", "A2", "A2b")));
+		assertEquals("C", messages.get(messages.size() - 1));
+
+		// A should be first
+		assertEquals("A", messages.get(0));
+		// B must occur before C
+		int idxB = messages.lastIndexOf("B");
+		int idxC = messages.lastIndexOf("C");
+		assertTrue(idxB >= 0 && idxC > idxB);
+		// Total messages: A + (A1, A1b, A2, A2b in any order) + B + C = 7
+		assertEquals(7, messages.size());
+	}
+}
+


### PR DESCRIPTION
…merging; add tests; fixes #2180


### Describe what this PR does / why we need it
- Adds support for parallel branches that span multiple nodes before converging at a common join.
- Fixes state merging for parallel subgraphs so “messages” are not duplicated.
- Unblocks importing Dify workflows that model fan-out → multi-node chains → join patterns.
- Preserves existing validation semantics for unsupported patterns.

### Does this pull request fix one issue?
Fixes #2180

### Describe how you did it
- Compiler (CompiledGraph):
  - Detects a common join for a parallel fan-out when all branches are linear (no conditionals/forks) and share the same join.
  - Excludes `END` as a join candidate to keep prior error behavior unchanged.
  - Requires branch subpaths to be pairwise disjoint before the join; if any node appears in more than one branch, fallback to the existing validation error (prevents shared-node duplication).
  - Wraps each branch path as a compiled subgraph and executes them in parallel via `ParallelNode`, then continues execution at the join node.
- Executor (NodeExecutor):
  - When a branch yields a Map (typical subgraph completion), merges it into state with key-strategy awareness.
  - Captures a baseline snapshot of `messages` at fan-out and merges only the delta beyond this baseline for each branch to avoid duplicates across branches and the parent.

### Describe how to verify it
- Run graph-core unit tests:
  - `mvn -q -pl spring-ai-alibaba-graph-core -DskipITs test`
- Focused test:
  - `mvn -q -pl spring-ai-alibaba-graph-core -Dtest=ParallelMultiNodeBranchTest test`
- Expected:
  - `ParallelMultiNodeBranchTest` passes with correct message count and “B before C”.
  - Existing error tests remain valid: conditionals on any branch, convergence only at `END`, or shared nodes before the join still throw the appropriate errors.

### Special notes for reviews
- Scope intentionally limited to linear branches with a proper common join; complex patterns (branch conditionals, additional fan-outs, shared nodes pre-join) remain invalid to retain predictable semantics.
- No public API changes; previously valid graphs keep their behavior.
- If future needs require supporting shared-node joins, we can introduce a dedicated join-aggregator in a follow-up PR.
