### PR TITLE
fix(agent): Fix Qwen3 tool call not working in streaming output (Ollama deployment) (#3050)

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
@@ -151,6 +151,15 @@ public class AgentLlmNode implements NodeActionWithConfig {
 				.messages(messages)
 				.options(toolCallingChatOptions)
 				.context(config.metadata().orElse(new HashMap<>()));
+
+        // Extract tool names from toolCallbacks and pass them to ModelRequest
+        if (toolCallbacks != null && !toolCallbacks.isEmpty()) {
+            List<String> toolNames = toolCallbacks.stream()
+                    .map(callback -> callback.getToolDefinition().name())
+                    .toList();
+            requestBuilder.tools(toolNames);
+        }
+
 		if (StringUtils.hasLength(this.systemPrompt)) {
 			requestBuilder.systemMessage(new SystemMessage(this.systemPrompt));
 		}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -227,7 +227,9 @@ public class NodeExecutor extends BaseGraphExecutor {
 						GraphResponse<NodeOutput> lastGraphResponse = GraphResponse
 							.of(context.buildStreamingOutput(currentMessage, response, context.getCurrentNodeId()));
 						lastGraphResponseRef.set(lastGraphResponse);
-						return lastGraphResponse;
+                        // Also update lastChatResponseRef to ensure consistency
+                        lastChatResponseRef.set(response);
+                        return lastGraphResponse;
 					}
 
 					final var lastMessageText = requireNonNull(lastResponse.getResult().getOutput().getText(),


### PR DESCRIPTION
fix(agent): Fix Qwen3 tool call not working in streaming output (Ollama deployment) (#3050)


### Describe what this PR does / why we need it
Fixes Qwen3 tool call not working in streaming output when using Ollama. The model wasn't receiving tool names, and the conversation state wasn't updated correctly during streaming.

### Does this pull request fix one issue?
Fixes #3050

### Describe how you did it

1. In AgentLlmNode.java: Added code to pass tool names to the model request when streaming.
2. In NodeExecutor.java: Ensured the latest streaming response is used to update the conversation state.

### Describe how to verify it

1. Use a Qwen3 model with Ollama and enable streaming.
2. Send a query that should trigger a tool call.
3. Verify that the tool is called correctly during the streaming process.

### Special notes for reviews

- This fix is specific to Qwen3 + Ollama streaming scenarios.
- Changes are minimal and targeted.