### PR TITLE
fix: extract subgraph result from GraphResponse in parallel execution (#4516)

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -839,7 +839,26 @@ public class NodeExecutor extends BaseGraphExecutor {
 				String nodeId = graphFlux.getNodeId();
 				Object nodeData = nodeDataRefs.get(nodeId).get();
 
-				combinedResultMap.put(graphFlux.getKey(),nodeData);
+				// Extract actual result data from GraphResponse completion signals
+				// (e.g., from subgraph completion or streaming aggregation done events).
+				// Without this extraction, the raw GraphResponse object would be stored
+				// in the parent state, which serializes as empty '{}' and loses the
+				// subgraph's output data. This mirrors the extraction logic used in
+				// processGraphResponseFlux for non-parallel subgraph execution.
+				if (nodeData instanceof GraphResponse<?> graphResponse
+						&& graphResponse.resultValue().isPresent()) {
+					Object resultVal = graphResponse.resultValue().get();
+					if (resultVal instanceof Map<?, ?>) {
+						@SuppressWarnings("unchecked")
+						Map<String, Object> resultMap = (Map<String, Object>) resultVal;
+						combinedResultMap = OverAllState.updateState(
+								combinedResultMap, resultMap, context.getKeyStrategyMap());
+					} else {
+						combinedResultMap.put(graphFlux.getKey(), resultVal);
+					}
+				} else {
+					combinedResultMap.put(graphFlux.getKey(), nodeData);
+				}
 			}
 
 			// Merge non-ParallelGraphFlux state


### PR DESCRIPTION
## Summary

Fixes #4516

When a parent graph executes subgraphs **in parallel**, the subgraph output is lost — the parent state shows empty `{}` for keys like `subgraph_*_compiled_graph`.

### Problem

In `NodeExecutor.handleParallelGraphFlux()`, the completion handler collects results from each parallel `GraphFlux` stream and stores them into `combinedResultMap`. However, the collected `nodeData` is a raw `GraphResponse` object (specifically `GraphResponse.done(subgraphFinalStateMap)`). Since `GraphResponse.output` is annotated with `@JsonIgnore`, storing it directly into the parent state causes serialization to produce empty `{}`.

The non-parallel subgraph path (`processGraphResponseFlux`) correctly extracts the actual state data via `data.resultValue()` — but this extraction was missing in the parallel path.

### Solution

In the result collection loop of `handleParallelGraphFlux`, added a check: when `nodeData` is a `GraphResponse` with a `resultValue` present and of type `Map`, extract the map and merge it into `combinedResultMap` using `OverAllState.updateState()` with proper key strategies. This mirrors the extraction logic already used in `processGraphResponseFlux`.

### Changes

- `NodeExecutor.java` (`handleParallelGraphFlux`): Extract subgraph final state from `GraphResponse.resultValue()` instead of storing the raw `GraphResponse` object

### Testing

- [x] All 288 existing tests in `spring-ai-alibaba-graph-core` pass (0 failures, 0 errors)
- [x] `SubGraphTest` (12 tests) — including `testParallelSubgraph`
- [x] `StateGraphParallelTest` (7 tests)
- [x] `CompiledSubGraphTest` (4 tests)