### PR TITLE
feat(graph): add langfuse tracing support for graph and agent flows

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/Builder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/Builder.java
@@ -33,6 +33,7 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
 import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.observation.GraphObservationSupport;
 
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 import com.alibaba.cloud.ai.graph.serializer.std.SpringAIStateSerializer;
@@ -424,18 +425,19 @@ public abstract class Builder {
 	}
 
 	protected CompileConfig buildConfig() {
-		if (compileConfig != null) {
-			return compileConfig;
-		}
-
-		SaverConfig saverConfig = SaverConfig.builder()
-				.register(saver)
-				.build();
-		return CompileConfig.builder()
+		CompileConfig baseConfig = this.compileConfig;
+		if (baseConfig == null) {
+			SaverConfig saverConfig = SaverConfig.builder()
+					.register(saver)
+					.build();
+			baseConfig = CompileConfig.builder()
 				.saverConfig(saverConfig)
 				.recursionLimit(Integer.MAX_VALUE)
 				.releaseThread(releaseThread)
 				.build();
+		}
+
+		return GraphObservationSupport.enhance(baseConfig, this.observationRegistry);
 	}
 
 	public abstract ReactAgent build();

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/builder/FlowAgentBuilder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/builder/FlowAgentBuilder.java
@@ -22,7 +22,9 @@ import com.alibaba.cloud.ai.graph.agent.hook.Hook;
 import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
+import com.alibaba.cloud.ai.graph.observation.GraphObservationSupport;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
+import io.micrometer.observation.ObservationRegistry;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,6 +56,8 @@ public abstract class FlowAgentBuilder<T extends FlowAgent, B extends FlowAgentB
 	public Executor executor;
 
 	public List<Hook> hooks;
+
+	public ObservationRegistry observationRegistry;
 
 	/**
 	 * Sets the agent name.
@@ -161,6 +165,16 @@ public abstract class FlowAgentBuilder<T extends FlowAgent, B extends FlowAgentB
 	}
 
 	/**
+	 * Sets the observation registry used by the underlying graph execution.
+	 * @param observationRegistry the observation registry
+	 * @return this builder instance for method chaining
+	 */
+	public B observationRegistry(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
+		return self();
+	}
+
+	/**
 	 * Returns the concrete builder instance. This method enables fluent interface support
 	 * in subclasses.
 	 * @return this builder instance
@@ -194,9 +208,15 @@ public abstract class FlowAgentBuilder<T extends FlowAgent, B extends FlowAgentB
 			}
 			this.compileConfig = CompileConfig.builder(compileConfig).saverConfig(SaverConfig.builder().register(saver).build()).build();
 		}
+		this.compileConfig = GraphObservationSupport.enhance(this.compileConfig, this.observationRegistry);
 		return doBuild();
 	};
 
+	/**
+	 * Creates the concrete FlowAgent instance after common builder processing has
+	 * completed.
+	 * @return the built FlowAgent instance
+	 */
 	public abstract T doBuild();
 
 }

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompileConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompileConfig.java
@@ -328,10 +328,11 @@ public class CompileConfig {
 		this.interruptsBefore = config.interruptsBefore;
 		this.interruptsAfter = config.interruptsAfter;
 		this.releaseThread = config.releaseThread;
-		this.lifecycleListeners = config.lifecycleListeners;
+		this.lifecycleListeners = new LinkedBlockingDeque<>(config.lifecycleListeners);
 		this.observationRegistry = config.observationRegistry;
 		this.interruptBeforeEdge = config.interruptBeforeEdge;
 		this.store = config.store;
+		this.recursionLimit = config.recursionLimit;
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationLifecycleListener.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationLifecycleListener.java
@@ -54,6 +54,14 @@ public class GraphObservationLifecycleListener implements GraphLifecycleListener
 		this.observationRegistry = observationRegistry;
 	}
 
