### PR TITLE
docs: add chat memory reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ There's a ChatBot example provided by the community at [examples/chatbot](https:
 * [Agent Framework Tutorials](https://java2ai.com/docs/frameworks/agent-framework/tutorials/agents) - Step by step tutorials
 * [Use Graph API to Build Complex Workflows](https://java2ai.com/docs/frameworks/agent-framework/advanced/context-engineering) - In-depth user guide for building multi-agent and workflows
 * [Spring AI Basics](https://java2ai.com/ecosystem/spring-ai/reference/concepts) - Ai Application basic concepts, including ChatModel, MCP, Tool, Messages, etc.
+* [Chat Memory](https://docs.spring.io/spring-ai/reference/api/chatclient.html#chat-memory) - Spring AI reference for chat memory repositories and usage
 
 ## Project Structure
 
@@ -165,4 +166,3 @@ This project consists of several core components:
 
 <p align="center">
     Made with ❤️ by the Spring AI Alibaba Team
-


### PR DESCRIPTION
This PR adds a direct Chat Memory reference link to the top-level README so readers can jump to the current Spring AI documentation without relying on an outdated page path.