### PR TITLE
fix(graph): fix non-deterministic store key generation and test assertion logic

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/store/stores/BaseStore.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/store/stores/BaseStore.java
@@ -19,6 +19,7 @@ import com.alibaba.cloud.ai.graph.store.*;
 
 import java.util.*;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -114,7 +115,7 @@ public abstract class BaseStore implements Store {
 	 */
 	protected String createStoreKey(List<String> namespace, String key) {
 		try {
-			Map<String, Object> keyData = new HashMap<>();
+			Map<String, Object> keyData = new LinkedHashMap<>();
 			keyData.put("namespace", namespace);
 			keyData.put("key", key);
 			return Base64.getEncoder().encodeToString(new ObjectMapper().writeValueAsBytes(keyData));

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphFileSystemSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphFileSystemSaverTest.java
@@ -40,7 +40,6 @@ import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -202,7 +201,7 @@ public class StateGraphFileSystemSaverTest {
 		var tagState = tag.checkpoints().stream().map(Checkpoint::getState).findFirst();
 		assertTrue(tagState.isPresent());
 
-		assertIterableEquals(state.get().data().entrySet(), tagState.get().entrySet());
+		assertEquals(state.get().data(), tagState.get());
 
 		var messages = (List<String>) state.get().data().get("messages");
 
@@ -230,7 +229,7 @@ public class StateGraphFileSystemSaverTest {
 		tagState = tag.checkpoints().stream().map(Checkpoint::getState).findFirst();
 		assertTrue(tagState.isPresent());
 
-		assertIterableEquals(state.get().data().entrySet(), tagState.get().entrySet());
+		assertEquals(state.get().data(), tagState.get());
 
 		assertEquals(expectedSteps, messages.size());
 
@@ -247,7 +246,7 @@ public class StateGraphFileSystemSaverTest {
 		tagState = tag.checkpoints().stream().map(Checkpoint::getState).findFirst();
 		assertTrue(tagState.isPresent());
 
-		assertIterableEquals(state.get().data().entrySet(), tagState.get().entrySet());
+		assertEquals(state.get().data(), tagState.get());
 
 	}
 
@@ -357,7 +356,7 @@ public class StateGraphFileSystemSaverTest {
 		tagState = tag.checkpoints().stream().map(Checkpoint::getState).findFirst();
 
 		assertTrue(tagState.isPresent());
-		assertIterableEquals(state_1.get().data().entrySet(), tagState.get().entrySet());
+		assertEquals(state_1.get().data(), tagState.get());
 
 	}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR addresses non-deterministic behaviors that could cause test instability and potential data inconsistency detected by 
[NonDex](https://github.com/TestingResearchIllinois/NonDex), a tool developed by UIUC researchers.

1.  Fix potential Data Inconsistency in `BaseStore` :
    *   **Problem**: The `createStoreKey` method previously used a `HashMap` to construct the key payload. Since `HashMap` iteration order is undefined, the resulting JSON byte array and Base64-encoded key could vary across JVM implementations or executions. In production, this could lead to a Key Mismatch where data cannot be retrieved, updated, or deleted because the generated key differs from the stored key.
    *   **Fix**: Switched to `LinkedHashMap` to ensure a deterministic insertion order (`namespace` then `key`), guaranteeing identical store keys for identical inputs.

2.  Improve Assertion Logic in `StateGraphFileSystemSaverTest`:
    *   **Problem**: Tests relied on `assertIterableEquals` on `Map.entrySet()`, which relies on iteration order on sets backed by HashMaps that does not guarantee order of elements.
    *   **Fix**: Updated to use `assertEquals` on the `Map` objects directly. This verifies content match without relying on iteration order.

### Does this pull request fix one issue?
None

### Describe how you did it
1.  **`BaseStore.java`**: Replaced `HashMap` with `LinkedHashMap` in `createStoreKey` method.
2.  **`StateGraphFileSystemSaverTest.java`**: Replaced `assertIterableEquals(expected.entrySet(), actual.entrySet())` with `assertEquals(expected, actual)` in checkpoint tests.

### Describe how to verify it
To reproduce the issue or to verify the fix, run the following command:

```bash
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -DnondexRuns=50 -pl spring-ai-alibaba-graph-core -Dtest=com.alibaba.cloud.ai.graph.store.stores.MemoryStoreTest#testPutAndGetItem
```
(You can replace the `-Dtest=` filter with other tests listed below. Seeing `BUILD FAILURE` means successfully reproduced the issue.)

### Special notes for reviews
The following tests are stabilized by this PR:
   `com.alibaba.cloud.ai.graph.store.StoreIntegrationTest#testAllStoreImplementations`
   `com.alibaba.cloud.ai.graph.store.StoreIntegrationTest#testStoreConsistencyAcrossImplementations`
   `com.alibaba.cloud.ai.graph.store.stores.MongoStoreTest#testUpdateExistingItem`
   `com.alibaba.cloud.ai.graph.store.stores.MongoStoreTest#testDeleteItem`
   `com.alibaba.cloud.ai.graph.store.stores.MongoStoreTest#testPutAndGetItem`
   `com.alibaba.cloud.ai.graph.store.stores.RedisStoreTest#testUpdateExistingItem`
   `com.alibaba.cloud.ai.graph.store.stores.RedisStoreTest#testPutAndGetItem`
   `com.alibaba.cloud.ai.graph.store.stores.RedisStoreTest#testDeleteItem`
   `com.alibaba.cloud.ai.graph.store.stores.MemoryStoreTest#testUpdateExistingItem`
   `com.alibaba.cloud.ai.graph.store.stores.MemoryStoreTest#testDeleteItem`
   `com.alibaba.cloud.ai.graph.store.stores.MemoryStoreTest#testPutAndGetItem`
   `com.alibaba.cloud.ai.graph.store.stores.DatabaseStoreTest#testUpdateExistingItem`
   `com.alibaba.cloud.ai.graph.store.stores.DatabaseStoreTest#testDeleteItem`
   `com.alibaba.cloud.ai.graph.store.stores.DatabaseStoreTest#testPutAndGetItem`
   `com.alibaba.cloud.ai.graph.store.GraphStoreIntegrationTest#testUserSessionWorkflowWithDatabaseStore`
   `com.alibaba.cloud.ai.graph.store.GraphStoreIntegrationTest#testUserSessionWorkflowWithMemoryStore`
   `com.alibaba.cloud.ai.graph.store.GraphStoreIntegrationTest#testMultiStepDataProcessingWithStore`
   `com.alibaba.cloud.ai.graph.StateGraphTest#testWithParallelBranchWithErrors`
   `com.alibaba.cloud.ai.graph.StateGraphFileSystemSaverTest#testCheckpointSaverWithAutoRelease`
   `com.alibaba.cloud.ai.graph.StateGraphFileSystemSaverTest#testCheckpointSaverWithManualRelease`