### PR TITLE
fix: clear jump_to state after each MessagesModelHook execution to prevent residual values

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/messages/MessagesModelHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/messages/MessagesModelHook.java
@@ -108,9 +108,9 @@ public abstract class MessagesModelHook implements Hook {
 					result.put("messages", command.getMessages());
 				}
 			}
-			if (command.getJumpTo() != null) {
-				result.put("jump_to", command.getJumpTo().name());
-			}
+			// Always write jump_to to state to prevent stale values from previous executions.
+			// If the command has no jump intent, explicitly set null to clear any residual value.
+			result.put("jump_to", command.getJumpTo() != null ? command.getJumpTo().name() : null);
 
 			return CompletableFuture.completedFuture(result);
 		}
@@ -142,10 +142,9 @@ public abstract class MessagesModelHook implements Hook {
 					result.put("messages", command.getMessages());
 				}
 			}
-			if (command.getJumpTo() != null) {
-				result.put("jump_to", command.getJumpTo().name());
-			}
-
+			// Always write jump_to to state to prevent stale values from previous executions.
+			// If the command has no jump intent, explicitly set null to clear any residual value.
+			result.put("jump_to", command.getJumpTo() != null ? command.getJumpTo().name() : null);
 
 			return CompletableFuture.completedFuture(result);
 		}


### PR DESCRIPTION
## Problem

When a `MessagesModelHook` overrides `canJumpTo()` to return `List.of(JumpTo.end)`, the framework registers a conditional edge that reads the `jump_to` field from state to decide routing.

Previously, if `beforeModel()` or `afterModel()` returned `new AgentCommand(messages)` (no jump intent), the `jump_to` field was **not written to state**. This left any residual value from a previous execution intact, causing the workflow to terminate prematurely even when the hook did not intend to jump.

## Root Cause

In `MessagesModelHook.BeforeModelAction` and `AfterModelAction`:

```java
// Before fix - only writes when jumpTo != null
if (command.getJumpTo() != null) {
    result.put("jump_to", command.getJumpTo().name());
}
```

## Fix
Always write jump_to to state. When there is no jump intent, explicitly set null to clear any stale value from prior executions.

// After fix - always clears or sets jump_to
result.put("jump_to", command.getJumpTo() != null ? command.getJumpTo().name() : null);
Fixes #4421