### PR TITLE
fix: the issue where rmq docker could not be started on MAC

### DIFF
--- a/spring-ai-alibaba-admin/docker/middleware/docker-compose.yaml
+++ b/spring-ai-alibaba-admin/docker/middleware/docker-compose.yaml
@@ -126,7 +126,6 @@ services:
   rmq_namesrv:
     image: apache/rocketmq:5.3.2
     container_name: rmq_namesrv
-    user: "${UID}:${GID}"
     restart: always
     env_file:
       - ./.env
@@ -147,7 +146,6 @@ services:
     image: apache/rocketmq:5.3.2
     container_name: rmq_broker
     restart: always
-    user: "${UID}:${GID}"
     env_file:
       - ./.env
     environment:
@@ -173,7 +171,6 @@ services:
     image: apache/rocketmq:5.3.2
     container_name: rmq_proxy
     restart: always
-    user: "${UID}:${GID}"
     volumes:
       - ${MIDDLEWARE_HOME:-.}/conf/rocketmq:/home/rocketmq/conf
     env_file:


### PR DESCRIPTION
Fixed the issue where rmq docker could not be started on MAC

### Does this pull request fix one issue?

https://github.com/alibaba/spring-ai-alibaba/issues/4151
