### PR TITLE
fix:HumanInTheLoopExample bug

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/examples/HumanInTheLoopExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/examples/HumanInTheLoopExample.java
@@ -299,8 +299,13 @@ public class HumanInTheLoopExample {
 	 * 继续执行 Graph（interruptBefore 模式）
 	 */
 	public static void continueExecutionWithInterruptBefore(CompiledGraph graph, RunnableConfig updateConfig) {
+		// 添加恢复执行的元数据标记
+		RunnableConfig resumeConfig = RunnableConfig.builder(updateConfig)
+				.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, "placeholder")
+				.build();
+
 		// 继续执行 Graph（input 为 null，使用之前的状态）
-		graph.stream(null, updateConfig)
+		graph.stream(null, resumeConfig)
 				.doOnNext(event -> System.out.println(event))
 				.doOnError(error -> System.err.println("流错误: " + error.getMessage()))
 				.doOnComplete(() -> System.out.println("流完成"))
@@ -328,8 +333,13 @@ public class HumanInTheLoopExample {
 	 * 继续执行直到完成（interruptBefore 模式）
 	 */
 	public static void continueExecutionUntilComplete(CompiledGraph graph, RunnableConfig updateConfig) {
+		// 添加恢复执行的元数据标记
+		RunnableConfig resumeConfig = RunnableConfig.builder(updateConfig)
+				.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, "placeholder")
+				.build();
+
 		// 继续执行 Graph
-		graph.stream(null, updateConfig)
+		graph.stream(null, resumeConfig)
 				.doOnNext(event -> System.out.println(event))
 				.doOnError(error -> System.err.println("流错误: " + error.getMessage()))
 				.doOnComplete(() -> System.out.println("流完成"))


### PR DESCRIPTION
Fix the interruptBefore mode in Example 2 of Human-in-the-Loop.

Add metadata tags for resuming execution.


### Describe what this PR does / why we need it
This PR fixes the `Checkpoint with id xxx not found!` exception that occurs in the `interruptBefore` mode of the Human-in-the-Loop example (Example 2). The root cause is the lack of critical recovery metadata (`HUMAN_FEEDBACK_METADATA_KEY`) when resuming execution after human feedback, and the loss of Checkpoint context due to recreated `RunnableConfig`. 

Adding the recovery metadata tag ensures the graph correctly identifies the resumption of execution after human intervention, and retaining the original `RunnableConfig` preserves the Checkpoint ID context, thus resolving the Checkpoint not found error and making the `interruptBefore` mode work as expected.


### Does this pull request fix one issue?
Fixes #3337

### Describe how you did it
1. **Add recovery metadata tag**: Added `HUMAN_FEEDBACK_METADATA_KEY` metadata to the resume configuration in `continueExecutionWithInterruptBefore` and `continueExecutionUntilComplete` methods, consistent with the recovery logic of InterruptionMetadata mode.
2. **Preserve Checkpoint context**: Modified the call logic of `waitUserInputSecondTime` to pass the updated `RunnableConfig` (instead of recreating it), ensuring the Checkpoint ID and context are not lost.
3. **Unify recovery logic**: Aligned the recovery execution logic of `interruptBefore` mode with InterruptionMetadata mode to avoid state exceptions caused by inconsistent logic.

### Describe how to verify it
1. Run the `HumanInTheLoopExample` main method directly.
2. Verify that the `interruptBefore` mode (Example 2) can execute without throwing `Checkpoint not found` exceptions.
3. Confirm the execution flow:
   - Execute until the `human_feedback` node and interrupt normally.
   - Update the state with user input ("back") and resume execution, returning to the `step_1` node correctly.
   - Update the state with user input ("next") again and resume execution, proceeding to the `step_3` node and completing the graph normally.

### Special notes for reviews
1. The modification only involves the example code, no impact on the core framework logic.
2. The recovery metadata `HUMAN_FEEDBACK_METADATA_KEY` is a built-in constant of the framework, consistent with the official recommended usage.
3. The Checkpoint context retention is critical for the `interruptBefore` mode, and reusing the updated `RunnableConfig` is the correct practice to avoid context loss.