### PR TITLE
feat(graph): add ChatResponse serializer

### DIFF
--- a/spring-ai-alibaba-graph-core/pom.xml
+++ b/spring-ai-alibaba-graph-core/pom.xml
@@ -194,6 +194,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/CustomChatGenerationMetadata.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/CustomChatGenerationMetadata.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.serializer.plain_text.jackson;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.util.Assert;
+
+import java.beans.ConstructorProperties;
+import java.util.*;
+
+/**
+ * auth: dahua
+ */
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"@class"})
+public class CustomChatGenerationMetadata implements ChatGenerationMetadata {
+
+    private final Map<String, Object> metadata;
+    private final String finishReason;
+    private final Set<String> contentFilters;
+
+    @ConstructorProperties({"metadata", "finishReason", "contentFilters"})
+    public CustomChatGenerationMetadata(Map<String, Object> metadata, String finishReason, Set<String> contentFilters) {
+        Assert.notNull(metadata, "Metadata must not be null");
+        Assert.notNull(contentFilters, "Content filters must not be null");
+        this.metadata = metadata;
+        this.finishReason = finishReason;
+        this.contentFilters = new HashSet(contentFilters);
+    }
+
+    public <T> T get(String key) {
+        return (T) this.metadata.get(key);
+    }
+
+    public boolean containsKey(String key) {
+        return this.metadata.containsKey(key);
+    }
+
+    public <T> T getOrDefault(String key, T defaultObject) {
+        return (T) (this.containsKey(key) ? this.get(key) : defaultObject);
+    }
+
+    public Set<Map.Entry<String, Object>> entrySet() {
+        return Collections.unmodifiableSet(this.metadata.entrySet());
+    }
+
+    public Set<String> keySet() {
+        return Collections.unmodifiableSet(this.metadata.keySet());
+    }
+
+    public boolean isEmpty() {
+        return this.metadata.isEmpty();
+    }
+
+    public String getFinishReason() {
+        return this.finishReason;
+    }
+
+    public Set<String> getContentFilters() {
+        return Collections.unmodifiableSet(this.contentFilters);
+    }
+
+    public int hashCode() {
+        return Objects.hash(new Object[]{this.metadata, this.finishReason, this.contentFilters});
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj != null && this.getClass() == obj.getClass()) {
+            CustomChatGenerationMetadata other = (CustomChatGenerationMetadata) obj;
+            return Objects.equals(this.metadata, other.metadata) && Objects.equals(this.finishReason, other.finishReason) && Objects.equals(this.contentFilters, other.contentFilters);
+        } else {
+            return false;
+        }
+    }
+
+    public String toString() {
+        return String.format("CustomChatGenerationMetadata[finishReason='%s', filters=%d, metadata=%d]", this.finishReason, this.contentFilters.size(), this.metadata.size());
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonChatResponseDeserializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonChatResponseDeserializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.serializer.plain_text.jackson;
+
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * auth: dahua
+ */
+public class JacksonChatResponseDeserializer extends StdDeserializer<ChatResponse> {
+
+    protected JacksonChatResponseDeserializer() {
+        super(ChatResponse.class);
+    }
+
+    @Override
+    public ChatResponse deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JacksonException {
+        ObjectMapper objectMapper = (ObjectMapper) ctxt.getParser().getCodec();
+        TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+        List<Generation> generations = new ArrayList<>();
+        TreeNode generationsNodes = treeNode.get("generations");
+        if (generationsNodes.isArray()) {
+            ArrayNode arrayNodes = (ArrayNode) generationsNodes;
+            arrayNodes.forEach(node -> {
+                try {
+                    generations.add(objectMapper.treeToValue(node, Generation.class));
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        TreeNode chatResponseMetadataNode = treeNode.get("chatResponseMetadata");
+        ChatResponseMetadata chatResponseMetadata = objectMapper.treeToValue(chatResponseMetadataNode, ChatResponseMetadata.class);
+        return new ChatResponse(generations, chatResponseMetadata);
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonChatResponseMetadataDeserializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonChatResponseMetadataDeserializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.serializer.plain_text.jackson;
+
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.openai.metadata.OpenAiRateLimit;
+
+import java.io.IOException;
+
+/**
+ * auth: dahua
+ */
+public class JacksonChatResponseMetadataDeserializer extends StdDeserializer<ChatResponseMetadata> {
+
+    public JacksonChatResponseMetadataDeserializer() {
+        super(ChatResponseMetadata.class);
+    }
+
+    @Override
+    public ChatResponseMetadata deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JacksonException {
+        ObjectMapper objectMapper = (ObjectMapper) ctxt.getParser().getCodec();
+        TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+        String id = treeNode.get("id").toString();
+        String model = treeNode.get("model").toString();
+        TreeNode rateLimitNode = treeNode.get("rateLimit");
+        OpenAiRateLimit rateLimit = objectMapper.treeToValue(rateLimitNode, OpenAiRateLimit.class);
+        TreeNode usageNode = treeNode.get("usage");
+        DefaultUsage usage = objectMapper.treeToValue(usageNode, DefaultUsage.class);
+        return ChatResponseMetadata.builder().id(id).model(model).rateLimit(rateLimit).usage(usage).promptMetadata(PromptMetadata.empty()).build();
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonDefaultUsageDeserializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonDefaultUsageDeserializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.serializer.plain_text.jackson;
+
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.openai.api.OpenAiApi;
+
+import java.io.IOException;
+
+/**
+ * auth: dahua
+ */
+public class JacksonDefaultUsageDeserializer extends StdDeserializer<DefaultUsage> {
+
+    public JacksonDefaultUsageDeserializer() {
+        super(DefaultUsage.class);
+    }
+
+    @Override
+    public DefaultUsage deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JacksonException {
+        ObjectMapper objectMapper = (ObjectMapper) ctxt.getParser().getCodec();
+        TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+        String promptTokensNode = treeNode.get("promptTokens").toString();
+        String completionTokensNode = treeNode.get("completionTokens").toString();
+        String totalTokensNode = treeNode.get("totalTokens").toString();
+        TreeNode nativeUsageNode = treeNode.get("nativeUsage");
+        Integer promptTokens = promptTokensNode == null || "null".equals(promptTokensNode) ? null : Integer.parseInt(promptTokensNode);
+        Integer completionTokens = completionTokensNode == null || "null".equals(completionTokensNode) ? null : Integer.parseInt(completionTokensNode);
+        int totalTokens = totalTokensNode == null || "null".equals(totalTokensNode) ? 0 : Integer.parseInt(totalTokensNode);
+        Object nativeUsage = nativeUsageNode == null || "null".equals(nativeUsageNode) ? null : objectMapper.treeToValue(nativeUsageNode, OpenAiApi.Usage.class);
+        return new DefaultUsage(promptTokens, completionTokens, totalTokens, nativeUsage);
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonGenerationDeserializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonGenerationDeserializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.serializer.plain_text.jackson;
+
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.Generation;
+
+import java.io.IOException;
+
+/**
+ * auth: dahua
+ */
+public class JacksonGenerationDeserializer extends StdDeserializer<Generation> {
+
+    protected JacksonGenerationDeserializer() {
+        super(Generation.class);
+    }
+
+    @Override
+    public Generation deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JacksonException {
+        ObjectMapper objectMapper = (ObjectMapper) ctxt.getParser().getCodec();
+        TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+        TreeNode assistantMessageNode = treeNode.get("assistantMessage");
+        TreeNode chatGenerationMetadataNode = treeNode.get("chatGenerationMetadata");
+        AssistantMessage assistantMessage = objectMapper.treeToValue(assistantMessageNode, AssistantMessage.class);
+        CustomChatGenerationMetadata customChatGenerationMetadata = objectMapper.treeToValue(chatGenerationMetadataNode, CustomChatGenerationMetadata.class);
+        return new Generation(assistantMessage, customChatGenerationMetadata);
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonOpenAiRateLimitDeserializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonOpenAiRateLimitDeserializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.serializer.plain_text.jackson;
+
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.springframework.ai.openai.metadata.OpenAiRateLimit;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/**
+ * auth: dahua
+ */
+public class JacksonOpenAiRateLimitDeserializer extends StdDeserializer<OpenAiRateLimit> {
+
+    public JacksonOpenAiRateLimitDeserializer() {
+        super(OpenAiRateLimit.class);
+    }
+
+    @Override
+    public OpenAiRateLimit deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JacksonException {
+        TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
+        String requestsLimitNode = treeNode.get("requestsLimit").toString();
+        String requestsRemainingNode = treeNode.get("requestsRemaining").toString();
+        String tokensLimitNode = treeNode.get("tokensLimit").toString();
+        String tokensRemainingNode = treeNode.get("tokensRemaining").toString();
+        String requestsResetNode = treeNode.get("requestsReset").toString();
+        String tokensResetNode = treeNode.get("tokensReset").toString();
+        Long requestsLimit = requestsLimitNode == null || "null".equals(requestsLimitNode) ? null : Long.parseLong(requestsLimitNode);
+        Long requestsRemaining = requestsRemainingNode == null || "null".equals(requestsRemainingNode) ? null : Long.parseLong(requestsRemainingNode);
+        Long tokensLimit = tokensLimitNode == null || "null".equals(tokensLimitNode) ? null : Long.parseLong(tokensLimitNode);
+        Long tokensRemaining = tokensRemainingNode == null || "null".equals(tokensRemainingNode) ? null : Long.parseLong(tokensRemainingNode);
+        Duration requestsReset = requestsResetNode == null || "null".equals(requestsResetNode) ? null : Duration.parse(requestsResetNode);
+        Duration tokensReset = tokensResetNode == null || "null".equals(tokensResetNode) ? null : Duration.parse(tokensResetNode);
+        return new OpenAiRateLimit(requestsLimit, requestsRemaining, requestsReset, tokensLimit, tokensRemaining, tokensReset);
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/SpringAIJacksonStateSerializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/SpringAIJacksonStateSerializer.java
@@ -29,11 +29,16 @@ import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.document.Document;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import com.alibaba.cloud.ai.graph.serializer.AgentInstructionMessage;
+import org.springframework.ai.openai.metadata.OpenAiRateLimit;
 
 import java.util.Collection;
 import java.util.Map;
@@ -178,6 +183,11 @@ public class SpringAIJacksonStateSerializer extends JacksonStateSerializer {
 		ChatMessageSerializer.registerTo(module);
 		ChatMessageDeserializer.registerTo(module);
 		NodeOutputDeserializer.registerTo(module);
+        ChatResponseDeserializer.registerTo(module);
+        GenerationDeserializer.registerTo(module);
+        ChatResponseMetadataDeserializer.registerTo(module);
+        UsageMetadataDeserializer.registerTo(module);
+        RateLimitDeserializer.registerTo(module);
 	}
 
 	interface ChatMessageSerializer {
@@ -241,5 +251,54 @@ public class SpringAIJacksonStateSerializer extends JacksonStateSerializer {
 			module.addDeserializer(NodeOutput.class, nodeOutput);
 		}
 	}
+
+    interface ChatResponseDeserializer {
+
+        JacksonChatResponseDeserializer chatResponse = new JacksonChatResponseDeserializer();
+
+        static void registerTo(SimpleModule module) {
+            module.addDeserializer(ChatResponse.class, chatResponse);
+        }
+    }
+
+    interface GenerationDeserializer {
+
+        JacksonGenerationDeserializer generation = new JacksonGenerationDeserializer();
+
+        static void registerTo(SimpleModule module) {
+            module.addDeserializer(Generation.class, generation);
+        }
+    }
+
+    interface ChatResponseMetadataDeserializer {
+
+        JacksonChatResponseMetadataDeserializer chatResponseMetadata = new JacksonChatResponseMetadataDeserializer();
+
+        static void registerTo(SimpleModule module) {
+            module.addDeserializer(ChatResponseMetadata.class, chatResponseMetadata);
+        }
+    }
+
+    interface UsageMetadataDeserializer {
+
+        JacksonDefaultUsageDeserializer usage = new JacksonDefaultUsageDeserializer();
+
+        static void registerTo(SimpleModule module) {
+            module.addDeserializer(DefaultUsage.class, usage);
+        }
+    }
+
+    /**
+     * openai implements
+     */
+
+    interface RateLimitDeserializer {
+
+        JacksonOpenAiRateLimitDeserializer openAiRateLimit = new JacksonOpenAiRateLimitDeserializer();
+
+        static void registerTo(SimpleModule module) {
+            module.addDeserializer(OpenAiRateLimit.class, openAiRateLimit);
+        }
+    }
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it
添加了ChatResponse反序列化机制，直接在graph节点中直接返回ChatResponse对象。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
