### PR TITLE
fix: multiAgent example4 for CustomMergeStrategy error

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/MultiAgentExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/MultiAgentExample.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.examples.documentation.framework.advanced;
 
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatModel;
+import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
@@ -245,13 +246,22 @@ public class MultiAgentExample {
 			public Map<String, Object> merge(Map<String, Object> mergedState, OverAllState state) {
 				// 从每个Agent的状态中提取输出
 				state.data().forEach((key, value) -> {
-					if (key.endsWith("_result")) {
+					// 检查key不为null且以"_result"结尾
+					if (key != null && key.endsWith("_result")) {
+						String resultText = "";
+						if (value instanceof GraphResponse graphResponse) {
+                            if (graphResponse.resultValue().isPresent()) {
+                                resultText = graphResponse.resultValue().get().toString();
+                            }
+						} else if (value != null) {
+							resultText = value.toString();
+						}
 						Object existing = mergedState.get("all_results");
 						if (existing == null) {
-							mergedState.put("all_results", value.toString());
+							mergedState.put("all_results", resultText);
 						}
 						else {
-							mergedState.put("all_results", existing + "\n\n---\n\n" + value.toString());
+							mergedState.put("all_results", existing + "\n\n---\n\n" + resultText);
 						}
 					}
 				});
@@ -263,19 +273,19 @@ public class MultiAgentExample {
 		ReactAgent agent1 = ReactAgent.builder()
 				.name("agent1")
 				.model(chatModel)
-				.outputKey("result1")
+				.outputKey("agent1_result")
 				.build();
 
 		ReactAgent agent2 = ReactAgent.builder()
 				.name("agent2")
 				.model(chatModel)
-				.outputKey("result2")
+				.outputKey("agent2_result")
 				.build();
 
 		ReactAgent agent3 = ReactAgent.builder()
 				.name("agent3")
 				.model(chatModel)
-				.outputKey("result3")
+				.outputKey("agent3_result")
 				.build();
 
 		// 使用自定义合并策略
@@ -283,11 +293,16 @@ public class MultiAgentExample {
 				.name("parallel_agent")
 				.subAgents(List.of(agent1, agent2, agent3))
 				.mergeStrategy(new CustomMergeStrategy())
+				.mergeOutputKey("all_results")
 				.build();
 
 		Optional<OverAllState> result = parallelAgent.invoke("分析这个主题");
 
 		if (result.isPresent()) {
+			OverAllState state = result.get();
+			state.value("all_results").ifPresent(mergeResult -> {
+				System.out.println("合并结果: " + mergeResult);
+			});
 			System.out.println("自定义合并策略示例执行成功");
 		}
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it
The ParallelAgent instance was not configured with a `mergeOutputKey`, causing its state to be empty, which subsequently led to serialization failure.

### Does this pull request fix one issue?
Fixes #3319 

### Describe how you did it
1. add `mergeOutputKey`
2. improve the example with right key

### Describe how to verify it


### Special notes for reviews
