### PR TITLE
fix(graph): preserve toolCalls when merging streaming ChatResponse objects

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -27,7 +27,9 @@ import com.alibaba.cloud.ai.graph.exception.RunnableErrors;
 import com.alibaba.cloud.ai.graph.streaming.GraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.ParallelGraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
+import java.util.LinkedHashMap;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 
@@ -240,7 +242,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 					var newMessage = AssistantMessage.builder()
 						.content(currentMessageText != null ? lastMessageText.concat(currentMessageText) : lastMessageText)
 						.properties(currentMessage.getMetadata())
-						.toolCalls(currentMessage.getToolCalls())
+						.toolCalls(mergeToolCalls(lastResponse.getResult().getOutput().getToolCalls(),
+                currentMessage.getToolCalls()))
 						.media(currentMessage.getMedia())
 						.build();
 
@@ -296,6 +299,35 @@ public class NodeExecutor extends BaseGraphExecutor {
 			}));
 		});
 	}
+
+  /**
+   * Merges tool calls from two messages.
+   * Tool calls with the same id will be merged.
+   *
+   * @return the merged list of tool calls
+   */
+  private List<ToolCall> mergeToolCalls(List<ToolCall> lastToolCalls, List<ToolCall> currentToolCalls) {
+
+    if (lastToolCalls == null || lastToolCalls.isEmpty()) {
+      return currentToolCalls != null ? currentToolCalls : List.of();
+    }
+    if (currentToolCalls == null || currentToolCalls.isEmpty()) {
+      return lastToolCalls;
+    }
+
+    Map<String, AssistantMessage.ToolCall> toolCallMap = new LinkedHashMap<>();
+
+    lastToolCalls.forEach(tc -> toolCallMap.put(tc.id(), tc));
+
+    // Merge tool calls with the same id
+    currentToolCalls.forEach(tc -> {
+      if( !toolCallMap.containsKey(tc.id()) ) {
+        toolCallMap.put(tc.id(), tc);
+      }
+    });
+
+    return toolCallMap.values().stream().toList();
+  }
 
 	/**
 	 * Handles embedded flux processing.


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes a critical bug in the Flux streaming processing logic where tool calls fail to execute properly, causing graph execution to stop prematurely.

**Root Cause Analysis:**
1. When the AI-generated Flux ChatResponse sequence is `text -> tool -> text`, the final cached result is of text type rather than tool type
2. Subsequently, the `makeModelToTools` method in ReactAgent cannot route to the tool node, naturally failing to trigger the tool callback logic

**Solution:**
Rewrote the logic to properly merge `toolCalls` while merging text content, ensuring tool calls are preserved throughout the streaming process and can be correctly routed by ReactAgent.

### Does this pull request fix one issue?

Fixes the issue where tool calls are lost during Flux streaming, preventing proper tool routing and execution in ReactAgent workflows.

### Describe how you did it

1. Added a new `mergeToolCalls()` method that intelligently merges tool calls from both last and current messages
2. Uses `LinkedHashMap` to preserve tool call order while avoiding duplicates based on tool call ID
3. Modified the message building logic in `getEmbedFlux()` to call `mergeToolCalls()` when constructing the new `AssistantMessage`
4. This ensures that when processing streaming responses with sequence `text -> tool -> text`, all tool calls are properly preserved and available for routing by ReactAgent's `makeModelToTools` method

**Key Changes:**
- Added `mergeToolCalls(List<ToolCall> lastToolCalls, List<ToolCall> currentToolCalls)` method
- Updated `AssistantMessage.builder()` to use merged tool calls: `.toolCalls(mergeToolCalls(lastResponse.getResult().getOutput().getToolCalls(), currentMessage.getToolCalls()))`

### Describe how to verify it

1. Create a test scenario where AI generates a streaming response with sequence: `text -> tool -> text`
2. Verify that tool calls are properly extracted and cached in the final message
3. Verify that ReactAgent's `makeModelToTools` method can correctly route to the tool node
4. Verify that tool callback logic is successfully triggered and executed
5. Verify that graph execution continues properly after tool execution
6. Local testing has confirmed the fix resolves the issue

### Special notes for reviews

- The fix maintains backward compatibility with existing streaming logic
- Tool calls are now preserved across the entire streaming sequence, ensuring proper routing in ReactAgent
- The `LinkedHashMap` ensures both order preservation and deduplication of tool calls