### PR TITLE
fix(agent): make hasTools an instance variable to resolve multi-agent conflicts

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -95,7 +95,7 @@ public class ReactAgent extends BaseAgent {
 	
 	private StateSerializer stateSerializer;
 
-    private static Boolean hasTools = false;
+    private final Boolean hasTools;
 
 	public ReactAgent(AgentLlmNode llmNode, AgentToolNode toolNode, CompileConfig compileConfig, Builder builder) {
 		super(builder.name, builder.description, builder.includeContents, builder.returnReasoningContents, builder.outputKey, builder.outputKeyStrategy);
@@ -430,7 +430,7 @@ public class ReactAgent extends BaseAgent {
 		}
 
 		// Add tool routing if tools exist
-		if (hasTools) {
+		if (agentInstance.hasTools) {
 			setupToolRouting(graph, loopExitNode, loopEntryNode, exitNode, agentInstance);
 		} else if (!loopExitNode.equals("model")) {
 			// No tools but have after_model - connect to exit


### PR DESCRIPTION
fix(agent): make hasTools an instance variable to resolve multi-agent conflicts

### Describe what this PR does / why we need it

- This PR fixes an issue where the **hasTools** static variable in ReactAgent causes state pollution across multiple agent instances. Since static variables are shared across all instances, the **hasTools** value from one agent can overwrite another’s, leading to incorrect graph construction. By changing **hasTools** from a static variable to a final instance variable, each agent maintains its own tool state independently.

### Does this pull request fix one issue?

- https://github.com/alibaba/spring-ai-alibaba/issues/3136

### Describe how you did it

1. Changed the **hasTools** field from **private static Boolean hasTools = false** to **private final Boolean hasTools**.
2. Updated the reference in the **setupHookEdges** method to use the instance-level **agentInstance.hasTools** instead of the static variable.
3. Kept the initialization logic in the constructor unchanged to ensure each instance receives the correct tool state.

### Describe how to verify it

1. Create two ReactAgent instances — one with tools and one without.
2. Verify that each agent correctly builds its graph according to its own tool configuration.
3. Confirm that the presence or absence of tools in one agent does not affect graph construction in another.

### Special notes for reviews

- This change ensures proper instance isolation for the **hasTools** flag while maintaining backward compatibility. Making the field final enforces immutability after construction, improving both thread safety and code clarity.