### PR TITLE
fix(agent): preserve tools when chatOptions is not set (#4094)

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
@@ -332,6 +332,12 @@ public class AgentLlmNode implements NodeActionWithConfig {
 	@Nullable
 	private ToolCallingChatOptions buildChatOptions(ChatOptions chatOptions, List<ToolCallback> toolCallbacks) {
 		if (chatOptions == null) {
+			if (toolCallbacks != null && !toolCallbacks.isEmpty()) {
+				return ToolCallingChatOptions.builder()
+						.toolCallbacks(toolCallbacks)
+						.internalToolExecutionEnabled(false)
+						.build();
+			}
 			return null;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/Issue4094BugReproductionTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/Issue4094BugReproductionTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
+import com.alibaba.cloud.ai.graph.agent.node.AgentLlmNode;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.Tool;
+
+import reactor.core.publisher.Flux;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verification test for Issue #4094: https://github.com/alibaba/spring-ai-alibaba/issues/4094
+ *
+ * This test ensures that toolCallbacks are correctly managed even when chatOptions is not
+ * explicitly provided during ReactAgent construction.
+ */
+public class Issue4094BugReproductionTest {
+
+	private ChatModel mockChatModel;
+
+	@BeforeEach
+	void setUp() {
+		mockChatModel = new MockChatModel();
+	}
+
+	@Test
+	@DisplayName("Scenario 1: Set chatOptions and tools -> tools should be passed correctly")
+	void testWithChatOptionsAndTools() throws Exception {
+		System.out.println("\n" + "=".repeat(60));
+		System.out.println("Scenario 1: Set chatOptions and tools");
+		System.out.println("=".repeat(60));
+
+		ToolCallingChatOptions chatOptions = ToolCallingChatOptions.builder()
+				.temperature(0.7)
+				.build();
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("test-agent-with-options")
+				.model(mockChatModel)
+				.chatOptions(chatOptions)
+				.tools(ToolCallbacks.from(new MyTools()))
+				.saver(new MemorySaver())
+				.build();
+
+		AgentLlmNode llmNode = getLlmNode(agent);
+		ToolCallingChatOptions internalOptions = getChatOptions(llmNode);
+		List<ToolCallback> toolCallbacksField = getToolCallbacksField(llmNode);
+
+		System.out.println("AgentLlmNode.chatOptions is null: " + (internalOptions == null));
+		System.out.println("AgentLlmNode.toolCallbacks count: " + toolCallbacksField.size());
+		if (internalOptions != null && internalOptions.getToolCallbacks() != null) {
+			System.out.println("chatOptions.toolCallbacks count: " + internalOptions.getToolCallbacks().size());
+		}
+
+		List<String> toolNames = toolCallbacksField.stream()
+				.map(tc -> tc.getToolDefinition().name())
+				.toList();
+		ModelRequest modelRequest = ModelRequest.builder()
+				.messages(List.of(new UserMessage("test")))
+				.options(internalOptions)
+				.tools(toolNames)
+				.build();
+
+		List<ToolCallback> filtered = invokeFilterToolCallbacks(llmNode, modelRequest);
+		System.out.println("filterToolCallbacks returned count: " + filtered.size());
+
+		assertNotNull(internalOptions, "chatOptions should not be null");
+		assertFalse(filtered.isEmpty(), "filtered tools should not be empty");
+		assertEquals(1, filtered.size(), "should have 1 tool");
+
+		System.out.println("Scenario 1 passed");
+	}
+
+	@Test
+	@DisplayName("Scenario 2 (Fix verification): tools should be preserved when chatOptions is null")
+	void testToolsArePreservedWhenChatOptionsIsNull() throws Exception {
+		System.out.println("\n" + "=".repeat(60));
+		System.out.println("Scenario 2 (Fix verification): No chatOptions + tools");
+		System.out.println("=".repeat(60));
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("test-agent-no-options")
+				.model(mockChatModel)
+				// .chatOptions(...)  // Intentional: chatOptions is not set
+				.tools(ToolCallbacks.from(new MyTools()))
+				.saver(new MemorySaver())
+				.build();
+
+		AgentLlmNode llmNode = getLlmNode(agent);
+		ToolCallingChatOptions internalOptions = getChatOptions(llmNode);
+		List<ToolCallback> toolCallbacksField = getToolCallbacksField(llmNode);
+
+		System.out.println("AgentLlmNode.chatOptions is null: " + (internalOptions == null));
+		System.out.println("AgentLlmNode.toolCallbacks count: " + toolCallbacksField.size());
+
+		assertNotNull(internalOptions, "chatOptions should be automatically created");
+		assertNotNull(internalOptions.getToolCallbacks(), "chatOptions.toolCallbacks should not be null");
+		assertFalse(internalOptions.getToolCallbacks().isEmpty(), "chatOptions.toolCallbacks should not be empty");
+
+		System.out.println("chatOptions.toolCallbacks count: " + internalOptions.getToolCallbacks().size());
+
+		List<String> toolNames = toolCallbacksField.stream()
+				.map(tc -> tc.getToolDefinition().name())
+				.toList();
+
+		ModelRequest modelRequest = ModelRequest.builder()
+				.messages(List.of(new UserMessage("test")))
+				.options(internalOptions)
+				.tools(toolNames)
+				.build();
+
+		List<ToolCallback> filtered = invokeFilterToolCallbacks(llmNode, modelRequest);
+
+		System.out.println("\n----- filterToolCallbacks verification -----");
+		System.out.println("modelRequest.getOptions() is null: " + (modelRequest.getOptions() == null));
+		System.out.println("filterToolCallbacks returned count: " + filtered.size());
+
+		assertFalse(filtered.isEmpty(), "filterToolCallbacks returned tools should not be empty");
+		assertEquals("testTool", filtered.get(0).getToolDefinition().name(), "testTool should be preserved");
+
+		System.out.println("Scenario 2 passed: tools are preserved even if chatOptions is null");
+	}
+
+	private AgentLlmNode getLlmNode(ReactAgent agent) throws Exception {
+		Field llmNodeField = ReactAgent.class.getDeclaredField("llmNode");
+		llmNodeField.setAccessible(true);
+		return (AgentLlmNode) llmNodeField.get(agent);
+	}
+
+	private ToolCallingChatOptions getChatOptions(AgentLlmNode llmNode) throws Exception {
+		Field chatOptionsField = AgentLlmNode.class.getDeclaredField("chatOptions");
+		chatOptionsField.setAccessible(true);
+		return (ToolCallingChatOptions) chatOptionsField.get(llmNode);
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<ToolCallback> getToolCallbacksField(AgentLlmNode llmNode) throws Exception {
+		Field toolCallbacksField = AgentLlmNode.class.getDeclaredField("toolCallbacks");
+		toolCallbacksField.setAccessible(true);
+		return (List<ToolCallback>) toolCallbacksField.get(llmNode);
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<ToolCallback> invokeFilterToolCallbacks(AgentLlmNode llmNode, ModelRequest modelRequest)
+			throws Exception {
+		Method method = AgentLlmNode.class.getDeclaredMethod("filterToolCallbacks", ModelRequest.class);
+		method.setAccessible(true);
+		return (List<ToolCallback>) method.invoke(llmNode, modelRequest);
+	}
+
+	static class MockChatModel implements ChatModel {
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("Mock response"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("Mock stream response")))));
+		}
+	}
+
+	static class MyTools {
+		@Tool(description = "A test tool")
+		public String testTool(String input) {
+			return "result: " + input;
+		}
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

1.   Fixed a bug where tools were lost when building ReactAgent without explicitly setting `chatOptions`
2.   Modified `AgentLlmNode.buildChatOptions()` to automatically create `ToolCallingChatOptions` when tools are provided but chatOptions is null

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #4094 
### Describe how you did it

  When users configure ReactAgent like this:

```
  ReactAgent.builder()
      .name("my-agent")
      .model(chatModel)
      .tools(myTools)      // ✓ tools set
      // .chatOptions()    // ✗ chatOptions not set
      .build();
```

  The tools were not being sent to the LLM, causing tool calls to fail silently.

  Root Cause

  In AgentLlmNode.buildChatOptions():
```
  if (chatOptions == null) {
      return null;  // ← Problem: tools were ignored
  }
```

  This caused filterToolCallbacks() to receive null options and return an empty tool list.

  Solution

```
  if (chatOptions == null) {
      if (toolCallbacks != null && !toolCallbacks.isEmpty()) {
          return ToolCallingChatOptions.builder()
                  .toolCallbacks(toolCallbacks)
                  .internalToolExecutionEnabled(false)
                  .build();
      }
      return null;
  }
```

### Describe how to verify it
 Added Issue4094BugReproductionTest to verify the fix

### Special notes for reviews
After a thorough review of the code, I ensured that this modification strictly adheres to the Javadoc on the buildChatOptions method: 'If chatOptions is null or not of type ToolCallingChatOptions, create a new ToolCallingChatOptions.'

Furthermore, this change aligns with the design intent mentioned in the toolCallbacks FIXME: 'FIXME: toolCallbacks should be managed in chatOptions only. Currently it's guaranteed immutable with unmodifiableList.'

My goal was to respect and follow the original design philosophy of the codebase.

