### PR TITLE
fix(agent): prevent infinite loop when skill requires missing tools

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
@@ -97,7 +97,7 @@ public class SkillsInterceptor extends ModelInterceptor {
 
 	/**
 	 * Threshold for triggering the infinite loop circuit breaker:
-	 * reading the same skill more than 2 times in a single conversational turn.
+	 * reading the same skill more than the configured threshold in a single conversational turn.
 	 */
 	private static final int LOOP_THRESHOLD = 2;
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
**What this PR does:** 
This PR introduces a "Graceful Degradation with Circuit Breaker" (带熔断的优雅降级) mechanism to the ReactAgent's skill execution flow. 

**Why we need it:** 
Currently, if a `SKILL.md` requires specific execution tools (e.g., Python, Shell) but those tools are not registered with the agent, the LLM falls into an infinite loop. It repeatedly calls the `read_skill` tool because it doesn't know how to proceed without the required tools. This exhausts tokens and breaks the agent's execution. This PR prevents the loop and guides the LLM to return a graceful failure message to the user.

### Does this pull request fix one issue?
Close #4192

### Describe how you did it
1. **Added Circuit Breaker in `SkillsInterceptor`**: 
   Introduced a unified `extractSkillData` method that traverses the message history backwards. It tracks the invocation count of `read_skill` per skill within the *current conversational turn*.
2. **Dynamic Prompt Injection**: 
   If a skill is read more than `LOOP_THRESHOLD` (set to 2) times in a single turn, the interceptor triggers the circuit breaker. It dynamically appends a `[CRITICAL] Runtime Safety Instructions` block to the system prompt, forcing the LLM to stop calling `read_skill` and explicitly instructing it to inform the user about the missing execution tools (or other errors).
3. **Added Warning Logs for Debugging**:
   When the circuit breaker is triggered, a warning log is emitted.

### Describe how to verify it
1. Create a `ReactAgent` and configure it with `SkillsAgentHook`.
2. Load a skill that explicitly requires executing a script (e.g., executing a Python script).
3. **Intentionally DO NOT register** the corresponding tool (e.g., `PythonTool` or `ShellTool`) to the agent.
4. Delete all scripts in the skill's `scripts/` directory to simulate missing execution resources.
5. Send a user request that triggers the skill.
6. **Expected Result**: 
   - The agent will call the read_skill tool multiple times.
   - A warning log will be printed: `SkillsInterceptor Circuit Breaker triggered for looping skills: [...]`.
   - The agent will break the loop and output a graceful text response explaining: *"I have loaded the skill, but since the system has not provided the necessary execution tools... I cannot complete the subsequent operations."*

<img width="2058" height="660" alt="增加死循环异常提示日志" src="https://github.com/user-attachments/assets/73213519-59e3-4c7a-9b15-aee6d7ba6e94" />

<img width="2051" height="809" alt="增加熔断指令" src="https://github.com/user-attachments/assets/e2ed0dc6-aa92-4188-99a8-d53c1f71e329" />

### Special notes for reviews
