### PR TITLE
fix: AppendStrategy.apply method result maybe miss the  "newValue"

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
@@ -78,20 +78,17 @@ public class AppendStrategy implements KeyStrategy {
 				if (list.isEmpty()) {
 					return oldValue;
 				}
-				if (oldValueIsList) {
-					var result = evaluateRemoval((List<Object>) oldValue, list);
-					if (allowDuplicate) {
-						return Stream.concat(result.oldValues().stream(), result.newValues()
-										.stream())
-								.collect(Collectors.toList());
-					} else {
-						return Stream.concat(result.oldValues().stream(), result.newValues()
-										.stream())
-								.distinct()
-								.collect(Collectors.toList());
-					}
+				var result = evaluateRemoval((List<Object>) oldValue, list);
+				if (allowDuplicate) {
+					return Stream.concat(result.oldValues().stream(), result.newValues()
+									.stream())
+							.collect(Collectors.toList());
+				} else {
+					return Stream.concat(result.oldValues().stream(), result.newValues()
+									.stream())
+							.distinct()
+							.collect(Collectors.toList());
 				}
-				oldList.addAll(list);
 			}
 			else {
 				oldList.add(newValue);

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
@@ -100,9 +100,7 @@ public class AppendStrategy implements KeyStrategy {
 			if (list != null) {
 				arrayResult.addAll(list);
 			}
-			else {
-				arrayResult.add(newValue);
-			}
+			arrayResult.add(newValue);
 			return arrayResult;
 		}
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it
The AppendStrategy.apply result miss the newValue when oldValue is not a list object and newValue is a list object.

### Does this pull request fix one issue?
Yes, It fixed one issue and optimize a "if-else" logic branch.

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1.Removed lines 81 and 94, the line 81 always be true because the line 75 is true.
2.Fixed the "newValue" missed logic for line 106
### Describe how to verify it


### Special notes for reviews
