### PR TITLE
fix(graph): validate conditional parallel convergence

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -176,13 +176,16 @@ public class CompiledGraph {
 						}
 
 						var parallelNodeTargets = findParallelNodeTargets(mappedNodeIds);
-						if (!parallelNodeTargets.isEmpty()) {
-							// Set edge from ConditionalParallelNode to the next node
-							// All parallel nodes point to the same target, use that target
-							edges.put(conditionalParallelNode.id(), new EdgeValue(parallelNodeTargets.iterator().next()));
-						} else {
-							throw Errors.illegalMultipleTargetsOnParallelNode.exception(e.sourceId(), 0);
+						if (parallelNodeTargets.size() != 1) {
+							throw Errors.inconsistentConditionalParallelTargets.exception(
+									e.sourceId(),
+									parallelNodeTargets,
+									mappedNodeIds);
 						}
+
+						// Set edge from ConditionalParallelNode to the next node
+						// All parallel nodes point to the same target, use that target
+						edges.put(conditionalParallelNode.id(), new EdgeValue(parallelNodeTargets.iterator().next()));
 						// The ConditionalParallelNode will handle parallel execution internally
 					} else {
 						// Single Command action - same as regular single target edge

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/exception/Errors.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/exception/Errors.java
@@ -35,6 +35,8 @@ public enum Errors {
 	unsupportedConditionalEdgeOnParallelNode(
 			"parallel node doesn't support conditional branch, but on [%s] a conditional branch on %s have been found!"),
 	illegalMultipleTargetsOnParallelNode("parallel node [%s] must have only one target, but %s have been found!"),
+	inconsistentConditionalParallelTargets(
+			"conditional multi-command mappings from node '%s' must converge to a single target, but found targets %s from mapped nodes %s!"),
 	interruptionNodeNotExist("node '%s' configured as interruption doesn't exist!"),
 	emptySourceNodeByEdge("Source nodeIds missing for addEdges(sourceIds, %s)!"),
 	emptyTargetNodeByEdge("Target nodeIds missing for addEdges(%s, targetIds)!");

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
@@ -1715,6 +1715,54 @@ public class StateGraphTest {
 	}
 
 	/**
+	 * Tests addParallelConditionalEdges rejects mapped nodes that do not converge to the
+	 * same direct successor.
+	 */
+	@Test
+	public void testAddParallelConditionalEdgesRejectsNonConvergingTargets() throws Exception {
+		StateGraph workflow = new StateGraph(() -> {
+			Map<String, KeyStrategy> keyStrategyMap = new HashMap<>();
+			keyStrategyMap.put("messages", new AppendStrategy());
+			return keyStrategyMap;
+		});
+
+		workflow.addNode("start", node_async(state -> Map.of("messages", "start")))
+				.addNode("conditional_node", node_async(state -> Map.of("messages", "processing")))
+				.addNode("node_a", node_async(state -> Map.of("messages", "node_a_result")))
+				.addNode("node_b", node_async(state -> Map.of("messages", "node_b_result")))
+				.addNode("skip_1", node_async(state -> Map.of("messages", "skip_1_result")))
+				.addNode("skip_2", node_async(state -> Map.of("messages", "skip_2_result")))
+				.addNode("convergence", node_async(state -> Map.of("messages", "convergence")))
+				.addNode("end", node_async(state -> Map.of("messages", "end")));
+
+		workflow.addParallelConditionalEdges(
+				"conditional_node",
+				AsyncMultiCommandAction.node_async((state, config) ->
+						new MultiCommand(List.of("route_a", "route_b", "route_skip"))
+				),
+				Map.of(
+						"route_a", "node_a",
+						"route_b", "node_b",
+						"route_skip", "skip_1"
+				)
+		);
+
+		workflow.addEdge(START, "start")
+				.addEdge("start", "conditional_node")
+				.addEdge("node_a", "convergence")
+				.addEdge("node_b", "convergence")
+				.addEdge("skip_1", "skip_2")
+				.addEdge("skip_2", "convergence")
+				.addEdge("convergence", "end")
+				.addEdge("end", END);
+
+		GraphStateException exception = assertThrows(GraphStateException.class, workflow::compile);
+		assertTrue(exception.getMessage().contains("conditional_node"));
+		assertTrue(exception.getMessage().contains("convergence"));
+		assertTrue(exception.getMessage().contains("skip_2"));
+	}
+
+	/**
 	 * Tests addParallelConditionalEdges with single node (edge case).
 	 * Verifies that even when only one node is returned, it still works correctly.
 	 */


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR adds compile-time validation for `addParallelConditionalEdges` so that all mapped target nodes must converge to the same direct successor.

Previously, `CompiledGraph` only checked whether mapped nodes had outgoing edges. If those edges pointed to different targets, it still selected one target from a `Set`, which could lead to nondeterministic routing behavior at runtime.

This change makes that invalid graph definition fail fast with a clear `GraphStateException` instead of producing silent or unstable behavior.

### Does this pull request fix one issue?

Fixes #4411

### Describe how you did it

- Added validation in `CompiledGraph` to require exactly one direct successor across all mapped nodes in a conditional multi-command branch.
- Added a dedicated error message for inconsistent conditional parallel convergence.
- Added a regression test covering the case where two routes converge directly but one route goes through an intermediate node first.

### Describe how to verify it

Run:

```bash
./mvnw.cmd -pl spring-ai-alibaba-graph-core -Dtest=StateGraphTest#testAddParallelConditionalEdgesRejectsNonConvergingTargets+testAddParallelConditionalEdges+testAddParallelConditionalEdgesDynamic+testAddParallelConditionalEdgesWithSingleNode test
