### PR TITLE
fix(agent): sync knowledge base search config to agent context

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/impl/AgentServiceImpl.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/impl/AgentServiceImpl.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.cloud.ai.studio.core.base.service.impl;
 
+import com.alibaba.cloud.ai.studio.core.rag.KnowledgeBaseService;
+import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.KnowledgeBase;
 import com.alibaba.cloud.ai.studio.runtime.exception.BizException;
 import com.alibaba.cloud.ai.studio.runtime.enums.AppType;
 import com.alibaba.cloud.ai.studio.runtime.enums.ErrorCode;
@@ -64,6 +66,9 @@ public class AgentServiceImpl implements AgentService {
 	/** Service for managing application configurations */
 	private final AppService appService;
 
+	/** Service for managing knowledge base operations */
+	private final KnowledgeBaseService knowledgeBaseService;
+
 	/** Common configuration settings */
 	private final CommonConfig commonConfig;
 
@@ -73,10 +78,11 @@ public class AgentServiceImpl implements AgentService {
 	/** Executor for workflow agent type */
 	private final AgentExecutor workflowAgentExecutor;
 
-	public AgentServiceImpl(AppService appService, CommonConfig commonConfig,
+	public AgentServiceImpl(AppService appService, CommonConfig commonConfig,KnowledgeBaseService knowledgeBaseService,
 			@Qualifier("basicAgentExecutor") AgentExecutor basicAgentExecutor,
 			@Qualifier("workflowAgentExecutor") AgentExecutor workflowAgentExecutor) {
 		this.appService = appService;
+		this.knowledgeBaseService = knowledgeBaseService;
 		this.commonConfig = commonConfig;
 		this.workflowAgentExecutor = workflowAgentExecutor;
 		this.basicAgentExecutor = basicAgentExecutor;
@@ -177,6 +183,17 @@ public class AgentServiceImpl implements AgentService {
 
 			context.setAppType(app.getType());
 			context.setConfig(JsonUtils.fromJson(configStr, AgentConfig.class));
+
+			// set file search config
+			if(!CollectionUtils.isEmpty(context.getConfig().getFileSearch().getKbIds())) {
+				for (String kbId : context.getConfig().getFileSearch().getKbIds()) {
+					KnowledgeBase kb = knowledgeBaseService.getKnowledgeBase(kbId);
+					Integer topK = kb.getSearchConfig().getTopK();
+					Float similarityThreshold = kb.getSearchConfig().getSimilarityThreshold();
+					context.getConfig().getFileSearch().setTopK(topK);
+					context.getConfig().getFileSearch().setSimilarityThreshold(similarityThreshold);
+				}
+			}
 
 			boolean memoryEnabled = memoryEnabled(context, request);
 			context.setMemoryEnabled(memoryEnabled);


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复创建应用并关联知识库后，发起 AI 对话时因为topN字段为null导致空指针异常的bug。

### Does this pull request fix one issue?
Fixes [#4312 ](https://github.com/alibaba/spring-ai-alibaba/issues/4312)

### Describe how you did it
- 注入 KnowledgeBaseService 服务以管理知识库操作
- 在构造函数中添加 knowledgeBaseService 参数依赖注入
- 实现基于知识库ID的文件搜索配置设置逻辑
- 根据知识库搜索配置动态设置 topK 和相似度阈值参数
- 支持多知识库ID的遍历处理和配置合并

### Describe how to verify it
创建应用并关联知识库后，AI 对话正常完成，未抛出异常。
<img width="2098" height="684" alt="image" src="https://github.com/user-attachments/assets/49113283-970b-48ea-a35b-4da3e17c9398" />


### Special notes for reviews