+	/**
+	 * Returns the observation registry bound to this listener.
+	 * @return the observation registry
+	 */
+	public ObservationRegistry observationRegistry() {
+		return observationRegistry;
+	}
+
 	public static class GraphObservationContext {
 		final Observation graphObservation;
 		final Map<String, Observation> nodeObservations = new ConcurrentHashMap<>();

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationSupport.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/observation/GraphObservationSupport.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.observation;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.GraphLifecycleListener;
+import io.micrometer.observation.ObservationRegistry;
+
+import java.util.Objects;
+
+/**
+ * Utilities for attaching graph observation support to compile configurations.
+ */
+public final class GraphObservationSupport {
+
+	private GraphObservationSupport() {
+	}
+
+	/**
+	 * Enhances a compile configuration with graph observation support.
+	 * @param compileConfig the base compile configuration
+	 * @param observationRegistry the observation registry to apply
+	 * @return the enhanced compile configuration
+	 */
+	public static CompileConfig enhance(CompileConfig compileConfig, ObservationRegistry observationRegistry) {
+		CompileConfig baseConfig = compileConfig != null ? compileConfig : CompileConfig.builder().build();
+		ObservationRegistry effectiveRegistry = observationRegistry != null ? observationRegistry
+				: baseConfig.observationRegistry();
+
+		if (effectiveRegistry == null || effectiveRegistry == ObservationRegistry.NOOP) {
+			return baseConfig;
+		}
+
+		GraphObservationLifecycleListener existingListener = findGraphObservationLifecycleListener(baseConfig);
+		boolean hasLifecycleListener = existingListener != null;
+		boolean sameRegistry = baseConfig.observationRegistry() == effectiveRegistry;
+		boolean listenerMatchesRegistry = existingListener == null
+				|| Objects.equals(existingListener.observationRegistry(), effectiveRegistry);
+
+		if (sameRegistry && hasLifecycleListener && listenerMatchesRegistry) {
+			return baseConfig;
+		}
+
+		CompileConfig.Builder builder = CompileConfig.builder(baseConfig).observationRegistry(effectiveRegistry);
+		if (hasLifecycleListener && !listenerMatchesRegistry) {
+			builder = CompileConfig.builder(baseConfig)
+					.observationRegistry(effectiveRegistry);
+
+			baseConfig.lifecycleListeners()
+					.stream()
+					.filter(listener -> !(listener instanceof GraphObservationLifecycleListener))
+					.forEach(builder::withLifecycleListener);
+		}
+
+		if (!hasLifecycleListener || !listenerMatchesRegistry) {
+			builder.withLifecycleListener(new GraphObservationLifecycleListener(effectiveRegistry));
+		}
+
+		return builder.build();
+	}
+
+	/**
+	 * Checks whether the compile configuration already contains a lifecycle listener
+	 * assignable to the given type.
+	 * @param compileConfig the compile configuration
+	 * @param listenerType the listener type to search for
+	 * @return {@code true} if a matching listener is present
+	 */
+	public static boolean hasLifecycleListener(CompileConfig compileConfig,
+			Class<? extends GraphLifecycleListener> listenerType) {
+		if (compileConfig == null || listenerType == null) {
+			return false;
+		}
+		return compileConfig.lifecycleListeners()
+				.stream()
+				.anyMatch(listener -> listenerType.isAssignableFrom(listener.getClass()));
+	}
+
+	/**
+	 * Returns the graph observation lifecycle listener from the compile
+	 * configuration, if present.
+	 * @param compileConfig the compile configuration
+	 * @return the graph observation lifecycle listener, or {@code null} if absent
+	 */
+	public static GraphObservationLifecycleListener findGraphObservationLifecycleListener(CompileConfig compileConfig) {
+		if (compileConfig == null) {
+			return null;
+		}
+		return compileConfig.lifecycleListeners()
+				.stream()
+				.filter(GraphObservationLifecycleListener.class::isInstance)
+				.map(GraphObservationLifecycleListener.class::cast)
+				.findFirst()
+				.orElse(null);
+	}
+
+}

--- a/spring-ai-alibaba-studio/README-langfuse.md
+++ b/spring-ai-alibaba-studio/README-langfuse.md
@@ -1,0 +1,73 @@
+# Langfuse Setup For Studio
+
+The `langfuse` profile is available on the `studio` test classpath for validating
+Spring AI and graph traces with Langfuse.
+
+## Environment variables
+
+Do not put real keys into YAML.
+
+```bash
+export AI_DASHSCOPE_API_KEY='your-dashscope-key'
+export LANGFUSE_ENABLED=true
+export LANGFUSE_PUBLIC_KEY='your-public-key'
+export LANGFUSE_SECRET_KEY='your-secret-key'
+export LANGFUSE_OTEL_AUTH=$(printf '%s' "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" | base64)
+```
+
+Optional:
+
+```bash
+export LANGFUSE_SERVICE_NAME='spring-ai-alibaba-studio-langfuse'
+export LANGFUSE_ENV='development'
+export SPRING_AI_LOG_PROMPT=false
+export SPRING_AI_LOG_COMPLETION=false
+export SPRING_AI_LOG_QUERY_RESPONSE=false
+```
+
+## Run Studio with Langfuse
+
+```bash
+env MAVEN_USER_HOME=/tmp/codex-m2 ./mvnw -U \
+  -pl spring-ai-alibaba-studio \
+  -am \
+  -DskipTests \
+  -Dspring-boot.run.useTestClasspath=true \
+  -Dspring-boot.run.mainClass=com.alibaba.cloud.ai.StudioApplication \
+  -Dspring-boot.run.profiles=graph,langfuse \
+  spring-boot:run
+```
+
+Useful endpoints:
+
+- `GET /list-apps`
+- `GET /list-graphs`
+- `POST /run_sse`
+- `POST /graph_run_sse`
+
+Langfuse:
+
+- UI: [https://us.cloud.langfuse.com](https://us.cloud.langfuse.com)
+- OTLP traces: `https://us.cloud.langfuse.com/api/public/otel/v1/traces`
+
+## Tests
+
+Profile smoke test:
+
+```bash
+env MAVEN_USER_HOME=/tmp/codex-m2 ./mvnw -U \
+  -pl spring-ai-alibaba-studio \
+  -am \
+  -Dtest=LangfuseProfileContextTest \
+  test
+```
+
+Live Langfuse test:
+
+```bash
+env MAVEN_USER_HOME=/tmp/codex-m2 ./mvnw -U \
+  -pl spring-ai-alibaba-studio \
+  -am \
+  -Dtest=LangfuseAgentStudioLiveTest \
+  test
+```

--- a/spring-ai-alibaba-studio/pom.xml
+++ b/spring-ai-alibaba-studio/pom.xml
@@ -68,6 +68,12 @@
 
         <dependency>
             <groupId>com.alibaba.cloud.ai</groupId>
+            <artifactId>spring-ai-alibaba-starter-graph-observation</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba.cloud.ai</groupId>
             <artifactId>spring-ai-alibaba-agent-framework</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
@@ -84,8 +90,23 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/agentic/AgentStaticLoader.java
+++ b/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/agentic/AgentStaticLoader.java
@@ -23,6 +23,7 @@ import com.alibaba.cloud.ai.graph.GraphRepresentation;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.ToolCallback;
@@ -30,6 +31,7 @@ import org.springframework.ai.tool.ToolCallbackProvider;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,15 +59,24 @@ public class AgentStaticLoader implements AgentLoader {
 
 	private final Map<String, BaseAgent> agents = new ConcurrentHashMap<>();
 
-	public AgentStaticLoader(@Autowired(required = false) ToolCallbackProvider toolCallbackProvider) {
+	public AgentStaticLoader(ObservationRegistry observationRegistry,
+			@Autowired(required = false) ToolCallbackProvider toolCallbackProvider) {
+		String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+		if (!StringUtils.hasText(apiKey)) {
+			apiKey = "test-key-for-graph-integration-test";
+		}
 		// Create DashScopeApi instance using the API key from environment variable
-		DashScopeApi dashScopeApi = DashScopeApi.builder().apiKey(System.getenv("AI_DASHSCOPE_API_KEY")).build();
+		DashScopeApi dashScopeApi = DashScopeApi.builder().apiKey(apiKey).build();
 		// Create DashScope ChatModel instance
-		ChatModel chatModel = DashScopeChatModel.builder().dashScopeApi(dashScopeApi).build();
+		ChatModel chatModel = DashScopeChatModel.builder()
+				.dashScopeApi(dashScopeApi)
+				.observationRegistry(observationRegistry)
+				.build();
 
 		ReactAgent agent = ReactAgent.builder()
 				.name("single_agent")
 				.model(chatModel)
+				.observationRegistry(observationRegistry)
 				.saver(new MemorySaver())
 				.tools(PoetTool.createPoetToolCallback())
 				.build();
@@ -77,7 +88,7 @@ public class AgentStaticLoader implements AgentLoader {
 				: Collections.emptyList();
 
 		if (!toolCallbacks.isEmpty()) {
-			ReactAgent researchAgent = new DeepResearchAgent().getResearchAgent(toolCallbacks);
+			ReactAgent researchAgent = new DeepResearchAgent(observationRegistry).getResearchAgent(toolCallbacks);
 			GraphRepresentation representation = researchAgent.getAndCompileGraph().stateGraph.getGraph(GraphRepresentation.Type.PLANTUML);
 			this.agents.put("research_agent", researchAgent);
 		}

--- a/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/agentic/DeepResearchAgent.java
+++ b/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/agentic/DeepResearchAgent.java
@@ -32,9 +32,11 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.contextediting.ContextEditin
 import com.alibaba.cloud.ai.graph.agent.interceptor.todolist.TodoListInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.toolretry.ToolRetryInterceptor;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -47,6 +49,7 @@ public class DeepResearchAgent {
 			"In order to complete the objective that the user asks of you, " +
 					"you have access to a number of standard tools.";
 
+	private final ObservationRegistry observationRegistry;
 	private String systemPrompt;
 	private ChatModel chatModel;
 
@@ -66,11 +69,19 @@ public class DeepResearchAgent {
 
 //	private ShellTool shellTool = ShellTool.builder().build();
 
-	public DeepResearchAgent() {
+	public DeepResearchAgent(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
+		String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+		if (!StringUtils.hasText(apiKey)) {
+			apiKey = "test-key-for-graph-integration-test";
+		}
 		// Create DashScopeApi instance using the API key from environment variable
-		DashScopeApi dashScopeApi = DashScopeApi.builder().apiKey(System.getenv("AI_DASHSCOPE_API_KEY")).build();
+		DashScopeApi dashScopeApi = DashScopeApi.builder().apiKey(apiKey).build();
 		// Create DashScope ChatModel instance
-		this.chatModel = DashScopeChatModel.builder().dashScopeApi(dashScopeApi).build();
+		this.chatModel = DashScopeChatModel.builder()
+				.dashScopeApi(dashScopeApi)
+				.observationRegistry(observationRegistry)
+				.build();
 
 		this.systemPrompt = researchInstructions + "\n\n" + BASE_AGENT_PROMPT;
 
@@ -145,6 +156,7 @@ public class DeepResearchAgent {
 		return ReactAgent.builder()
 				.name("DeepResearchAgent")
 				.model(chatModel)
+				.observationRegistry(observationRegistry)
 				.tools(toolsFromMcp)
 				.systemPrompt(systemPrompt)
 				.enableLogging(true)

--- a/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/langfuse/LangfuseAgentStudioLiveTest.java
+++ b/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/langfuse/LangfuseAgentStudioLiveTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.langfuse;
+
+import com.alibaba.cloud.ai.StudioApplication;
+import com.alibaba.cloud.ai.agent.studio.dto.Thread;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = StudioApplication.class)
+@AutoConfigureMockMvc
+@ActiveProfiles({ "graph", "langfuse" })
+@TestPropertySource(properties = {
+		"logging.level.io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor=OFF",
+		"logging.level.reactor.core.scheduler.Schedulers=OFF"
+})
+@EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "LANGFUSE_ENABLED", matches = "(?i:true|1|yes)")
+@EnabledIfEnvironmentVariable(named = "LANGFUSE_OTEL_AUTH", matches = ".+")
+class LangfuseAgentStudioLiveTest {
+
+	private static final String APP_NAME = "single_agent";
+
+	private static final String USER_ID = "langfuse-user";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void runAgentAndExportTraceToLangfuse() throws Exception {
+		MvcResult createResult = mockMvc.perform(post("/apps/{appName}/users/{userId}/threads", APP_NAME, USER_ID)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		Thread created = objectMapper.readValue(createResult.getResponse().getContentAsString(), Thread.class);
+
+		Map<String, Object> requestBody = Map.of(
+				"appName", APP_NAME,
+				"userId", USER_ID,
+				"threadId", created.threadId(),
+				"newMessage", Map.of(
+						"messageType", "user",
+						"content", "简单介绍下Spring Ai Alibaba",
+						"metadata", Map.of(),
+						"media", List.of()
+				),
+				"streaming", true
+		);
+
+		MvcResult asyncResult = mockMvc.perform(post("/run_sse")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestBody))
+				.accept(MediaType.TEXT_EVENT_STREAM_VALUE))
+			.andExpect(request().asyncStarted())
+			.andReturn();
+
+		MvcResult runResult = mockMvc.perform(asyncDispatch(asyncResult))
+			.andExpect(status().isOk())
+			.andReturn();
+
+		assertThat(runResult.getResponse().getContentAsString()).isNotBlank();
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/langfuse/LangfuseProfileContextTest.java
+++ b/spring-ai-alibaba-studio/src/test/java/com/alibaba/cloud/ai/langfuse/LangfuseProfileContextTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.langfuse;
+
+import com.alibaba.cloud.ai.StudioApplication;
+import com.alibaba.cloud.ai.graph.observation.GraphObservationLifecycleListener;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = StudioApplication.class)
+@ActiveProfiles({ "graph", "langfuse" })
+class LangfuseProfileContextTest {
+
+	@Autowired
+	private ObservationRegistry observationRegistry;
+
+	@Autowired
+	private GraphObservationLifecycleListener graphObservationLifecycleListener;
+
+	@Test
+	void contextLoadsWithLangfuseProfile() {
+		assertThat(observationRegistry).isNotNull();
+		assertThat(graphObservationLifecycleListener).isNotNull();
+	}
+
+}

--- a/spring-ai-alibaba-studio/src/test/resources/application-langfuse.yml
+++ b/spring-ai-alibaba-studio/src/test/resources/application-langfuse.yml
@@ -1,0 +1,50 @@
+spring:
+  application:
+    name: ${LANGFUSE_SERVICE_NAME:spring-ai-alibaba-studio-langfuse}
+  ai:
+    chat:
+      client:
+        observations:
+          log-prompt: ${SPRING_AI_LOG_PROMPT:false}
+          log-completion: ${SPRING_AI_LOG_COMPLETION:false}
+      observations:
+        log-prompt: ${SPRING_AI_LOG_PROMPT:false}
+        log-completion: ${SPRING_AI_LOG_COMPLETION:false}
+    image:
+      observations:
+        log-prompt: ${SPRING_AI_LOG_PROMPT:false}
+    vectorstore:
+      observations:
+        log-query-response: ${SPRING_AI_LOG_QUERY_RESPONSE:false}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      enabled: false
+  observations:
+    annotations:
+      enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  opentelemetry:
+    resource-attributes:
+      service.name: ${LANGFUSE_SERVICE_NAME:spring-ai-alibaba-studio-langfuse}
+      deployment.environment: ${LANGFUSE_ENV:development}
+  otlp:
+    tracing:
+      endpoint: ${LANGFUSE_OTLP_TRACES_ENDPOINT:https://us.cloud.langfuse.com/api/public/otel/v1/traces}
+      headers:
+        Authorization: Basic ${LANGFUSE_OTEL_AUTH:}
+      export:
+        enabled: ${LANGFUSE_ENABLED:false}
+    metrics:
+      export:
+        enabled: false
+    logging:
+      export:
+        enabled: false

--- a/spring-boot-starters/spring-ai-alibaba-starter-graph-observation/src/main/java/com/alibaba/cloud/ai/autoconfigure/graph/GraphObservationAutoConfiguration.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-graph-observation/src/main/java/com/alibaba/cloud/ai/autoconfigure/graph/GraphObservationAutoConfiguration.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.autoconfigure.graph;
 import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.observation.GraphObservationLifecycleListener;
+import com.alibaba.cloud.ai.graph.observation.GraphObservationSupport;
 import com.alibaba.cloud.ai.graph.observation.edge.GraphEdgeObservationHandler;
 import com.alibaba.cloud.ai.graph.observation.graph.GraphObservationHandler;
 import com.alibaba.cloud.ai.graph.observation.node.GraphNodeObservationHandler;
@@ -116,13 +117,13 @@ public class GraphObservationAutoConfiguration {
 	@ConditionalOnMissingBean
 	public CompileConfig observationGraphCompileConfig(ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<GraphObservationLifecycleListener> graphObservationLifecycleListeners) {
-
-		CompileConfig.Builder builder = CompileConfig.builder()
-				.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP));
-
-		graphObservationLifecycleListeners.ifUnique(builder::withLifecycleListener);
-
-		return builder.build();
+		ObservationRegistry registry = observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP);
+		CompileConfig compileConfig = CompileConfig.builder().observationRegistry(registry).build();
+		GraphObservationLifecycleListener listener = graphObservationLifecycleListeners.getIfUnique();
+		if (listener != null && !GraphObservationSupport.hasLifecycleListener(compileConfig, listener.getClass())) {
+			return CompileConfig.builder(compileConfig).withLifecycleListener(listener).build();
+		}
+		return GraphObservationSupport.enhance(compileConfig, registry);
 	}
 
 	/**


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR wires `ObservationRegistry` through the agent and graph layers so that
Spring AI chat/model observations and graph execution observations are attached
to the same trace. It also adds a Langfuse-based verification path in `spring-ai-alibaba-studio`.

We need this because previously the registry set on the agent builder only affected
the Spring AI model layer, while graph execution observations were not consistently
connected to the same registry.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Added `GraphObservationSupport` to centralize graph observation enhancement
- Updated agent builders to propagate `ObservationRegistry` into graph `CompileConfig`
- Reused the same enhancement logic in graph observation auto-configuration
- Fixed `CompileConfig` copy behavior to avoid shared listener state
- Added Langfuse profile config and verification tests in `spring-ai-alibaba-studio`

### Describe how to verify it

- Run:
  - `./mvnw -pl spring-boot-starters/spring-ai-alibaba-starter-graph-observation -Dtest=GraphObservationAutoConfigurationTest test`
  - `./mvnw -pl spring-ai-alibaba-studio -Dtest=LangfuseProfileContextTest test`
- With `AI_DASHSCOPE_API_KEY`, `LANGFUSE_ENABLED=true`, and `LANGFUSE_OTEL_AUTH` set, run:
  - `./mvnw -pl spring-ai-alibaba-studio -Dtest=LangfuseAgentStudioLiveTest test`
- Check in Langfuse that the trace includes HTTP, agent/graph, and Spring AI model spans

### Special notes for reviews

- Langfuse verification is test-focused; core behavior changes are in agent-framework, graph-core, and starter graph observation
- The studio live test suppresses known observation context propagation noise in test logs
