### PR TITLE
fix(autoconf): NacosAgentConfig load duplicate key error

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/config/NacosAgentConfig.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/config/NacosAgentConfig.java
@@ -17,8 +17,8 @@
 package com.alibaba.cloud.ai.agent.nacos.config;
 
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.alibaba.cloud.ai.agent.nacos.NacosOptions;
@@ -42,19 +42,25 @@ public class NacosAgentConfig {
 
 	@Bean
 	public Properties nacosAgentProxyProperties(ConfigurableEnvironment environment) {
-		Properties props = new Properties();
-		Map<String, Object> map = environment.getPropertySources().stream()
-				.filter(ps -> ps instanceof EnumerablePropertySource)
-				.map(ps -> ((EnumerablePropertySource) ps).getPropertyNames())
-				.flatMap(Arrays::stream)
-				.filter(name -> name.startsWith("spring.ai.alibaba.agent.proxy.nacos."))
-				.collect(Collectors.toMap(
-						key -> key.substring("spring.ai.alibaba.agent.proxy.nacos.".length()),
-						environment::getProperty
-				));
+        Properties props = new Properties();
+        String prefix = "spring.ai.alibaba.agent.proxy.nacos.";
 
-		map.forEach((k, v) -> props.setProperty(k, (String) v));
-		return props;
+
+        Set<String> propertyNames = environment.getPropertySources().stream()
+                .filter(ps -> ps instanceof EnumerablePropertySource)
+                .flatMap(ps -> Arrays.stream(((EnumerablePropertySource<?>) ps).getPropertyNames()))
+                .filter(name -> name.startsWith(prefix))
+                .collect(Collectors.toSet());
+
+
+        propertyNames.forEach(name -> {
+            String value = environment.getProperty(name);
+            if (value != null) {
+                props.setProperty(name.substring(prefix.length()), value);
+            }
+        });
+
+        return props;
 	}
 
 	@Bean


### PR DESCRIPTION
### Describe what this PR does / why we need it

When a configuration file repeatedly configures a certain key, for example:
1. In the application.yml configuration, set spring.ai.alibaba.agent.proxy.nacos.namespace to dev (this is written this way because there may be many test environments)
2. In the application-prod.yml configuration, set the value of spring.ai.alibaba.agent.proxy.nacos.namespace to "prod"
At this time, the toMap method of NacosAgentConfig will directly report an error due to duplicate keys, instead of performing an overwrite operation according to Spring's specifications
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Let Spring handle priority automatically and remove duplicates


### Describe how to verify it
its easy to see

### Special notes for reviews
