### PR TITLE
feat(agent): add AbstractInterruptableModelHook base class

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -30,16 +30,9 @@ import com.alibaba.cloud.ai.graph.action.NodeActionWithConfig;
 import com.alibaba.cloud.ai.graph.agent.exception.AgentException;
 import com.alibaba.cloud.ai.graph.agent.factory.AgentBuilderFactory;
 import com.alibaba.cloud.ai.graph.agent.factory.DefaultAgentBuilderFactory;
-import com.alibaba.cloud.ai.graph.agent.hook.AgentHook;
-import com.alibaba.cloud.ai.graph.agent.hook.Hook;
-import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
-import com.alibaba.cloud.ai.graph.agent.hook.InstructionAgentHook;
-import com.alibaba.cloud.ai.graph.agent.hook.InterruptionHook;
-import com.alibaba.cloud.ai.graph.agent.hook.JumpTo;
+import com.alibaba.cloud.ai.graph.agent.hook.*;
 import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesAgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesModelHook;
-import com.alibaba.cloud.ai.graph.agent.hook.ModelHook;
-import com.alibaba.cloud.ai.graph.agent.hook.ToolInjection;
 import com.alibaba.cloud.ai.graph.agent.hook.hip.HumanInTheLoopHook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
@@ -362,7 +355,9 @@ public class ReactAgent extends BaseAgent {
 		// Add hook nodes for beforeModel hooks
 		for (Hook hook : beforeModelHooks) {
 			if (hook instanceof ModelHook modelHook) {
-				if (hook instanceof InterruptionHook interruptionHook) {
+                if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
+                    graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", nodeActionHook);
+                } else if (hook instanceof InterruptionHook interruptionHook) {
 					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", interruptionHook);
 				} else {
 					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", modelHook::beforeModel);
@@ -374,7 +369,9 @@ public class ReactAgent extends BaseAgent {
 
 		// Add hook nodes for afterModel hooks
 		for (Hook hook : afterModelHooks) {
-			if (hook instanceof ModelHook modelHook) {
+            if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
+                graph.addNode(Hook.getFullHookName(hook) + ".afterModel", nodeActionHook);
+            } else if (hook instanceof ModelHook modelHook) {
 				if (hook instanceof HumanInTheLoopHook humanInTheLoopHook) {
 					graph.addNode(Hook.getFullHookName(hook) + ".afterModel", humanInTheLoopHook);
 				} else {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -35,11 +35,9 @@ import com.alibaba.cloud.ai.graph.agent.hook.AgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.Hook;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
 import com.alibaba.cloud.ai.graph.agent.hook.InstructionAgentHook;
-import com.alibaba.cloud.ai.graph.agent.hook.InterruptionHook;
 import com.alibaba.cloud.ai.graph.agent.hook.JumpTo;
 import com.alibaba.cloud.ai.graph.agent.hook.ModelHook;
 import com.alibaba.cloud.ai.graph.agent.hook.ToolInjection;
-import com.alibaba.cloud.ai.graph.agent.hook.hip.HumanInTheLoopHook;
 import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesAgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesModelHook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
@@ -369,14 +367,10 @@ public class ReactAgent extends BaseAgent {
 
 		// Add hook nodes for beforeModel hooks
 		for (Hook hook : beforeModelHooks) {
-			if (hook instanceof ModelHook modelHook) {
-                if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
-                    graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", nodeActionHook);
-                } else if (hook instanceof InterruptionHook interruptionHook) {
-					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", interruptionHook);
-				} else {
-					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", modelHook::beforeModel);
-				}
+			if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", nodeActionHook);
+			} else if (hook instanceof ModelHook modelHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", modelHook::beforeModel);
 			} else if (hook instanceof MessagesModelHook messagesModelHook) {
 				graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", MessagesModelHook.beforeModelAction(messagesModelHook));
 			}
@@ -384,14 +378,10 @@ public class ReactAgent extends BaseAgent {
 
 		// Add hook nodes for afterModel hooks
 		for (Hook hook : afterModelHooks) {
-            if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
-                graph.addNode(Hook.getFullHookName(hook) + ".afterModel", nodeActionHook);
-            } else if (hook instanceof ModelHook modelHook) {
-				if (hook instanceof HumanInTheLoopHook humanInTheLoopHook) {
-					graph.addNode(Hook.getFullHookName(hook) + ".afterModel", humanInTheLoopHook);
-				} else {
-					graph.addNode(Hook.getFullHookName(hook) + ".afterModel", modelHook::afterModel);
-				}
+			if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".afterModel", nodeActionHook);
+			} else if (hook instanceof ModelHook modelHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".afterModel", modelHook::afterModel);
 			} else if (hook instanceof MessagesModelHook messagesModelHook) {
 				graph.addNode(Hook.getFullHookName(hook) + ".afterModel", MessagesModelHook.afterModelAction(messagesModelHook));
 			}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -30,6 +30,7 @@ import com.alibaba.cloud.ai.graph.action.NodeActionWithConfig;
 import com.alibaba.cloud.ai.graph.agent.exception.AgentException;
 import com.alibaba.cloud.ai.graph.agent.factory.AgentBuilderFactory;
 import com.alibaba.cloud.ai.graph.agent.factory.DefaultAgentBuilderFactory;
+import com.alibaba.cloud.ai.graph.agent.hook.AbstractInterruptableModelHook;
 import com.alibaba.cloud.ai.graph.agent.hook.AgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.Hook;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
@@ -369,7 +370,9 @@ public class ReactAgent extends BaseAgent {
 		// Add hook nodes for beforeModel hooks
 		for (Hook hook : beforeModelHooks) {
 			if (hook instanceof ModelHook modelHook) {
-				if (hook instanceof InterruptionHook interruptionHook) {
+                if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
+                    graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", nodeActionHook);
+                } else if (hook instanceof InterruptionHook interruptionHook) {
 					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", interruptionHook);
 				} else {
 					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", modelHook::beforeModel);
@@ -381,7 +384,9 @@ public class ReactAgent extends BaseAgent {
 
 		// Add hook nodes for afterModel hooks
 		for (Hook hook : afterModelHooks) {
-			if (hook instanceof ModelHook modelHook) {
+            if (hook instanceof AbstractInterruptableModelHook nodeActionHook) {
+                graph.addNode(Hook.getFullHookName(hook) + ".afterModel", nodeActionHook);
+            } else if (hook instanceof ModelHook modelHook) {
 				if (hook instanceof HumanInTheLoopHook humanInTheLoopHook) {
 					graph.addNode(Hook.getFullHookName(hook) + ".afterModel", humanInTheLoopHook);
 				} else {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/AbstractInterruptableModelHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/AbstractInterruptableModelHook.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.hook;
+
+import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
+import com.alibaba.cloud.ai.graph.action.InterruptableAction;
+
+/**
+ * 可中断的 ModelHook 基类。
+ *
+ * <p>同时实现 {@link AsyncNodeActionWithConfig} 和 {@link InterruptableAction}，
+ * ReactAgent 的 {@code initGraph()} 会识别此类型，将其作为完整节点注册到图中，
+ * 而非像普通 ModelHook 那样包装为方法引用。</p>
+ *
+ * @see AsyncNodeActionWithConfig
+ * @see InterruptableAction
+ */
+public abstract class AbstractInterruptableModelHook extends ModelHook
+		implements AsyncNodeActionWithConfig, InterruptableAction {
+
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/InterruptionHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/InterruptionHook.java
@@ -18,8 +18,6 @@ package com.alibaba.cloud.ai.graph.agent.hook;
 import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
-import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
-import com.alibaba.cloud.ai.graph.action.InterruptableAction;
 import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 
@@ -48,7 +46,7 @@ import static com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver.THREAD_I
  * InterruptionHook hook = InterruptionHook.builder().build();
  */
 @HookPositions({HookPosition.BEFORE_MODEL})
-public class InterruptionHook extends ModelHook implements AsyncNodeActionWithConfig, InterruptableAction {
+public class InterruptionHook extends AbstractInterruptableModelHook {
 	private static final Logger log = LoggerFactory.getLogger(InterruptionHook.class);
 	
 	public static final String INTERRUPTION_FEEDBACK_KEY = "INTERRUPTION_FEEDBACK";

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/hip/HumanInTheLoopHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/hip/HumanInTheLoopHook.java
@@ -17,16 +17,14 @@ package com.alibaba.cloud.ai.graph.agent.hook.hip;
 
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
-import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
-import com.alibaba.cloud.ai.graph.action.InterruptableAction;
 import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
 import com.alibaba.cloud.ai.graph.action.InterruptionMetadata.ToolFeedback;
 import com.alibaba.cloud.ai.graph.action.InterruptionMetadata.ToolFeedback.FeedbackResult;
+import com.alibaba.cloud.ai.graph.agent.hook.AbstractInterruptableModelHook;
 import com.alibaba.cloud.ai.graph.agent.hook.Hook;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPositions;
 import com.alibaba.cloud.ai.graph.agent.hook.JumpTo;
-import com.alibaba.cloud.ai.graph.agent.hook.ModelHook;
 import com.alibaba.cloud.ai.graph.state.RemoveByHash;
 import com.alibaba.cloud.ai.graph.utils.TypeRef;
 
@@ -45,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @HookPositions(HookPosition.AFTER_MODEL)
-public class HumanInTheLoopHook extends ModelHook implements AsyncNodeActionWithConfig, InterruptableAction {
+public class HumanInTheLoopHook extends AbstractInterruptableModelHook {
 	private static final Logger log = LoggerFactory.getLogger(HumanInTheLoopHook.class);
     public static final String HITL_NODE_NAME = "HITL";
 	private Map<String, ToolConfig> approvalOn;


### PR DESCRIPTION
Register hooks of type AbstractInterruptableModelHook as full nodes in the ReactAgent initialization logic.
Supports hook registration at both beforeModel and afterModel stages.


### Describe what this PR does / why we need it
  Add AbstractInterruptableModelHook, a base class for model hooks that require full node-level interruptibility. Previously, ModelHook implementations were registered as method references in the graph, which limited their     
  ability to leverage graph-level interrupt mechanisms. This base class implements both AsyncNodeActionWithConfig and InterruptableAction, enabling such hooks to be registered as full graph nodes with proper interrupt support.

### Does this pull request fix one issue?
NONE

### Describe how you did it
  1. Created AbstractInterruptableModelHook extending ModelHook and implementing AsyncNodeActionWithConfig and InterruptableAction.                                                                                                
  2. Updated ReactAgent.initGraph() to detect AbstractInterruptableModelHook instances and register them directly as graph nodes, for both beforeModel and afterModel hook stages, instead of wrapping them as method references.

### Describe how to verify it
  1. Create a concrete subclass of AbstractInterruptableModelHook and add it to a ReactAgent via the hook configuration.                                                                                                           
  2. Verify the hook is invoked at the expected stage (beforeModel or afterModel) and that graph-level interruption works correctly when triggered by the hook.
  3. Run existing tests: ./mvnw -pl :spring-ai-alibaba-agent-framework test    

### Special notes for reviews
  - The AbstractInterruptableModelHook check is placed before the existing InterruptionHook / HumanInTheLoopHook / generic ModelHook checks, giving it higher priority in the registration logic.                                  
  - Import statements in ReactAgent.java were consolidated into wildcard imports as part of this change.
