### PR TITLE
refactor(graph): init keyStrategyMap via copy constructor instead of stream API

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -99,12 +99,8 @@ public class CompiledGraph {
 		this.maxIterations = compileConfig.recursionLimit();
 		this.stateGraph = stateGraph;
 
-		this.keyStrategyMap = stateGraph.getKeyStrategyFactory()
-				.apply()
-				.entrySet()
-				.stream()
-				.map(e -> Map.entry(e.getKey(), e.getValue()))
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+		// Defensive copy of key strategies to avoid sharing mutable maps from the factory
+		this.keyStrategyMap = new LinkedHashMap<>(stateGraph.getKeyStrategyFactory().apply());
 
 		this.processedData = ProcessedNodesEdgesAndConfig.process(stateGraph, compileConfig);
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Optimizes the initialization of the `keyStrategyMap` field during graph compilation to improve code readability and performance.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Refactored the keyStrategyMap initialization to use the LinkedHashMap copy constructor instead of the Stream API.

### Describe how to verify it

Added a new test case for NullKeyStrategy to verify the behavior.

### Special notes for reviews

Behavior Changes:

- Previously, null values caused a "fail-fast" NullPointerException. The new implementation accepts null values (logic will fallback to ReplaceStrategy when encountering nulls).
- The map is now initialized as a LinkedHashMap, which preserves the iteration order of the source map. Previously, the order was not guaranteed.
