### PR TITLE
fix(agent): 修复总结不生效的问题

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/summarization/SummarizationHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/summarization/SummarizationHook.java
@@ -77,6 +77,14 @@ public class SummarizationHook extends ModelHook {
     private static final String SUMMARY_PREFIX = "## Previous conversation summary:";
     private static final int DEFAULT_MESSAGES_TO_KEEP = 20;
 
+
+    private static final HashMap<String, KeyStrategy> keyStrategyHashMap;
+
+    static {
+        keyStrategyHashMap = new HashMap<>();
+        keyStrategyHashMap.put("messages", new ReplaceStrategy());
+    }
+
     private final ChatModel model;
     private final Integer maxTokensBeforeSummary;
     private final int messagesToKeep;
@@ -140,8 +148,6 @@ public class SummarizationHook extends ModelHook {
                 "Summarized {} messages, keeping {} recent messages",
                 toSummarize.size(), toPreserve.size()
         );
-        HashMap<String, KeyStrategy> keyStrategyHashMap = new HashMap<>();
-        keyStrategyHashMap.put("messages", new ReplaceStrategy());
         state.updateStateWithKeyStrategies(updates, keyStrategyHashMap);
         return CompletableFuture.completedFuture(new HashMap<>());
     }


### PR DESCRIPTION



### Describe what this PR does / why we need it
ReacAgent的messages对应的策略是AppendStrategy,因此虽然实际…触发了总结,但是实际并没有替换，而是append了，不符合预期。
### Does this pull request fix one issue?

None
### Describe how you did it
通过在hook中触发执行指定策略更新，然后将空对象返回，触发后续流程。
<img width="862" height="320" alt="image" src="https://github.com/user-attachments/assets/ceb71e24-c7ac-440e-b790-6f44d7aa4ea8" />

### Describe how to verify it
RUN `com.alibaba.cloud.ai.graph.agent.hooks.summarization.SummarizationTest`

### Special notes for reviews
