### PR TITLE
fix(graph): NacosMcpGatewayToolCallback toolContext lose

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -212,14 +212,10 @@ public class AgentToolNode implements NodeActionWithConfig {
 			String result;
 			try {
 				// Handle FunctionToolCallback and MethodToolCallback, which support passing state and config in ToolContext.
-				if (toolCallback instanceof FunctionToolCallback<?, ?> || toolCallback instanceof MethodToolCallback) {
-					Map<String, Object> toolContextMap = new HashMap<>(toolContext);
-					toolContextMap.putAll(Map.of(AGENT_STATE_CONTEXT_KEY, state, AGENT_CONFIG_CONTEXT_KEY, config, AGENT_STATE_FOR_UPDATE_CONTEXT_KEY, extraStateFromToolCall));
-					result = toolCallback.call(req.getArguments(), new ToolContext(toolContextMap));
-				} else {
-					// FIXME, currently MCP Tool does not support State and RunnableConfig transmission in ToolContext.
-					result = toolCallback.call(req.getArguments(), new ToolContext(toolContext));
-				}
+                Map<String, Object> toolContextMap = new HashMap<>(toolContext);
+                toolContextMap.putAll(Map.of(AGENT_STATE_CONTEXT_KEY, state, AGENT_CONFIG_CONTEXT_KEY, config, AGENT_STATE_FOR_UPDATE_CONTEXT_KEY, extraStateFromToolCall));
+                result = toolCallback.call(req.getArguments(), new ToolContext(toolContextMap));
+
 
 				if (enableActingLog) {
 					logger.info("[ThreadId {}] Agent {} acting, tool {} finished", config.threadId()


### PR DESCRIPTION
### Describe what this PR does / why we need it
想在基于nacos 为配置中心的 NacosMcpGatewayToolCallback 中拿到类似FunctionToolCallback 的ToolContext，但是发现AgentToolNode 中丢失了

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
FunctionToolCallback 和MethodToolCallback 以及其他情况合并，个人理解应该不需要特殊处理

### Describe how to verify it


### Special notes for reviews
