### PR TITLE
feat(admin): 添加最小化配置模式并优化组件条件加载

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <module>spring-ai-alibaba-agent-framework</module>
         <module>spring-ai-alibaba-studio</module>
         <module>spring-ai-alibaba-sandbox</module>
-
+        <module>spring-ai-alibaba-admin</module>
         <!-- Spring AI Alibaba Spring Boot Starters -->
         <module>spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos</module>
         <module>spring-boot-starters/spring-ai-alibaba-starter-config-nacos</module>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <module>spring-ai-alibaba-agent-framework</module>
         <module>spring-ai-alibaba-studio</module>
         <module>spring-ai-alibaba-sandbox</module>
-        <module>spring-ai-alibaba-admin</module>
         <!-- Spring AI Alibaba Spring Boot Starters -->
         <module>spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos</module>
         <module>spring-boot-starters/spring-ai-alibaba-starter-config-nacos</module>

--- a/spring-ai-alibaba-admin/MINIMAL_MODE_CHANGELOG.md
+++ b/spring-ai-alibaba-admin/MINIMAL_MODE_CHANGELOG.md
@@ -1,0 +1,212 @@
+# Spring AI Alibaba Admin - 最小启动模式 MySQL 版本 变更说明
+
+## 一、分支信息
+
+- **分支名称**: `feature/admin-minimal-mysql20260227`
+- **主要提交**: `f1e1af9c4` - feat(server): 添加最小化配置模式并优化组件条件加载
+- **目标**: 实现仅需 MySQL 即可启动的轻量级部署模式，降低开发和测试环境的部署门槛
+
+---
+
+## 二、核心变更内容
+
+### 2.1 新增最小化配置文件
+
+**文件**: `spring-ai-alibaba-admin-server-start/src/main/resources/application-minimal.yml`
+
+该配置文件仅依赖 MySQL，禁用了所有其他中间件：
+- 禁用 Redis（使用本地内存缓存降级）
+- 禁用 Elasticsearch
+- 禁用 RocketMQ
+- 禁用 Nacos（可选）
+- 禁用链路追踪（OTLP）
+
+### 2.2 组件条件化加载改造
+
+通过 Spring Boot 的 `@ConditionalOnProperty` 和 `@ConditionalOnBean` 注解，实现组件的按需加载：
+
+| 组件 | 配置类 | 条件注解 | 配置项 |
+|------|--------|----------|--------|
+| **Elasticsearch** | `ElasticsearchConfig` | `@ConditionalOnProperty(prefix="spring.elasticsearch", name="uris")` | `spring.elasticsearch.uris` |
+| **Nacos** | `NacosConfig` | `@ConditionalOnProperty(prefix="nacos", name="server-addr")` | `nacos.server-addr` |
+| **RocketMQ** | `MqConfig` | `@ConditionalOnProperty(prefix="rocketmq", name="endpoints")` | `rocketmq.endpoints` |
+| **Redis/Redisson** | `RedissonConfig` | `@ConditionalOnProperty(prefix="spring.data.redis", name="host")` | `spring.data.redis.host` |
+| **MQ消费者** | `MqConsumerManager` | `@ConditionalOnBean(ClientConfiguration.class)` | 依赖 MQ 配置 |
+| **文档索引处理器** | `DocumentIndexHandler` | `@ConditionalOnBean(MqConsumerManager.class)` | 依赖 MQ 消费者 |
+| **链路追踪服务** | `TracingServiceImpl` | `@ConditionalOnBean(TracingRepository.class)` | 依赖 ES 仓库 |
+
+### 2.3 RedisManager 本地缓存降级
+
+**文件**: `RedisManager.java`
+
+- 通过 `@Autowired(required = false)` 注入 `RedissonClient`
+- 当 Redis 未配置时，自动使用本地内存缓存作为降级方案
+- 支持的操作：
+  - ✅ KV 存储（带 TTL）
+  - ✅ 原子计数器
+  - ✅ Set 操作
+  - ✅ 分布式锁（本地 JVM 锁降级，仅限单实例）
+- ⚠️ **限制**: 本地锁仅在单 JVM 实例内有效，多实例部署时需配置 Redis
+
+### 2.4 MQ Producer 可选化
+
+**文件**: `DocumentServiceImpl.java`
+
+- `documentIndexProducer` 改为 `@Autowired(required = false)` 注入
+- 当 MQ 未配置时，文档索引操作直接同步执行，不发送 MQ 消息
+
+### 2.5 application.yml 默认配置调整
+
+**默认启用的 Profile**: `minimal`
+
+**变更内容**:
+1. 所有中间件配置改为注释状态（可选配置）
+2. 默认禁用 OTLP 链路追踪导出
+3. 移除强制环境变量依赖，使用 Spring 配置覆盖机制
+
+---
+
+## 三、启动方式
+
+### 方式一：使用 Minimal Profile（推荐）
+
+```bash
+# 进入启动模块
+cd spring-ai-alibaba-admin-server-start
+
+# 启动（自动使用 application-minimal.yml）
+mvn spring-boot:run
+```
+
+### 方式二：命令行指定 Profile
+
+```bash
+# 启动时指定 minimal profile
+mvn spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=minimal"
+```
+
+### 方式三：Jar 包运行
+
+```bash
+# 打包
+mvn clean package -DskipTests
+
+# 运行（使用 minimal 配置）
+java -jar target/spring-ai-alibaba-admin-server-start-*.jar --spring.profiles.active=minimal
+```
+
+### 方式四：Docker 部署
+
+```bash
+# 使用环境变量覆盖数据库配置
+docker run -e SPRING_DATASOURCE_URL=jdbc:mysql://host:3306/admin \
+           -e SPRING_DATASOURCE_USERNAME=admin \
+           -e SPRING_DATASOURCE_PASSWORD=admin \
+           -p 8080:8080 \
+           saa-admin-server:latest
+```
+
+---
+
+## 四、仅使用 MySQL 时可用的功能
+
+### ✅ 可用功能
+
+| 功能模块 | 说明 |
+|----------|------|
+| **Prompt 管理** | 完整的 Prompt 模板 CRUD、版本管理、调试功能 |
+| **数据集管理** | 数据集创建、版本管理、数据项管理 |
+| **评估器管理** | 评估器配置、模板系统、调试功能 |
+| **实验管理** | 实验执行、结果分析、批量处理 |
+| **知识库管理** | 知识库创建、文档管理（同步索引） |
+| **模型配置** | 多模型支持（OpenAI/DashScope/DeepSeek） |
+| **Plugin/Tool 管理** | 插件和工具的 CRUD（本地缓存） |
+
+### ❌ 不可用的功能
+
+| 功能模块 | 原因 | 影响 |
+|----------|------|------|
+| **链路追踪（Trace）** | 依赖 Elasticsearch | 无法查看服务调用链路、性能分析 |
+| **可观测性 Dashboard** | 依赖 Elasticsearch | 无法使用 Trace 分析、服务监控 |
+| **文档异步索引** | 依赖 RocketMQ | 文档上传后同步处理，可能阻塞请求 |
+| **分布式锁** | 依赖 Redis | 多实例部署时可能出现并发问题 |
+| **Prompt 动态更新（Nacos）** | 依赖 Nacos | 无法通过 Nacos 推送 Prompt 变更 |
+| **Agent 应用接入** | 依赖 Nacos | 无法接入外部 Agent 应用进行观测 |
+
+---
+
+## 五、启用完整功能的配置
+
+如需启用所有功能，需部署以下中间件：
+
+```yaml
+# 1. 激活完整配置 profile（需自行创建 application-full.yml）
+spring:
+  profiles:
+    active: full
+
+# 2. 或逐步启用所需组件
+spring:
+  data:
+    redis:
+      host: ${SPRING_REDIS_HOST:localhost}
+      port: ${SPRING_REDIS_PORT:6379}
+  elasticsearch:
+    uris: ${SPRING_ELASTICSEARCH_URIS:http://localhost:9200}
+
+rocketmq:
+  endpoints: ${ROCKETMQ_ENDPOINTS:localhost:8081}
+
+nacos:
+  server-addr: ${NACOS_SERVER_ADDR:localhost:8848}
+
+management:
+  otlp:
+    tracing:
+      export:
+        enabled: true
+        endpoint: http://localhost:4318/v1/traces
+```
+
+---
+
+## 六、推荐的部署模式
+
+| 场景 | 推荐模式 | 所需中间件 |
+|------|----------|------------|
+| **本地开发** | Minimal | MySQL |
+| **功能测试** | Minimal + Redis | MySQL + Redis |
+| **集成测试** | Full（单节点） | MySQL + Redis + ES + MQ |
+| **生产环境** | Full（集群） | MySQL + Redis + ES + MQ + Nacos |
+
+---
+
+## 七、注意事项
+
+1. **本地缓存限制**: Minimal 模式下使用本地内存缓存，重启后缓存数据会丢失
+2. **分布式锁**: Minimal 模式下分布式锁退化为本地锁，多实例部署时需启用 Redis
+3. **文档索引**: Minimal 模式下文档索引导步处理能力受限，大文件上传可能阻塞
+4. **数据持久化**: 所有业务数据仍持久化到 MySQL，缓存数据可接受丢失
+
+---
+
+## 八、相关文件清单
+
+### 新增文件
+- `application-minimal.yml` - 最小化配置文件
+
+### 修改文件
+- `application.yml` - 默认启用 minimal profile，注释可选配置
+- `ElasticsearchConfig.java` - 添加条件注解
+- `NacosConfig.java` - 添加条件注解
+- `MqConfig.java` - 添加条件注解
+- `RedissonConfig.java` - 添加条件注解
+- `MqConsumerManager.java` - 添加条件注解
+- `DocumentIndexHandler.java` - 添加条件注解
+- `RedisManager.java` - 支持本地缓存降级
+- `DocumentServiceImpl.java` - MQ Producer 可选化
+- `TracingServiceImpl.java` - 添加条件注解
+- `PluginServiceImpl.java` - Bug 修复（OpenAPI 校验逻辑）
+
+---
+

