### PR TITLE
fix: Add variableList prop to CustomInputsControl

### DIFF
--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/Workflow/nodes/APINode/panel.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/Workflow/nodes/APINode/panel.tsx
@@ -238,6 +238,7 @@ export default memo(function ApiPanel({
               .type === 'form-data' ? (
             <CustomInputsControl
               disabled={disabled}
+              variableList={variableList}
               onChange={(val) =>
                 changeNodeParam({
                   body: {


### PR DESCRIPTION
## 变更说明
- 修复了 应用管理 "节点管理" 中  [API节点-Body设置-form-data-添加变量] 变量值下拉选择框无数据的问题
- 修改文件：`spring-ai-alibaba/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/Workflow/nodes/APINode/panel.tsx`

## 解决的问题
- "节点管理" 中  [API节点-Body设置-form-data-添加变量] 变量值下拉选择框无数据
- 问题根因：form-data类型CustomInputsControl组件未传入数据（应添加 `variableList={variableList}`）

## 实现思路
- 通过参考百炼页面展示数据，【Header设置】、【Param设置】、【Body设置-from-data】变量值下拉框数据
展示一致 
- 通过代码查看三个设置的是一个组件，但【Body设置-from-data】缺少了“variableList ”传值
- 通过参考以上两个案例补全 `variableList={variableList}`

## 测试验证
- 本地启动项目，编辑应用-API节点，Body设置-选择from-data，新增变量，变量值下拉选择框展示数据，符合预期
<img width="1772" height="886" alt="4f9c5be602c74a6ead64f198557d6f84" src="https://github.com/user-attachments/assets/994a7fff-9730-4ef5-87a6-b803234f5100" />
<img width="1898" height="958" alt="cea1c9b52bc54a03b62b3b7dc8b45944" src="https://github.com/user-attachments/assets/94e15ca0-a1e1-4f87-921c-2af7f9c66421" />
