### PR TITLE
fix(graph): prevent duplicated append results when merging serial subgraphs

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/OverAllState.java
@@ -117,6 +117,20 @@ public final class OverAllState implements Serializable {
 	}
 
 	/**
+	 * Create a new state copy with the provided keys removed.
+	 * @param keysToReset keys that should be removed from the copied state
+	 * @return copied state with reset keys removed
+	 */
+	public OverAllState withResetKeys(Set<String> keysToReset) {
+		if (keysToReset == null || keysToReset.isEmpty()) {
+			return this;
+		}
+		Map<String, Object> newData = new HashMap<>(this.data);
+		keysToReset.forEach(newData::remove);
+		return new OverAllState(newData, new HashMap<>(this.keyStrategies), this.store);
+	}
+
+	/**
 	 * Instantiates a new Over all state.
 	 * @param data the data
 	 */

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -18,13 +18,17 @@ package com.alibaba.cloud.ai.graph.internal.node;
 
 import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.utils.TypeRef;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
@@ -79,18 +83,14 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 				return CompletableFuture
 					.failedFuture(new IllegalStateException("Missing CheckpointSaver in parent graph!"));
 			}
-
-			// Check saver are the same instance
-			if (parentSaver.get() == subGraphSaver.get()) {
-				subGraphRunnableConfig = RunnableConfig.builder(config)
-					.threadId(config.threadId()
-						.map(threadId -> format("%s_%s", threadId, subGraphId(nodeId)))
-						.orElseGet(() -> subGraphId(nodeId)))
-					.nextNode(null)
-					.checkPointId(null)
-					.build();
-				subGraphRunnableConfig.clearContext();
-			}
+			subGraphRunnableConfig = RunnableConfig.builder(config)
+				.threadId(config.threadId()
+					.map(threadId -> format("%s_%s", threadId, subGraphId(nodeId)))
+					.orElseGet(() -> subGraphId(nodeId)))
+				.nextNode(null)
+				.checkPointId(null)
+				.build();
+			subGraphRunnableConfig.clearContext();
 		}
 
 		final CompletableFuture<Map<String, Object>> future = new CompletableFuture<>();
@@ -100,7 +100,8 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 				subGraphRunnableConfig = subGraph.updateState(subGraphRunnableConfig, state.data());
 			}
 
-			var fluxStream = subGraph.graphResponseStream(state, subGraphRunnableConfig);
+			OverAllState subGraphInitState = buildSubGraphInitState(state);
+			var fluxStream = subGraph.graphResponseStream(subGraphInitState, subGraphRunnableConfig);
 
 			future.complete(Map.of(outputKeyToParent(nodeId), fluxStream));
 
@@ -111,5 +112,15 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 		}
 
 		return future;
