### PR TITLE
fix(graph): resolve subgraph interrupt propagation by correct ID mapping #4153

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/ProcessedNodesEdgesAndConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/ProcessedNodesEdgesAndConfig.java
@@ -101,8 +101,16 @@ public record ProcessedNodesEdgesAndConfig(StateGraph.Nodes nodes, StateGraph.Ed
 
 			// Process Interruption (Before) Subgraph(s)
 			interruptsBefore = interruptsBefore.stream()
-					.map(interrupt -> Objects.equals(subgraphNode.id(), interrupt) ? sgEdgeStartRealTargetId
-							: interrupt)
+					.map(interrupt -> {
+						if (Objects.equals(subgraphNode.id(), interrupt)) {
+							return sgEdgeStartRealTargetId;
+						}
+						if (!stateGraph.nodes.anyMatchById(interrupt)
+								&& processedSubGraphNodes.anyMatchById(interrupt)) {
+							return subgraphNode.formatId(interrupt);
+						}
+						return interrupt;
+					})
 					.collect(Collectors.toUnmodifiableSet());
 
 			var edgesWithSubgraphTargetId = edges.edgesByTargetId(subgraphNode.id());


### PR DESCRIPTION
### Describe what this PR does / why we need it


### Does this pull request fix one issue?

Fixes #4153

### Describe how you did it

Updated `ProcessedNodesEdgesAndConfig` to prioritize ID mapping:
1. Subgraph container ID -> Subgraph start node.
2. Parent node ID (collision) -> Keep as-is.
3. Subgraph internal ID -> Flattened ID.

### Describe how to verify it

### Special notes for reviews
