### PR TITLE
fix: agent studio repeated output and disorder

### DIFF
--- a/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/agent/studio/controller/ExecutionController.java
+++ b/spring-ai-alibaba-studio/src/main/java/com/alibaba/cloud/ai/agent/studio/controller/ExecutionController.java
@@ -178,7 +178,7 @@ public class ExecutionController {
 					.addMetadata("user_id", request.userId)
 					.build();
 
-			return executeAgent(request.newMessage.toUserMessage(), agent, runnableConfig);
+			return executeAgent(request.newMessage.toUserMessage(), agent, runnableConfig).cache();
 		}
 		catch (Exception e) {
 			log.error("Error during agent run for session {}", request.threadId, e);
@@ -239,7 +239,7 @@ public class ExecutionController {
 					.addHumanFeedback(metadataBuilder.build())
 					.build();
 
-			return executeAgent(null, agent, runnableConfig);
+			return executeAgent(null, agent, runnableConfig).cache();
 		}
 		catch (Exception e) {
 			log.error("Error during agent run for session {}", request.threadId, e);
@@ -281,8 +281,14 @@ public class ExecutionController {
 									.build();
 						}
 						if (message instanceof AssistantMessage assistantMessage) {
+							String finishReason = message.getMetadata().get("finishReason").toString();
 							if (assistantMessage.hasToolCalls()) {
 								agentResponse = new AgentRunResponse(node, agentName, assistantMessage, tokenUsage, "");
+							}
+							else if ("STOP".equals(finishReason)) {
+								return ServerSentEvent.<String>builder()
+										.data("{}")
+										.build();
 							}
 							else {
 //						chunkBuilder.append(assistantMessage.getText());


### PR DESCRIPTION
### Describe what this PR does / why we need it
修复：spring-ai-alibaba-studio界面, 响应内容为「逐片文本 + 完整拼接文本」的重复内容且是乱序的问题
核心原因：transformFluxToGraphResponse 方法末尾的 concatWith 逻辑会在流式结束后，额外返回聚合后的完整 ChatResponse，与分片文本重复
<img width="2538" height="1624" alt="image" src="https://github.com/user-attachments/assets/eae3f422-c6d3-45ae-aa5f-2928b7c53863" />

### Does this pull request fix one issue?

Fixes #3993 

### Describe how you did it
修改com.alibaba.cloud.ai.agent.studio.controller.ExecutionController类
1. 解决内容重复问题: 在 executeAgent 方法中，识别并过滤流式结束的完整拼接文本响应，仅保留逐片分片输出
2. 解决乱序问题: 对 executeAgent 方法的返回结果Flux<ServerSentEvent<String>>调用.cache()方法

### Describe how to verify it
1. 启动 spring-ai-alibaba-studio 服务，打开 Agent Chat 界面；
2. 输入任意流式对话指令（如“介绍家附近的超市”），观察响应输出：
   - 预期结果1（无重复）：仅展示逐片流式文本，无最后一条完整拼接文本；
   - 预期结果2（无乱序）：分片文本按自然语言顺序输出（如“你好”→“！”→“推荐以下超市”，无交叉/颠倒）；

### Special notes for reviews
