### PR TITLE
fix(graph): add JsonCreator for InterruptionMetadata to support Jackson deserialization

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/action/InterruptionMetadata.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/action/InterruptionMetadata.java
@@ -19,8 +19,10 @@ import com.alibaba.cloud.ai.graph.HasMetadata;
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.utils.CollectionsUtils;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.Usage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +54,26 @@ public final class InterruptionMetadata extends NodeOutput implements HasMetadat
 		} else {
 			this.toolsAutomaticallyApproved = new ArrayList<>();
 		}
+	}
+
+	/**
+	 * Jackson deserialization constructor.
+	 */
+	@JsonCreator
+	public InterruptionMetadata(
+			@JsonProperty("node") String node,
+			@JsonProperty("agent") String agent,
+			@JsonProperty("state") OverAllState state,
+			@JsonProperty("subGraph") boolean subGraph,
+			@JsonProperty("tokenUsage") Usage tokenUsage,
+			@JsonProperty("metadata") Map<String, Object> metadata,
+			@JsonProperty("toolFeedbacks") List<ToolFeedback> toolFeedbacks,
+			@JsonProperty("toolsAutomaticallyApproved") List<AssistantMessage.ToolCall> toolsAutomaticallyApproved) {
+		super(node, agent, tokenUsage, state);
+		this.setSubGraph(subGraph);
+		this.metadata = metadata != null ? metadata : Map.of();
+		this.toolFeedbacks = toolFeedbacks != null ? new ArrayList<>(toolFeedbacks) : new ArrayList<>();
+		this.toolsAutomaticallyApproved = toolsAutomaticallyApproved != null ? new ArrayList<>(toolsAutomaticallyApproved) : new ArrayList<>();
 	}
 
 	/**
@@ -199,7 +221,13 @@ public final class InterruptionMetadata extends NodeOutput implements HasMetadat
 		FeedbackResult result;
 		String description;
 
-		public ToolFeedback(String id, String name, String arguments, FeedbackResult result, String description) {
+		@JsonCreator
+		public ToolFeedback(
+				@JsonProperty("id") String id,
+				@JsonProperty("name") String name,
+				@JsonProperty("arguments") String arguments,
+				@JsonProperty("result") FeedbackResult result,
+				@JsonProperty("description") String description) {
 			this.id = id;
 			this.name = name;
 			this.arguments = arguments;

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/action/InterruptionMetadata.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/action/InterruptionMetadata.java
@@ -60,7 +60,7 @@ public final class InterruptionMetadata extends NodeOutput implements HasMetadat
 	 * Jackson deserialization constructor.
 	 */
 	@JsonCreator
-	public InterruptionMetadata(
+	InterruptionMetadata(
 			@JsonProperty("node") String node,
 			@JsonProperty("agent") String agent,
 			@JsonProperty("state") OverAllState state,


### PR DESCRIPTION
### Describe what this PR does / why we need it
When building a graph where a node implements `InterruptableAction`, if that node is the last one before the `end` node, the system currently throws an `IllegalArgumentException` during Jackson deserialization. 

This occurs because `InterruptionMetadata` and its inner class `ToolFeedback` lack proper Jackson annotations. This PR adds `@JsonCreator` and `@JsonProperty` to the relevant constructors to ensure the graph state can be correctly reconstructed from JSON.

```java
java.lang.IllegalArgumentException: Cannot construct instance of `com.alibaba.cloud.ai.graph.action.InterruptionMetadata` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
```

### Does this pull request fix one issue?
NONE

### Describe how you did it
* Added `@JsonCreator` and `@JsonProperty` annotations to the constructor of `InterruptionMetadata`.
* Added `@JsonCreator` and `@JsonProperty` annotations to the `ToolFeedback` inner class constructor.
* Ensured collection fields (`metadata`, `toolFeedbacks`, etc.) handle null values gracefully during deserialization to prevent `NullPointerException`.

### Describe how to verify it
1. Create a graph with an `InterruptableAction` node as the penultimate node (before `end`).
2. Trigger the interruption and attempt to serialize/deserialize the graph state.
3. Verify that the `IllegalArgumentException` no longer occurs and the state is correctly restored.