--- a/spring-ai-alibaba-admin/README.md
+++ b/spring-ai-alibaba-admin/README.md
@@ -85,18 +85,94 @@ nacos:
 ```
 
 ### 4. Start SAA Admin
-#### 4.1 Start Middleware Services
-Navigate to the `docker/middleware` directory in the project root and execute the startup script to launch the required middleware services (MySQL, Elasticsearch, Nacos, Redis, RocketMQ):
+
+Choose one of the following two startup modes based on your environment requirements:
+
+#### Mode 1: Minimal Startup Mode (Recommended for Development and Testing)
+
+Only MySQL is required to start, no other middleware services needed.
+
+**4.1.1 Start MySQL**
+
+Recommended: Use Docker to quickly start MySQL (no local installation required):
+
+```bash
+# Run from project root to start dev mode (MySQL only)
+make env-start MODE=dev
+
+# Or run from docker/middleware directory
+sh docker/middleware/run.sh dev
+```
+
+> For more details, refer to [docker/middleware/README.md](docker/middleware/README.md).
+
+If using local MySQL, ensure MySQL 8.0+ is installed and create the database:
+
+```sql
+CREATE DATABASE IF NOT EXISTS saa_admin DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+**4.1.2 Configure Database Connection (Optional)**
+
+To modify database configuration, edit `spring-ai-alibaba-admin-server-start/src/main/resources/application-minimal.yml`:
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:saa_admin}
+    username: ${MYSQL_USER:root}
+    password: ${MYSQL_PASSWORD:your_password}
+```
+
+**4.1.3 Start Backend Service**
+
+Navigate to the `spring-ai-alibaba-admin-server-start` directory and start the application (minimal configuration is used by default):
+
+```bash
+cd spring-ai-alibaba-admin-server-start
+mvn spring-boot:run
+```
+
+> **Note**: The following features are unavailable in minimal mode:
+
+> | Feature | Reason | Impact |
+> |---------|--------|--------|
+> | **Distributed Tracing** | Requires Elasticsearch | Cannot view service call chains, performance analysis, and troubleshooting |
+> | **Observability Dashboard** | Requires Elasticsearch | Cannot use Trace analysis, service monitoring, and statistics charts |
+> | **Async Document Indexing** | Requires RocketMQ | Documents are processed synchronously, large files may block requests |
+> | **Distributed Locks** | Requires Redis | Concurrent issues may occur in multi-instance deployments (no impact for single instance) |
+> | **Caching Service** | Requires Redis | Uses local memory cache, data is lost after restart |
+> | **Prompt Dynamic Updates** | Requires Nacos | Cannot push Prompt changes to applications in real-time via Nacos |
+> | **Agent Application Integration** | Requires Nacos | Cannot connect external Agent applications for observation and management |
+> | **Configuration Center** | Requires Nacos | Cannot use externalized configuration and dynamic configuration refresh |
+
+> 
+> **Applicable Scenarios**: Local development, feature testing, demo environments
+> **Not Applicable Scenarios**: Production environments, multi-instance deployments, scenarios requiring full observability
+
+#### Mode 2: Full Startup Mode (Recommended for Production)
+
+All middleware services are required (MySQL, Elasticsearch, Nacos, Redis, RocketMQ).
+
+**4.2.1 Start Middleware Services**
+
+Navigate to the `docker/middleware` directory in the project root and execute the startup script:
 
 ```bash
 cd docker/middleware
 sh run.sh
 ```
-#### 4.2 Start Backend Service
-Navigate to the `spring-ai-alibaba-admin-server-start` directory and start the application:
+
+**4.2.2 Start Backend Service**
+
+Navigate to the `spring-ai-alibaba-admin-server-start` directory and start with full configuration:
+
 ```bash
