### PR TITLE
fix: support streaming calls in ModelRetryInterceptor

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelretry/ModelRetryInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelretry/ModelRetryInterceptor.java
@@ -19,16 +19,13 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
-
-import org.springframework.ai.chat.messages.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatResponse;
-import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
-
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRetryInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRetryInterceptorTest.java
@@ -18,7 +18,6 @@ package com.alibaba.cloud.ai.graph.agent.interceptors;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
-
 import com.alibaba.cloud.ai.graph.agent.interceptor.modelretry.ModelRetryInterceptor;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -29,7 +28,6 @@ import reactor.core.publisher.Flux;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.awt.SystemColor.text;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ModelRetryInterceptorTest {


### PR DESCRIPTION
### Description
This PR fixes a bug in `ModelRetryInterceptor` introduced in version 1.1.2.0, where it only supported blocking (synchronous) calls. Streaming calls (returning `Flux<ChatResponse>`) would cause an exception or fail to retry correctly when network errors occurred.

### Key Changes
- **Implemented `handleStreamRetry`**: Added logic to handle `Flux` return types by consuming the initial `ModelResponse` and using `retryWhen` for subsequent attempts.
- **Data Integrity**: Used `AtomicBoolean` (`hasOutput`) to ensure that retries are strictly prohibited if any data chunks have already been emitted to the client, preventing duplicate data.
- **Unified Logic**: Aligned the backoff calculation (multiplier and max delay) with the existing blocking retry logic for consistent behavior.
- **Improved Testing**: Added test cases (`testStreamRetryBeforeOutput`, `testPartialOutputThenFail`) to verify streaming retry behavior.

### Verification
- Ran existing blocking retry tests to ensure no regression.
- Tested the new streaming retry logic with simulated network failures.
