### PR TITLE
fix(graph): preserve RunnableConfig context in compiled subgraph

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -69,7 +69,6 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 		}).orElse(false);
 
 		RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config).checkPointId(null).nextNode(null).build();
-		subGraphRunnableConfig.clearContext();
 
 		var parentSaver = parentCompileConfig.checkpointSaver();
 		var subGraphSaver = subGraph.compileConfig.checkpointSaver();
@@ -89,7 +88,6 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 					.nextNode(null)
 					.checkPointId(null)
 					.build();
-				subGraphRunnableConfig.clearContext();
 			}
 		}
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR fixes context propagation for compiled subgraphs. `RunnableConfig.context` is meant to carry per-run mutable data across nodes, but `SubCompiledGraphNodeAction` cleared context before invoking the compiled subgraph, causing data loss.

### Does this pull request fix one issue?
Fixes #4191

### Describe how you did it
- Removed `subGraphRunnableConfig.clearContext()` in `SubCompiledGraphNodeAction` so subgraph execution keeps parent run context.
- Added regression test `testCompiledSubGraphShouldInheritRunnableContext` in `CompiledSubGraphTest`.
  - Parent node writes `trace_id` into `RunnableConfig.context`.
  - Subgraph node reads the same key and emits it in output.
  - Test verifies expected output includes `[SUB:ctx-123]`.

### Describe how to verify it
Run:
- `JAVA_HOME=/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -pl spring-ai-alibaba-graph-core -am test`

Result:
- `Tests run: 277, Failures: 0, Errors: 0, Skipped: 52`

### Special notes for reviews
- Change scope is limited to compiled-subgraph runnable config handling and one focused regression test.
- No API changes.
