### PR TITLE
fix(admin): update chat memory reference links

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/resources/initializr.yml
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/resources/initializr.yml
@@ -1744,7 +1744,7 @@ initializr:
           bom: spring-ai
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-ai/reference/api/chat-memory.html
+              href: https://docs.spring.io/spring-ai/reference/api/chatclient.html#chat-memory
         - name: Cassandra Chat Memory Repository
           id: spring-ai-chat-memory-repository-cassandra
           group-id: org.springframework.ai
@@ -1753,7 +1753,7 @@ initializr:
           bom: spring-ai
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-ai/reference/api/chat-memory.html
+              href: https://docs.spring.io/spring-ai/reference/api/chatclient.html#chat-memory
         - name: Neo4j Chat Memory Repository
           id: spring-ai-chat-memory-repository-neo4j
           group-id: org.springframework.ai
@@ -1762,7 +1762,7 @@ initializr:
           bom: spring-ai
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-ai/reference/api/chat-memory.html
+              href: https://docs.spring.io/spring-ai/reference/api/chatclient.html#chat-memory
         - name: Oracle Vector Database
           id: spring-ai-vectordb-oracle
           group-id: org.springframework.ai


### PR DESCRIPTION
This PR updates the chat memory reference links used by the admin starter metadata so they point to the current Spring AI chat memory section.