### PR TITLE
fix: systemPrompt not work

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentTest.java
@@ -268,4 +268,18 @@ class ReactAgentTest {
 		}).blockLast();
 	}
 
+	@Test
+	public void testAgentSystemPrompt() throws Exception {
+		ReactAgent agent = ReactAgent.builder()
+				.name("test_agent")
+				.model(chatModel)
+				.saver(new MemorySaver())
+				.systemPrompt("你是一个诗歌写作助理，你能帮我写一首关于春天的现代诗。")
+				.enableLogging(true)
+				.build();
+
+		AssistantMessage assistantMessage = agent.call("帮我写一首关于春天的现代诗。");
+		System.out.println(assistantMessage.getText());
+	}
+
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
metadata里 steam 默认是false, 导致在 AgentLlmNode stream false分支下构造modelRequest, 没有添加Systemprompt
目前只能通过构造chatClient, 并且在chatClient.defaultSystem 设置规避

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
yes

### Describe how you did it
add systemPrompt in requestBuilder

### Describe how to verify it
see testAgentSystemPrompt

### Special notes for reviews
