### PR TITLE
refactor(RedisSaver): distributed locking improvements

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/redis/RedisSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/redis/RedisSaver.java
@@ -42,6 +42,8 @@ import org.redisson.api.RBucket;
 import org.redisson.api.RLock;
 import org.redisson.api.RMap;
 import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -54,6 +56,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class RedisSaver implements BaseCheckpointSaver {
 
+	private static final Logger log = LoggerFactory.getLogger(RedisSaver.class);
+
 	// Redis key prefixes
 	private static final String CHECKPOINT_PREFIX = "graph:checkpoint:content:";
 	private static final String THREAD_META_PREFIX = "graph:thread:meta:";
@@ -63,6 +67,25 @@ public class RedisSaver implements BaseCheckpointSaver {
 	private static final String FIELD_THREAD_ID = "thread_id";
 	private static final String FIELD_IS_RELEASED = "is_released";
 	private static final String FIELD_THREAD_NAME = "thread_name";
+
+	/**
+	 * Lease time for read lock operations (e.g., list, get).
+	 * Specifying leaseTime disables Redisson's lock watchdog, which avoids
+	 * the "EVAL command keys must in same slot" error in Redis Cluster.
+	 * NOTE: Once leaseTime expires, the lock is auto-released regardless of whether the business logic has completed.
+	 * Must be set large enough to cover the worst-case execution time.
+	 */
+	private static final long READ_LOCK_LEASE_TIME_MS = 10000;
+
+	/**
+	 * Lease time for write lock operations (e.g., put, release).
+	 * Specifying leaseTime disables Redisson's lock watchdog, which avoids
+	 * the "EVAL command keys must in same slot" error in Redis Cluster.
+	 * NOTE: Once leaseTime expires, the lock is auto-released regardless of whether the business logic has completed.
+	 * Must be set large enough to cover the worst-case execution time.
+	 */
+	private static final long WRITE_LOCK_LEASE_TIME_MS = 30000;
+
 	private final Serializer<Checkpoint> checkpointSerializer;
 	private RedissonClient redisson;
 
@@ -182,11 +205,12 @@ public class RedisSaver implements BaseCheckpointSaver {
 
 		String threadName = threadNameOpt.get();
 		RLock lock = redisson.getLock(LOCK_PREFIX + threadName);
-		boolean tryLock = false;
+		boolean lockAcquired = false;
 		try {
-			// 500ms timeout for read operations (list)
-			tryLock = lock.tryLock(500, TimeUnit.MILLISECONDS);
-			if (!tryLock) {
+			// Specify leaseTime to disable Redisson lock watchdog, avoiding Redis Cluster cross-slot EVAL errors
+			lockAcquired = lock.tryLock(500, READ_LOCK_LEASE_TIME_MS, TimeUnit.MILLISECONDS);
+			if (!lockAcquired) {
+				log.warn("RedisSaver list failed to acquire lock due to timeout, threadName={}", threadName);
 				return List.of();
 			}
 
@@ -209,6 +233,10 @@ public class RedisSaver implements BaseCheckpointSaver {
 			throw new RuntimeException("Failed to deserialize checkpoints", e);
 		}
 		finally {
+			if (lockAcquired && !lock.isHeldByCurrentThread()) {
+				log.error("RedisSaver list lock auto-released due to leaseTime expiry, concurrent read risk exists, threadName={}, leaseTimeMs={}",
+						threadName, READ_LOCK_LEASE_TIME_MS);
+			}
 			if (lock.isHeldByCurrentThread()) {
 				lock.unlock();
 			}
@@ -224,11 +252,12 @@ public class RedisSaver implements BaseCheckpointSaver {
 
 		String threadName = threadNameOpt.get();
 		RLock lock = redisson.getLock(LOCK_PREFIX + threadName);
-		boolean tryLock = false;
+		boolean lockAcquired = false;
 		try {
-			// 500ms timeout for read operations (get)
-			tryLock = lock.tryLock(500, TimeUnit.MILLISECONDS);
-			if (!tryLock) {
+			// Specify leaseTime to disable Redisson lock watchdog, avoiding Redis Cluster cross-slot EVAL errors
+			lockAcquired = lock.tryLock(500, READ_LOCK_LEASE_TIME_MS, TimeUnit.MILLISECONDS);
+			if (!lockAcquired) {
+				log.warn("RedisSaver get failed to acquire lock due to timeout, threadName={}", threadName);
 				return Optional.empty();
 			}
 
@@ -259,6 +288,10 @@ public class RedisSaver implements BaseCheckpointSaver {
 			throw new RuntimeException("Failed to deserialize checkpoints", e);
 		}
 		finally {
+			if (lockAcquired && !lock.isHeldByCurrentThread()) {
+				log.error("RedisSaver get lock auto-released due to leaseTime expiry, concurrent read risk exists, threadName={}, leaseTimeMs={}",
+						threadName, READ_LOCK_LEASE_TIME_MS);
+			}
 			if (lock.isHeldByCurrentThread()) {
 				lock.unlock();
 			}
@@ -274,11 +307,12 @@ public class RedisSaver implements BaseCheckpointSaver {
 
 		String threadName = threadNameOpt.get();
 		RLock lock = redisson.getLock(LOCK_PREFIX + threadName);
-		boolean tryLock = false;
+		boolean lockAcquired = false;
 		try {
-			// 3 seconds timeout for write operations (put) - longer timeout for concurrent scenarios
-			tryLock = lock.tryLock(3, TimeUnit.SECONDS);
-			if (!tryLock) {
+			// Specify leaseTime to disable Redisson lock watchdog, avoiding Redis Cluster cross-slot EVAL errors
+			lockAcquired = lock.tryLock(3000, WRITE_LOCK_LEASE_TIME_MS, TimeUnit.MILLISECONDS);
+			if (!lockAcquired) {
+				log.warn("RedisSaver put failed to acquire lock due to timeout, threadName={}", threadName);
 				throw new RuntimeException("Failed to acquire lock for thread: " + threadName);
 			}
 
@@ -316,6 +350,10 @@ public class RedisSaver implements BaseCheckpointSaver {
 			throw new RuntimeException("Failed to serialize/deserialize checkpoints", e);
 		}
 		finally {
+			if (lockAcquired && !lock.isHeldByCurrentThread()) {
+				log.error("RedisSaver put lock auto-released due to leaseTime expiry, concurrent write risk may cause data inconsistency, threadName={}, leaseTimeMs={}",
+						threadName, WRITE_LOCK_LEASE_TIME_MS);
+			}
 			if (lock.isHeldByCurrentThread()) {
 				lock.unlock();
 			}
@@ -331,11 +369,12 @@ public class RedisSaver implements BaseCheckpointSaver {
 
 		String threadName = threadNameOpt.get();
 		RLock lock = redisson.getLock(LOCK_PREFIX + threadName);
-		boolean tryLock = false;
+		boolean lockAcquired = false;
 		try {
-			// 3 seconds timeout for write operations (release) - longer timeout for concurrent scenarios
-			tryLock = lock.tryLock(3, TimeUnit.SECONDS);
-			if (!tryLock) {
+			// Specify leaseTime to disable Redisson lock watchdog, avoiding Redis Cluster cross-slot EVAL errors
+			lockAcquired = lock.tryLock(3000, WRITE_LOCK_LEASE_TIME_MS, TimeUnit.MILLISECONDS);
+			if (!lockAcquired) {
+				log.warn("RedisSaver release failed to acquire lock due to timeout, threadName={}", threadName);
 				throw new RuntimeException("Failed to acquire lock for thread: " + threadName);
 			}
 
@@ -373,6 +412,10 @@ public class RedisSaver implements BaseCheckpointSaver {
 			throw new RuntimeException("Failed to deserialize checkpoints", e);
 		}
 		finally {
+			if (lockAcquired && !lock.isHeldByCurrentThread()) {
+				log.error("RedisSaver release lock auto-released due to leaseTime expiry, concurrent write risk may cause data inconsistency, threadName={}, leaseTimeMs={}",
+						threadName, WRITE_LOCK_LEASE_TIME_MS);
+			}
 			if (lock.isHeldByCurrentThread()) {
 				lock.unlock();
 			}


### PR DESCRIPTION
#4361 
This pull request improves the reliability and safety of distributed locking in the `RedisSaver` class by introducing explicit lock lease times for both read and write operations, enhancing error handling and logging, and addressing potential concurrency issues in Redis Cluster environments.

**Distributed Locking Improvements**
* Added explicit lease times for read (`READ_LOCK_LEASE_TIME_MS`) and write (`WRITE_LOCK_LEASE_TIME_MS`) locks to disable Redisson's lock watchdog, preventing Redis Cluster cross-slot EVAL errors and ensuring locks are auto-released after a set duration.
* Updated all lock acquisition calls in `list`, `get`, `put`, and `release` methods to use the new lease times, improving consistency and reliability of lock management. [[1]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceL185-R213) [[2]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceL227-R260) [[3]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceL277-R315) [[4]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceL334-R377)

**Error Handling and Logging Enhancements**
* Integrated SLF4J logging to provide warnings when lock acquisition fails due to timeouts and errors when locks are auto-released before business logic completes, highlighting potential concurrent read/write risks. [[1]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR45-R46) [[2]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR59-R60) [[3]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR236-R239) [[4]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR291-R294) [[5]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR353-R356) [[6]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR415-R418)

**Concurrency Risk Awareness**
* Added error logs to notify when a lock is auto-released due to lease time expiry, alerting developers to possible data inconsistency or concurrent access risks in both read and write operations. [[1]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR236-R239) [[2]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR291-R294) [[3]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR353-R356) [[4]](diffhunk://#diff-b71aa672e172ac61c2b48a2a9f86e543335a004ecb445827a3ab78b353f394ceR415-R418)