### PR TITLE
refactor(graph): centralize key strategy aggregation

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -99,21 +99,9 @@ public class CompiledGraph {
 		this.maxIterations = compileConfig.recursionLimit();
 		this.stateGraph = stateGraph;
 
-		this.keyStrategyMap = stateGraph.getKeyStrategyFactory()
-				.apply()
-				.entrySet()
-				.stream()
-				.map(e -> Map.entry(e.getKey(), e.getValue()))
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
 		this.processedData = ProcessedNodesEdgesAndConfig.process(stateGraph, compileConfig);
 
-		// set extra Key and KeyStrategy defined from sub Graphs (StateGraph)
-		for (var entry : processedData.keyStrategyMap().entrySet()) {
-			if (!this.keyStrategyMap.containsKey(entry.getKey())) {
-				this.keyStrategyMap.put(entry.getKey(), entry.getValue());
-			}
-		}
+		this.keyStrategyMap = processedData.keyStrategyMap();
 
 		// CHECK INTERRUPTIONS
 		for (String interruption : processedData.interruptsBefore()) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

- Avoid duplicating key strategy aggregation in multiple places.
- Make the compiled graph’s keyStrategyMap come from a single, well-defined processing pipeline.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Centralized key strategy aggregation in ProcessedNodesEdgesAndConfig.process(...):
- merge current graph key strategies first
- then merge recursively processed subgraph key strategies
- Simplified CompiledGraph to directly use the processed keyStrategyMap.

### Describe how to verify it

mvn -pl spring-ai-alibaba-graph-core test (PASS)

### Special notes for reviews
