### PR TITLE
fix: memory example get store by right key

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/MemoryExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/MemoryExample.java
@@ -43,6 +43,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 
+import static com.alibaba.cloud.ai.graph.agent.tools.ToolContextConstants.AGENT_CONFIG_CONTEXT_KEY;
+
 /**
  * 记忆管理（Memory）示例
  *
@@ -116,7 +118,7 @@ public class MemoryExample {
 		// 创建获取用户信息的工具
 		BiFunction<GetMemoryRequest, ToolContext, MemoryResponse> getUserInfoFunction =
 				(request, context) -> {
-					RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get("config");
+					RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get(AGENT_CONFIG_CONTEXT_KEY);
 					Store store = runnableConfig.store();
 					Optional<StoreItem> itemOpt = store.getItem(request.namespace(), request.key());
 					if (itemOpt.isPresent()) {
@@ -169,7 +171,7 @@ public class MemoryExample {
 		// 创建保存用户信息的工具
 		BiFunction<SaveMemoryRequest, ToolContext, MemoryResponse> saveUserInfoFunction =
 				(request, context) -> {
-					RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get("config");
+					RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get(AGENT_CONFIG_CONTEXT_KEY);
 					Store store = runnableConfig.store();
 					StoreItem item = StoreItem.of(request.namespace(), request.key(), request.value());
 					store.putItem(item);
@@ -481,7 +483,7 @@ public class MemoryExample {
 		ToolCallback saveMemoryTool = FunctionToolCallback.builder("saveMemory",
 						(BiFunction<SaveMemoryRequest, ToolContext, MemoryResponse>) (request, context) -> {
 							StoreItem item = StoreItem.of(request.namespace(), request.key(), request.value());
-							RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get("config");
+							RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get(AGENT_CONFIG_CONTEXT_KEY);
 							Store memoryStore = runnableConfig.store();
 							memoryStore.putItem(item);
 							return new MemoryResponse("已保存", request.value());
@@ -492,7 +494,7 @@ public class MemoryExample {
 
 		ToolCallback getMemoryTool = FunctionToolCallback.builder("getMemory",
 						(BiFunction<GetMemoryRequest, ToolContext, MemoryResponse>) (request, context) -> {
-							RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get("config");
+							RunnableConfig runnableConfig = (RunnableConfig) context.getContext().get(AGENT_CONFIG_CONTEXT_KEY);
 							Store memoryStore = runnableConfig.store();
 							Optional<StoreItem> itemOpt = memoryStore.getItem(request.namespace(), request.key());
 							return new MemoryResponse(


### PR DESCRIPTION
### Describe what this PR does / why we need it
memory example run fail because get runnableConfig by wrong key.

### Does this pull request fix one issue?
NONE

### Describe how you did it
Get runnableConfig by right key `_AGENT_CONFIG_`

### Describe how to verify it


### Special notes for reviews