+	}
+
+	private OverAllState buildSubGraphInitState(OverAllState parentState) {
+		Map<String, KeyStrategy> subKeyStrategies = subGraph.getKeyStrategyMap();
+		Set<String> appendKeys = subKeyStrategies.entrySet()
+			.stream()
+			.filter(entry -> entry.getValue() instanceof AppendStrategy)
+			.map(Map.Entry::getKey)
+			.collect(Collectors.toSet());
+		return parentState.withResetKeys(appendKeys);
 	}
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/Issue4515ReproductionTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/Issue4515ReproductionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import com.alibaba.cloud.ai.graph.exception.GraphStateException;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Issue4515ReproductionTest {
+
+	private static final Logger log = LoggerFactory.getLogger(Issue4515ReproductionTest.class);
+
+	private KeyStrategyFactory createKeyStrategyFactory() {
+		return () -> {
+			Map<String, KeyStrategy> keyStrategies = new HashMap<>();
+			keyStrategies.put("input", new ReplaceStrategy());
+			keyStrategies.put("output", new AppendStrategy());
+			return keyStrategies;
+		};
+	}
+
+	private CompiledGraph makeSubGraph() throws GraphStateException {
+		return new StateGraph(createKeyStrategyFactory())
+			.addNode("subA", node_async(state -> Map.of("output", "sub_graph_output")))
+			.addEdge(START, "subA")
+			.addEdge("subA", END)
+			.compile();
+	}
+
+	@SuppressWarnings("rawtypes")
+	private List outputOf(Optional<OverAllState> result) {
+		return (List) result.orElseThrow().value("output").orElseThrow();
+	}
+
+	@Test
+	void test01_twoDistinctSubGraphsInSerial() throws Exception {
+		CompiledGraph graph = new StateGraph(createKeyStrategyFactory())
+			.addNode("B", makeSubGraph())
+			.addNode("C", makeSubGraph())
+			.addEdge(START, "B")
+			.addEdge("B", "C")
+			.addEdge("C", END)
+			.compile();
+
+		List<?> output = outputOf(graph.invoke(Map.of("input", "hello")));
+		log.info("[spring-ai-alibaba-repro] test01 output size={}, output={}", output.size(), output);
+		assertEquals(2, output.size());
+	}
+
+	@Test
+	void test02_sameSubGraphInstanceRegisteredTwice() throws Exception {
+		CompiledGraph subGraph = makeSubGraph();
+
+		CompiledGraph graph = new StateGraph(createKeyStrategyFactory())
+			.addNode("B", subGraph)
+			.addNode("C", subGraph)
+			.addEdge(START, "B")
+			.addEdge("B", "C")
+			.addEdge("C", END)
+			.compile();
+
+		List<?> output = outputOf(graph.invoke(Map.of("input", "hello")));
+		log.info("[spring-ai-alibaba-repro] test02 output size={}, output={}", output.size(), output);
+		assertEquals(2, output.size());
+	}
+
+	@Test
+	void test03_parentNodePlusSerialSubGraphs() throws Exception {
+		CompiledGraph graph = new StateGraph(createKeyStrategyFactory())
+			.addNode("A", node_async(state -> Map.of("output", "parent_output")))
+			.addNode("B", makeSubGraph())
+			.addNode("C", makeSubGraph())
+			.addEdge(START, "A")
+			.addEdge("A", "B")
+			.addEdge("B", "C")
+			.addEdge("C", END)
+			.compile();
+
+		List<?> output = outputOf(graph.invoke(Map.of("input", "hello")));
+		log.info("[spring-ai-alibaba-repro] test03 output size={}, output={}", output.size(), output);
+		assertEquals(3, output.size());
+		assertTrue(output.contains("parent_output"));
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/Issue4515ReproductionTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/Issue4515ReproductionTest.java
@@ -60,6 +60,13 @@ class Issue4515ReproductionTest {
 		return (List) result.orElseThrow().value("output").orElseThrow();
 	}
 
+	/**
+	 * Scenario 01:
+	 * START -> B(subGraph1) -> C(subGraph2) -> END.
+	 *
+	 * Both subgraphs are distinct compiled instances. Each subgraph contributes one
+	 * "sub_graph_output", so final output size must be 2.
+	 */
 	@Test
 	void test01_twoDistinctSubGraphsInSerial() throws Exception {
 		CompiledGraph graph = new StateGraph(createKeyStrategyFactory())
@@ -75,6 +82,13 @@ class Issue4515ReproductionTest {
 		assertEquals(2, output.size());
 	}
 
+	/**
+	 * Scenario 02:
+	 * START -> B(subGraph) -> C(same subGraph instance) -> END.
+	 *
+	 * The same compiled subgraph instance is reused by two parent nodes. This case
+	 * verifies checkpoint/threadId isolation and ensures no cross-node state pollution.
+	 */
 	@Test
 	void test02_sameSubGraphInstanceRegisteredTwice() throws Exception {
 		CompiledGraph subGraph = makeSubGraph();
@@ -92,6 +106,13 @@ class Issue4515ReproductionTest {
 		assertEquals(2, output.size());
 	}
 
+	/**
+	 * Scenario 03:
+	 * START -> A(parent node) -> B(subGraph1) -> C(subGraph2) -> END.
+	 *
+	 * Parent node A contributes "parent_output" once, and the two serial subgraphs
+	 * contribute two "sub_graph_output" items. Final output size must be 3.
+	 */
 	@Test
 	void test03_parentNodePlusSerialSubGraphs() throws Exception {
 		CompiledGraph graph = new StateGraph(createKeyStrategyFactory())


### PR DESCRIPTION
## Describe what this PR does / why we need it
This PR fixes duplicated/over-amplified `AppendStrategy` results when parent graph merges serial subgraph outputs (Issue #4515).

Before the fix, serial subgraph executions could produce duplicated `output` values:
- two distinct subgraphs in serial -> expected 2, got 3
- same subgraph instance reused by two nodes -> expected 2, got 4
- parent node + two serial subgraphs -> expected 3, got 7

## Does this pull request fix one issue?
Closes #4515

## Describe how you did it
Two changes were applied:

1. **Isolate subgraph checkpoint namespace by nodeId**
- In `SubCompiledGraphNodeAction`, once subgraph saver exists, always assign deterministic node-scoped threadId:
  - `${parentThreadId}_${subGraphId(nodeId)}` or `subGraphId(nodeId)`
- This avoids checkpoint/state pollution across different parent nodes using subgraphs.

2. **Reset append-based keys before subgraph execution**
- Added `OverAllState.withResetKeys(Set<String>)`.
- In `SubCompiledGraphNodeAction`, build subgraph initial state by removing all keys whose strategy is `AppendStrategy`.
- This ensures each subgraph run starts append accumulation from a clean baseline instead of inheriting parent historical append state.

Also added a non-mock reproduction test class:
- `Issue4515ReproductionTest` (3 scenarios)

## Describe how to verify it
Run:

```bash
./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=Issue4515ReproductionTest test
./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=Issue4515ReproductionTest,CompiledSubGraphTest,SubGraphTest,StateGraphTest test
