### PR TITLE
fix: Replace deprecated method for ChatClient#builder

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
@@ -51,7 +51,7 @@ public class DefaultBuilder extends Builder {
 		if (chatClient == null) {
 
 			ChatClient.Builder clientBuilder = ChatClient.builder(model, this.observationRegistry == null ? ObservationRegistry.NOOP : this.observationRegistry,
-					this.customObservationConvention);
+					this.customObservationConvention, null);
 
 			if (chatOptions != null) {
 				clientBuilder.defaultOptions(chatOptions);

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/RedisSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/RedisSaverTest.java
@@ -340,7 +340,10 @@ class RedisSaverTest {
 				new ToolResponseMessage.ToolResponse("tool_call_1", "calculator", "{\"result\": 42}"),
 				new ToolResponseMessage.ToolResponse("tool_call_2", "weather", "{\"temperature\": 25}"));
 
-		ToolResponseMessage original = new ToolResponseMessage(responses, metadata);
+		ToolResponseMessage original = ToolResponseMessage.builder()
+			.responses(responses)
+			.metadata(metadata)
+			.build();
 
 		Checkpoint checkpoint = Checkpoint.builder()
 				.id("cp-tool")

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosReactAgentBuilder.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosReactAgentBuilder.java
@@ -91,7 +91,7 @@ public class NacosReactAgentBuilder extends NacosAgentPromptBuilder {
 		}
 		else {
 			clientBuilder = ChatClient.builder(model, observationConfiguration.getObservationRegistry() == null ? ObservationRegistry.NOOP : observationConfiguration.getObservationRegistry(), nacosOptions.getObservationConfiguration()
-					.getChatClientObservationConvention());
+					.getChatClientObservationConvention(), null);
 		}
 
 		clientBuilder.defaultOptions(chatOptions);


### PR DESCRIPTION
# Summary
Prepare next 1.1.0.0 release version, adapt Spring AI 1.1.0.
This submission supplements the previous one (#3073).
# Note
Spring AI delete the deprecated APIs by this commit : https://github.com/spring-projects/spring-ai/commit/c63134072deb81b3ac458ac28a6a6debe16f2222
# Influence
The Changes affecting the project fall into follow three classes. 
**This pr add adaption update for ChatClient**
* AssistantMessage
* ToolResponseMessage
* ChatClient