### PR TITLE
fix(graph): Enhance state management with delta tracking and result handling

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompileConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompileConfig.java
@@ -191,6 +191,12 @@ public class CompileConfig {
 			return this;
 		}
 
+		/**
+		 * Enables or disables delta tracking for the graph execution.
+		 * @see OverAllState#deltaData()
+		 * @param enableDeltaTracking Flag indicating whether to enable delta tracking.
+		 * @return This builder instance for method chaining.
+		 */
 		public Builder enableDeltaTracking(boolean enableDeltaTracking) {
 			this.config.enableDeltaTracking = enableDeltaTracking;
 			return this;

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompileConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompileConfig.java
@@ -56,12 +56,18 @@ public class CompileConfig {
 
 	private int recursionLimit = 100;
 
+	private boolean enableDeltaTracking = false;
+
 	// ================================================================================================================
 	// Getter Methods
 	// ================================================================================================================
 
 	public int recursionLimit() {
 		return recursionLimit;
+	}
+
+	public boolean enableDeltaTracking() {
+		return enableDeltaTracking;
 	}
 
 	/**
@@ -182,6 +188,11 @@ public class CompileConfig {
 				throw new IllegalArgumentException("recursionLimit must be > 0!");
 			}
 			this.config.recursionLimit = recursionLimit;
+			return this;
+		}
+
+		public Builder enableDeltaTracking(boolean enableDeltaTracking) {
+			this.config.enableDeltaTracking = enableDeltaTracking;
 			return this;
 		}
 
@@ -332,6 +343,7 @@ public class CompileConfig {
 		this.observationRegistry = config.observationRegistry;
 		this.interruptBeforeEdge = config.interruptBeforeEdge;
 		this.store = config.store;
+		this.enableDeltaTracking = config.enableDeltaTracking;
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -486,6 +486,21 @@ public class CompiledGraph {
 	}
 
 	/**
+	 * Clone state over all state with delta data.
+	 *
+	 * @param data the data
+	 * @param deltaData the delta data
+	 * @return the over all state
+	 */
+	public OverAllState cloneState(Map<String, Object> data, Map<String, Object> deltaData) throws IOException, ClassNotFoundException {
+		return new OverAllState(
+				stateGraph.getStateSerializer().cloneObject(data).data(),
+				stateGraph.getStateSerializer().cloneObject(deltaData).data(),
+				getKeyStrategyMap()
+		);
+	}
+
+	/**
 	 * Package-private access to nodes for ReactiveNodeGenerator.
 	 */
 	public AsyncNodeActionWithConfig getNodeAction(String nodeId) {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -486,21 +486,6 @@ public class CompiledGraph {
 	}
 
 	/**
-	 * Clone state over all state with delta data.
-	 *
-	 * @param data the data
-	 * @param deltaData the delta data
-	 * @return the over all state
-	 */
-	public OverAllState cloneState(Map<String, Object> data, Map<String, Object> deltaData) throws IOException, ClassNotFoundException {
-		return new OverAllState(
-				stateGraph.getStateSerializer().cloneObject(data).data(),
-				stateGraph.getStateSerializer().cloneObject(deltaData).data(),
-				getKeyStrategyMap()
-		);
-	}
-
-	/**
 	 * Package-private access to nodes for ReactiveNodeGenerator.
 	 */
 	public AsyncNodeActionWithConfig getNodeAction(String nodeId) {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -133,6 +133,10 @@ public class GraphRunnerContext {
 		this.overallState = stateCreate(compiledGraph.getInitialState(inputs, config), initialState);
 		this.currentNodeId = START;
 		this.nextNodeId = null;
+
+		if (compiledGraph.compileConfig.enableDeltaTracking() || initialState.isDeltaTrackingEnabled()) {
+			this.overallState.enableDeltaTracking();
+		}
 	}
 
 	// FIXME, duplicated method with CompiledGraph.stateCreate, need to have a

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -123,7 +123,7 @@ public class GraphRunnerContext {
 	private void initializeFromStart(OverAllState initialState, RunnableConfig config) {
 		log.trace("START");
 
-		Map<String, Object> inputs = initialState.data();
+		Map<String, Object> inputs = initialState.dataWithoutDelta();
 		if (!CollectionUtils.isEmpty(inputs)) {
 			// Simple validation without accessing protected method
 			log.debug("Initializing with inputs: {}", inputs.keySet());
@@ -290,7 +290,7 @@ public class GraphRunnerContext {
 		return NodeOutput.of(
 				nodeId,
 				(String) config.metadata("_AGENT_").orElse(""),
-				compiledGraph.cloneState(this.overallState.data(), this.overallState.deltaData()),
+				cloneState(this.overallState.data()),
 				this.tokenUsage);
 	}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -290,7 +290,7 @@ public class GraphRunnerContext {
 		return NodeOutput.of(
 				nodeId,
 				(String) config.metadata("_AGENT_").orElse(""),
-				cloneState(this.overallState.data()),
+				compiledGraph.cloneState(this.overallState.data(), this.overallState.deltaData()),
 				this.tokenUsage);
 	}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph;
 
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import com.alibaba.cloud.ai.graph.store.Store;
+import com.alibaba.cloud.ai.graph.utils.SerializationUtils;
 import org.springframework.ai.util.json.JsonParser;
 import org.springframework.util.CollectionUtils;
 
@@ -148,7 +149,7 @@ public final class OverAllState implements Serializable {
 	 */
 	public Optional<OverAllState> snapShot() {
 		return Optional
-			.of(new OverAllState(new HashMap<>(this.data), new HashMap<>(this.keyStrategies), this.store));
+			.of(new OverAllState(SerializationUtils.deepCopyMap(this.data), new HashMap<>(this.keyStrategies), this.store));
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -138,14 +138,31 @@ public final class OverAllState implements Serializable {
 		this.data.clear();
 	}
 
+	/**
+	 * Reset delta data, without affecting the state of delta tracking.
+	 */
 	public void resetDeltaData() {
+		mutableDeltaData().ifPresent(Map::clear);
+	}
+
+	/**
+	 * Disable delta tracking. This will remove any existing delta data and stop tracking changes.
+	 */
+	public void disableDeltaTracking() {
 		this.data.remove(SYSTEM_DELTA_DATA_KEY);
 	}
 
+	/**
+	 * Enable delta tracking. This will initialize the delta data map if it does not already exist.
+	 */
 	public void enableDeltaTracking() {
 		this.data.computeIfAbsent(SYSTEM_DELTA_DATA_KEY, k -> new HashMap<>());
 	}
 
+	/**
+	 * Checks if delta tracking is enabled by verifying the presence of the SYSTEM_DELTA_DATA_KEY in the data map.
+	 * @return true if delta tracking is enabled, false otherwise
+	 */
 	public boolean isDeltaTrackingEnabled() {
 		Object deltaValue = this.data.get(SYSTEM_DELTA_DATA_KEY);
 		return deltaValue instanceof Map<?, ?>;

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -84,12 +84,6 @@ public final class OverAllState implements Serializable {
 	private final Map<String, Object> data;
 
 	/**
-	 * Internal map for tracking changes to the state. This can be used to store deltas or
-	 * changes that need to be applied to the main data map.
-	 */
-	private Map<String, Object> deltaData;
-
-	/**
 	 * Mapping of keys to their respective update strategies. Determines how values for
 	 * each key should be merged or updated.
 	 */
@@ -107,11 +101,29 @@ public final class OverAllState implements Serializable {
 	public static final String DEFAULT_INPUT_KEY = "input";
 
 	/**
+	 * Internal key used to store delta data representing changes made to the state during
+	 * updates. This allows tracking of what has changed in the state since the last reset.
+	 */
+	public static final String SYSTEM_DELTA_DATA_KEY = "__SYSTEM_DELTA_DATA_KEY__";
+
+	/**
+	 * @return a mutable map representing the delta data
+	 * @apiNote only for internal use
+	 */
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> mutableDeltaData() {
+		return (Map<String, Object>) this.data.computeIfAbsent(SYSTEM_DELTA_DATA_KEY, k -> new HashMap<String, Object>());
+	}
+
+	/**
 	 * Reset.
 	 */
 	public void reset() {
 		this.data.clear();
-		this.deltaData = this.data;
+	}
+
+	public void resetDeltaData() {
+        this.data.remove(SYSTEM_DELTA_DATA_KEY);
 	}
 
 	/**
@@ -129,7 +141,6 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState(Map<String, Object> data) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
-		this.deltaData = data != null ? new HashMap<>() : this.data;
 		this.keyStrategies = new HashMap<>();
 	}
 
@@ -140,7 +151,6 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState(Map<String, Object> data, Store store) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
-		this.deltaData = data != null ? new HashMap<>() : this.data;
 		this.keyStrategies = new HashMap<>();
 		this.store = store;
 	}
@@ -150,7 +160,6 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState() {
 		this.data = new HashMap<>();
-		this.deltaData = this.data;
 		this.keyStrategies = new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 	}
@@ -161,7 +170,6 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState(Store store) {
 		this.data = new HashMap<>();
-		this.deltaData = this.data;
 		this.keyStrategies = new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 		this.store = store;
@@ -174,20 +182,6 @@ public final class OverAllState implements Serializable {
 	 */
 	protected OverAllState(Map<String, Object> data, Map<String, KeyStrategy> keyStrategies) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
-		this.deltaData = data != null ? new HashMap<>() : this.data;
-		this.keyStrategies = keyStrategies != null ? keyStrategies : new HashMap<>();
-		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
-	}
-
-	/**
-	 * Instantiates a new Over all state with delta data.
-	 * @param data the data
-	 * @param deltaData the delta data
-	 * @param keyStrategies the key strategies
-	 */
-	protected OverAllState(Map<String, Object> data, Map<String, Object> deltaData, Map<String, KeyStrategy> keyStrategies) {
-		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
-		this.deltaData = deltaData != null ? new HashMap<>(deltaData) : this.data;
 		this.keyStrategies = keyStrategies != null ? keyStrategies : new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 	}
@@ -201,7 +195,6 @@ public final class OverAllState implements Serializable {
 	protected OverAllState(Map<String, Object> data, Map<String, KeyStrategy> keyStrategies,
 			Store store) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
-		this.deltaData = data != null ? new HashMap<>() : this.data;
 		this.keyStrategies = keyStrategies != null ? keyStrategies : new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 		this.store = store;
@@ -213,9 +206,6 @@ public final class OverAllState implements Serializable {
 	 */
 	public void clear() {
 		this.data.clear();
-		if (this.deltaData != this.data) {
-			this.deltaData = this.data;
-		}
 	}
 
 	/**
@@ -230,17 +220,6 @@ public final class OverAllState implements Serializable {
 		this.keyStrategies.putAll(overAllState.keyStrategies());
 		this.data.clear();
 		this.data.putAll(overAllState.data());
-
-		if (overAllState.data == overAllState.deltaData) {
-			this.deltaData = this.data;
-		} else {
-			if (this.deltaData == this.data) {
-				this.deltaData = new HashMap<>();
-			} else {
-				this.deltaData.clear();
-			}
-			this.deltaData.putAll(overAllState.deltaData);
-		}
 		this.store = overAllState.store;
 	}
 
@@ -258,12 +237,14 @@ public final class OverAllState implements Serializable {
 			return this;
 		}
 
+		if (input.containsKey(SYSTEM_DELTA_DATA_KEY)) {
+			// Retain existing delta data for Resume-From scenarios
+			this.data.put(SYSTEM_DELTA_DATA_KEY, input.get(SYSTEM_DELTA_DATA_KEY));
+		}
+
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
 		input.keySet().stream().filter(key -> keyStrategies.containsKey(key)).forEach(key -> {
 			this.data.put(key, keyStrategies.get(key).apply(value(key, null), input.get(key)));
-			if (this.data != this.deltaData) {
-				this.deltaData.put(key, keyStrategies.get(key).apply(deltaData.get(key), input.get(key)));
-			}
 		});
 		return this;
 	}
@@ -313,14 +294,10 @@ public final class OverAllState implements Serializable {
 			}
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
-				if (this.data != this.deltaData) {
-					this.deltaData.remove(key);
-				}
+				this.mutableDeltaData().remove(key);
 			} else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
-				if (this.data != this.deltaData) {
-					this.deltaData.put(key, strategy.apply(deltaData.get(key), partialState.get(key)));
-				}
+				this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
 			}
 		});
 		return data();
@@ -347,15 +324,11 @@ public final class OverAllState implements Serializable {
 			}
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
-				if (this.data != this.deltaData) {
-					this.deltaData.remove(key);
-				}
+				this.mutableDeltaData().remove(key);
 			}
 			else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
-				if (this.data != this.deltaData) {
-					this.deltaData.put(key, strategy.apply(deltaData.get(key), partialState.get(key)));
-				}
+				this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
 			}
 		});
 	}
@@ -530,8 +503,32 @@ public final class OverAllState implements Serializable {
 		return data != null ? unmodifiableMap(data) : unmodifiableMap(new HashMap<>());
 	}
 
+	/**
+	 * Data without delta map.
+	 * @return the map
+	 */
+	public final Map<String, Object> dataWithoutDelta() {
+		if (data == null) {
+			return Collections.emptyMap();
+		}
+		if (data.containsKey(SYSTEM_DELTA_DATA_KEY)) {
+			Map<String, Object> result = new HashMap<>(data);
+			result.remove(SYSTEM_DELTA_DATA_KEY);
+			return unmodifiableMap(result);
+		} else {
+			return unmodifiableMap(data);
+		}
+	}
+
+	/**
+	 * Delta data map.
+	 * @return the map
+	 */
 	public final Map<String, Object> deltaData() {
-		return deltaData != null ? unmodifiableMap(deltaData) : unmodifiableMap(new HashMap<>());
+		if (data == null || !data.containsKey(SYSTEM_DELTA_DATA_KEY)) {
+			return Collections.emptyMap();
+		}
+		return unmodifiableMap(mutableDeltaData());
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -180,6 +180,19 @@ public final class OverAllState implements Serializable {
 	}
 
 	/**
+	 * Instantiates a new Over all state with delta data.
+	 * @param data the data
+	 * @param deltaData the delta data
+	 * @param keyStrategies the key strategies
+	 */
+	protected OverAllState(Map<String, Object> data, Map<String, Object> deltaData, Map<String, KeyStrategy> keyStrategies) {
+		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
+		this.deltaData = deltaData != null ? new HashMap<>(deltaData) : this.data;
+		this.keyStrategies = keyStrategies != null ? keyStrategies : new HashMap<>();
+		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
+	}
+
+	/**
 	 * Instantiates a new Over all state with Store.
 	 * @param data the data
 	 * @param keyStrategies the key strategies

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -112,7 +112,12 @@ public final class OverAllState implements Serializable {
 	 */
 	@SuppressWarnings("unchecked")
 	private Map<String, Object> mutableDeltaData() {
-		return (Map<String, Object>) this.data.computeIfAbsent(SYSTEM_DELTA_DATA_KEY, k -> new HashMap<String, Object>());
+		Object mutableDelta = this.data.computeIfAbsent(SYSTEM_DELTA_DATA_KEY, k -> new HashMap<String, Object>());
+		if (mutableDelta instanceof Map<?, ?> deltaMap) {
+			return (Map<String, Object>) deltaMap;
+		} else {
+			throw new IllegalStateException("Value for " + SYSTEM_DELTA_DATA_KEY + " is not a Map but " + mutableDelta.getClass());
+		}
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -108,6 +108,14 @@ public final class OverAllState implements Serializable {
 	public static final String SYSTEM_DELTA_DATA_KEY = "__SYSTEM_DELTA_DATA_KEY__";
 
 	/**
+	 * Set of keys that are protected from being modified or removed through the updateState
+	 * method. This includes internal keys like SYSTEM_DELTA_DATA_KEY that are essential for
+	 * the correct functioning of the state management and should not be altered by external
+	 * updates.
+	 */
+	private static final Set<String> PROTECTED_KEYS = Set.of(SYSTEM_DELTA_DATA_KEY);
+
+	/**
 	 * @return an Optional containing the mutable delta data map, or empty if tracking is not enabled
 	 * @apiNote only for internal use
 	 */
@@ -304,6 +312,11 @@ public final class OverAllState implements Serializable {
 	public Map<String, Object> updateState(Map<String, Object> partialState) {
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
 		partialState.keySet().forEach(key -> {
+			if (PROTECTED_KEYS.contains(key)) {
+				// Skip protected keys
+				return;
+			}
+
 			// If no specific strategy is found, use the default REPLACE strategy
 			final KeyStrategy strategy = Optional.ofNullable(keyStrategies.get(key))
 					.orElse(KeyStrategy.REPLACE);
@@ -334,6 +347,11 @@ public final class OverAllState implements Serializable {
 	public void updateStateWithKeyStrategies(Map<String, Object> partialState, Map<String, KeyStrategy> keyStrategyMap) {
 		Optional<Map<String, KeyStrategy>> optionalKeyStrategies = ofNullable(keyStrategyMap);
 		partialState.keySet().forEach(key -> {
+			if (PROTECTED_KEYS.contains(key)) {
+				// Skip protected keys
+				return;
+			}
+
 			// If no specific strategy is found, use the default REPLACE strategy
 			final KeyStrategy strategy = optionalKeyStrategies
 					.map(map -> map.get(key))

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -302,6 +302,7 @@ public final class OverAllState implements Serializable {
 	public Map<String, Object> updateState(Map<String, Object> partialState) {
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
 		partialState.keySet().forEach(key -> {
+			// If no specific strategy is found, use the default REPLACE strategy
 			final KeyStrategy strategy = Optional.ofNullable(keyStrategies.get(key))
 					.orElse(KeyStrategy.REPLACE);
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
@@ -331,6 +332,7 @@ public final class OverAllState implements Serializable {
 	public void updateStateWithKeyStrategies(Map<String, Object> partialState, Map<String, KeyStrategy> keyStrategyMap) {
 		Optional<Map<String, KeyStrategy>> optionalKeyStrategies = ofNullable(keyStrategyMap);
 		partialState.keySet().forEach(key -> {
+			// If no specific strategy is found, use the default REPLACE strategy
 			final KeyStrategy strategy = optionalKeyStrategies
 					.map(map -> map.get(key))
 					.orElse(KeyStrategy.REPLACE);

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -107,17 +107,19 @@ public final class OverAllState implements Serializable {
 	public static final String SYSTEM_DELTA_DATA_KEY = "__SYSTEM_DELTA_DATA_KEY__";
 
 	/**
-	 * @return a mutable map representing the delta data
+	 * @return an Optional containing the mutable delta data map, or empty if tracking is not enabled
 	 * @apiNote only for internal use
 	 */
 	@SuppressWarnings("unchecked")
-	private Map<String, Object> mutableDeltaData() {
-		Object mutableDelta = this.data.computeIfAbsent(SYSTEM_DELTA_DATA_KEY, k -> new HashMap<String, Object>());
-		if (mutableDelta instanceof Map<?, ?> deltaMap) {
-			return (Map<String, Object>) deltaMap;
-		} else {
-			throw new IllegalStateException("Value for " + SYSTEM_DELTA_DATA_KEY + " is not a Map but " + mutableDelta.getClass());
+	private Optional<Map<String, Object>> mutableDeltaData() {
+		if (!isDeltaTrackingEnabled()) {
+			return Optional.empty();
 		}
+		Object mutableDelta = this.data.get(SYSTEM_DELTA_DATA_KEY);
+		if (mutableDelta instanceof Map<?, ?> deltaMap) {
+			return Optional.of((Map<String, Object>) deltaMap);
+		}
+		return Optional.empty();
 	}
 
 	/**
@@ -300,20 +302,15 @@ public final class OverAllState implements Serializable {
 	public Map<String, Object> updateState(Map<String, Object> partialState) {
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
 		partialState.keySet().forEach(key -> {
-			KeyStrategy strategy = keyStrategies != null ? keyStrategies.get(key) : null;
-			if (strategy == null) {
-				strategy = KeyStrategy.REPLACE;
-			}
+			final KeyStrategy strategy = Optional.ofNullable(keyStrategies.get(key))
+					.orElse(KeyStrategy.REPLACE);
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
-				if (isDeltaTrackingEnabled()) {
-					this.mutableDeltaData().remove(key);
-				}
+				mutableDeltaData().ifPresent(delta -> delta.remove(key));
 			} else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
-				if (isDeltaTrackingEnabled()) {
-					this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
-				}
+				mutableDeltaData().ifPresent(delta -> 
+						delta.put(key, strategy.apply(delta.get(key), partialState.get(key))));
 			}
 		});
 		return data();
@@ -332,22 +329,19 @@ public final class OverAllState implements Serializable {
 	 * default REPLACE strategy is used
 	 */
 	public void updateStateWithKeyStrategies(Map<String, Object> partialState, Map<String, KeyStrategy> keyStrategyMap) {
+		Optional<Map<String, KeyStrategy>> optionalKeyStrategies = ofNullable(keyStrategyMap);
 		partialState.keySet().forEach(key -> {
-			KeyStrategy strategy = keyStrategyMap != null ? keyStrategyMap.get(key) : null;
-			if (strategy == null) {
-				strategy = KeyStrategy.REPLACE;
-			}
+			final KeyStrategy strategy = optionalKeyStrategies
+					.map(map -> map.get(key))
+					.orElse(KeyStrategy.REPLACE);
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
-				if (isDeltaTrackingEnabled()) {
-					this.mutableDeltaData().remove(key);
-				}
+				mutableDeltaData().ifPresent(delta -> delta.remove(key));
 			}
 			else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
-				if (isDeltaTrackingEnabled()) {
-					this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
-				}
+				mutableDeltaData().ifPresent(delta -> 
+						delta.put(key, strategy.apply(delta.get(key), partialState.get(key))));
 			}
 		});
 	}
@@ -544,10 +538,9 @@ public final class OverAllState implements Serializable {
 	 * @return the map
 	 */
 	public final Map<String, Object> deltaData() {
-		if (data == null || !data.containsKey(SYSTEM_DELTA_DATA_KEY)) {
-			return Collections.emptyMap();
-		}
-		return unmodifiableMap(mutableDeltaData());
+		return mutableDeltaData()
+				.map(Collections::unmodifiableMap)
+				.orElse(Collections.emptyMap());
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -577,8 +577,8 @@ public final class OverAllState implements Serializable {
 	}
 
 	/**
-	 * Delta data map.
-	 * @return the map
+	 * Delta data map which tracking the changes of state since last reset.
+	 * @return the delta data map, or an {@link Collections#emptyMap} if delta tracking is not enabled or no delta data is present
 	 */
 	public final Map<String, Object> deltaData() {
 		return mutableDeltaData()

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -123,7 +123,7 @@ public final class OverAllState implements Serializable {
 	}
 
 	public void resetDeltaData() {
-        this.data.remove(SYSTEM_DELTA_DATA_KEY);
+		this.data.remove(SYSTEM_DELTA_DATA_KEY);
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -219,7 +219,7 @@ public final class OverAllState implements Serializable {
 		this.data.putAll(overAllState.data());
 
 		if (overAllState.data == overAllState.deltaData) {
-			this.deltaData = this.data();
+			this.deltaData = this.data;
 		} else {
 			if (this.deltaData == this.data) {
 				this.deltaData = new HashMap<>();

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -264,7 +264,11 @@ public final class OverAllState implements Serializable {
 
 		if (input.containsKey(SYSTEM_DELTA_DATA_KEY)) {
 			// Retain existing delta data for Resume-From scenarios
-			this.data.put(SYSTEM_DELTA_DATA_KEY, input.get(SYSTEM_DELTA_DATA_KEY));
+			Object deltaObject = input.get(SYSTEM_DELTA_DATA_KEY);
+			// ignore if delta data is not in expected format
+			if (deltaObject instanceof Map<?, ?> deltaMap) {
+				this.data.put(SYSTEM_DELTA_DATA_KEY, new HashMap<>(deltaMap));
+			}
 		}
 
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -138,7 +138,8 @@ public final class OverAllState implements Serializable {
 	}
 
 	public boolean isDeltaTrackingEnabled() {
-		return this.data.containsKey(SYSTEM_DELTA_DATA_KEY);
+		Object deltaValue = this.data.get(SYSTEM_DELTA_DATA_KEY);
+		return deltaValue instanceof Map<?, ?>;
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -131,6 +131,14 @@ public final class OverAllState implements Serializable {
 		this.data.remove(SYSTEM_DELTA_DATA_KEY);
 	}
 
+	public void enableDeltaTracking() {
+		this.data.computeIfAbsent(SYSTEM_DELTA_DATA_KEY, k -> new HashMap<>());
+	}
+
+	public boolean isDeltaTrackingEnabled() {
+		return this.data.containsKey(SYSTEM_DELTA_DATA_KEY);
+	}
+
 	/**
 	 * Snap shot optional.
 	 * @return the optional
@@ -248,7 +256,7 @@ public final class OverAllState implements Serializable {
 		}
 
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
-		input.keySet().stream().filter(key -> keyStrategies.containsKey(key)).forEach(key -> {
+		input.keySet().stream().filter(key -> keyStrategies.containsKey(key) && !key.equals(SYSTEM_DELTA_DATA_KEY)).forEach(key -> {
 			this.data.put(key, keyStrategies.get(key).apply(value(key, null), input.get(key)));
 		});
 		return this;
@@ -293,16 +301,19 @@ public final class OverAllState implements Serializable {
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
 		partialState.keySet().forEach(key -> {
 			KeyStrategy strategy = keyStrategies != null ? keyStrategies.get(key) : null;
-			// If no specific strategy is found, use the default REPLACE strategy
 			if (strategy == null) {
 				strategy = KeyStrategy.REPLACE;
 			}
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
-				this.mutableDeltaData().remove(key);
+				if (isDeltaTrackingEnabled()) {
+					this.mutableDeltaData().remove(key);
+				}
 			} else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
-				this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
+				if (isDeltaTrackingEnabled()) {
+					this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
+				}
 			}
 		});
 		return data();
@@ -323,17 +334,20 @@ public final class OverAllState implements Serializable {
 	public void updateStateWithKeyStrategies(Map<String, Object> partialState, Map<String, KeyStrategy> keyStrategyMap) {
 		partialState.keySet().forEach(key -> {
 			KeyStrategy strategy = keyStrategyMap != null ? keyStrategyMap.get(key) : null;
-			// If no specific strategy is found, use the default REPLACE strategy
 			if (strategy == null) {
 				strategy = KeyStrategy.REPLACE;
 			}
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
-				this.mutableDeltaData().remove(key);
+				if (isDeltaTrackingEnabled()) {
+					this.mutableDeltaData().remove(key);
+				}
 			}
 			else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
-				this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
+				if (isDeltaTrackingEnabled()) {
+					this.mutableDeltaData().put(key, strategy.apply(this.mutableDeltaData().get(key), partialState.get(key)));
+				}
 			}
 		});
 	}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -84,6 +84,12 @@ public final class OverAllState implements Serializable {
 	private final Map<String, Object> data;
 
 	/**
+	 * Internal map for tracking changes to the state. This can be used to store deltas or
+	 * changes that need to be applied to the main data map.
+	 */
+	private Map<String, Object> deltaData;
+
+	/**
 	 * Mapping of keys to their respective update strategies. Determines how values for
 	 * each key should be merged or updated.
 	 */
@@ -105,6 +111,7 @@ public final class OverAllState implements Serializable {
 	 */
 	public void reset() {
 		this.data.clear();
+		this.deltaData = this.data;
 	}
 
 	/**
@@ -122,6 +129,7 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState(Map<String, Object> data) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
+		this.deltaData = data != null ? new HashMap<>() : this.data;
 		this.keyStrategies = new HashMap<>();
 	}
 
@@ -132,6 +140,7 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState(Map<String, Object> data, Store store) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
+		this.deltaData = data != null ? new HashMap<>() : this.data;
 		this.keyStrategies = new HashMap<>();
 		this.store = store;
 	}
@@ -141,6 +150,7 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState() {
 		this.data = new HashMap<>();
+		this.deltaData = this.data;
 		this.keyStrategies = new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 	}
@@ -151,6 +161,7 @@ public final class OverAllState implements Serializable {
 	 */
 	public OverAllState(Store store) {
 		this.data = new HashMap<>();
+		this.deltaData = this.data;
 		this.keyStrategies = new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 		this.store = store;
@@ -163,6 +174,7 @@ public final class OverAllState implements Serializable {
 	 */
 	protected OverAllState(Map<String, Object> data, Map<String, KeyStrategy> keyStrategies) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
+		this.deltaData = data != null ? new HashMap<>() : this.data;
 		this.keyStrategies = keyStrategies != null ? keyStrategies : new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 	}
@@ -176,6 +188,7 @@ public final class OverAllState implements Serializable {
 	protected OverAllState(Map<String, Object> data, Map<String, KeyStrategy> keyStrategies,
 			Store store) {
 		this.data = data != null ? new HashMap<>(data) : new HashMap<>();
+		this.deltaData = data != null ? new HashMap<>() : this.data;
 		this.keyStrategies = keyStrategies != null ? keyStrategies : new HashMap<>();
 		this.registerKeyAndStrategy(OverAllState.DEFAULT_INPUT_KEY, new ReplaceStrategy());
 		this.store = store;
@@ -187,6 +200,9 @@ public final class OverAllState implements Serializable {
 	 */
 	public void clear() {
 		this.data.clear();
+		if (this.deltaData != this.data) {
+			this.deltaData = this.data;
+		}
 	}
 
 	/**
@@ -201,6 +217,17 @@ public final class OverAllState implements Serializable {
 		this.keyStrategies.putAll(overAllState.keyStrategies());
 		this.data.clear();
 		this.data.putAll(overAllState.data());
+
+		if (overAllState.data == overAllState.deltaData) {
+			this.deltaData = this.data();
+		} else {
+			if (this.deltaData == this.data) {
+				this.deltaData = new HashMap<>();
+			} else {
+				this.deltaData.clear();
+			}
+			this.deltaData.putAll(overAllState.deltaData);
+		}
 		this.store = overAllState.store;
 	}
 
@@ -221,6 +248,9 @@ public final class OverAllState implements Serializable {
 		Map<String, KeyStrategy> keyStrategies = keyStrategies();
 		input.keySet().stream().filter(key -> keyStrategies.containsKey(key)).forEach(key -> {
 			this.data.put(key, keyStrategies.get(key).apply(value(key, null), input.get(key)));
+			if (this.data != this.deltaData) {
+				this.deltaData.put(key, keyStrategies.get(key).apply(deltaData.get(key), input.get(key)));
+			}
 		});
 		return this;
 	}
@@ -270,8 +300,14 @@ public final class OverAllState implements Serializable {
 			}
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
+				if (this.data != this.deltaData) {
+					this.deltaData.remove(key);
+				}
 			} else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
+				if (this.data != this.deltaData) {
+					this.deltaData.put(key, strategy.apply(deltaData.get(key), partialState.get(key)));
+				}
 			}
 		});
 		return data();
@@ -298,9 +334,15 @@ public final class OverAllState implements Serializable {
 			}
 			if (partialState.get(key) == MARK_FOR_REMOVAL) {
 				this.data.remove(key);
+				if (this.data != this.deltaData) {
+					this.deltaData.remove(key);
+				}
 			}
 			else {
 				this.data.put(key, strategy.apply(value(key, null), partialState.get(key)));
+				if (this.data != this.deltaData) {
+					this.deltaData.put(key, strategy.apply(deltaData.get(key), partialState.get(key)));
+				}
 			}
 		});
 	}
@@ -473,6 +515,10 @@ public final class OverAllState implements Serializable {
 	 */
 	public final Map<String, Object> data() {
 		return data != null ? unmodifiableMap(data) : unmodifiableMap(new HashMap<>());
+	}
+
+	public final Map<String, Object> deltaData() {
+		return deltaData != null ? unmodifiableMap(deltaData) : unmodifiableMap(new HashMap<>());
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
@@ -60,8 +60,10 @@ public abstract class BaseGraphExecutor {
 						.get()
 						.release(context.getConfig());
 					resultValue.set(tag);
-				} else {
+				} else if (context.getOverallState().isDeltaTrackingEnabled()) {
 					resultValue.set(new HashMap<>(context.getOverallState().deltaData()));
+				} else {
+					resultValue.set(new HashMap<>(context.getOverallState().data()));
 				}
 				return Flux.just(GraphResponse.done(resultValue.get()));
 			}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
@@ -61,7 +61,7 @@ public abstract class BaseGraphExecutor {
 						.release(context.getConfig());
 					resultValue.set(tag);
 				} else {
-					resultValue.set(new HashMap<>(context.getOverallState().data()));
+					resultValue.set(new HashMap<>(context.getOverallState().deltaData()));
 				}
 				return Flux.just(GraphResponse.done(resultValue.get()));
 			}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -34,6 +34,7 @@ import static com.alibaba.cloud.ai.graph.StateGraph.START;
 import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for OverAllState behavior with append strategy and subgraph execution.
@@ -105,7 +106,11 @@ public class OverAllStateDeltaDataTest {
 		mainGraph.addEdge("a", "subA");
 		mainGraph.addEdge("subA", "subB");
 		mainGraph.addEdge("subB", END);
-		CompiledGraph compiledGraph = mainGraph.compile();
+		CompiledGraph compiledGraph = mainGraph.compile(
+				CompileConfig.builder()
+						.enableDeltaTracking(true)
+						.build()
+		);
 
 		OverAllState state = compiledGraph.invoke(Map.of(KEY_OUTPUT, "A")).orElseThrow();
 		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
@@ -148,7 +153,11 @@ public class OverAllStateDeltaDataTest {
 		mainGraph.addEdge("b", "c");
 		mainGraph.addEdge("c", END);
 
-		CompiledGraph compiledGraph = mainGraph.compile();
+		CompiledGraph compiledGraph = mainGraph.compile(
+				CompileConfig.builder()
+						.enableDeltaTracking(true)
+						.build()
+		);
 
 		OverAllState state = compiledGraph.invoke(Map.of(KEY_OUTPUT, "A")).orElseThrow();
 		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
@@ -185,6 +194,7 @@ public class OverAllStateDeltaDataTest {
 
 		CompiledGraph compiledGraph = mainGraph.compile(
 				CompileConfig.builder()
+						.enableDeltaTracking(true)
 						.interruptAfter("a")
 						.saverConfig(
 								SaverConfig.builder()
@@ -232,6 +242,76 @@ public class OverAllStateDeltaDataTest {
 		assertEquals(List.of("a", "b"), deltaOutputResumed,
 				"Delta output should be [a, b]");
 
+	}
+
+	@Test
+	void testDeltaTrackingDisabledByDefault() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = createKeyStrategyFactory();
+
+		// Build sub graph A
+		StateGraph subGraphA = new StateGraph(keyStrategyFactory);
+		subGraphA.addNode("b", makeNode("b"));
+		subGraphA.addEdge(START, "b");
+		subGraphA.addEdge("b", END);
+		CompiledGraph compiledGraphA = subGraphA.compile();
+
+		// Build main graph
+		StateGraph mainGraph = new StateGraph(keyStrategyFactory);
+		mainGraph.addNode("a", makeNode("a"));
+		mainGraph.addNode("subA", compiledGraphA);
+		mainGraph.addEdge(START, "a");
+		mainGraph.addEdge("a", "subA");
+		mainGraph.addEdge("subA", END);
+		// delta tracking DISABLED by default
+		CompiledGraph compiledGraph = mainGraph.compile();
+
+		OverAllState state = compiledGraph.invoke(Map.of(KEY_OUTPUT, "A")).orElseThrow();
+		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
+
+		assertNotNull(output, "Output should not be null");
+		assertEquals(5, output.size(), "Output should contain 5 elements without delta tracking");
+		assertEquals(List.of("A", "a", "A", "a", "b"), output, "Output should be [A, a, A, a, b] without delta tracking");
+
+		Map<String, Object> deltaData = state.deltaData();
+		assertNotNull(deltaData, "Delta data should not be null even if tracking is disabled");
+		assertTrue(deltaData.isEmpty(), "Delta data should be empty when tracking is disabled");
+
+	}
+
+	@Test
+	void testDeltaTrackingEnabledOnlyInSubGraph() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = createKeyStrategyFactory();
+
+		// Build sub graph A with delta tracking enabled
+		StateGraph subGraphA = new StateGraph(keyStrategyFactory);
+		subGraphA.addNode("b", makeNode("b"));
+		subGraphA.addEdge(START, "b");
+		subGraphA.addEdge("b", END);
+		CompiledGraph compiledGraphA = subGraphA.compile(
+				CompileConfig.builder()
+						.enableDeltaTracking(true) // Enable delta tracking for subgraph A
+						.build()
+		);
+
+		// Build main graph with delta tracking disabled
+		StateGraph mainGraph = new StateGraph(keyStrategyFactory);
+		mainGraph.addNode("a", makeNode("a"));
+		mainGraph.addNode("subA", compiledGraphA);
+		mainGraph.addEdge(START, "a");
+		mainGraph.addEdge("a", "subA");
+		mainGraph.addEdge("subA", END);
+		CompiledGraph compiledGraph = mainGraph.compile();
+
+		OverAllState state = compiledGraph.invoke(Map.of(KEY_OUTPUT, "A")).orElseThrow();
+		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
+
+		assertNotNull(output, "Output should not be null");
+		assertEquals(3, output.size(), "Output should contain 3 elements");
+		assertEquals(List.of("A", "a", "b"), output, "Output should be [A, a, b]");
+
+		Map<String, Object> deltaData = state.deltaData();
+		assertNotNull(deltaData, "Delta data should not be null");
+		assertTrue(deltaData.isEmpty(), "Delta data should be empty when tracking is disabled");
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -107,9 +107,9 @@ public class OverAllStateDeltaDataTest {
 		OverAllState state = compiledGraph.invoke(Collections.emptyMap()).orElseThrow();
 		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
 
-		log.info("actual output size: {}, which suppose to be 6", output.size());
+		log.info("actual output size: {}, which is supposed to be 6", output.size());
 		log.info("actual output: {}", output);
-		log.info(", which suppose to be [a, a, b, c, c, d]");
+		log.info("expected output: [a, a, b, c, c, d]");
 
 		assertNotNull(output, "Output should not be null");
 		assertEquals(6, output.size(), "Output should contain 6 elements");

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -24,10 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
@@ -312,6 +309,44 @@ public class OverAllStateDeltaDataTest {
 		Map<String, Object> deltaData = state.deltaData();
 		assertNotNull(deltaData, "Delta data should not be null");
 		assertTrue(deltaData.isEmpty(), "Delta data should be empty when tracking is disabled");
+	}
+
+	@Test
+	void testDeltaTrackingWithStreamMethod() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = createKeyStrategyFactory();
+
+		StateGraph mainGraph = new StateGraph(keyStrategyFactory);
+		mainGraph.addNode("a", makeNode("a"));
+		mainGraph.addNode("b", makeNode("b"));
+
+		mainGraph.addEdge(START, "a");
+		mainGraph.addEdge("a", "b");
+		mainGraph.addEdge("b", END);
+
+		CompiledGraph compiledGraph = mainGraph.compile(
+				CompileConfig.builder()
+						.enableDeltaTracking(true)
+						.build()
+		);
+
+		NodeOutput lastOutput = compiledGraph.stream(Map.of(KEY_OUTPUT, "A"))
+				.reduce((first, second) -> second)
+				.block();
+
+		assertNotNull(lastOutput, "Last output should not be null");
+		OverAllState state = lastOutput.state();
+		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
+
+		assertNotNull(output, "Output should not be null");
+		assertEquals(3, output.size(), "Output should contain 3 elements");
+		assertEquals(List.of("A", "a", "b"), output, "Output should be [A, a, b]");
+
+		Map<String, Object> deltaData = state.deltaData();
+		assertNotNull(deltaData, "Delta data should not be null");
+		List<String> deltaOutput = (List<String>) deltaData.get(KEY_OUTPUT);
+		assertNotNull(deltaOutput, "Delta data should contain output key");
+		assertEquals(2, deltaOutput.size(), "Delta data should contain 2 entries");
+		assertEquals(List.of("a", "b"), deltaOutput, "Delta output should be [a, b]");
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.action.AsyncNodeAction;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Unit tests for OverAllState serialization with subgraph execution.
+ */
+public class OverAllStateDeltaDataTest {
+
+	private static final Logger log = LoggerFactory.getLogger(OverAllStateDeltaDataTest.class);
+
+	private static final String KEY_OUTPUT = "output";
+
+	/**
+	 * Create KeyStrategyFactory with append strategy for output key.
+	 * @return KeyStrategyFactory configured with append strategy.
+	 */
+	private KeyStrategyFactory createKeyStrategyFactory() {
+		return () -> {
+			Map<String, KeyStrategy> keyStrategyMap = new HashMap<>();
+			keyStrategyMap.put(KEY_OUTPUT, new AppendStrategy());
+			return keyStrategyMap;
+		};
+	}
+
+	/**
+	 * Create a simple async node that returns a map with the given ID as value for
+	 * the output key.
+	 * @param id The identifier for the node action.
+	 * @return An AsyncNodeAction producing a map with the message ID.
+	 */
+	private AsyncNodeAction makeNode(String id) {
+		return node_async(state -> {
+			log.info("Executing node: {}", id);
+			return Map.of(KEY_OUTPUT, id);
+		});
+	}
+
+	/**
+	 * Test serialization and execution of graph with multiple sub-graphs using append
+	 * strategy.
+	 */
+	@Test
+	public void testMarkForRemovalSerialization() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = createKeyStrategyFactory();
+
+		// Build sub graph A
+		StateGraph subGraphA = new StateGraph(keyStrategyFactory);
+		subGraphA.addNode("a", makeNode("a"));
+		subGraphA.addNode("b", makeNode("b"));
+		subGraphA.addNode("c", makeNode("c"));
+		subGraphA.addEdge(START, "a");
+		subGraphA.addEdge("a", "b");
+		subGraphA.addEdge("b", "c");
+		subGraphA.addEdge("c", END);
+		CompiledGraph compiledGraphA = subGraphA.compile();
+
+		// Build sub graph B
+		StateGraph subGraphB = new StateGraph(keyStrategyFactory);
+		subGraphB.addNode("c", makeNode("c"));
+		subGraphB.addNode("d", makeNode("d"));
+		subGraphB.addEdge(START, "c");
+		subGraphB.addEdge("c", "d");
+		subGraphB.addEdge("d", END);
+		CompiledGraph compiledGraphB = subGraphB.compile();
+
+		// Build main graph
+		StateGraph mainGraph = new StateGraph(keyStrategyFactory);
+		mainGraph.addNode("a", makeNode("a"));
+		mainGraph.addNode("subA", compiledGraphA);
+		mainGraph.addNode("subB", compiledGraphB);
+		mainGraph.addEdge(START, "a");
+		mainGraph.addEdge("a", "subA");
+		mainGraph.addEdge("subA", "subB");
+		mainGraph.addEdge("subB", END);
+		CompiledGraph compiledGraph = mainGraph.compile();
+
+		OverAllState state = compiledGraph.invoke(Collections.emptyMap()).orElseThrow();
+		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
+
+		log.info("actual output size: {}, which suppose to be 6", output.size());
+		log.info("actual output: {}", output);
+		log.info(", which suppose to be [a, a, b, c, c, d]");
+
+		assertNotNull(output, "Output should not be null");
+		assertEquals(6, output.size(), "Output should contain 6 elements");
+		assertEquals(List.of("a", "a", "b", "c", "c", "d"), output,
+				"Output should be [a, a, b, c, c, d]");
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -115,7 +115,7 @@ public class OverAllStateDeltaDataTest {
 		log.info("expected output: [A, a, a, b, c, c, d]");
 
 		assertNotNull(output, "Output should not be null");
-		assertEquals(7, output.size(), "Output should contain 6 elements");
+		assertEquals(7, output.size(), "Output should contain 7 elements");
 		assertEquals(List.of("A", "a", "a", "b", "c", "c", "d"), output,
 				"Output should be [A, a, a, b, c, c, d]");
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -104,17 +104,64 @@ public class OverAllStateDeltaDataTest {
 		mainGraph.addEdge("subB", END);
 		CompiledGraph compiledGraph = mainGraph.compile();
 
-		OverAllState state = compiledGraph.invoke(Collections.emptyMap()).orElseThrow();
+		OverAllState state = compiledGraph.invoke(Map.of(KEY_OUTPUT, "A")).orElseThrow();
 		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
 
-		log.info("actual output size: {}, which is supposed to be 6", output.size());
+		log.info("actual output size: {}, which is supposed to be 7", output.size());
 		log.info("actual output: {}", output);
-		log.info("expected output: [a, a, b, c, c, d]");
+		log.info("expected output: [A, a, a, b, c, c, d]");
 
 		assertNotNull(output, "Output should not be null");
-		assertEquals(6, output.size(), "Output should contain 6 elements");
-		assertEquals(List.of("a", "a", "b", "c", "c", "d"), output,
-				"Output should be [a, a, b, c, c, d]");
+		assertEquals(7, output.size(), "Output should contain 6 elements");
+		assertEquals(List.of("A", "a", "a", "b", "c", "c", "d"), output,
+				"Output should be [A, a, a, b, c, c, d]");
+
+		Map<String, Object> deltaData = state.deltaData();
+		assertNotNull(deltaData, "Delta data should not be null");
+		List<String> deltaOutput = (List<String>) deltaData.get(KEY_OUTPUT);
+		assertNotNull(deltaOutput, "Delta data should contain output key");
+		assertEquals(6, deltaOutput.size(), "Delta data should contain 6 entries");
+		assertEquals(List.of("a", "a", "b", "c", "c", "d"), deltaOutput,
+				"Delta output should be [a, a, b, c, c, d]");
+	}
+
+	/**
+	 * Test execution of graph with parallel nodes using the append strategy.
+	 */
+	@Test
+	void testAppendStrategyWithParallelNodes() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = createKeyStrategyFactory();
+
+		// Build main graph with parallel nodes
+		StateGraph mainGraph = new StateGraph(keyStrategyFactory);
+
+		mainGraph.addNode("a", makeNode("a"));
+		mainGraph.addNode("b", makeNode("b"));
+		mainGraph.addNode("c", makeNode("c"));
+
+		mainGraph.addEdge(START, "a");
+		mainGraph.addEdge(START, "b");
+		mainGraph.addEdge("a", "c");
+		mainGraph.addEdge("b", "c");
+		mainGraph.addEdge("c", END);
+
+		CompiledGraph compiledGraph = mainGraph.compile();
+
+		OverAllState state = compiledGraph.invoke(Map.of(KEY_OUTPUT, "A")).orElseThrow();
+		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
+
+		assertNotNull(output, "Output should not be null");
+		assertEquals(4, output.size(), "Output should contain 4 elements");
+		// parallel result processing ordered as Node Registration order, which is a, b, c
+		assertEquals(List.of("A", "a", "b", "c"), output,
+				"Output should be [A, a, b, c]");
+
+		assertNotNull(state.deltaData(), "Delta data should not be null");
+		List<String> outPutDeltas = (List<String>) state.deltaData().get(KEY_OUTPUT);
+		assertNotNull(outPutDeltas, "Delta data should contain output key");
+		assertEquals(3, outPutDeltas.size(), "Delta data should contain 3 entries");
+		assertEquals(List.of("a", "b", "c"), outPutDeltas,
+				"Delta output should be [a, b, c]");
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * Unit tests for OverAllState serialization with subgraph execution.
+ * Unit tests for OverAllState behavior with append strategy and subgraph execution.
  */
 public class OverAllStateDeltaDataTest {
 
@@ -67,11 +67,10 @@ public class OverAllStateDeltaDataTest {
 	}
 
 	/**
-	 * Test serialization and execution of graph with multiple sub-graphs using append
-	 * strategy.
+	 * Test execution of graph with multiple sub-graphs using the append strategy.
 	 */
 	@Test
-	public void testMarkForRemovalSerialization() throws Exception {
+	public void testAppendStrategyWithSubGraphs() throws Exception {
 		KeyStrategyFactory keyStrategyFactory = createKeyStrategyFactory();
 
 		// Build sub graph A

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/OverAllStateDeltaDataTest.java
@@ -16,6 +16,9 @@
 package com.alibaba.cloud.ai.graph;
 
 import com.alibaba.cloud.ai.graph.action.AsyncNodeAction;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.StateSnapshot;
 import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -162,6 +165,73 @@ public class OverAllStateDeltaDataTest {
 		assertEquals(3, outPutDeltas.size(), "Delta data should contain 3 entries");
 		assertEquals(List.of("a", "b", "c"), outPutDeltas,
 				"Delta output should be [a, b, c]");
+	}
+
+	@Test
+	void testDeltaDataWithSnapshot() throws Exception {
+
+		final String threadId = "test-thread-1";
+
+		KeyStrategyFactory keyStrategyFactory = createKeyStrategyFactory();
+
+		// Build main graph
+		StateGraph mainGraph = new StateGraph(keyStrategyFactory);
+		mainGraph.addNode("a", makeNode("a"));
+		mainGraph.addNode("b", makeNode("b"));
+
+		mainGraph.addEdge(START, "a");
+		mainGraph.addEdge("a", "b");
+		mainGraph.addEdge("b", END);
+
+		CompiledGraph compiledGraph = mainGraph.compile(
+				CompileConfig.builder()
+						.interruptAfter("a")
+						.saverConfig(
+								SaverConfig.builder()
+										.register(new MemorySaver())
+										.build()
+						).build()
+		);
+
+		RunnableConfig runnableConfig = RunnableConfig.builder()
+				.threadId(threadId)
+				.build();
+
+		// First execution to capture snapshot after node "a"
+		OverAllState state = compiledGraph.invoke(Map.of(KEY_OUTPUT, "A"), runnableConfig).orElseThrow();
+		List<Object> output = state.value(KEY_OUTPUT, Collections.emptyList());
+		log.info("Output after first execution: {}", output);
+		assertNotNull(output, "Output should not be null");
+		assertEquals(2, output.size(), "Output should contain 2 elements");
+		assertEquals(List.of("A", "a"), output,
+				"Output should be [A, a]");
+
+		Map<String, Object> deltaData = state.deltaData();
+		assertNotNull(deltaData, "Delta data should not be null");
+		List<String> deltaOutput = (List<String>) deltaData.get(KEY_OUTPUT);
+		assertNotNull(deltaOutput, "Delta data should contain output key");
+		assertEquals(1, deltaOutput.size(), "Delta data should contain 1 entry");
+		assertEquals(List.of("a"), deltaOutput,
+				"Delta output should be [a]");
+
+		// Simulate resuming from snapshot
+		StateSnapshot stateSnapshot = compiledGraph.getState(runnableConfig);
+		OverAllState stateResumed = compiledGraph.invoke(Collections.emptyMap(), stateSnapshot.config()).orElseThrow();
+		List<Object> outputResumed = stateResumed.value(KEY_OUTPUT, Collections.emptyList());
+		log.info("Output after resuming from snapshot: {}", outputResumed);
+		assertNotNull(outputResumed, "Output should not be null");
+		assertEquals(3, outputResumed.size(), "Output should contain 3 elements");
+		assertEquals(List.of("A", "a", "b"), outputResumed,
+				"Output should be [A, a, b]");
+
+		Map<String, Object> deltaDataResumed = stateResumed.deltaData();
+		assertNotNull(deltaDataResumed, "Delta data should not be null");
+		List<String> deltaOutputResumed = (List<String>) deltaDataResumed.get(KEY_OUTPUT);
+		assertNotNull(deltaOutputResumed, "Delta data should contain output key");
+		assertEquals(2, deltaOutputResumed.size(), "Delta data should contain 2 entry");
+		assertEquals(List.of("a", "b"), deltaOutputResumed,
+				"Delta output should be [a, b]");
+
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

当子图共享父图的 AppendStrategy 键时，会导致数据重复记录的问题。例如：
- 父图更新状态添加值 A
- 子图接收状态后再次添加值 B，然后**向父图返回了 [A, B]**
- 最终结果为 [A, A, B] 而非预期的 [A, B]

本 PR 引入可选的增量数据追踪功能，仅记录执行过程中的变更，解决上述问题。

### Does this pull request fix one issue?

Fixes #4305
Fixes #4414

### Describe how you did it

- 在 OverAllState 中引入 deltaData 增量记录，通过内部键 SYSTEM_DELTA_DATA_KEY 存储在 data 中，支持 checkpoint 持久化
- 在 CompileConfig 中添加 enableDeltaTracking 配置项，默认关闭，用户需显式启用
- 在入口节点 START 时初始化空的增量记录
- 从 checkpoint 恢复时自动继承已有的增量记录
- 子图执行时自动继承父图的增量追踪状态
- snapShot() 使用深拷贝确保并行执行时状态隔离
- 使用 Optional 模式简化 mutableDeltaData() 的调用

### Describe how to verify it

运行新增的单元测试：
- OverAllStateDeltaDataTest.testAppendStrategyWithSubGraphs - 验证子图增量追踪
- OverAllStateDeltaDataTest.testAppendStrategyWithParallelNodes - 验证并行节点增量追踪
- OverAllStateDeltaDataTest.testDeltaDataWithSnapshot - 验证 checkpoint 恢复场景
- OverAllStateDeltaDataTest.testDeltaTrackingDisabledByDefault - 验证默认不启用
- OverAllStateDeltaDataTest.testDeltaTrackingEnabledOnlyInSubGraph - 验证子图独立启用

### Special notes for reviews

1. 子图的 MARK_FOR_REMOVAL 操作仍然不会影响父图数据
2. 深拷贝 snapShot() 确保并行分支状态隔离，避免嵌套对象（如 delta map）共享引用
3. 向后兼容：现有工作流无影响，需要增量追踪的用户需显式配置 enableDeltaTracking(true)