### PR TITLE
fix: RunnableConfig context propagation issue #4191

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -69,7 +69,7 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 		}).orElse(false);
 
 		RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config).checkPointId(null).nextNode(null).build();
-		subGraphRunnableConfig.clearContext();
+
 
 		var parentSaver = parentCompileConfig.checkpointSaver();
 		var subGraphSaver = subGraph.compileConfig.checkpointSaver();
@@ -89,7 +89,7 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 					.nextNode(null)
 					.checkPointId(null)
 					.build();
-				subGraphRunnableConfig.clearContext();
+		
 			}
 		}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/ContextPropagationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/ContextPropagationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+
+import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ContextPropagationTest {
+
+    @Test
+    public void testContextPropagationToSubgraph() throws Exception {
+        // Child graph node that reads from context
+        AsyncNodeActionWithConfig childNode = AsyncNodeActionWithConfig.node_async((state, config) -> {
+            String contextValue = (String) config.context().get("testKey");
+            return Map.of("result", contextValue != null ? contextValue : "MISSING");
+        });
+
+        StateGraph childGraph = new StateGraph()
+                .addNode("childNode", childNode)
+                .addEdge(START, "childNode")
+                .addEdge("childNode", END);
+
+        // Parent graph
+        StateGraph parentGraph = new StateGraph()
+                .addNode("subgraph", childGraph.compile())
+                .addEdge(START, "subgraph")
+                .addEdge("subgraph", END);
+
+        CompiledGraph compiledGraph = parentGraph.compile();
+
+        // Create config with context
+        RunnableConfig config = RunnableConfig.builder()
+                .build();
+        config.context().put("testKey", "testValue");
+
+        // Run graph
+        Map<String, Object> result = compiledGraph.invoke(Map.of(), config).orElseThrow().data();
+
+        // Verify result
+        assertEquals("testValue", result.get("result"), "Context value should be propagated to subgraph");
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

	/**
	 * Adds a subgraph to the state graph by creating a node with the specified
	 * identifier. This implies that the subgraph shares the same state with the parent
	 * graph.
         ...
	 */
	public StateGraph addNode(String id, CompiledGraph subGraph) throws GraphStateException {
	}

	/**
	 * Adds a subgraph to the state graph by creating a node with the specified
	 * identifier. This implies that the subgraph will share the same state with the
	 * parent graph and will be compiled when the parent is compiled.
	 ...
         * /
	public StateGraph addNode(String id, StateGraph subGraph) throws GraphStateException {
	}
当前这两个重载方法的文档描述的功能是一样的，但是使用上有差异，前者会清除传向子图的context，后者不会。


### Does this pull request fix one issue?

Fixes #4191 

### Describe how you did it

将前者功能向后者对齐。

### Describe how to verify it


### Special notes for reviews
