### PR TITLE
fix(graph): 优化子图中断ID映射逻辑，支持短名称引用 

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/ProcessedNodesEdgesAndConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/ProcessedNodesEdgesAndConfig.java
@@ -101,8 +101,16 @@ public record ProcessedNodesEdgesAndConfig(StateGraph.Nodes nodes, StateGraph.Ed
 
 			// Process Interruption (Before) Subgraph(s)
 			interruptsBefore = interruptsBefore.stream()
-					.map(interrupt -> Objects.equals(subgraphNode.id(), interrupt) ? sgEdgeStartRealTargetId
-							: interrupt)
+					.map(interrupt -> {
+						if (Objects.equals(subgraphNode.id(), interrupt)) {
+							return sgEdgeStartRealTargetId;
+						}
+						if (!stateGraph.nodes.anyMatchById(interrupt)
+								&& processedSubGraphNodes.anyMatchById(interrupt)) {
+							return subgraphNode.formatId(interrupt);
+						}
+						return interrupt;
+					})
 					.collect(Collectors.toUnmodifiableSet());
 
 			var edgesWithSubgraphTargetId = edges.edgesByTargetId(subgraphNode.id());


### PR DESCRIPTION
1. 修复子图内部节点中断失效的问题：
   - 增加对子图内部节点短名称（如 copyNode）的自动识别与映射支持。
   - 允许用户直接使用子图内的节点名配置中断，无需手动拼接扁平化后的全名。

2. 解决父子图节点命名冲突：
   - 优先匹配父图中的同名节点（如 C），避免因子图内存在同名节点而导致父图中断配置失效。

3. 支持子图容器本身的中断：
   - 自动将针对子图容器节点（如 B）的中断请求转发至子图的起始节点（B-B1）。

此次修复兼容现有的全名引用方式。


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

Fixes #4153 

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
