### PR TITLE
fix: handle FileSystemAlreadyExistsException in ClasspathSkillRegistry

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -80,6 +81,9 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	private final Map<String, String> jarSkillContentCache = new HashMap<>();
 	// JAR FileSystem for classpath resources (only created if resource is in JAR)
 	private FileSystem jarFileSystem;
+	// Whether this registry instance created (and thus owns) the JAR FileSystem.
+	// If false, the FileSystem was pre-existing and should NOT be closed by this instance.
+	private boolean ownsJarFileSystem;
 
 	private ClasspathSkillRegistry(Builder builder) {
 		this.classpathPath = builder.classpathPath != null && !builder.classpathPath.isEmpty()
@@ -150,7 +154,16 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 					// Resource is in a JAR file (production mode)
 					// Create or reuse JAR FileSystem
 					if (jarFileSystem == null) {
-						jarFileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+						try {
+							jarFileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+							ownsJarFileSystem = true;
+						}
+						catch (FileSystemAlreadyExistsException e) {
+							// Another ClasspathSkillRegistry (or other code) already created
+							// a FileSystem for this JAR. Reuse the existing one.
+							jarFileSystem = FileSystems.getFileSystem(uri);
+							ownsJarFileSystem = false;
+						}
 					}
 					// Get path within the JAR file system
 					// URI format: jar:file:/path/to.jar!/skills
@@ -462,18 +475,23 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	}
 
 	/**
-	 * Closes the JAR FileSystem if it was created.
+	 * Closes the JAR FileSystem if it was created by this instance.
+	 * Only the instance that originally created the FileSystem will close it;
+	 * instances that reused a pre-existing FileSystem will simply release the reference.
 	 * Should be called when the registry is no longer needed.
 	 */
 	public void close() {
 		if (jarFileSystem != null) {
-			try {
-				jarFileSystem.close();
-			}
-			catch (IOException e) {
-				logger.warn("Failed to close JAR filesystem: {}", e.getMessage());
+			if (ownsJarFileSystem) {
+				try {
+					jarFileSystem.close();
+				}
+				catch (IOException e) {
+					logger.warn("Failed to close JAR filesystem: {}", e.getMessage());
+				}
 			}
 			jarFileSystem = null;
+			ownsJarFileSystem = false;
 		}
 	}
 


### PR DESCRIPTION

### Describe what this PR does / why we need it

When multiple `ClasspathSkillRegistry` instances attempt to load skills from the same JAR file, the second instance fails because `ZipFileSystemProvider` caches filesystems by `realPath`. Calling `FileSystems.newFileSystem(uri, ...)` a second time for the same JAR throws `FileSystemAlreadyExistsException`, preventing the registry from being created.

This PR fixes the issue by catching `FileSystemAlreadyExistsException` and falling back to `FileSystems.getFileSystem(uri)` to reuse the already-existing `FileSystem`. It also introduces ownership tracking (`ownsJarFileSystem`) so that only the instance that originally created the `FileSystem` will close it in its `close()` method, preventing one instance from breaking others that share the same `FileSystem`.

### Does this pull request fix one issue?

Fixes #4547

### Describe how you did it

1. **Added `FileSystemAlreadyExistsException` import** to handle the specific exception from `ZipFileSystemProvider`.
2. **Added `ownsJarFileSystem` boolean field** to track whether this registry instance created (owns) the JAR `FileSystem`.
3. **Modified `loadSkillsToRegistry()`**: wrapped the `FileSystems.newFileSystem()` call in a try-catch; on `FileSystemAlreadyExistsException`, falls back to `FileSystems.getFileSystem(uri)` and marks `ownsJarFileSystem = false`.
4. **Modified `close()`**: only closes the `FileSystem` if `ownsJarFileSystem` is true; otherwise just releases the reference.

### Describe how to verify it

1. Create two `ClasspathSkillRegistry` instances pointing to the same classpath resources directory (same JAR).
2. Both should initialize successfully without throwing exceptions.
3. Existing unit test `ClasspathSkillRegistryEnhancementsTest` passes.

### Special notes for reviews

- Minimal change — only the affected file `ClasspathSkillRegistry.java` is modified (25 lines added, 7 removed).
- The fix is backward-compatible: single-instance usage is unaffected since `newFileSystem` succeeds on the first call as before.

---
<sub>🔧 Generated by [issue-to-pr](https://github.com/4yDX3906/issue-to-pr)</sub>