### PR TITLE
feat(a2a): support multi-agent registration in single application

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/pom.xml
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/pom.xml
@@ -103,5 +103,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/A2aMultiAgentProperties.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/A2aMultiAgentProperties.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.a2a.autoconfigure;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for multi-agent A2A server support.
+ * <p>
+ * Supports registering multiple agents from a single application:
+ * <pre>
+ * spring:
+ *   ai:
+ *     alibaba:
+ *       a2a:
+ *         server:
+ *           agents:
+ *             weather-agent:
+ *               name: "Weather Agent"
+ *               description: "Provides weather information"
+ *             translate-agent:
+ *               name: "Translate Agent"
+ *               description: "Translation service"
+ * </pre>
+ * <p>
+ * Each agent will be accessible at its own URL path:
+ * <ul>
+ *   <li>weather-agent: /a2a/weather-agent</li>
+ *   <li>translate-agent: /a2a/translate-agent</li>
+ * </ul>
+ * <p>
+ * Note: Multi-agent mode (using 'agents') and single-agent mode (using 'card')
+ * are mutually exclusive. Do not use both configurations simultaneously.
+ *
+ * @author xiweng.yy
+ */
+@ConfigurationProperties(prefix = A2aMultiAgentProperties.CONFIG_PREFIX)
+public class A2aMultiAgentProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.alibaba.a2a.server";
+
+	/**
+	 * Multi-agent configuration map.
+	 * Key is the agent identifier (used in URL path), value is the agent card properties.
+	 */
+	private Map<String, A2aAgentCardProperties> agents = new LinkedHashMap<>();
+
+	public Map<String, A2aAgentCardProperties> getAgents() {
+		return agents;
+	}
+
+	public void setAgents(Map<String, A2aAgentCardProperties> agents) {
+		this.agents = agents;
+	}
+
+	/**
+	 * Check if multi-agent mode is enabled (agents map is not empty).
+	 * @return true if multi-agent mode is enabled
+	 */
+	public boolean isMultiAgentMode() {
+		return agents != null && !agents.isEmpty();
+	}
+
+}

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerAgentCardAutoConfiguration.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerAgentCardAutoConfiguration.java
@@ -18,8 +18,9 @@ package com.alibaba.cloud.ai.a2a.autoconfigure.server;
 
 import com.alibaba.cloud.ai.a2a.autoconfigure.A2aServerAgentCardProperties;
 import com.alibaba.cloud.ai.a2a.autoconfigure.A2aServerProperties;
-import com.alibaba.cloud.ai.graph.agent.Agent;
 import com.alibaba.cloud.ai.a2a.core.constants.A2aConstants;
+import com.alibaba.cloud.ai.a2a.core.route.MultiAgentRequestRouter;
+import com.alibaba.cloud.ai.graph.agent.Agent;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -36,10 +37,16 @@ import io.a2a.spec.AgentInterface;
 import io.a2a.spec.AgentSkill;
 
 /**
+ * Auto-configuration for single-agent A2A server.
+ * <p>
+ * This configuration is used when only a single agent is registered (traditional mode).
+ * When multi-agent mode is enabled (agents map is configured), this configuration
+ * is skipped in favor of {@link A2aServerMultiAgentAutoConfiguration}.
+ *
  * @author xiweng.yy
  */
