### PR TITLE
fix(graph): Fixed checkpoint state merge when in resume mode

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -114,7 +114,7 @@ public class GraphRunnerContext {
 
 		this.currentNodeId = null;
 		this.nextNodeId = checkpoint.getNextNodeId();
-		this.overallState = initialState.input(checkpoint.getState());
+		this.overallState = initialState.mergeWithCheckpointState(checkpoint.getState());
 		this.resumeFrom = checkpoint.getNodeId();
 
 		log.trace("RESUME FROM {}", checkpoint.getNodeId());

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -235,8 +235,18 @@ public final class OverAllState implements Serializable {
 		}
 
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
-		this.data.keySet().stream().filter(keyStrategies::containsKey).forEach(key -> {
-			this.data.put(key, keyStrategies.get(key).apply(value(key, null), checkpointState.get(key)));
+		checkpointState.keySet().stream().filter(keyStrategies::containsKey).forEach(key -> {
+			if (this.data.containsKey(key)) {
+				Optional<Object> newValue = value(key, null);
+				if (newValue.isPresent()) {
+					this.data.put(key, keyStrategies.get(key)
+							.apply(checkpointState.get(key), newValue.get()));
+				} else {
+					this.data.put(key, checkpointState.get(key));
+				}
+			} else {
+				this.data.put(key, checkpointState.get(key));
+			}
 		});
 		return this;
 	}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -235,8 +235,8 @@ public final class OverAllState implements Serializable {
 		}
 
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
-		checkpointState.keySet().stream().filter(keyStrategies::containsKey).forEach(key -> {
-			this.data.put(key, keyStrategies.get(key).apply(checkpointState.get(key), value(key, null)));
+		this.data.keySet().stream().filter(keyStrategies::containsKey).forEach(key -> {
+			this.data.put(key, keyStrategies.get(key).apply(value(key, null), checkpointState.get(key)));
 		});
 		return this;
 	}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -219,8 +219,24 @@ public final class OverAllState implements Serializable {
 		}
 
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
-		input.keySet().stream().filter(key -> keyStrategies.containsKey(key)).forEach(key -> {
+		input.keySet().stream().filter(keyStrategies::containsKey).forEach(key -> {
 			this.data.put(key, keyStrategies.get(key).apply(value(key, null), input.get(key)));
+		});
+		return this;
+	}
+
+	public OverAllState mergeWithCheckpointState(Map<String, Object> checkpointState) {
+		if (checkpointState == null) {
+			return this;
+		}
+
+		if (CollectionUtils.isEmpty(checkpointState)){
+			return this;
+		}
+
+		Map<String, KeyStrategy> keyStrategies = keyStrategies();
+		checkpointState.keySet().stream().filter(keyStrategies::containsKey).forEach(key -> {
+			this.data.put(key, keyStrategies.get(key).apply(checkpointState.get(key), value(key, null)));
 		});
 		return this;
 	}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
@@ -41,6 +41,10 @@ public class AppendStrategy implements KeyStrategy {
 
 	@Override
 	public Object apply(Object oldValue, Object newValue) {
+		if (newValue instanceof Optional<?> newValueOptional) {
+			newValue = newValueOptional.orElse(null);
+		}
+
 		if (newValue == null) {
 			return oldValue;
 		}
@@ -51,10 +55,6 @@ public class AppendStrategy implements KeyStrategy {
 
 		if (oldValue instanceof Optional<?> oldValueOptional) {
 			oldValue = oldValueOptional.orElse(null);
-		}
-
-		if (newValue instanceof Optional<?> newValueOptional) {
-			newValue = newValueOptional.orElse(null);
 		}
 
 		boolean oldValueIsList = oldValue instanceof List<?>;

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
@@ -41,10 +41,6 @@ public class AppendStrategy implements KeyStrategy {
 
 	@Override
 	public Object apply(Object oldValue, Object newValue) {
-		if (newValue instanceof Optional<?> newValueOptional) {
-			newValue = newValueOptional.orElse(null);
-		}
-
 		if (newValue == null) {
 			return oldValue;
 		}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
@@ -53,6 +53,10 @@ public class AppendStrategy implements KeyStrategy {
 			oldValue = oldValueOptional.orElse(null);
 		}
 
+		if (newValue instanceof Optional<?> newValueOptional) {
+			newValue = newValueOptional.orElse(null);
+		}
+
 		boolean oldValueIsList = oldValue instanceof List<?>;
 
 		if (oldValueIsList && newValue instanceof AppenderChannel.RemoveIdentifier<?>) {


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix the parameter order issue in OverAllState.input during resume scenarios. When resuming from a checkpoint, the passed input represents the old state, while the current state holds the new value. The original implementation reversed these, causing incorrect merge behavior

> graphrunnercontext.java 117
```java
private void initializeFromResume(OverAllState initialState, RunnableConfig config) {
		log.trace("RESUME REQUEST");

		var saver = compiledGraph.compileConfig.checkpointSaver()
				.orElseThrow(() -> new IllegalStateException("Resume request without a configured checkpoint saver!"));
		var checkpoint = saver.get(config)
				.orElseThrow(() -> new IllegalStateException("Resume request without a valid checkpoint!"));

		var startCheckpointNextNodeAction = compiledGraph.getNodeAction(checkpoint.getNextNodeId());
		if (startCheckpointNextNodeAction instanceof ResumableSubGraphAction resumableAction) {
			// RESUME FORM SUBGRAPH DETECTED
			this.config = RunnableConfig.builder(config)
					.checkPointId(null) // Reset checkpoint id
					.addMetadata(resumableAction.getResumeSubGraphId(), true) // add metadata for
					// sub graph
					.build();
			this.config.clearContext();
		} else {
			// Reset checkpoint id
			this.config = config.withCheckPointId(null);
		}

		this.currentNodeId = null;
		this.nextNodeId = checkpoint.getNextNodeId();
		this.overallState = initialState.input(checkpoint.getState()); // !! Call the input function here !!
		this.resumeFrom = checkpoint.getNodeId();

		log.trace("RESUME FROM {}", checkpoint.getNodeId());
	}
```
> overallstate.java 222
```java
	public OverAllState input(Map<String, Object> input) {
		if (input == null) {
			return this;
		}

		if (CollectionUtils.isEmpty(input)) {
			return this;
		}

		Map<String, KeyStrategy> keyStrategies = keyStrategies();
		input.keySet().stream().filter(key -> keyStrategies.containsKey(key)).forEach(key -> {
			this.data.put(key, keyStrategies.get(key).apply(value(key, null), input.get(key))); // The semantics within the function are correct, but the input passed at the calling site is actually the old value of the checkpoint state.
		});
		return this;
	}
```

### Does this pull request fix one issue?
Fixed checkpoint state merge when in resume mode

### Describe how you did it
Changed the strategy call in OverAllState.input from keyStrategies.get(key).apply(value(key, null), input.get(key)) to keyStrategies.get(key).apply(input.get(key), value(key, null)), ensuring that during resume, oldValue is the checkpoint’s old value and newValue is the current state’s new value

### Describe how to verify it
- Add a unit test simulating resume: use a key with AppendStrategy, set a new value in the current state, then call input(checkpointState), and verify the merged list order is [oldValue, newValue].
- Run the existing test suite to ensure no regression.
- Enable checkpointing in a real workflow, perform interrupt and resume, and observe that state merging behaves as expected.

### Special notes for reviews
- This change only affects resume scenarios (initializeFromResume); normal startup is unaffected 

>  GraphRunnerContext.java:115-118 。

- Pay special attention to AppendStrategy and MergeStrategy to ensure the order adjustment preserves correct semantics.