### PR TITLE
fix(graph): remove redundant if-else in NodeExecutor streaming handler

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -208,14 +208,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 					ChatResponse lastResponse = lastChatResponseRef.get();
 					if (lastResponse == null) {
 						var message = response.getResult().getOutput();
-						GraphResponse<NodeOutput> lastGraphResponse = null;
-						if (message.hasToolCalls()) {
-							lastGraphResponse =
-									GraphResponse.of(context.buildStreamingOutput(message, response, context.getCurrentNodeId()));
-						} else {
-							lastGraphResponse =
-									GraphResponse.of(context.buildStreamingOutput(message, response, context.getCurrentNodeId()));
-						}
+						GraphResponse<NodeOutput> lastGraphResponse =
+								GraphResponse.of(context.buildStreamingOutput(message, response, context.getCurrentNodeId()));
 						lastChatResponseRef.set(response);
 						lastGraphResponseRef.set(lastGraphResponse);
 						return lastGraphResponse;


### PR DESCRIPTION
### Describe what this PR does / why we need it

The if-else condition checking `message.hasToolCalls()` in `NodeExecutor.java` was redundant as both branches executed exactly the same code. This simplifies the code by removing the unnecessary conditional logic.

Before:
```java
if (message.hasToolCalls()) {
    lastGraphResponse = GraphResponse.of(context.buildStreamingOutput(message, response, context.getCurrentNodeId()));
} else {
    lastGraphResponse = GraphResponse.of(context.buildStreamingOutput(message, response, context.getCurrentNodeId()));
}
```

After:
```java
GraphResponse<NodeOutput> lastGraphResponse =
    GraphResponse.of(context.buildStreamingOutput(message, response, context.getCurrentNodeId()));
```

### Does this pull request fix one issue?

NONE

### Describe how you did it

Removed the redundant if-else statement and replaced it with a direct assignment since the condition check served no purpose - both branches were doing exactly the same thing.

### Describe how to verify it

1. Code review: Compare the if and else branches in the original code - they are identical
2. Run existing unit tests to ensure no regression
3. The streaming output behavior remains unchanged as the logic is equivalent

### Special notes for reviews

This is a simple code cleanup with no behavioral changes. The conditional `message.hasToolCalls()` was likely added with the intention of implementing different logic for tool calls, but both branches ended up with the same implementation.