### PR TITLE
fix(graph): subagent overallState history

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/DeltaAwareKeyStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/DeltaAwareKeyStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+public interface DeltaAwareKeyStrategy extends KeyStrategy {
+
+	/**
+	 * Computes an incremental delta based on current state and a newly produced value.
+	 * @param currentValue value currently stored in state
+	 * @param newValue newly produced value, potentially materialized
+	 * @return delta to merge, or {@code null} when no update is needed
+	 */
+	Object computeDelta(Object currentValue, Object newValue);
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/StateDeltaHelper.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/StateDeltaHelper.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+
+public final class StateDeltaHelper {
+
+	private StateDeltaHelper() {
+	}
+
+	/**
+	 * Normalizes update values using {@link DeltaAwareKeyStrategy} if applicable.
+	 * @param currentState current state data
+	 * @param updateState update state data
+	 * @param keyStrategies strategy map
+	 * @param forceDelta when {@code true}, always invokes delta strategy for matching keys
+	 * @return normalized update map
+	 */
+	public static Map<String, Object> normalizeWithDeltaStrategies(Map<String, Object> currentState,
+			Map<String, Object> updateState, Map<String, KeyStrategy> keyStrategies, boolean forceDelta) {
+		if (updateState == null || updateState.isEmpty()) {
+			return Map.of();
+		}
+
+		Map<String, Object> normalized = new HashMap<>();
+		for (Map.Entry<String, Object> entry : updateState.entrySet()) {
+			String key = entry.getKey();
+			Object newValue = entry.getValue();
+			KeyStrategy strategy = keyStrategies != null ? keyStrategies.get(key) : null;
+			Object currentValue = currentState != null ? currentState.get(key) : null;
+
+			if (strategy instanceof DeltaAwareKeyStrategy deltaStrategy
+					&& (forceDelta || isLikelyMaterializedUpdate(currentValue, newValue))) {
+				Object delta = deltaStrategy.computeDelta(currentValue, newValue);
+				if (delta != null) {
+					normalized.put(key, delta);
+				}
+			}
+			else {
+				normalized.put(key, newValue);
+			}
+		}
+		return normalized;
+	}
+
+	private static boolean isLikelyMaterializedUpdate(Object currentValue, Object newValue) {
+		if (newValue == null) {
+			return false;
+		}
+		if (currentValue instanceof Optional<?> currentOptional) {
+			currentValue = currentOptional.orElse(null);
+		}
+
+		List<?> currentList = asList(currentValue);
+		List<?> newList = asList(newValue);
+		if (currentList == null || newList == null || newList.size() < currentList.size()) {
+			return false;
+		}
+
+		for (int i = 0; i < currentList.size(); i++) {
+			if (!java.util.Objects.equals(currentList.get(i), newList.get(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static List<?> asList(Object value) {
+		if (value instanceof List<?> list) {
+			return list;
+		}
+		if (value instanceof Collection<?> collection) {
+			return new ArrayList<>(collection);
+		}
+		if (value != null && value.getClass().isArray()) {
+			if (value instanceof Object[] objArray) {
+				return Arrays.asList(objArray);
+			}
+		}
+		return null;
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph.executor;
 
 import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.GraphRunnerContext;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
@@ -25,12 +26,18 @@ import com.alibaba.cloud.ai.graph.action.Command;
 import com.alibaba.cloud.ai.graph.action.InterruptableAction;
 import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
 import com.alibaba.cloud.ai.graph.exception.RunnableErrors;
+import com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction;
+import com.alibaba.cloud.ai.graph.state.ReplaceAllWith;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.streaming.GraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.ParallelGraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -66,6 +73,9 @@ import static com.alibaba.cloud.ai.graph.internal.node.ParallelNode.getExecutor;
 public class NodeExecutor extends BaseGraphExecutor {
 
 	private static final Logger log = LoggerFactory.getLogger(NodeExecutor.class);
+
+	private record EmbeddedFlux(String key, Flux<GraphResponse<NodeOutput>> flux) {
+	}
 
 	private final MainGraphExecutor mainGraphExecutor;
 
@@ -148,7 +158,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 		try {
 
 			// Check for Flux
-			Optional<Flux<GraphResponse<NodeOutput>>> embedFlux = getEmbedFlux(context, updateState);
+			Optional<EmbeddedFlux> embedFlux = getEmbedFlux(context, updateState);
 			if (embedFlux.isPresent()) {
 				return handleEmbeddedFlux(mainGraphExecutor, context, embedFlux.get(), updateState, resultValue);
 			}
@@ -395,7 +405,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 	private Flux<GraphResponse<NodeOutput>> processGraphResponseFlux(
 			MainGraphExecutor mainGraphExecutor, GraphRunnerContext context,
 			Flux<GraphResponse<NodeOutput>> embedFlux, Map<String, Object> partialState,
-			AtomicReference<Object> resultValue) {
+			AtomicReference<Object> resultValue, String embedKey) {
 		AtomicReference<GraphResponse<NodeOutput>> lastData = new AtomicReference<>();
 
 		Flux<GraphResponse<NodeOutput>> processedFlux = embedFlux.map(data -> {
@@ -450,6 +460,10 @@ public class NodeExecutor extends BaseGraphExecutor {
 				}
 			}
 
+			if (isSubgraphOutputKey(embedKey)) {
+				updateState = buildSubgraphDelta(context, updateState);
+			}
+
 			Map<String, Object> combinedUpdateState = new HashMap<>(partialStateWithoutFlux);
 			combinedUpdateState.putAll(updateState);
 			Optional<InterruptionMetadata> interruptAfterMetadata = interruptAfterForStreaming(context, combinedUpdateState);
@@ -475,17 +489,96 @@ public class NodeExecutor extends BaseGraphExecutor {
 			.concatWith(updateContextMono.thenMany(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue))));
 	}
 
+	private boolean isSubgraphOutputKey(String key) {
+		return key != null && key.endsWith(ResumableSubGraphAction.OUTPUT_KEY_TO_PARENT_SUFFIX);
+	}
+
+	private Map<String, Object> buildSubgraphDelta(GraphRunnerContext context, Map<String, Object> updateState) {
+		Map<String, Object> currentState = context.getCurrentStateData();
+		Map<String, KeyStrategy> keyStrategyMap = context.getKeyStrategyMap();
+		Map<String, Object> adjusted = new HashMap<>();
+
+		for (var entry : updateState.entrySet()) {
+			String key = entry.getKey();
+			Object newValue = entry.getValue();
+			KeyStrategy strategy = keyStrategyMap != null ? keyStrategyMap.get(key) : null;
+			if (strategy instanceof AppendStrategy) {
+				Object oldValue = currentState.get(key);
+				Object delta = computeAppendDelta(oldValue, newValue);
+				if (delta != null) {
+					adjusted.put(key, delta);
+				}
+			}
+			else {
+				adjusted.put(key, newValue);
+			}
+		}
+
+		return adjusted;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Object computeAppendDelta(Object oldValue, Object newValue) {
+		if (newValue == null) {
+			return null;
+		}
+		if (newValue instanceof ReplaceAllWith<?>) {
+			return newValue;
+		}
+
+		if (oldValue instanceof Optional<?> oldOptional) {
+			oldValue = oldOptional.orElse(null);
+		}
+
+		List<?> newList = asList(newValue);
+		if (oldValue instanceof List<?> oldList && newList != null) {
+			if (newList.size() < oldList.size()) {
+				return ReplaceAllWith.of((List<Object>) newList);
+			}
+			boolean isPrefix = true;
+			for (int i = 0; i < oldList.size(); i++) {
+				if (!Objects.equals(oldList.get(i), newList.get(i))) {
+					isPrefix = false;
+					break;
+				}
+			}
+			if (isPrefix) {
+				if (newList.size() == oldList.size()) {
+					return null;
+				}
+				return new ArrayList<>(newList.subList(oldList.size(), newList.size()));
+			}
+			return ReplaceAllWith.of((List<Object>) newList);
+		}
+
+		return newValue;
+	}
+
+	private List<?> asList(Object value) {
+		if (value instanceof List<?> list) {
+			return list;
+		}
+		if (value instanceof Collection<?> collection) {
+			return new ArrayList<>(collection);
+		}
+		if (value != null && value.getClass().isArray()) {
+			return Arrays.asList((Object[]) value);
+		}
+		return null;
+	}
+
 	/**
 	 * Gets embed flux from partial state.
 	 * @param context the graph runner context
 	 * @param partialState the partial state containing flux instances
 	 * @return an Optional containing Data with the flux if found, empty otherwise
 	 */
-	public Optional<Flux<GraphResponse<NodeOutput>>> getEmbedFlux(GraphRunnerContext context,
+	public Optional<EmbeddedFlux> getEmbedFlux(GraphRunnerContext context,
 			Map<String, Object> partialState) {
 		return partialState.entrySet().stream().filter(e -> e.getValue() instanceof Flux<?>).findFirst().map(e -> {
 			var chatFlux = (Flux<?>) e.getValue();
-			return transformFluxToGraphResponse(context, chatFlux, e.getKey(), context.getCurrentNodeId());
+			return new EmbeddedFlux(e.getKey(),
+					transformFluxToGraphResponse(context, chatFlux, e.getKey(), context.getCurrentNodeId()));
 		});
 	}
 
@@ -497,10 +590,11 @@ public class NodeExecutor extends BaseGraphExecutor {
 	 * @param resultValue the atomic reference to store the result value
 	 * @return Flux of GraphResponse with embedded flux handling result
 	 */
-	public Flux<GraphResponse<NodeOutput>> handleEmbeddedFlux(MainGraphExecutor mainGraphExecutor, GraphRunnerContext context,
-			Flux<GraphResponse<NodeOutput>> embedFlux, Map<String, Object> partialState,
+	public Flux<GraphResponse<NodeOutput>> handleEmbeddedFlux(MainGraphExecutor mainGraphExecutor,
+			GraphRunnerContext context, EmbeddedFlux embedFlux, Map<String, Object> partialState,
 			AtomicReference<Object> resultValue) {
-		return processGraphResponseFlux(mainGraphExecutor, context, embedFlux, partialState, resultValue);
+		return processGraphResponseFlux(mainGraphExecutor, context, embedFlux.flux(), partialState, resultValue,
+				embedFlux.key());
 	}
 
 	/**


### PR DESCRIPTION
### Describe what this PR does / why we need it
因为子图和主图共享的是一个overallState 所以，子图返回的是完整的状态，这部分父图已经有了！所以应该是增量添加，不是全量添加，这样就解决了对应的重复问题了
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Close #4305
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
