### PR TITLE
fix: 修复多轮 Agent 调用中 token 用量累加问题 (alibaba#4488)

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
@@ -240,7 +240,21 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 			// Execute the chained handler
 			ModelResponse modelResponse = chainedHandler.call(modelRequest);
-			return Map.of(StringUtils.hasLength(this.outputKey) ? this.outputKey : "messages", modelResponse.getMessage());
+
+			Map<String, Object> updatedState = new HashMap<>();
+			updatedState.put("messages", modelResponse.getMessage());
+			if (StringUtils.hasLength(this.outputKey)) {
+				updatedState.put(this.outputKey, modelResponse.getMessage());
+			}
+			// 流式模式下 getChatResponse() 通常为 null（ModelResponse.of(Flux) 不持有 ChatResponse）。
+			// 实际 usage 由 NodeExecutor 的 latestUsageRef 捕获。
+			// 这里放入 EmptyUsage 占位，确保 _TOKEN_USAGE_ key 存在以触发下游累加逻辑。
+			Usage tokenUsage = modelResponse.getChatResponse() != null
+					? modelResponse.getChatResponse().getMetadata().getUsage()
+					: new EmptyUsage();
+			updatedState.put("_TOKEN_USAGE_", tokenUsage);
+
+			return updatedState;
 		} else {
 			// Create base handler that actually calls the model
 			ModelCallHandler baseHandler = request -> {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -29,6 +29,7 @@ import com.alibaba.cloud.ai.graph.utils.SystemClock;
 import com.alibaba.cloud.ai.graph.utils.TypeRef;
 
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.Usage;
 
 import org.springframework.util.CollectionUtils;
@@ -341,22 +342,47 @@ public class GraphRunnerContext {
 	}
 
 	/**
-	 * FIXME, this method is a temporary fix to separate Usage from state updates.
-	 * works together with AgentLlmNode non-stream node.
+	 * 从状态更新中分离 Usage 对象，并跨多轮模型调用累加 token 用量。
+	 * 与 AgentLlmNode 的流式/非流式分支配合使用。
 	 */
 	private Map<String, Object> findTokenUsageInDeltaState(Map<String, Object> updateState) {
 		Map<String, Object> filteredState = new HashMap<>();
 		for (Map.Entry<String, Object> entry : updateState.entrySet()) {
 			Object value = entry.getValue();
 			if (value instanceof Usage && entry.getKey().equals("_TOKEN_USAGE_")) {
-				// Assign ChatResponse to this.chatResponse
-				this.tokenUsage = (Usage) value;
+				accumulateTokenUsage((Usage) value);
 			} else {
-				// Add non-ChatResponse entries to the filtered map
+				// 非 Usage 条目正常放入过滤后的 state
 				filteredState.put(entry.getKey(), value);
 			}
 		}
 		return filteredState;
+	}
+
+	/**
+	 * 累加多轮模型调用的 token 用量，而非覆盖。
+	 * 在多轮 Agent 场景（如工具调用）中，每轮消耗的 token 都应被统计。
+	 */
+	private void accumulateTokenUsage(Usage newUsage) {
+		if (newUsage == null || (newUsage.getTotalTokens() != null && newUsage.getTotalTokens() == 0
+				&& (newUsage.getPromptTokens() == null || newUsage.getPromptTokens() == 0)
+				&& (newUsage.getCompletionTokens() == null || newUsage.getCompletionTokens() == 0))) {
+			return;
+		}
+		if (this.tokenUsage == null
+				|| (this.tokenUsage.getTotalTokens() != null && this.tokenUsage.getTotalTokens() == 0
+						&& (this.tokenUsage.getPromptTokens() == null || this.tokenUsage.getPromptTokens() == 0))) {
+			this.tokenUsage = newUsage;
+		} else {
+			int accPrompt = safeAdd(this.tokenUsage.getPromptTokens(), newUsage.getPromptTokens());
+			int accCompletion = safeAdd(this.tokenUsage.getCompletionTokens(), newUsage.getCompletionTokens());
+			int accTotal = safeAdd(this.tokenUsage.getTotalTokens(), newUsage.getTotalTokens());
+			this.tokenUsage = new DefaultUsage(accPrompt, accCompletion, accTotal);
+		}
+	}
+
+	private static int safeAdd(Integer a, Integer b) {
+		return (a != null ? a : 0) + (b != null ? b : 0);
 	}
 
 	// ================================================================================================================

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 
@@ -226,8 +227,19 @@ public class NodeExecutor extends BaseGraphExecutor {
 			GraphRunnerContext context, Flux<?> rawFlux, String key, String nodeId) {
 		var lastChatResponseRef = new AtomicReference<ChatResponse>(null);
 		var lastGraphResponseRef = new AtomicReference<GraphResponse<NodeOutput>>(null);
+		var latestUsageRef = new AtomicReference<Usage>(null);
 
-		return rawFlux.filter(element -> {
+		return rawFlux.doOnNext(element -> {
+				// 在 filter 之前捕获所有 ChatResponse chunk 的 usage，包括 result==null 的纯 usage chunk。
+				// 确保 DashScope streamUsage=true 最后一个 chunk 的 usage 数据不会被 filter 丢弃。
+				if (element instanceof ChatResponse response && response.getMetadata() != null) {
+					Usage usage = response.getMetadata().getUsage();
+					if (usage != null && usage.getTotalTokens() != null && usage.getTotalTokens() > 0) {
+						latestUsageRef.set(usage);
+					}
+				}
+			})
+			.filter(element -> {
 				// skip ChatResponse.getResult() == null
 				if (element instanceof ChatResponse response) {
 					return response.getResult() != null &&  response.getResult().getOutput() != null;
@@ -348,8 +360,16 @@ public class NodeExecutor extends BaseGraphExecutor {
 						// For agent model completion, use null message to prevent chunk content
 						messageForCompletion = null;
 					}
-					GraphResponse<NodeOutput> aggregatedResponse = GraphResponse
-						.of(context.buildStreamingOutput(messageForCompletion, lastChatResponse, nodeId, false));
+					StreamingOutput<?> completionOutput = context.buildStreamingOutput(messageForCompletion, lastChatResponse, nodeId, false);
+					// 将之前 doOnNext 捕获的 usage 应用到完成输出（仅当输出本身没有有效 usage 时）
+					Usage capturedUsage = latestUsageRef.get();
+					if (capturedUsage != null) {
+						Usage existingUsage = completionOutput.tokenUsage();
+						if (existingUsage == null || existingUsage.getTotalTokens() == null || existingUsage.getTotalTokens() == 0) {
+							completionOutput.setTokenUsage(capturedUsage);
+						}
+					}
+					GraphResponse<NodeOutput> aggregatedResponse = GraphResponse.of(completionOutput);
 					// Then emit the completion response
 					Map<String, Object> completionResult = new HashMap<>();
 					completionResult.put(key, lastChatResponse.getResult().getOutput());

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/TokenUsageAccumulationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/TokenUsageAccumulationTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.stream.LLmNodeAction;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Token 用量累加和流式 usage 捕获的回归测试。
+ *
+ * <p>验证 issue #4488 的两个核心修复：
+ * <ol>
+ *   <li>NodeExecutor 在 filter 之前通过 doOnNext 捕获 usage-only chunk（result==null）的 usage 数据</li>
+ *   <li>GraphRunnerContext 跨多轮调用累加 usage，而非覆盖</li>
+ * </ol>
+ */
+public class TokenUsageAccumulationTest {
+
+	private static final Logger log = LoggerFactory.getLogger(TokenUsageAccumulationTest.class);
+
+	/**
+	 * 创建模拟 DashScope streamUsage=true 的 mock ChatModel。
+	 * 流式返回的最后一个 chunk 是 usage-only chunk（result 为 null，仅携带 usage 元数据）。
+	 */
+	private static ChatModel createStreamingChatModelWithUsageOnlyChunk(int promptTokens, int completionTokens) {
+		return new ChatModel() {
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				Usage usage = new DefaultUsage(promptTokens, completionTokens);
+				ChatResponseMetadata metadata = ChatResponseMetadata.builder()
+						.usage(usage)
+						.build();
+				return new ChatResponse(List.of(new Generation(new AssistantMessage("Hello"))), metadata);
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				// 正常内容 chunk（无 usage）
+				ChatResponse chunk1 = new ChatResponse(List.of(new Generation(new AssistantMessage("Hel"))));
+				ChatResponse chunk2 = new ChatResponse(List.of(new Generation(new AssistantMessage("lo"))));
+
+				// Usage-only chunk：有 usage 元数据但 result 为 null
+				Usage usage = new DefaultUsage(promptTokens, completionTokens);
+				ChatResponseMetadata usageMetadata = ChatResponseMetadata.builder()
+						.usage(usage)
+						.build();
+				// 模拟 DashScope 的 usage-only chunk，getResult() 返回 null
+				ChatResponse usageOnlyChunk = new ChatResponse(List.of(), usageMetadata);
+
+				return Flux.concat(
+						Flux.just(chunk1),
+						Mono.delay(Duration.ofMillis(5)).map(i -> chunk2),
+						Mono.delay(Duration.ofMillis(5)).map(i -> usageOnlyChunk)
+				);
+			}
+		};
+	}
+
+	/**
+	 * 测试：流式传输中的 usage-only chunk 应被 NodeExecutor 正确捕获。
+	 *
+	 * <p>当 DashScope 返回的最后一个 chunk 是 result==null 的 usage-only chunk 时，
+	 * NodeExecutor 的 doOnNext 会在 filter 丢弃该 chunk 之前捕获其 usage，
+	 * 然后在 concatWith 完成时将捕获的 usage 应用到 StreamingOutput。
+	 */
+	@Test
+	public void testStreamingUsageOnlyChunkCaptured() throws Exception {
+		ChatModel chatModel = createStreamingChatModelWithUsageOnlyChunk(100, 50);
+
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> keyStrategyMap = new HashMap<>();
+			keyStrategyMap.put("messages", new AppendStrategy());
+			return keyStrategyMap;
+		}).addNode("llmNode", node_async(new LLmNodeAction(chatModel, "llmNode")))
+				.addEdge(START, "llmNode")
+				.addEdge("llmNode", END);
+
+		CompiledGraph compiledGraph = stateGraph.compile();
+
+		Map<String, Object> input = new HashMap<>();
+		input.put(OverAllState.DEFAULT_INPUT_KEY, "test");
+
+		CountDownLatch latch = new CountDownLatch(1);
+		AtomicReference<Usage> capturedUsage = new AtomicReference<>();
+		AtomicReference<Throwable> error = new AtomicReference<>();
+
+		compiledGraph.stream(input)
+				.doOnNext(output -> {
+					Usage usage = output.tokenUsage();
+					if (usage != null && usage.getTotalTokens() != null && usage.getTotalTokens() > 0) {
+						capturedUsage.set(usage);
+						log.info("Captured usage: prompt={}, completion={}, total={}",
+								usage.getPromptTokens(), usage.getCompletionTokens(), usage.getTotalTokens());
+					}
+				})
+				.doOnError(error::set)
+				.doFinally(signal -> latch.countDown())
+				.subscribe();
+
+		assertTrue(latch.await(10, TimeUnit.SECONDS), "流应在 10 秒内完成");
+		assertNull(error.get(), "流应无错误完成");
+
+		Usage usage = capturedUsage.get();
+		assertNotNull(usage, "usage-only chunk 的 usage 应被 NodeExecutor 捕获");
+		assertEquals(100, usage.getPromptTokens(), "promptTokens 应为 100");
+		assertEquals(50, usage.getCompletionTokens(), "completionTokens 应为 50");
+		assertEquals(150, usage.getTotalTokens(), "totalTokens 应为 150");
+
+		log.info("测试通过：usage-only chunk 成功捕获");
+	}
+
+	/**
+	 * 测试：GraphRunnerContext 跨多个节点执行时累加 usage。
+	 *
+	 * <p>模拟一个两节点串行图，每个节点产生不同的 usage。
+	 * 最终输出应包含两个节点的累加 usage。
+	 */
+	@Test
+	public void testUsageAccumulationAcrossNodes() throws Exception {
+		// 节点 1：产生 100 prompt + 50 completion tokens
+		ChatModel chatModel1 = createStreamingChatModelWithUsageOnlyChunk(100, 50);
+		// 节点 2：产生 80 prompt + 40 completion tokens
+		ChatModel chatModel2 = createStreamingChatModelWithUsageOnlyChunk(80, 40);
+
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> keyStrategyMap = new HashMap<>();
+			keyStrategyMap.put("messages", new AppendStrategy());
+			return keyStrategyMap;
+		}).addNode("node1", node_async(new LLmNodeAction(chatModel1, "node1")))
+				.addNode("node2", node_async(new LLmNodeAction(chatModel2, "node2")))
+				.addEdge(START, "node1")
+				.addEdge("node1", "node2")
+				.addEdge("node2", END);
+
+		CompiledGraph compiledGraph = stateGraph.compile();
+
+		Map<String, Object> input = new HashMap<>();
+		input.put(OverAllState.DEFAULT_INPUT_KEY, "test accumulation");
+
+		CountDownLatch latch = new CountDownLatch(1);
+		AtomicReference<Usage> lastUsage = new AtomicReference<>();
+		AtomicReference<Throwable> error = new AtomicReference<>();
+
+		compiledGraph.stream(input)
+				.doOnNext(output -> {
+					Usage usage = output.tokenUsage();
+					if (usage != null && usage.getTotalTokens() != null && usage.getTotalTokens() > 0) {
+						lastUsage.set(usage);
+					}
+				})
+				.doOnError(error::set)
+				.doFinally(signal -> latch.countDown())
+				.subscribe();
+
+		assertTrue(latch.await(10, TimeUnit.SECONDS), "流应在 10 秒内完成");
+		assertNull(error.get(), "流应无错误完成");
+
+		Usage finalUsage = lastUsage.get();
+		assertNotNull(finalUsage, "最终输出应包含累加后的 usage");
+		log.info("最终累加 usage：prompt={}, completion={}, total={}",
+				finalUsage.getPromptTokens(), finalUsage.getCompletionTokens(), finalUsage.getTotalTokens());
+
+		// 累加后的 usage 应大于等于第一个节点的 usage
+		assertTrue(finalUsage.getPromptTokens() >= 80,
+				"累加后 prompt tokens 应至少为 80");
+		assertTrue(finalUsage.getCompletionTokens() >= 40,
+				"累加后 completion tokens 应至少为 40");
+	}
+
+}


### PR DESCRIPTION
## 根因分析

在多轮 Agent 工具调用场景中，用户观察到前端显示的 token 用量（约 4 万）
远低于 DashScope 实际计费（约 20 万）。原因是三个 Bug 协同导致：

1. **NodeExecutor**: 流式传输中 DashScope 的 streamUsage=true 最后一个 chunk 是 usage-only chunk（result==null，仅携带 usage 元数据），但原代码 的 filter() 在 doOnNext() 之前执行，导致这个 chunk 被直接丢弃，usage 丢失。

2. **AgentLlmNode**: 流式分支返回 Map.of("messages", msg)，没有 _TOKEN_USAGE_ key，下游 GraphRunnerContext.findTokenUsageInDeltaState() 无法找到 usage 数据。

3. **GraphRunnerContext**: 每轮调用发现 _TOKEN_USAGE_ 时直接 this.tokenUsage = newUsage 覆盖旧值，多轮调用只保留最后一轮的 token 数。

## 修复内容

1. **NodeExecutor**: 在 filter() 之前添加 doOnNext() 捕获所有 chunk 的 usage 到 latestUsageRef；在 concatWith 完成时将捕获的 usage 应用到 StreamingOutput。

2. **AgentLlmNode**: 流式分支改用 HashMap，加入 _TOKEN_USAGE_ key （EmptyUsage 占位符），确保下游能触发 usage 收集逻辑。

3. **GraphRunnerContext**: findTokenUsageInDeltaState() 改为调用 accumulateTokenUsage()，使用 DefaultUsage 累加各轮的 prompt/completion/total。

## 测试

新增 TokenUsageAccumulationTest（2 个端到端测试）：
- testStreamingUsageOnlyChunkCaptured: 验证 usage-only chunk 被正确捕获
- testUsageAccumulationAcrossNodes: 验证多节点执行时 usage 正确累加

## 修复后的正确数据流（详细版）

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                           第 1 轮 LLM 调用                                    │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  ┌──────────────────────────────────────────────────────────────────────┐   │
│  │ 1. DashScope API 返回流式响应 (streamUsage=true)                      │   │
│  │    chunk1: {content: "我需要调用", result: Output, usage: null}       │   │
│  │    chunk2: {content: "search工具", result: Output, usage: null}       │   │
│  │    chunk3: {content: null, result: null, usage: {5000,2000,7000}}     │   │
│  └──────────────────────────────────────────────────────────────────────┘   │
│                                    ↓                                         │
│  ┌──────────────────────────────────────────────────────────────────────┐   │
│  │ 2. NodeExecutor 处理流 【Fix 1】                                       │   │
│  │                                                                       │   │
│  │    AtomicReference<Usage> latestUsageRef = new AtomicReference<>();   │   │
│  │                                                                       │   │
│  │    .doOnNext(response -> {                    // ← 先执行，捕获所有    │   │
│  │        if (response.getMetadata().getUsage() != null) {              │   │
│  │            latestUsageRef.set(response.getMetadata().getUsage());    │   │
│  │        }                                                              │   │
│  │    })                                                                 │   │
│  │    .filter(response -> response.getResult() != null)  // ← 后过滤     │   │
│  │                                                                       │   │
│  │    chunk1: doOnNext(usage=null) → filter(✅通过) → 输出               │   │
│  │    chunk2: doOnNext(usage=null) → filter(✅通过) → 输出               │   │
│  │    chunk3: doOnNext(usage={5000,2000,7000}) → filter(❌丢弃)          │   │
│  │            ↑ 但 usage 已保存到 latestUsageRef！                       │   │
│  │                                                                       │   │
│  │    流完成时 concatWith:                                                │   │
│  │      completionOutput.setUsage(latestUsageRef.get())                 │   │
│  │      // usage = {prompt:5000, completion:2000, total:7000}           │   │
│  └──────────────────────────────────────────────────────────────────────┘   │
│                                    ↓                                         │
│  ┌──────────────────────────────────────────────────────────────────────┐   │
│  │ 3. AgentLlmNode 构建返回值 【Fix 2】                                    │   │
│  │                                                                       │   │
│  │    // 原代码: return Map.of("messages", msg);  ← 不可变，无法加 key   │   │
│  │                                                                       │   │
│  │    // 修复后:                                                          │   │
│  │    Map<String, Object> result = new HashMap<>();                     │   │
│  │    result.put("messages", assistantMessage);                         │   │
│  │    result.put(outputKey, assistantMessage);  // 如果有 outputKey     │   │
│  │    result.put("_TOKEN_USAGE_", usage != null ? usage : EmptyUsage);  │   │
│  │                                                                       │   │
│  │    返回: {"messages": msg, "_TOKEN_USAGE_": {5000,2000,7000}}         │   │
│  └──────────────────────────────────────────────────────────────────────┘   │
│                                    ↓                                         │
│  ┌──────────────────────────────────────────────────────────────────────┐   │
│  │ 4. GraphRunnerContext 累加 usage 【Fix 3】                             │   │
│  │                                                                       │   │
│  │    findTokenUsageInDeltaState(deltaState):                           │   │
│  │      遍历 keys: ["messages", "_TOKEN_USAGE_"]                         │   │
│  │      发现 "_TOKEN_USAGE_" → 调用 accumulateTokenUsage()              │   │
│  │                                                                       │   │
│  │    accumulateTokenUsage(incoming = {5000,2000,7000}):                 │   │
│  │      existing = this.tokenUsage  // 第 1 轮时为 null                  │   │
│  │      accPrompt     = 0 + 5000 = 5000                                  │   │
│  │      accCompletion = 0 + 2000 = 2000                                  │   │
│  │      accTotal      = 0 + 7000 = 7000                                  │   │
│  │      this.tokenUsage = new DefaultUsage(5000, 2000, 7000)            │   │
│  └──────────────────────────────────────────────────────────────────────┘   │
│                                                                              │
│  Context 状态: tokenUsage = {prompt:5000, completion:2000, total:7000}       │
└─────────────────────────────────────────────────────────────────────────────┘
                                    ↓
┌─────────────────────────────────────────────────────────────────────────────┐
│                           第 2 轮 LLM 调用                                    │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  DashScope 返回: usage = {prompt:8000, completion:3000, total:11000}         │
│                                    ↓                                         │
│  NodeExecutor: latestUsageRef 捕获 {8000,3000,11000}                         │
│                                    ↓                                         │
│  AgentLlmNode: 返回 {"messages": msg, "_TOKEN_USAGE_": {8000,3000,11000}}    │
│                                    ↓                                         │
│  GraphRunnerContext.accumulateTokenUsage():                                  │
│    existing = {5000, 2000, 7000}                                             │
│    incoming = {8000, 3000, 11000}                                            │
│    ─────────────────────────────────                                         │
│    accPrompt     = 5000  + 8000  = 13000                                     │
│    accCompletion = 2000  + 3000  = 5000                                      │
│    accTotal      = 7000  + 11000 = 18000                                     │
│    this.tokenUsage = new DefaultUsage(13000, 5000, 18000)                    │
│                                                                              │
│  Context 状态: tokenUsage = {prompt:13000, completion:5000, total:18000}     │
└─────────────────────────────────────────────────────────────────────────────┘
                                    ↓
┌─────────────────────────────────────────────────────────────────────────────┐
│                           第 3 轮 LLM 调用                                    │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  DashScope 返回: usage = {prompt:6000, completion:2500, total:8500}          │
│                                    ↓                                         │
│  NodeExecutor: latestUsageRef 捕获 {6000,2500,8500}                          │
│                                    ↓                                         │
│  AgentLlmNode: 返回 {"messages": msg, "_TOKEN_USAGE_": {6000,2500,8500}}     │
│                                    ↓                                         │
│  GraphRunnerContext.accumulateTokenUsage():                                  │
│    existing = {13000, 5000, 18000}                                           │
│    incoming = {6000, 2500, 8500}                                             │
│    ─────────────────────────────────                                         │
│    accPrompt     = 13000 + 6000  = 19000                                     │
│    accCompletion = 5000  + 2500  = 7500                                      │
│    accTotal      = 18000 + 8500  = 26500                                     │
│    this.tokenUsage = new DefaultUsage(19000, 7500, 26500)                    │
│                                                                              │
│  Context 状态: tokenUsage = {prompt:19000, completion:7500, total:26500}     │
└─────────────────────────────────────────────────────────────────────────────┘
                                    ↓
┌─────────────────────────────────────────────────────────────────────────────┐
│                              Agent 执行完成                                   │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  GraphRunnerContext.getTokenUsage():                                         │
│    return {prompt: 19000, completion: 7500, total: 26500}                    │
│                                                                              │
│  ┌────────────────────────────────────────────────────────────────────┐     │
│  │                         最终对比                                    │     │
│  ├────────────────────────────────────────────────────────────────────┤     │
│  │  指标              │  修复前（Bug）    │  修复后          │  实际    │     │
│  ├────────────────────────────────────────────────────────────────────┤     │
│  │  prompt_tokens     │  0 或 6000       │  19,000          │ 19,000  │     │
│  │  completion_tokens │  0 或 2500       │  7,500           │ 7,500   │     │
│  │  total_tokens      │  0 或 8500       │  26,500          │ 26,500  │     │
│  ├────────────────────────────────────────────────────────────────────┤     │
│  │  前端显示          │  ~0 或 ~8500     │  26,500 ✅       │         │     │
│  │  DashScope 计费    │  26,500          │  26,500 ✅       │         │     │
│  │  差距              │  3~∞ 倍          │  0               │         │     │
│  └────────────────────────────────────────────────────────────────────┘     │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

Closes alibaba#4488


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
