### PR TITLE
Add null check for tool call arguments in TokenCounter

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/TokenCounter.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/TokenCounter.java
@@ -71,7 +71,10 @@ public interface TokenCounter {
 					// Count tokens in tool calls
 					for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
 						// Count tokens in tool arguments (JSON string)
-						total += toolCall.arguments().length() / charsPerToken;
+						//加判空，不然无参数工具会报错
+						if(toolCall.arguments()!=null){
+						  total += toolCall.arguments().length() / charsPerToken;
+						}
 					}
 				}
 				// Handle other message types


### PR DESCRIPTION
Added null check for tool call arguments to prevent errors.

spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/TokenCounter.java
### Describe what this PR does / why we need it

在压缩消息中，工具调用的没有参数的话 报错
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
FIx  在压缩消息中，工具调用的没有参数的话 报错

	for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
						// Count tokens in tool arguments (JSON string)
						total += toolCall.arguments().length() / charsPerToken;
						//加判空，不然无参数工具会报错
						if(toolCall.arguments()!=null){
						  total += toolCall.arguments().length() / charsPerToken;
						}
					}
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
