### PR TITLE
test(graph): delete `addParallelNodeExecutor("A", ForkJoinPool.commonPool()` to make the test case more suitable for the newly added default executor feature

### DIFF
--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
@@ -939,7 +939,7 @@ public class StateGraphTest {
 			}
 		}).build());
 
-		app.stream(Map.of(), RunnableConfig.builder().addParallelNodeExecutor("A", ForkJoinPool.commonPool()).build())
+		app.stream(Map.of(), RunnableConfig.builder().build())
 			.blockLast();
 
 		log.info("Before nodeIds: {}", beforeNodeIds);


### PR DESCRIPTION
…Pool()` to make the test case more suitable for the newly added default executor feature


### Describe what this PR does / why we need it
This PR deletes the use of  `ForkJoinPool.commonPool()` in `testParallelNodeLifecycleListenerNodeId` test case, the default executor implementation is a better choice. Still use commonPool is unnecessary and may cause confusion for new developers who want to learn from unit test.


### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
just delete the code

### Describe how to verify it
Re-run the unit test and it passed

### Special notes for reviews