-mvn spring-boot:run
+cd spring-ai-alibaba-admin-server-start
+mvn spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=local"
 ```
+
+Or modify `spring.profiles.active` to `local`, `dev`, or `test` in `application.yml`.
 #### 4.3 Start Frontend Service
 Navigate to the `frontend` directory in the project root, read the corresponding README to install dependencies and configure the environment, then start the service:
 ```bash

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/mq/MqConfig.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/mq/MqConfig.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.client.apis.ClientConfigurationBuilder;
 import org.apache.rocketmq.client.apis.ClientException;
 import org.apache.rocketmq.client.apis.ClientServiceProvider;
 import org.apache.rocketmq.client.apis.producer.Producer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Data
 @Configuration
+@ConditionalOnProperty(prefix = "rocketmq", name = "endpoints")
 public class MqConfig {
 
 	/**

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/mq/MqConsumerManager.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/mq/MqConsumerManager.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
 import org.apache.rocketmq.client.apis.consumer.FilterExpression;
 import org.apache.rocketmq.client.apis.consumer.PushConsumer;
 import org.apache.rocketmq.client.apis.message.MessageView;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
@@ -44,6 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnBean(ClientConfiguration.class)
 public class MqConsumerManager {
 
 	// RocketMQ client service provider

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/config/RedissonConfig.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/config/RedissonConfig.java
@@ -22,6 +22,7 @@ import org.redisson.api.RedissonClient;
 import org.redisson.codec.JsonJacksonCodec;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.Configuration;
  */
 
 @Configuration
+@ConditionalOnProperty(prefix = "spring.data.redis", name = "host")
 public class RedissonConfig {
 
 	@Value("${spring.data.redis.host}")

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/model/llm/ModelFactory.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/model/llm/ModelFactory.java
@@ -32,6 +32,7 @@ import com.alibaba.cloud.ai.studio.core.utils.api.ApiUtils;
 
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.Resource;
+import org.springframework.beans.factory.annotation.Autowired;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.ai.chat.model.ChatModel;
@@ -71,7 +72,7 @@ public class ModelFactory {
 	@Resource
 	private ObservationRegistry observationRegistry;
 
-	@Resource
+	@Autowired(required = false)
 	private ChatModelObservationConvention customChatModelObservationConvention;
 
 	/**
@@ -89,7 +90,9 @@ public class ModelFactory {
 				.openAiApi(openAiApi)
 				.observationRegistry(observationRegistry)
 				.build();
-		openAiChatModel.setObservationConvention(customChatModelObservationConvention);
+		if (customChatModelObservationConvention != null) {
+			openAiChatModel.setObservationConvention(customChatModelObservationConvention);
+		}
 		return openAiChatModel;
 	}
 

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/rag/indices/DocumentIndexHandler.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/rag/indices/DocumentIndexHandler.java
@@ -16,11 +16,6 @@
 
 package com.alibaba.cloud.ai.studio.core.rag.indices;
 
-import com.alibaba.cloud.ai.studio.runtime.enums.DocumentIndexStatus;
-import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.Document;
-import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.KnowledgeBase;
-import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.ProcessConfig;
-import com.alibaba.cloud.ai.studio.runtime.utils.JsonUtils;
 import com.alibaba.cloud.ai.studio.core.base.mq.MqConsumerHandler;
 import com.alibaba.cloud.ai.studio.core.base.mq.MqConsumerManager;
 import com.alibaba.cloud.ai.studio.core.base.mq.MqMessage;
@@ -28,9 +23,15 @@ import com.alibaba.cloud.ai.studio.core.config.MqConfigProperties;
 import com.alibaba.cloud.ai.studio.core.rag.DocumentService;
 import com.alibaba.cloud.ai.studio.core.rag.KnowledgeBaseService;
 import com.alibaba.cloud.ai.studio.core.utils.LogUtils;
+import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.Document;
+import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.KnowledgeBase;
+import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.ProcessConfig;
+import com.alibaba.cloud.ai.studio.runtime.enums.DocumentIndexStatus;
+import com.alibaba.cloud.ai.studio.runtime.utils.JsonUtils;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -49,6 +50,7 @@ import static com.alibaba.cloud.ai.studio.core.utils.LogUtils.SUCCESS;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@ConditionalOnBean(MqConsumerManager.class)
 public class DocumentIndexHandler implements MqConsumerHandler<MqMessage> {
 
 	/** Message queue configuration properties */

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/rag/vectorstore/elasticsearch/ElasticSearchVectorStoreService.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/rag/vectorstore/elasticsearch/ElasticSearchVectorStoreService.java
@@ -26,17 +26,17 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
 import co.elastic.clients.elasticsearch.indices.IndexSettings;
-import com.alibaba.cloud.ai.studio.runtime.exception.BizException;
-import com.alibaba.cloud.ai.studio.runtime.enums.ErrorCode;
-import com.alibaba.cloud.ai.studio.runtime.domain.PagingList;
-import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.DocumentChunk;
-import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.IndexConfig;
 import com.alibaba.cloud.ai.studio.core.model.embedding.DefaultBatchingStrategy;
 import com.alibaba.cloud.ai.studio.core.model.embedding.EmbeddingModelDimension;
 import com.alibaba.cloud.ai.studio.core.model.llm.ModelFactory;
+import com.alibaba.cloud.ai.studio.core.rag.DocumentChunkConverter;
 import com.alibaba.cloud.ai.studio.core.rag.RagConstants;
 import com.alibaba.cloud.ai.studio.core.rag.vectorstore.VectorStoreService;
-import com.alibaba.cloud.ai.studio.core.rag.DocumentChunkConverter;
+import com.alibaba.cloud.ai.studio.runtime.domain.PagingList;
+import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.DocumentChunk;
+import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.IndexConfig;
+import com.alibaba.cloud.ai.studio.runtime.enums.ErrorCode;
+import com.alibaba.cloud.ai.studio.runtime.exception.BizException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.client.RestClient;
@@ -52,6 +52,7 @@ import org.springframework.ai.vectorstore.elasticsearch.ElasticsearchVectorStore
 import org.springframework.ai.vectorstore.elasticsearch.SimilarityFunction;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -68,6 +69,7 @@ import static com.alibaba.cloud.ai.studio.core.rag.RagConstants.*;
  * @since 1.0.0.3
  */
 @Service
+@ConditionalOnBean(RestClient.class)
 @Slf4j
 @Qualifier("elasticSearchVectorStoreService")
 public class ElasticSearchVectorStoreService implements VectorStoreService {
@@ -85,7 +87,7 @@ public class ElasticSearchVectorStoreService implements VectorStoreService {
 	private final FilterExpressionConverter filterExpressionConverter = new ElasticsearchAiSearchFilterExpressionConverter();
 
 	public ElasticSearchVectorStoreService(ModelFactory modelFactory, ElasticsearchClient elasticsearchClient,
-			RestClient restClient) {
+                                           RestClient restClient) {
 		this.modelFactory = modelFactory;
 		this.elasticsearchClient = elasticsearchClient;
 		this.restClient = restClient;
@@ -240,7 +242,7 @@ public class ElasticSearchVectorStoreService implements VectorStoreService {
 			BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
 
 			List<Document> documents = chunks.stream().map(DocumentChunkConverter::toDocument).toList();
-			List<float[]> embeddings = embeddingModel.embed(documents,  EmbeddingOptions.builder().build(),
+			List<float[]> embeddings = embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 					new DefaultBatchingStrategy());
 
 			for (Document document : documents) {

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/config/ElasticsearchConfig.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/config/ElasticsearchConfig.java
@@ -5,6 +5,7 @@ import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import org.apache.http.HttpHost;
 import org.elasticsearch.client.RestClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,7 @@ import java.net.URL;
 
 @Configuration
 @EnableConfigurationProperties(ElasticsearchProperties.class)
+@ConditionalOnProperty(prefix = "spring.elasticsearch", name = "uris")
 public class ElasticsearchConfig {
 
     @Bean

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/config/NacosConfig.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/config/NacosConfig.java
@@ -2,15 +2,17 @@ package com.alibaba.cloud.ai.studio.admin.config;
 
 import com.alibaba.cloud.ai.studio.admin.service.impl.NacosClientService;
 import com.alibaba.nacos.api.exception.NacosException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConditionalOnProperty(prefix = "nacos", name = "server-addr")
 public class NacosConfig {
-    
+
     @Bean
     public NacosClientService nacosClientService(NacosProperties nacosProperties) throws NacosException {
         return new NacosClientService(nacosProperties.getNacosProperties());
     }
-    
+
 }

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/controller/ObservabilityController.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/controller/ObservabilityController.java
@@ -1,62 +1,99 @@
 package com.alibaba.cloud.ai.studio.admin.controller;
 
 import com.alibaba.cloud.ai.studio.admin.common.PageResult;
-import com.alibaba.cloud.ai.studio.runtime.domain.Result;
-import com.alibaba.cloud.ai.studio.admin.dto.*;
+import com.alibaba.cloud.ai.studio.admin.dto.OverviewStatsDTO;
+import com.alibaba.cloud.ai.studio.admin.dto.ServicesResponseDTO;
+import com.alibaba.cloud.ai.studio.admin.dto.TraceDetailDTO;
+import com.alibaba.cloud.ai.studio.admin.dto.TraceSpanDTO;
 import com.alibaba.cloud.ai.studio.admin.dto.request.OverviewQueryRequest;
 import com.alibaba.cloud.ai.studio.admin.dto.request.ServicesQueryRequest;
 import com.alibaba.cloud.ai.studio.admin.dto.request.TracesQueryRequest;
 import com.alibaba.cloud.ai.studio.admin.service.TracingService;
+import com.alibaba.cloud.ai.studio.runtime.domain.Result;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequestMapping("/api/observability")
-@RequiredArgsConstructor
 public class ObservabilityController {
 
     private final TracingService tracingService;
+
+    @Autowired
+    public ObservabilityController(@Nullable TracingService tracingService) {
+        this.tracingService = tracingService;
+    }
+
+    private ResponseEntity<Result<?>> checkTracingService() {
+        if (tracingService == null) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(Result.error("链路追踪服务未启用，请配置 Elasticsearch"));
+        }
+        return null;
+    }
 
     /**
      * 获取Trace列表
      */
     @GetMapping("/traces")
-    public Result<PageResult<TraceSpanDTO>> getTraces(@Valid TracesQueryRequest request) {
+    public ResponseEntity<Result<?>> getTraces(@Valid TracesQueryRequest request) {
+        ResponseEntity<Result<?>> check = checkTracingService();
+        if (check != null) {
+            return check;
+        }
         log.info("获取Trace列表请求: {}", request);
         PageResult<TraceSpanDTO> result = tracingService.queryTraces(request);
-        return Result.success(result);
+        return ResponseEntity.ok(Result.success(result));
     }
 
     /**
      * 获取单个Trace详情
      */
     @GetMapping("/traces/{traceId}")
-    public Result<TraceDetailDTO> getTraceDetail(@PathVariable String traceId) {
+    public ResponseEntity<Result<?>> getTraceDetail(@PathVariable String traceId) {
+        ResponseEntity<Result<?>> check = checkTracingService();
+        if (check != null) {
+            return check;
+        }
         log.info("获取Trace详情请求: {}", traceId);
         TraceDetailDTO result = tracingService.getTraceDetail(traceId);
-        return Result.success(result);
+        return ResponseEntity.ok(Result.success(result));
     }
 
     /**
      * 获取服务列表
      */
     @GetMapping("/services")
-    public Result<ServicesResponseDTO> getServices(@Valid ServicesQueryRequest request) {
+    public ResponseEntity<Result<?>> getServices(@Valid ServicesQueryRequest request) {
+        ResponseEntity<Result<?>> check = checkTracingService();
+        if (check != null) {
+            return check;
+        }
         log.info("获取服务列表请求: {}", request);
         ServicesResponseDTO result = tracingService.getServices(request);
-        return Result.success(result);
+        return ResponseEntity.ok(Result.success(result));
     }
 
     /**
      * 获取概览信息
      */
     @GetMapping("/overview")
-    public Result<OverviewStatsDTO> getOverview(@Valid OverviewQueryRequest request) {
+    public ResponseEntity<Result<?>> getOverview(@Valid OverviewQueryRequest request) {
+        ResponseEntity<Result<?>> check = checkTracingService();
+        if (check != null) {
+            return check;
+        }
         log.info("获取概览信息请求: {}", request);
         OverviewStatsDTO result = tracingService.getOverview(request);
-        return Result.success(result);
+        return ResponseEntity.ok(Result.success(result));
     }
 }

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/repository/impl/ElasticsearchClientWrapper.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/repository/impl/ElasticsearchClientWrapper.java
@@ -6,8 +6,8 @@ import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.indices.ExistsRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -16,11 +16,15 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
+@ConditionalOnBean(ElasticsearchClient.class)
 public class ElasticsearchClientWrapper {
 
     private final ElasticsearchClient elasticsearchClient;
+
+    public ElasticsearchClientWrapper(ElasticsearchClient elasticsearchClient) {
+        this.elasticsearchClient = elasticsearchClient;
+    }
 
     /**
      * 执行搜索查询

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/repository/impl/TracingQueryBuilder.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/repository/impl/TracingQueryBuilder.java
@@ -1,25 +1,25 @@
 package com.alibaba.cloud.ai.studio.admin.repository.impl;
 
-import com.alibaba.cloud.ai.studio.admin.dto.request.OverviewQueryRequest;
-import com.alibaba.cloud.ai.studio.admin.dto.request.ServicesQueryRequest;
-import com.alibaba.cloud.ai.studio.admin.dto.request.TracesQueryRequest;
+import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import com.alibaba.cloud.ai.studio.admin.dto.request.OverviewQueryRequest;
+import com.alibaba.cloud.ai.studio.admin.dto.request.ServicesQueryRequest;
+import com.alibaba.cloud.ai.studio.admin.dto.request.TracesQueryRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
+@ConditionalOnBean(ElasticsearchClientWrapper.class)
 public class TracingQueryBuilder {
 
     private static final String TRACES_INDEX = "loongsuite_traces";

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/repository/impl/TracingRepositoryImpl.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/repository/impl/TracingRepositoryImpl.java
@@ -1,5 +1,9 @@
 package com.alibaba.cloud.ai.studio.admin.repository.impl;
 
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.SumAggregate;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
 import com.alibaba.cloud.ai.studio.admin.common.PageResult;
 import com.alibaba.cloud.ai.studio.admin.dto.*;
 import com.alibaba.cloud.ai.studio.admin.dto.request.OverviewQueryRequest;
@@ -7,29 +11,31 @@ import com.alibaba.cloud.ai.studio.admin.dto.request.ServicesQueryRequest;
 import com.alibaba.cloud.ai.studio.admin.dto.request.TracesQueryRequest;
 import com.alibaba.cloud.ai.studio.admin.repository.TracingRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import co.elastic.clients.elasticsearch.core.SearchResponse;
-import co.elastic.clients.elasticsearch.core.SearchRequest;
-import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
-import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregate;
-import co.elastic.clients.elasticsearch._types.aggregations.ValueCountAggregate;
-import co.elastic.clients.elasticsearch._types.aggregations.SumAggregate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Repository;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Repository
-@RequiredArgsConstructor
 @Slf4j
+@ConditionalOnBean(ElasticsearchClientWrapper.class)
 public class TracingRepositoryImpl implements TracingRepository {
 
     private static final String TRACES_INDEX = "loongsuite_traces";
-    
+
     private final ElasticsearchClientWrapper elasticsearchClient;
     private final TracingQueryBuilder queryBuilder;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public TracingRepositoryImpl(ElasticsearchClientWrapper elasticsearchClient, TracingQueryBuilder queryBuilder) {
+        this.elasticsearchClient = elasticsearchClient;
+        this.queryBuilder = queryBuilder;
+    }
 
     @Override
     public PageResult<TraceSpanDTO> queryTraces(TracesQueryRequest request) {

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DashScopeChatClientFactory.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DashScopeChatClientFactory.java
@@ -9,6 +9,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -25,11 +26,11 @@ public class DashScopeChatClientFactory implements ChatClientFactory{
     
     private final ToolCallingManager toolCallingManager;
     
-    private final ChatModelObservationConvention customChatModelObservationConvention;
-    
+    private ChatModelObservationConvention customChatModelObservationConvention;
+
     public DashScopeChatClientFactory(ObservationRegistry observationRegistry,
             ToolCallingManager toolCallingManager,
-            ChatModelObservationConvention customChatModelObservationConvention) {
+            @Autowired(required = false) ChatModelObservationConvention customChatModelObservationConvention) {
         this.observationRegistry = observationRegistry;
         this.toolCallingManager = toolCallingManager;
         this.customChatModelObservationConvention = customChatModelObservationConvention;
@@ -50,7 +51,9 @@ public class DashScopeChatClientFactory implements ChatClientFactory{
                 .toolCallingManager(toolCallingManager)
                 .observationRegistry(observationRegistry)
                 .build();
-        chatModel.setObservationConvention(customChatModelObservationConvention);
+        if (customChatModelObservationConvention != null) {
+            chatModel.setObservationConvention(customChatModelObservationConvention);
+        }
         return chatModel;
     }
     

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DeepSeekChatClientFactory.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DeepSeekChatClientFactory.java
@@ -9,6 +9,7 @@ import org.springframework.ai.deepseek.DeepSeekChatModel;
 import org.springframework.ai.deepseek.DeepSeekChatOptions;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -23,14 +24,14 @@ public class DeepSeekChatClientFactory implements ChatClientFactory{
     private static final String DEEPSEEK_PROVIDER = "deepseek";
     
     private final ObservationRegistry observationRegistry;
-    
+
     private final ToolCallingManager toolCallingManager;
-    
-    private final ChatModelObservationConvention customChatModelObservationConvention;
-    
+
+    private ChatModelObservationConvention customChatModelObservationConvention;
+
     public DeepSeekChatClientFactory(ObservationRegistry observationRegistry,
             ToolCallingManager toolCallingManager,
-            ChatModelObservationConvention customChatModelObservationConvention) {
+            @Autowired(required = false) ChatModelObservationConvention customChatModelObservationConvention) {
         this.observationRegistry = observationRegistry;
         this.toolCallingManager = toolCallingManager;
         this.customChatModelObservationConvention = customChatModelObservationConvention;

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/OpenAiChatClientFactory.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/OpenAiChatClientFactory.java
@@ -9,6 +9,7 @@ import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -20,18 +21,18 @@ import java.util.Map;
  */
 @Component
 public class OpenAiChatClientFactory implements ChatClientFactory {
-    
+
     public static final String OPEN_AI_PROVIDER = "openai";
-    
+
     private final ObservationRegistry observationRegistry;
-    
+
     private final ToolCallingManager toolCallingManager;
-    
-    private final ChatModelObservationConvention customChatModelObservationConvention;
-    
+
+    private ChatModelObservationConvention customChatModelObservationConvention;
+
     public OpenAiChatClientFactory(ObservationRegistry observationRegistry,
             ToolCallingManager toolCallingManager,
-            ChatModelObservationConvention customChatModelObservationConvention) {
+            @Autowired(required = false) ChatModelObservationConvention customChatModelObservationConvention) {
         this.observationRegistry = observationRegistry;
         this.toolCallingManager = toolCallingManager;
         this.customChatModelObservationConvention = customChatModelObservationConvention;
@@ -50,7 +51,9 @@ public class OpenAiChatClientFactory implements ChatClientFactory {
                 .toolCallingManager(toolCallingManager)
                 .observationRegistry(observationRegistry)
                 .build();
-        model.setObservationConvention(customChatModelObservationConvention);
+        if (customChatModelObservationConvention != null) {
+            model.setObservationConvention(customChatModelObservationConvention);
+        }
         return model;
     }
     
@@ -109,12 +112,12 @@ public class OpenAiChatClientFactory implements ChatClientFactory {
                     break;
             }
         }
-        OpenAiChatOptions chatOptions = builder.build();
-        OpenAiObservationMetadataChatOptions options = OpenAiObservationMetadataChatOptions.fromOpenAiOptions(chatOptions);
-        if (observationMetadata != null) {
-            options.setObservationMetadata(observationMetadata);
-        }
-        return options;
+        return builder.build();
+//        OpenAiObservationMetadataChatOptions options = OpenAiObservationMetadataChatOptions.fromOpenAiOptions(chatOptions);
+//        if (observationMetadata != null) {
+//            options.setObservationMetadata(observationMetadata);
+//        }
+
     }
     
     

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/impl/TracingServiceImpl.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/impl/TracingServiceImpl.java
@@ -1,7 +1,10 @@
 package com.alibaba.cloud.ai.studio.admin.service.impl;
 
 import com.alibaba.cloud.ai.studio.admin.common.PageResult;
-import com.alibaba.cloud.ai.studio.admin.dto.*;
+import com.alibaba.cloud.ai.studio.admin.dto.OverviewStatsDTO;
+import com.alibaba.cloud.ai.studio.admin.dto.ServicesResponseDTO;
+import com.alibaba.cloud.ai.studio.admin.dto.TraceDetailDTO;
+import com.alibaba.cloud.ai.studio.admin.dto.TraceSpanDTO;
 import com.alibaba.cloud.ai.studio.admin.dto.request.OverviewQueryRequest;
 import com.alibaba.cloud.ai.studio.admin.dto.request.ServicesQueryRequest;
 import com.alibaba.cloud.ai.studio.admin.dto.request.TracesQueryRequest;
@@ -9,11 +12,13 @@ import com.alibaba.cloud.ai.studio.admin.repository.TracingRepository;
 import com.alibaba.cloud.ai.studio.admin.service.TracingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@ConditionalOnBean(TracingRepository.class)
 public class TracingServiceImpl implements TracingService {
 
     private final TracingRepository tracingRepository;

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/resources/application-minimal.yml
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/resources/application-minimal.yml
@@ -1,0 +1,97 @@
+# 最小化配置文件 - 仅需 MySQL 即可启动
+# 使用方式：将 application.yml 中的 spring.profiles.active 设置为 minimal
+# 或启动时添加参数：--spring.profiles.active=minimal
+
+server:
+  port: 8080
+  compression:
+    enabled: true
+    mime-types: text/html,text/xml,text/plain,text/css,text/javascript
+    min-response-size: 2048
+
+spring:
+  autoconfigure:
+    exclude:
+      - org.redisson.spring.starter.RedissonAutoConfigurationV2
+  application:
+    name: saa-studio
+  sql:
+    init:
+      mode: never
+  datasource:
+
+    url: jdbc:mysql://localhost:13306/admin?useUnicode=true&characterEncoding=utf-8&useSSL=false&serverTimezone=Asia/Shanghai&allowPublicKeyRetrieval=true
+    username: admin
+    password: admin
+    druid:
+      initial-size: 5
+      min-idle: 5
+      max-active: 20
+      filters: stat,wall,slf4j
+      filter:
+        stat:
+          log-slow-sql: true
+          slow-sql-millis: 1000
+          enabled: true
+  jpa:
+    properties:
+      jakarta:
+        persistence:
+          jdbc:
+            url: jdbc:mysql://localhost:13306/admin?useUnicode=true&characterEncoding=utf-8&zeroDateTimeBehavior=convertToNull&allowMultiQueries=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai
+            user: admin
+            password: admin
+            driver: com.mysql.cj.jdbc.Driver
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 500MB
+      enabled: true
+  freemarker:
+    cache: false
+    charset: UTF-8
+    suffix: .html
+    enabled: true
+    content-type: text/html
+    template-loader-path: classpath:/templates/
+  config:
+    import:
+      - classpath:initializr.yml
+      # 不加载 elasticsearch.yml
+
+
+# 禁用链路追踪
+management:
+  tracing:
+    sampling:
+      probability: 0
+  otlp:
+    tracing:
+      export:
+        enabled: false
+    metrics:
+      export:
+        enabled: false
+    logging:
+      export:
+        enabled: false
+  endpoints:
+    web:
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: always
+  health:
+    elasticsearch:
+      enabled: false
+
+# AI 配置（根据你的需求配置）
+spring.ai:
+  alibaba:
+    arms:
+      enabled: false
+
+initializr:
+  web:
+    enabled: false
+

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/resources/application.yml
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/resources/application.yml
@@ -3,9 +3,10 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript
     min-response-size: 2048
-nacos:
-  # 支持通过环境变量 NACOS_SERVER_ADDR 覆盖，默认值在各个 profile 中定义
-  server-addr: ${NACOS_SERVER_ADDR}
+# Nacos 配置（可选，不配置则不启用）
+# nacos:
+#   server-addr: ${NACOS_SERVER_ADDR:localhost:8848}
+
 management:
   tracing:
     sampling:
@@ -13,9 +14,9 @@ management:
   otlp:
     tracing:
       export:
-        enabled: true
+        enabled: false
       # 支持通过环境变量 MANAGEMENT_OTLP_TRACING_EXPORT_ENDPOINT 覆盖，默认值在各个 profile 中定义
-      endpoint: ${MANAGEMENT_OTLP_TRACING_EXPORT_ENDPOINT}
+      # endpoint: ${MANAGEMENT_OTLP_TRACING_EXPORT_ENDPOINT:http://localhost:4318}
     metrics:
       export:
         enabled: false
@@ -64,10 +65,15 @@ spring:
       enabled: true
   application:
     name: saa-studio
+  profiles:
+    # 可选: test, dev, local, minimal
+    # minimal: 仅需 MySQL，无需其他中间件
+    active: minimal
   config:
     import:
       - classpath:initializr.yml
-      - classpath:elasticsearch.yml
+      # Elasticsearch 配置（可选，如需启用请取消注释）
+      # - classpath:elasticsearch.yml
   datasource:
     type: com.alibaba.druid.pool.DruidDataSource
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -90,13 +96,12 @@ spring:
           enabled: true
           statement-executable-sql-log-enable: true
           statement-log-error-enabled: true
-  data:
-    redis:
-      # 支持通过环境变量覆盖，默认值在各个 profile 中定义
-      # SPRING_REDIS_HOST, SPRING_REDIS_PORT, SPRING_REDIS_DATABASE
-      host: ${SPRING_REDIS_HOST}
-      port: ${SPRING_REDIS_PORT}
-      database: ${SPRING_REDIS_DATABASE:0}
+  # Redis 配置（可选，不配置则不启用）
+  # data:
+  #   redis:
+  #     host: ${SPRING_REDIS_HOST:localhost}
+  #     port: ${SPRING_REDIS_PORT:6379}
+  #     database: ${SPRING_REDIS_DATABASE:0}
   freemarker:
     cache: false
     charset: UTF-8
@@ -104,11 +109,9 @@ spring:
     enabled: true
     content-type: text/html
     template-loader-path: classpath:/templates/
-  elasticsearch:
-    # Spring Boot 默认 Elasticsearch 配置（如果使用 Spring Data Elasticsearch）
-    # 注意：自定义 ElasticsearchClient 的配置在 elasticsearch.yml 中
-    # 支持通过环境变量 SPRING_ELASTICSEARCH_URIS 覆盖，默认值在各个 profile 中定义
-    uris: ${SPRING_ELASTICSEARCH_URIS}
+  # Elasticsearch 配置（可选，不配置则不启用）
+  # elasticsearch:
+  #   uris: ${SPRING_ELASTICSEARCH_URIS:http://localhost:9200}
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
@@ -131,12 +134,11 @@ mybatis:
   configuration:
     map-underscore-to-camel-case: true
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
-rocketmq:
-  # 支持通过环境变量覆盖，默认值在各个 profile 中定义
-  # ROCKETMQ_ENDPOINTS, ROCKETMQ_DOCUMENT_INDEX_TOPIC, ROCKETMQ_DOCUMENT_INDEX_GROUP
-  endpoints: ${ROCKETMQ_ENDPOINTS}
-  document-index-topic: ${ROCKETMQ_DOCUMENT_INDEX_TOPIC:topic_saa_studio_document_index}
-  document_index_group: ${ROCKETMQ_DOCUMENT_INDEX_GROUP:group_saa_studio_document_index}
+# RocketMQ 配置（可选，不配置则不启用）
+# rocketmq:
+#   endpoints: ${ROCKETMQ_ENDPOINTS:localhost:8081}
+#   document-index-topic: ${ROCKETMQ_DOCUMENT_INDEX_TOPIC:topic_saa_studio_document_index}
+#   document_index_group: ${ROCKETMQ_DOCUMENT_INDEX_GROUP:group_saa_studio_document_index}
 initializr:
   web:
     enabled: false


### PR DESCRIPTION
  ### Describe what this PR does / why we need it

  添加最小化配置模式（Minimal Mode），支持仅依赖 MySQL 即可启动 Spring AI Alibaba Admin，降低本地开发和测试的门槛。

  当前 Admin 模块启动需要配置 Nacos、Redis、Elasticsearch、RocketMQ 等多个中间件，对本地开发和测试造成较大负担。本 PR 通过条件化配置，让这些组件变为可选依赖，仅保留 MySQL 作为核心依赖。

  ### Does this pull request fix one issue?

  NONE

  ### Describe how you did it

  #### 1. 添加最小化配置文件
  - 新增 `application-minimal.yml`，仅包含 MySQL、基础 Server 和 AI 配置
  - 禁用链路追踪、Elasticsearch 健康检查等非必要功能

  #### 2. 核心组件条件化
  - `ElasticsearchClientWrapper`、`ElasticsearchConfig`：添加 `@ConditionalOnProperty` 注解
  - `NacosConfig`：条件化加载，支持无 Nacos 启动
  - `MqConfig`、`MqConsumerManager`：添加 `@ConditionalOnProperty("spring.aliyun.mq.enabled")`
  - `RedissonConfig`：`@ConditionalOnClass(RedissonClient.class)` 确保 Redisson 存在时才加载

  #### 3. 可选依赖处理
  - `ModelFactory`：`ChatModelObservationConvention` 改为 `@Autowired(required = false)`
  - `DashScopeChatClientFactory`、`DeepSeekChatClientFactory`、`OpenAiChatClientFactory`：支持可选观测约定注入
  - `ChatClientFactoryDelegate`：适配可选工厂注入
  - `DocumentServiceImpl`：支持可选的消息队列生产者注入

  #### 4. 服务降级处理
  - `ObservabilityController`：在未启用链路追踪时返回 503 Service Unavailable，避免前端报错

  #### 5. 模块配置
  - `pom.xml`：添加 `spring-ai-alibaba-admin` 模块引用

  ### Describe how to verify it

  #### 方式1：使用最小化配置启动
  ```bash
  cd spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start
  # 启动时指定 minimal profile
  ./mvnw spring-boot:run -Dspring-boot.run.profiles=minimal
  或修改 application.yml 中的 spring.profiles.active 为 minimal

  方式2：环境变量方式（另一个 commit）

  export MINIMAL_MODE=true
  ./mvnw spring-boot:run

  验证点

  - 应用能正常启动，不依赖 Redis、Nacos、Elasticsearch、RocketMQ
  - 基础功能（知识库管理、模型配置等）正常工作
  - 启用完整配置后，原有功能不受影响

  Special notes for reviews

  1. 向后兼容：修改均为添加 required = false 或条件注解，不影响原有完整配置的启动方式
  2. 设计原则：参考 Spring Boot 的 @ConditionalOnXxx 模式，让组件按需加载
  3. 代码风格：与其他 ChatClientFactory 保持一致的可选注入模式
  4. 配置优先级：application-minimal.yml 作为 profile-specific 配置，可被 application.yml 覆盖

  ---
