### PR TITLE
fix: Missing input options when build AgentLlmNode

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
@@ -69,7 +69,10 @@ public class DefaultBuilder extends Builder {
 			chatClient = clientBuilder.build();
 		}
 
-		AgentLlmNode.Builder llmNodeBuilder = AgentLlmNode.builder().agentName(this.name).chatClient(chatClient);
+		AgentLlmNode.Builder llmNodeBuilder = AgentLlmNode.builder()
+			.agentName(this.name)
+			.chatOptions(this.chatOptions)
+			.chatClient(chatClient);
 
 		if (outputKey != null && !outputKey.isEmpty()) {
 			llmNodeBuilder.outputKey(outputKey);


### PR DESCRIPTION
## 关联issues
* fix: https://github.com/alibaba/spring-ai-alibaba/issues/3219
* fix: https://github.com/alibaba/spring-ai-alibaba/issues/3074
## 待确认点
* 是否需要合并`DashScopeChatModel#defaultOptions`和`com.alibaba.cloud.ai.graph.agent.Builder#chatOptions`，当前pr未做合并，只取`com.alibaba.cloud.ai.graph.agent.Builder#chatOptions`
## 问题分析
* com.alibaba.cloud.ai.graph.agent.DefaultBuilder#build方法将用户传入的options设置为defaultOptions，覆盖了默认的defaultOptions。
```java
			if (chatOptions != null) {
				clientBuilder.defaultOptions(chatOptions);
			}
```
* AgentLlmNode#buildChatClientRequestSpec方法会创建一个新的ToolCallingChatOptions，作为runtimeOptions传入chatClient，此时将会覆盖传入的options。
```java
	private ChatClient.ChatClientRequestSpec buildChatClientRequestSpec(ModelRequest modelRequest) {
		List<Message> messages = appendSystemPromptIfNeeded(modelRequest);

		List<ToolCallback> filteredToolCallbacks = filterToolCallbacks(modelRequest);
		this.toolCallingChatOptions = ToolCallingChatOptions.builder()
				.toolCallbacks(filteredToolCallbacks)
				.internalToolExecutionEnabled(false)
				.build();

		ChatClient.ChatClientRequestSpec chatClientRequestSpec = chatClient.prompt()
				.options(toolCallingChatOptions)
				.messages(messages)
				.advisors(advisors);

		return chatClientRequestSpec;
	}
```
* 总结：我觉得应该将用户传入options作为runtimeOptions，而不是覆盖defaultOptions。
## 解决思路
  将用户传入options作为runtimeOptions传递给chatClient。
```java
if (builder.chatOptions != null && builder.chatOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
			this.toolCallingChatOptions = toolCallingChatOptions;
			this.toolCallingChatOptions.setToolCallbacks(toolCallbacks);
			this.toolCallingChatOptions.setInternalToolExecutionEnabled(false);
		} else {
			this.toolCallingChatOptions = ToolCallingChatOptions.builder()
				.toolCallbacks(toolCallbacks)
				.internalToolExecutionEnabled(false)
				.build();
		}

	private ChatClient.ChatClientRequestSpec buildChatClientRequestSpec(ModelRequest modelRequest) {
		List<Message> messages = appendSystemPromptIfNeeded(modelRequest);

		List<ToolCallback> filteredToolCallbacks = filterToolCallbacks(modelRequest);
		this.toolCallingChatOptions.setToolCallbacks(filteredToolCallbacks);

		ChatClient.ChatClientRequestSpec chatClientRequestSpec = chatClient.prompt()
				.options(toolCallingChatOptions)
				.messages(messages)
				.advisors(advisors);

		return chatClientRequestSpec;
	}
```