### PR TITLE
feat(core): provides cross-platform shell detection

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
@@ -574,14 +574,23 @@ public class ShellSessionManager {
 		 */
 		private static List<String> getDefaultShellCommand() {
 			String os = System.getProperty("os.name").toLowerCase();
+			
 			if (os.contains("windows")) {
 				// Windows: use PowerShell for better compatibility and features
 				return Arrays.asList("powershell.exe");
+			} else if (os.contains("mac")) {
+				// macOS: prefer zsh (default since Catalina), fallback to bash, then sh
+				if (new File("/bin/zsh").exists()) {
+					return Arrays.asList("/bin/zsh");
+				} else if (new File("/bin/bash").exists()) {
+					return Arrays.asList("/bin/bash");
+				} else {
+					return Arrays.asList("/bin/sh");
+				}
 			} else {
-				// Linux/macOS: try bash first, fallback to sh
-				String bashPath = "/bin/bash";
-				if (new File(bashPath).exists()) {
-					return Arrays.asList(bashPath);
+				// Linux and other Unix-like systems: prefer bash, fallback to sh
+				if (new File("/bin/bash").exists()) {
+					return Arrays.asList("/bin/bash");
 				} else {
 					return Arrays.asList("/bin/sh");
 				}


### PR DESCRIPTION
### Describe what this PR does / why we need it
The `ShellSessionManager` class has hard-coded detection for Linux/macOS platforms, but ignores the shell type for Windows platforms.
```java
private List<String> shellCommand = Arrays.asList("/bin/bash");
```

This pull request provides an automatic detection method to provide different paths for different platforms, helping Windows users also use examples in the `examples/` directory, such as chatbot.
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
fixes #3382 
### Describe how you did it


### Describe how to verify it
After the fix, using the Windows platform detection, `chatbot` can now be successfully started and send/received.
<img width="709" height="84" alt="image" src="https://github.com/user-attachments/assets/523c5573-d631-4f88-9e38-4403d94d5be8" />
<img width="775" height="286" alt="image" src="https://github.com/user-attachments/assets/d4ea75e2-cf0e-49b4-b4af-0d907d850c5d" />

### Special notes for reviews
