### PR TITLE
fix(graph): redis time trave in checkPoint

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -81,7 +81,7 @@ public class GraphRunnerContext {
 		this.compiledGraph = compiledGraph;
 		this.config = config;
 
-		if (config.checkPointId().isPresent()) {
+		if (config.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isPresent() || config.checkPointId().isPresent()) {
 			initializeFromResume(initialState, config);
 		} else {
 			initializeFromStart(initialState, config);

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/TimeTravelRedisTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/TimeTravelRedisTest.java
@@ -105,8 +105,10 @@ class TimeTravelRedisTest {
 	void cleanupRedis() {
 		var config1 = RunnableConfig.builder().threadId("test-time-travel").build();
 		redisSaver.clear(config1);
-		var config2 = RunnableConfig.builder().threadId("test-branch").build();
+		var config2 = RunnableConfig.builder().threadId("test-main-thread").build();
 		redisSaver.clear(config2);
+		var config3 = RunnableConfig.builder().threadId("test-branch-thread").build();
+		redisSaver.clear(config3);
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it
initializeFromStart将 currentNodeId 设置为 START，导致：虽然状态从 checkpoint 正确恢复,但执行流程从头开始，而不是从 checkpoint 的下一个节点继续

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Close #3266 
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
