### PR TITLE
fix(graph): validate convergence targets in addParallelConditionalEdges

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -176,11 +176,18 @@ public class CompiledGraph {
 						}
 
 						var parallelNodeTargets = findParallelNodeTargets(mappedNodeIds);
-						if (!parallelNodeTargets.isEmpty()) {
+						if (parallelNodeTargets.size() > 1) {
+							// Multiple convergence targets found - this is ambiguous and not allowed
+							throw Errors.inconsistentConvergenceTargetsOnConditionalParallelEdge
+									.exception(e.sourceId(), parallelNodeTargets);
+						}
+						else if (!parallelNodeTargets.isEmpty()) {
 							// Set edge from ConditionalParallelNode to the next node
 							// All parallel nodes point to the same target, use that target
-							edges.put(conditionalParallelNode.id(), new EdgeValue(parallelNodeTargets.iterator().next()));
-						} else {
+							edges.put(conditionalParallelNode.id(),
+									new EdgeValue(parallelNodeTargets.iterator().next()));
+						}
+						else {
 							throw Errors.illegalMultipleTargetsOnParallelNode.exception(e.sourceId(), 0);
 						}
 						// The ConditionalParallelNode will handle parallel execution internally

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/exception/Errors.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/exception/Errors.java
@@ -35,6 +35,8 @@ public enum Errors {
 	unsupportedConditionalEdgeOnParallelNode(
 			"parallel node doesn't support conditional branch, but on [%s] a conditional branch on %s have been found!"),
 	illegalMultipleTargetsOnParallelNode("parallel node [%s] must have only one target, but %s have been found!"),
+	inconsistentConvergenceTargetsOnConditionalParallelEdge(
+			"all mapped nodes in conditional parallel edge from '%s' must have edges pointing to the same convergence node, but found multiple targets: %s"),
 	interruptionNodeNotExist("node '%s' configured as interruption doesn't exist!"),
 	emptySourceNodeByEdge("Source nodeIds missing for addEdges(sourceIds, %s)!"),
 	emptyTargetNodeByEdge("Target nodeIds missing for addEdges(%s, targetIds)!");

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
@@ -1851,6 +1851,59 @@ public class StateGraphTest {
 	}
 
 	/**
+	 * Tests that addParallelConditionalEdges throws an exception when mapped nodes
+	 * have edges pointing to different convergence targets.
+	 * This validates the fix for inconsistent convergence targets issue.
+	 */
+	@Test
+	public void testAddParallelConditionalEdgesWithInconsistentConvergenceTargets() throws Exception {
+		StateGraph workflow = new StateGraph(() -> {
+			Map<String, KeyStrategy> keyStrategyMap = new HashMap<>();
+			keyStrategyMap.put("messages", new AppendStrategy());
+			return keyStrategyMap;
+		});
+
+		// Setup nodes: node_a and node_b point to different targets
+		workflow.addNode("start", node_async(state -> Map.of("messages", "start")))
+				.addNode("conditional_node", node_async(state -> Map.of("messages", "processing")))
+				.addNode("node_a", node_async(state -> Map.of("messages", "node_a_result")))
+				.addNode("node_b", node_async(state -> Map.of("messages", "node_b_result")))
+				.addNode("convergence_a", node_async(state -> Map.of("messages", "convergence_a")))
+				.addNode("convergence_b", node_async(state -> Map.of("messages", "convergence_b")))
+				.addNode("end", node_async(state -> Map.of("messages", "end")));
+
+		// Add conditional edges with parallel routing
+		workflow.addParallelConditionalEdges(
+				"conditional_node",
+				AsyncMultiCommandAction.node_async((state, config) ->
+						new MultiCommand(List.of("route_a", "route_b"))
+				),
+				Map.of(
+						"route_a", "node_a",
+						"route_b", "node_b"
+				)
+		);
+
+		// Set up edges such that node_a and node_b point to DIFFERENT targets
+		// This should cause a GraphStateException during compilation
+		workflow.addEdge(START, "start")
+				.addEdge("start", "conditional_node")
+				.addEdge("node_a", "convergence_a")  // Points to convergence_a
+				.addEdge("node_b", "convergence_b")  // Points to convergence_b (different!)
+				.addEdge("convergence_a", "end")
+				.addEdge("convergence_b", "end")
+				.addEdge("end", END);
+
+		// Compilation should throw GraphStateException due to inconsistent convergence targets
+		GraphStateException exception = assertThrows(GraphStateException.class, workflow::compile);
+
+		// Verify the error message mentions the inconsistency
+		assertTrue(exception.getMessage().contains("conditional_node"));
+		assertTrue(exception.getMessage().contains("convergence"));
+		log.info("Expected exception thrown: {}", exception.getMessage());
+	}
+
+	/**
 	 * Used to provide test data for the testWithSubSerialize method
 	 *
 	 * @param name


### PR DESCRIPTION
## Summary

Fixes #4411

When using `addParallelConditionalEdges()`, if different route branches' mapped nodes have edges pointing to **different convergence targets**, `findParallelNodeTargets()` returns a `Set` with multiple elements. `HashSet.iterator().next()` then silently picks one **non-deterministically**, causing the `ConditionalParallelNode` to route to an unpredictable next node after parallel execution.

## Root Cause

In `CompiledGraph` constructor, when processing conditional parallel edges:

1. `findParallelNodeTargets()` collects each route branch node's edge target into a `Set<String>`
2. If node_a -> convergence and node_b -> some_other_node, the Set contains 2 elements
3. `parallelNodeTargets.iterator().next()` picks whichever element HashSet happens to return first - this is **non-deterministic**

## Fix

Added **compile-time validation** in `CompiledGraph`: when `parallelNodeTargets.size() > 1`, throw `GraphStateException` with a clear error message listing the conflicting convergence targets, rather than silently picking a random one.

This approach aligns with the issue reporter's suggestion: *'findParallelNodeTargets returns multiple targets should throw GraphStateException'*

## Changes

| File | Change |
|------|--------|
| `CompiledGraph.java` | Added `size() > 1` validation check before `iterator().next()` |
| `Errors.java` | Added `inconsistentConvergenceTargetsOnConditionalParallelEdge` error constant |
| `StateGraphTest.java` | Added regression test with inconsistent convergence targets |

## Test

All 4 `testAddParallelConditionalEdges*` tests pass (BUILD SUCCESS).