-@AutoConfiguration
-@ConditionalOnMissingBean(AgentCard.class)
+@AutoConfiguration(after = A2aServerMultiAgentAutoConfiguration.class)
+@ConditionalOnMissingBean({ AgentCard.class, MultiAgentRequestRouter.class })
 @EnableConfigurationProperties({ A2aServerProperties.class, A2aServerAgentCardProperties.class })
 public class A2aServerAgentCardAutoConfiguration {
 

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerAutoConfiguration.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerAutoConfiguration.java
@@ -18,22 +18,28 @@ package com.alibaba.cloud.ai.a2a.autoconfigure.server;
 
 import com.alibaba.cloud.ai.a2a.autoconfigure.A2aServerProperties;
 import com.alibaba.cloud.ai.a2a.core.route.JsonRpcA2aRouterProvider;
+import com.alibaba.cloud.ai.a2a.core.route.MultiAgentRequestRouter;
 import com.alibaba.cloud.ai.a2a.core.server.JsonRpcA2aRequestHandler;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.ServerResponse;
 
 /**
- * The AutoConfiguration for A2A server.
+ * The AutoConfiguration for A2A server in single-agent mode.
+ * <p>
+ * This configuration is skipped when multi-agent mode is active
+ * (when {@link MultiAgentRequestRouter} bean exists).
  *
  * @author xiweng.yy
  */
-@AutoConfiguration(after = A2aServerHandlerAutoConfiguration.class)
+@AutoConfiguration(after = { A2aServerHandlerAutoConfiguration.class, A2aServerMultiAgentAutoConfiguration.class })
 @EnableConfigurationProperties({ A2aServerProperties.class })
+@ConditionalOnMissingBean(MultiAgentRequestRouter.class)
 public class A2aServerAutoConfiguration {
 
 	@Bean

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerHandlerAutoConfiguration.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerHandlerAutoConfiguration.java
@@ -17,6 +17,7 @@
 package com.alibaba.cloud.ai.a2a.autoconfigure.server;
 
 import com.alibaba.cloud.ai.a2a.autoconfigure.A2aServerProperties;
+import com.alibaba.cloud.ai.a2a.core.route.MultiAgentRequestRouter;
 import com.alibaba.cloud.ai.graph.agent.Agent;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.a2a.A2aRemoteAgent;
@@ -48,13 +49,17 @@ import io.a2a.server.tasks.TaskStore;
 import io.a2a.spec.AgentCard;
 
 /**
- * A2A server handler autoconfiguration.
+ * A2A server handler auto-configuration for single-agent mode.
+ * <p>
+ * This configuration is skipped when multi-agent mode is active
+ * (when {@link MultiAgentRequestRouter} bean exists).
  *
  * @author xiweng.yy
  */
-@AutoConfiguration(after = A2aServerAgentCardAutoConfiguration.class)
+@AutoConfiguration(after = { A2aServerAgentCardAutoConfiguration.class, A2aServerMultiAgentAutoConfiguration.class })
 @EnableConfigurationProperties({ A2aServerProperties.class })
 @ConditionalOnBean({ AgentCard.class, Agent.class })
+@ConditionalOnMissingBean(MultiAgentRequestRouter.class)
 public class A2aServerHandlerAutoConfiguration {
 
 	@Bean

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerMultiAgentAutoConfiguration.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerMultiAgentAutoConfiguration.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.a2a.autoconfigure.server;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.alibaba.cloud.ai.a2a.autoconfigure.A2aAgentCardProperties;
+import com.alibaba.cloud.ai.a2a.autoconfigure.A2aMultiAgentProperties;
+import com.alibaba.cloud.ai.a2a.autoconfigure.A2aServerProperties;
+import com.alibaba.cloud.ai.a2a.autoconfigure.server.condition.OnMultiAgentModeCondition;
+import com.alibaba.cloud.ai.a2a.core.constants.A2aConstants;
+import com.alibaba.cloud.ai.a2a.core.registry.AgentRegistry;
+import com.alibaba.cloud.ai.a2a.core.registry.AgentRegistryService;
+import com.alibaba.cloud.ai.a2a.core.route.MultiAgentJsonRpcRouterProvider;
+import com.alibaba.cloud.ai.a2a.core.route.MultiAgentRequestRouter;
+import com.alibaba.cloud.ai.a2a.core.server.A2aServerExecutorProvider;
+import com.alibaba.cloud.ai.a2a.core.server.DefaultA2aServerExecutorProvider;
+import com.alibaba.cloud.ai.a2a.core.server.GraphAgentExecutor;
+import com.alibaba.cloud.ai.a2a.core.server.JsonRpcA2aRequestHandler;
+import com.alibaba.cloud.ai.a2a.core.server.ServerTypeEnum;
+import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.a2a.A2aRemoteAgent;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import io.a2a.server.agentexecution.AgentExecutor;
+import io.a2a.server.events.InMemoryQueueManager;
+import io.a2a.server.events.QueueManager;
+import io.a2a.server.requesthandlers.DefaultRequestHandler;
+import io.a2a.server.requesthandlers.JSONRPCHandler;
+import io.a2a.server.requesthandlers.RequestHandler;
+import io.a2a.server.tasks.BasePushNotificationSender;
+import io.a2a.server.tasks.InMemoryPushNotificationConfigStore;
+import io.a2a.server.tasks.InMemoryTaskStore;
+import io.a2a.server.tasks.PushNotificationConfigStore;
+import io.a2a.server.tasks.PushNotificationSender;
+import io.a2a.server.tasks.TaskStore;
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.AgentInterface;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Auto-configuration for multi-agent A2A server support.
+ * <p>
+ * This configuration is activated when multiple agents are defined in the configuration:
+ * <pre>
+ * spring:
+ *   ai:
+ *     alibaba:
+ *       a2a:
+ *         server:
+ *           agents:
+ *             agent1:
+ *               name: "Agent 1"
+ *             agent2:
+ *               name: "Agent 2"
+ * </pre>
+ *
+ * @author xiweng.yy
+ */
+@AutoConfiguration(before = { A2aServerAgentCardAutoConfiguration.class, A2aServerHandlerAutoConfiguration.class })
+@EnableConfigurationProperties({ A2aServerProperties.class, A2aMultiAgentProperties.class })
+@Conditional(OnMultiAgentModeCondition.class)
+public class A2aServerMultiAgentAutoConfiguration {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(A2aServerMultiAgentAutoConfiguration.class);
+
+	private static final String DEFAULT_PROTOCOL = "http://";
+
+	@Bean
+	@ConditionalOnMissingBean
+	public A2aServerExecutorProvider multiAgentA2aServerExecutorProvider() {
+		return new DefaultA2aServerExecutorProvider();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public TaskStore multiAgentTaskStore() {
+		return new InMemoryTaskStore();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public QueueManager multiAgentQueueManager() {
+		return new InMemoryQueueManager();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PushNotificationConfigStore multiAgentPushConfigStore() {
+		return new InMemoryPushNotificationConfigStore();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public PushNotificationSender multiAgentPushSender(PushNotificationConfigStore pushConfigStore) {
+		return new BasePushNotificationSender(pushConfigStore);
+	}
+
+	@Bean
+	public MultiAgentRequestRouter multiAgentRequestRouter() {
+		return new MultiAgentRequestRouter();
+	}
+
+	@Bean
+	public List<AgentCard> multiAgentCards(A2aServerProperties serverProperties,
+			A2aMultiAgentProperties multiAgentProperties, ObjectProvider<Map<String, Agent>> agentMapProvider,
+			MultiAgentRequestRouter router, TaskStore taskStore, QueueManager queueManager,
+			PushNotificationConfigStore pushConfigStore, PushNotificationSender pushSender,
+			A2aServerExecutorProvider executorProvider) {
+
+		Map<String, Agent> agents = agentMapProvider.getIfAvailable();
+		Map<String, A2aAgentCardProperties> agentConfigs = multiAgentProperties.getAgents();
+
+		List<AgentCard> agentCards = new ArrayList<>();
+
+		for (Map.Entry<String, A2aAgentCardProperties> entry : agentConfigs.entrySet()) {
+			String agentKey = entry.getKey();
+			A2aAgentCardProperties cardProps = entry.getValue();
+
+			// Find the corresponding agent bean
+			Agent agent = findAgentByName(agents, agentKey, cardProps);
+			if (agent == null) {
+				LOGGER.warn("No agent bean found for configuration key: {}. Skipping.", agentKey);
+				continue;
+			}
+
+			// Validate agent type
+			if (!(agent instanceof ReactAgent) && !(agent instanceof A2aRemoteAgent)) {
+				LOGGER.warn("Agent {} is not a ReactAgent or A2aRemoteAgent. Skipping.", agentKey);
+				continue;
+			}
+
+			// Build AgentCard
+			AgentCard agentCard = buildAgentCard(agentKey, agent, serverProperties, cardProps);
+			agentCards.add(agentCard);
+
+			// Create and register handler for this agent
+			AgentExecutor agentExecutor = new GraphAgentExecutor(agent);
+			RequestHandler requestHandler = new DefaultRequestHandler(agentExecutor, taskStore, queueManager,
+					pushConfigStore, pushSender, executorProvider.getA2aServerExecutor());
+			JSONRPCHandler jsonRpcHandler = new JSONRPCHandler(agentCard, requestHandler);
+			JsonRpcA2aRequestHandler a2aHandler = new JsonRpcA2aRequestHandler(jsonRpcHandler);
+
+			router.registerHandler(agentKey, a2aHandler);
+			LOGGER.info("Registered multi-agent A2A handler for: {} (bean: {})", agentKey, agent.name());
+		}
+
+		if (agentCards.isEmpty()) {
+			LOGGER.warn("No valid agents found for multi-agent configuration. "
+					+ "Make sure agent beans are registered and match configuration keys.");
+		}
+
+		return agentCards;
+	}
+
+	@Bean
+	@ConditionalOnBean(AgentRegistry.class)
+	public AgentRegistryService multiAgentRegistryService(List<AgentCard> multiAgentCards,
+			AgentRegistry agentRegistry) {
+		return new AgentRegistryService(agentRegistry, multiAgentCards);
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = A2aServerProperties.CONFIG_PREFIX, value = "type",
+			havingValue = ServerTypeEnum.JSON_RPC_TYPE, matchIfMissing = true)
+	public RouterFunction<ServerResponse> multiAgentRouterFunction(MultiAgentRequestRouter router) {
+		return new MultiAgentJsonRpcRouterProvider(router).getRouter();
+	}
+
+	private Agent findAgentByName(Map<String, Agent> agents, String agentKey, A2aAgentCardProperties cardProps) {
+		if (agents == null || agents.isEmpty()) {
+			return null;
+		}
+
+		// First, try to find by bean name matching the config key
+		if (agents.containsKey(agentKey)) {
+			return agents.get(agentKey);
+		}
+
+		// Second, try to find by agent name matching the config's name property
+		String configName = cardProps.getName();
+		if (StringUtils.hasLength(configName)) {
+			for (Agent agent : agents.values()) {
+				if (configName.equals(agent.name())) {
+					return agent;
+				}
+			}
+		}
+
+		// Third, try to find by agent name matching the config key
+		for (Agent agent : agents.values()) {
+			if (agentKey.equals(agent.name())) {
+				return agent;
+			}
+		}
+
+		return null;
+	}
+
+	private AgentCard buildAgentCard(String agentKey, Agent agent, A2aServerProperties serverProperties,
+			A2aAgentCardProperties cardProps) {
+		String name = StringUtils.hasLength(cardProps.getName()) ? cardProps.getName() : agent.name();
+		String description = StringUtils.hasLength(cardProps.getDescription()) ? cardProps.getDescription()
+				: agent.description();
+		List<String> inputModes = cardProps.getDefaultInputModes() != null ? cardProps.getDefaultInputModes()
+				: List.of("text/plain");
+		List<String> outputModes = cardProps.getDefaultOutputModes() != null ? cardProps.getDefaultOutputModes()
+				: List.of("text/plain");
+		AgentCapabilities capabilities = cardProps.getCapabilities() != null ? cardProps.getCapabilities()
+				: new AgentCapabilities.Builder().streaming(true).build();
+
+		String url = StringUtils.hasLength(cardProps.getUrl()) ? cardProps.getUrl()
+				: buildMultiAgentUrl(serverProperties, agentKey);
+
+		return new AgentCard.Builder().name(name)
+			.description(description)
+			.defaultInputModes(inputModes)
+			.defaultOutputModes(outputModes)
+			.capabilities(capabilities)
+			.version(serverProperties.getVersion())
+			.protocolVersion(A2aConstants.DEFAULT_A2A_PROTOCOL_VERSION)
+			.preferredTransport(serverProperties.getType())
+			.url(url)
+			.supportsAuthenticatedExtendedCard(cardProps.isSupportsAuthenticatedExtendedCard())
+			.skills(cardProps.getSkills() != null ? cardProps.getSkills() : List.of())
+			.provider(cardProps.getProvider())
+			.documentationUrl(cardProps.getDocumentationUrl())
+			.security(cardProps.getSecurity())
+			.securitySchemes(cardProps.getSecuritySchemes())
+			.iconUrl(cardProps.getIconUrl())
+			.additionalInterfaces(buildAdditionalInterfaces(cardProps, serverProperties, agentKey))
+			.build();
+	}
+
+	private String buildMultiAgentUrl(A2aServerProperties serverProperties, String agentKey) {
+		return DEFAULT_PROTOCOL + serverProperties.getAddress() + ":" + serverProperties.getPort() + "/a2a/"
+				+ agentKey;
+	}
+
+	private List<AgentInterface> buildAdditionalInterfaces(A2aAgentCardProperties cardProps,
+			A2aServerProperties serverProperties, String agentKey) {
+		if (cardProps.getAdditionalInterfaces() != null) {
+			return cardProps.getAdditionalInterfaces();
+		}
+		String url = StringUtils.hasLength(cardProps.getUrl()) ? cardProps.getUrl()
+				: buildMultiAgentUrl(serverProperties, agentKey);
+		return List.of(new AgentInterface(serverProperties.getType(), url));
+	}
+
+}

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerRegistryAutoConfiguration.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerRegistryAutoConfiguration.java
@@ -18,24 +18,33 @@ package com.alibaba.cloud.ai.a2a.autoconfigure.server;
 
 import com.alibaba.cloud.ai.a2a.core.registry.AgentRegistry;
 import com.alibaba.cloud.ai.a2a.core.registry.AgentRegistryService;
+import com.alibaba.cloud.ai.a2a.core.route.MultiAgentRequestRouter;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import io.a2a.spec.AgentCard;
 
 /**
- * The AutoConfiguration for A2A server registry.
+ * The AutoConfiguration for A2A server registry in single-agent mode.
+ * <p>
+ * This configuration is skipped when multi-agent mode is active
+ * (when {@link MultiAgentRequestRouter} bean exists). In multi-agent mode,
+ * the registry service is created by {@link A2aServerMultiAgentAutoConfiguration}.
  *
  * @author xiweng.yy
  */
-@AutoConfiguration(after = { A2aServerAgentCardAutoConfiguration.class, A2aServerAutoConfiguration.class })
+@AutoConfiguration(after = { A2aServerAgentCardAutoConfiguration.class, A2aServerAutoConfiguration.class,
+		A2aServerMultiAgentAutoConfiguration.class })
 @ConditionalOnBean({ AgentCard.class })
+@ConditionalOnMissingBean(MultiAgentRequestRouter.class)
 public class A2aServerRegistryAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean(AgentRegistry.class)
+	@ConditionalOnMissingBean(AgentRegistryService.class)
 	public AgentRegistryService agentRegistryService(AgentCard agentCard, AgentRegistry agentRegistry) {
 		return new AgentRegistryService(agentRegistry, agentCard);
 	}

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/condition/OnMultiAgentModeCondition.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/condition/OnMultiAgentModeCondition.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.a2a.autoconfigure.server.condition;
+
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition that checks if multi-agent mode is enabled.
+ * <p>
+ * Multi-agent mode is enabled when any property starting with
+ * "spring.ai.alibaba.a2a.server.agents." is present in the environment.
+ *
+ * @author xiweng.yy
+ */
+public class OnMultiAgentModeCondition extends SpringBootCondition {
+
+	private static final String AGENTS_PREFIX = "spring.ai.alibaba.a2a.server.agents.";
+
+	@Override
+	public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		Environment environment = context.getEnvironment();
+		boolean hasAgentsProperties = hasAgentsProperties(environment);
+
+		ConditionMessage.Builder message = ConditionMessage
+			.forCondition("Multi-Agent Mode");
+
+		if (hasAgentsProperties) {
+			return ConditionOutcome.match(message.foundExactly("agents configuration"));
+		}
+		return ConditionOutcome.noMatch(message.didNotFind("agents configuration").atAll());
+	}
+
+	private boolean hasAgentsProperties(Environment environment) {
+		if (environment instanceof ConfigurableEnvironment configurableEnvironment) {
+			for (PropertySource<?> propertySource : configurableEnvironment.getPropertySources()) {
+				if (propertySource instanceof EnumerablePropertySource<?> enumerablePropertySource) {
+					for (String propertyName : enumerablePropertySource.getPropertyNames()) {
+						if (propertyName.startsWith(AGENTS_PREFIX)) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+}

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/core/registry/AgentRegistryService.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/core/registry/AgentRegistryService.java
@@ -16,6 +16,9 @@
 
 package com.alibaba.cloud.ai.a2a.core.registry;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 
@@ -25,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Agent registry service.
+ * <p>
+ * Supports registering both single agent and multiple agents to the registry.
  *
  * @author xiweng.yy
  */
@@ -34,15 +39,36 @@ public class AgentRegistryService {
 
 	private final AgentRegistry agentRegistry;
 
-	private final AgentCard agentCard;
+	private final List<AgentCard> agentCards;
 
+	/**
+	 * Constructor for single agent mode.
+	 * @param agentRegistry the agent registry
+	 * @param agentCard the single agent card
+	 */
 	public AgentRegistryService(AgentRegistry agentRegistry, AgentCard agentCard) {
 		this.agentRegistry = agentRegistry;
-		this.agentCard = agentCard;
+		this.agentCards = Collections.singletonList(agentCard);
+	}
+
+	/**
+	 * Constructor for multi-agent mode.
+	 * @param agentRegistry the agent registry
+	 * @param agentCards the list of agent cards
+	 */
+	public AgentRegistryService(AgentRegistry agentRegistry, List<AgentCard> agentCards) {
+		this.agentRegistry = agentRegistry;
+		this.agentCards = agentCards;
 	}
 
 	@EventListener(ApplicationReadyEvent.class)
 	public void register() {
+		for (AgentCard agentCard : agentCards) {
+			registerSingleAgent(agentCard);
+		}
+	}
+
+	private void registerSingleAgent(AgentCard agentCard) {
 		LOGGER.info("Auto register agent {} into Registry {}.", agentCard.name(), agentRegistry.registryName());
 		try {
 			agentRegistry.register(agentCard);
@@ -53,6 +79,14 @@ public class AgentRegistryService {
 			LOGGER.error("Auto register agent {} into Registry {} failed.", agentCard.name(),
 					agentRegistry.registryName(), e);
 		}
+	}
+
+	/**
+	 * Get the list of registered agent cards.
+	 * @return an unmodifiable list of agent cards
+	 */
+	public List<AgentCard> getAgentCards() {
+		return Collections.unmodifiableList(agentCards);
 	}
 
 }

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/core/route/MultiAgentJsonRpcRouterProvider.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/core/route/MultiAgentJsonRpcRouterProvider.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.a2a.core.route;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import com.alibaba.cloud.ai.a2a.core.server.JsonRpcA2aRequestHandler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.function.HandlerFunction;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import io.a2a.spec.JSONRPCResponse;
+import io.a2a.spec.TaskStatusUpdateEvent;
+import io.a2a.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+/**
+ * Router provider for multi-agent A2A server.
+ * <p>
+ * Provides routing for multiple agents, each accessible at its own URL path:
+ * <ul>
+ *   <li>Agent card: /.well-known/agent.json/{agentName}</li>
+ *   <li>Message endpoint: /a2a/{agentName}</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class MultiAgentJsonRpcRouterProvider {
+
+	private static final Logger log = LoggerFactory.getLogger(MultiAgentJsonRpcRouterProvider.class);
+
+	public static final String MULTI_AGENT_WELL_KNOWN_URL = "/.well-known/agent.json/{agentName}";
+
+	public static final String MULTI_AGENT_MESSAGE_URL = "/a2a/{agentName}";
+
+	private final String messageUrl;
+
+	private final String wellKnownUrl;
+
+	private final MultiAgentRequestRouter router;
+
+	public MultiAgentJsonRpcRouterProvider(MultiAgentRequestRouter router) {
+		this(MULTI_AGENT_WELL_KNOWN_URL, MULTI_AGENT_MESSAGE_URL, router);
+	}
+
+	public MultiAgentJsonRpcRouterProvider(String wellKnownUrl, String messageUrl, MultiAgentRequestRouter router) {
+		this.wellKnownUrl = wellKnownUrl;
+		this.messageUrl = messageUrl;
+		this.router = router;
+	}
+
+	public RouterFunction<ServerResponse> getRouter() {
+		return RouterFunctions.route()
+			.GET(this.wellKnownUrl, new MultiAgentCardHandler(router))
+			.POST(this.messageUrl, new MultiAgentMessageHandler(router))
+			.build();
+	}
+
+	private static class MultiAgentCardHandler implements HandlerFunction<ServerResponse> {
+
+		private final MultiAgentRequestRouter router;
+
+		public MultiAgentCardHandler(MultiAgentRequestRouter router) {
+			this.router = router;
+		}
+
+		@Override
+		public ServerResponse handle(ServerRequest request) throws Exception {
+			String agentName = request.pathVariable("agentName");
+			JsonRpcA2aRequestHandler handler = router.getHandler(agentName);
+			if (handler == null) {
+				log.warn("Agent not found: {}", agentName);
+				return ServerResponse.status(HttpStatus.NOT_FOUND)
+					.body("Agent not found: " + agentName);
+			}
+			try {
+				return ServerResponse.ok().body(handler.getAgentCard());
+			}
+			catch (Exception e) {
+				log.error("Failed to get Agent Card for {}: {}", agentName, e.getMessage());
+				return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+			}
+		}
+
+	}
+
+	private static class MultiAgentMessageHandler implements HandlerFunction<ServerResponse> {
+
+		private final MultiAgentRequestRouter router;
+
+		private MultiAgentMessageHandler(MultiAgentRequestRouter router) {
+			this.router = router;
+		}
+
+		@Override
+		public ServerResponse handle(ServerRequest request) throws Exception {
+			String agentName = request.pathVariable("agentName");
+			JsonRpcA2aRequestHandler handler = router.getHandler(agentName);
+			if (handler == null) {
+				log.warn("Agent not found: {}", agentName);
+				return ServerResponse.status(HttpStatus.NOT_FOUND)
+					.body("Agent not found: " + agentName);
+			}
+			try {
+				String bodyString = request.body(String.class);
+				Object result = handler.onHandler(bodyString, request.headers());
+				if (result instanceof Flux<?>) {
+					return buildSseResponse((Flux<?>) result);
+				}
+				else {
+					return buildJsonRpcResponse(result);
+				}
+			}
+			catch (Exception e) {
+				log.error("Failed to handle request for {}: {}", agentName, e.getMessage());
+				return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+			}
+		}
+
+		private ServerResponse buildJsonRpcResponse(Object result) {
+			return ServerResponse.ok().body(result);
+		}
+
+		private ServerResponse buildSseResponse(Flux<?> result) {
+			return ServerResponse.sse(sseBuilder -> {
+				sseBuilder.onComplete(() -> {
+					log.debug("Agent SSE connection completed.");
+				});
+				sseBuilder.onTimeout(() -> {
+					log.debug("Agent SSE connection timeout.");
+				});
+				result.subscribe((Consumer<Object>) o -> {
+					if (o instanceof JSONRPCResponse) {
+						try {
+							String sseBody = Utils.OBJECT_MAPPER.writeValueAsString(o);
+							if (log.isDebugEnabled()) {
+								log.debug("send sse body to agent: {}", sseBody);
+							}
+							sseBuilder.data(sseBody);
+							if (((JSONRPCResponse<?>) o).getResult() instanceof TaskStatusUpdateEvent) {
+								TaskStatusUpdateEvent event = (TaskStatusUpdateEvent) ((JSONRPCResponse<?>) o)
+									.getResult();
+								if (event.isFinal()) {
+									sseBuilder.complete();
+								}
+							}
+						}
+						catch (IOException e) {
+							sseBuilder.error(e);
+						}
+					}
+				});
+			}, Duration.ZERO);
+		}
+
+	}
+
+}

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/core/route/MultiAgentRequestRouter.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/core/route/MultiAgentRequestRouter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.a2a.core.route;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.alibaba.cloud.ai.a2a.core.server.JsonRpcA2aRequestHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Router for multi-agent A2A request handling.
+ * <p>
+ * Routes incoming requests to the appropriate agent handler based on the agent name
+ * extracted from the URL path.
+ *
+ * @author xiweng.yy
+ */
+public class MultiAgentRequestRouter {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MultiAgentRequestRouter.class);
+
+	private final Map<String, JsonRpcA2aRequestHandler> handlers = new ConcurrentHashMap<>();
+
+	/**
+	 * Register a handler for an agent.
+	 * @param agentName the agent name (used as URL path segment)
+	 * @param handler the request handler for this agent
+	 */
+	public void registerHandler(String agentName, JsonRpcA2aRequestHandler handler) {
+		handlers.put(agentName, handler);
+		LOGGER.info("Registered A2A handler for agent: {}", agentName);
+	}
+
+	/**
+	 * Get the handler for the specified agent.
+	 * @param agentName the agent name
+	 * @return the request handler, or null if not found
+	 */
+	public JsonRpcA2aRequestHandler getHandler(String agentName) {
+		return handlers.get(agentName);
+	}
+
+	/**
+	 * Get all registered agent names.
+	 * @return an unmodifiable set of agent names
+	 */
+	public Set<String> getAgentNames() {
+		return Collections.unmodifiableSet(handlers.keySet());
+	}
+
+	/**
+	 * Check if a handler exists for the specified agent.
+	 * @param agentName the agent name
+	 * @return true if a handler exists
+	 */
+	public boolean hasHandler(String agentName) {
+		return handlers.containsKey(agentName);
+	}
+
+	/**
+	 * Get the number of registered handlers.
+	 * @return the count of registered handlers
+	 */
+	public int size() {
+		return handlers.size();
+	}
+
+}

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -28,7 +28,13 @@
       "name": "spring.ai.alibaba.a2a.server.card",
       "type": "com.alibaba.cloud.ai.a2a.A2aServerAgentCardProperties",
       "sourceType": "com.alibaba.cloud.ai.a2a.A2aServerAgentCardProperties",
-      "description": "Configuration properties for A2A Agent Card."
+      "description": "Configuration properties for A2A Agent Card (single-agent mode)."
+    },
+    {
+      "name": "spring.ai.alibaba.a2a.server.agents",
+      "type": "java.util.Map<java.lang.String, com.alibaba.cloud.ai.a2a.autoconfigure.A2aAgentCardProperties>",
+      "sourceType": "com.alibaba.cloud.ai.a2a.autoconfigure.A2aMultiAgentProperties",
+      "description": "Multi-agent configuration map (multi-agent mode). Key is the agent identifier used in URL path."
     }
   ],
   "properties": [
@@ -335,6 +341,12 @@
       "type": "java.util.List<io.a2a.spec.AgentInterface>",
       "description": "The additional interfaces of the agent.",
       "sourceType": "com.alibaba.cloud.ai.a2a.A2aServerAgentCardProperties"
+    },
+    {
+      "name": "spring.ai.alibaba.a2a.server.agents",
+      "type": "java.util.Map<java.lang.String, com.alibaba.cloud.ai.a2a.autoconfigure.A2aAgentCardProperties>",
+      "description": "Multi-agent configuration map. Each key is an agent identifier (used in URL path like /a2a/{agentKey}), and value contains the agent card properties. Note: multi-agent mode (agents) and single-agent mode (card) are mutually exclusive.",
+      "sourceType": "com.alibaba.cloud.ai.a2a.autoconfigure.A2aMultiAgentProperties"
     }
   ],
   "hints": []

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 com.alibaba.cloud.ai.a2a.autoconfigure.client.A2aClientAgentCardProviderAutoConfiguration
+com.alibaba.cloud.ai.a2a.autoconfigure.server.A2aServerMultiAgentAutoConfiguration
 com.alibaba.cloud.ai.a2a.autoconfigure.server.A2aServerAgentCardAutoConfiguration
 com.alibaba.cloud.ai.a2a.autoconfigure.server.A2aServerHandlerAutoConfiguration
 com.alibaba.cloud.ai.a2a.autoconfigure.server.A2aServerAutoConfiguration

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/test/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerMultiAgentAutoConfigurationTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/test/java/com/alibaba/cloud/ai/a2a/autoconfigure/server/A2aServerMultiAgentAutoConfigurationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.a2a.autoconfigure.server;
+
+import com.alibaba.cloud.ai.a2a.autoconfigure.A2aMultiAgentProperties;
+import com.alibaba.cloud.ai.a2a.core.route.MultiAgentRequestRouter;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link A2aServerMultiAgentAutoConfiguration}.
+ *
+ * @author xiweng.yy
+ */
+class A2aServerMultiAgentAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(A2aServerMultiAgentAutoConfiguration.class));
+
+	@Test
+	void shouldNotCreateMultiAgentBeansWhenNoAgentsConfigured() {
+		this.contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean(MultiAgentRequestRouter.class);
+		});
+	}
+
+	@Test
+	void shouldCreateMultiAgentPropertiesWhenAgentsConfigured() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.alibaba.a2a.server.agents.weather-agent.name=Weather Agent",
+					"spring.ai.alibaba.a2a.server.agents.weather-agent.description=Weather service",
+					"spring.ai.alibaba.a2a.server.agents.translate-agent.name=Translate Agent",
+					"spring.ai.alibaba.a2a.server.agents.translate-agent.description=Translation service",
+					"spring.ai.alibaba.a2a.server.address=localhost", "spring.ai.alibaba.a2a.server.port=8080")
+			.run(context -> {
+				assertThat(context).hasSingleBean(A2aMultiAgentProperties.class);
+				assertThat(context).hasSingleBean(MultiAgentRequestRouter.class);
+
+				A2aMultiAgentProperties props = context.getBean(A2aMultiAgentProperties.class);
+				assertThat(props.isMultiAgentMode()).isTrue();
+				assertThat(props.getAgents()).hasSize(2);
+				assertThat(props.getAgents()).containsKey("weather-agent");
+				assertThat(props.getAgents()).containsKey("translate-agent");
+				assertThat(props.getAgents().get("weather-agent").getName()).isEqualTo("Weather Agent");
+				assertThat(props.getAgents().get("translate-agent").getName()).isEqualTo("Translate Agent");
+			});
+	}
+
+	@Test
+	void shouldCreateRouterWithEmptyHandlersWhenNoAgentBeansMatch() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.alibaba.a2a.server.agents.weather-agent.name=Weather Agent",
+					"spring.ai.alibaba.a2a.server.address=localhost", "spring.ai.alibaba.a2a.server.port=8080")
+			.run(context -> {
+				assertThat(context).hasSingleBean(MultiAgentRequestRouter.class);
+				MultiAgentRequestRouter router = context.getBean(MultiAgentRequestRouter.class);
+				// Without agent beans, no handlers should be registered
+				assertThat(router.size()).isEqualTo(0);
+				assertThat(router.hasHandler("weather-agent")).isFalse();
+			});
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Support registering multiple agents from a single application with Nacos A2A. In enterprise development scenarios, an application typically develops multiple agents, but currently Nacos A2A only supports registering one agent per application.

### Does this pull request fix one issue?

Fixes #4379

### Describe how you did it

- Add multi-agent configuration support via `spring.ai.alibaba.a2a.server.agents` prefix
- Create `MultiAgentRequestRouter` for routing requests to different agents based on URL path
- Support URL pattern `/a2a/{agentName}/message` for multi-agent mode
- Add conditional auto-configuration `OnMultiAgentModeCondition` to distinguish single/multi agent modes
- Maintain backward compatibility with existing single-agent configuration

**Configuration Example:**
```yaml
spring:
  ai:
    alibaba:
      a2a:
        server:
          agents:
            weather-agent:
              name: "Weather Agent"
              description: "Provides weather information"
            translate-agent:
              name: "Translate Agent"
              description: "Translation service"
```

### Describe how to verify it

1. Configure multiple agents in application.yml using `spring.ai.alibaba.a2a.server.agents`
2. Start the application and check Nacos console for registered agents
3. Access different agents via their respective endpoints:
   - `POST /a2a/weather-agent/message`
   - `POST /a2a/translate-agent/message`

### Special notes for reviews

- Single-agent mode (`spring.ai.alibaba.a2a.server.card`) and multi-agent mode (`spring.ai.alibaba.a2a.server.agents`) are mutually exclusive
- URL routing follows pattern: `/a2a/{agentName}/message` where `agentName` matches the configuration key