### PR TITLE
feat(graph): add driver handshake metadata to MongoSaver

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mongo/MongoSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mongo/MongoSaver.java
@@ -41,6 +41,7 @@ import java.util.stream.IntStream;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.ClientSessionOptions;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.TransactionOptions;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.ClientSession;
@@ -61,6 +62,10 @@ import static java.lang.String.format;
 public class MongoSaver implements BaseCheckpointSaver {
 
 	private static final Logger logger = LoggerFactory.getLogger(MongoSaver.class);
+
+	private static final MongoDriverInformation DRIVER_INFO = MongoDriverInformation.builder()
+			.driverName("spring-ai-alibaba")
+			.build();
 	private static final String DB_NAME = "check_point_db";
 	private static final String THREAD_META_COLLECTION = "thread_meta";
 	private static final String CHECKPOINT_COLLECTION = "checkpoint_collection";
@@ -87,6 +92,13 @@ public class MongoSaver implements BaseCheckpointSaver {
 		Objects.requireNonNull(client, "client cannot be null");
 		Objects.requireNonNull(stateSerializer, "stateSerializer cannot be null");
 		this.client = client;
+		try {
+			java.lang.reflect.Method appendMetadata = client.getClass().getMethod("appendMetadata", MongoDriverInformation.class);
+			appendMetadata.invoke(client, DRIVER_INFO);
+		}
+		catch (Exception ignored) {
+			// appendMetadata not available in this driver version — skip silently
+		}
 		this.database = client.getDatabase(DB_NAME);
 		this.txnOptions = TransactionOptions.builder().writeConcern(WriteConcern.MAJORITY).build();
 		this.checkpointSerializer = new CheckPointSerializer(stateSerializer);

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mongo/MongoSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mongo/MongoSaver.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.Method;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -93,7 +94,7 @@ public class MongoSaver implements BaseCheckpointSaver {
 		Objects.requireNonNull(stateSerializer, "stateSerializer cannot be null");
 		this.client = client;
 		try {
-			java.lang.reflect.Method appendMetadata = client.getClass().getMethod("appendMetadata", MongoDriverInformation.class);
+			Method appendMetadata = client.getClass().getMethod("appendMetadata", MongoDriverInformation.class);
 			appendMetadata.invoke(client, DRIVER_INFO);
 		}
 		catch (Exception ignored) {

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mongo/MongoSaverDriverInfoTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mongo/MongoSaverDriverInfoTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers.mongo;
+
+import com.mongodb.MongoDriverInformation;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MongoSaverDriverInfoTest {
+
+	@Test
+	void driverInfo_hasExpectedName() throws Exception {
+		Field field = MongoSaver.class.getDeclaredField("DRIVER_INFO");
+		field.setAccessible(true);
+		MongoDriverInformation info = (MongoDriverInformation) field.get(null);
+		assertEquals("spring-ai-alibaba", info.getDriverNames().get(0));
+	}
+
+	@Test
+	void constructor_silentlySkipsAppendMetadataWhenUnavailable() {
+		// MongoClient (driver 5.5.2) has no appendMetadata — the reflection guard
+		// must not throw.
+		MongoClient mockClient = mock(MongoClient.class);
+		MongoDatabase mockDb = mock(MongoDatabase.class);
+		when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+
+		MongoSaver saver = MongoSaver.builder()
+				.client(mockClient)
+				.build();
+
+		// If we reach here without exception the guard worked correctly.
+		assertTrue(true);
+	}
+
+	@Test
+	void constructor_invokesAppendMetadataWhenAvailable() throws Exception {
+		// Simulate a client that exposes appendMetadata via a subinterface.
+		List<MongoDriverInformation> captured = new ArrayList<>();
+
+		MongoClientWithMetadata clientWithMetadata = mock(MongoClientWithMetadata.class);
+		MongoDatabase mockDb = mock(MongoDatabase.class);
+		when(clientWithMetadata.getDatabase(anyString())).thenReturn(mockDb);
+		org.mockito.Mockito.doAnswer(inv -> {
+			captured.add(inv.getArgument(0));
+			return null;
+		}).when(clientWithMetadata).appendMetadata(org.mockito.ArgumentMatchers.any(MongoDriverInformation.class));
+
+		MongoSaver.builder()
+				.client(clientWithMetadata)
+				.build();
+
+		assertFalse(captured.isEmpty(), "appendMetadata should have been called");
+		assertEquals("spring-ai-alibaba", captured.get(0).getDriverNames().get(0));
+	}
+
+	/** Extends MongoClient with appendMetadata to simulate driver >= 5.6.0. */
+	interface MongoClientWithMetadata extends MongoClient {
+		void appendMetadata(MongoDriverInformation driverInformation);
+	}
+
+}


### PR DESCRIPTION
Add MongoDB driver handshake metadata to `MongoSaver` so that
`spring-ai-alibaba` is identified in the MongoDB connection handshake, and is basically the same change as https://github.com/spring-projects/spring-ai/pull/5079.

This PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2025-07-26T11:33:05.688+00:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn70990","msg":"client metadata","attr":{"remote":"192.168.0.1:34567","client":"conn70990","negotiatedCompressors":["zstd"],"doc":{"application":{"name":"spring-ai-test"},`"driver":{"name":"mongo-java-driver|reactive-streams|spring-ai-alibaba"`,"version":"5.0.0"},"os":{"type":"Linux","name":"Linux","architecture":"amd64","version":"6.1.119-129.201.amzn2023.x86_64"},"platform":"Java/Amazon.com Inc./21.0.8+9-LTS"}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.

### Does this pull request fix one issue?

NONE

### Describe how you did it

`MongoSaver` receives a `MongoClient` from the caller (Pattern B), so the
client cannot be decorated at construction time. Instead, `appendMetadata`
is invoked on the received client in `MongoSaver`'s constructor using
reflection, guarded by a `try/catch` so that deployments on older driver
versions (< 5.6.0, where `appendMetadata` was introduced) continue to work
without any change in behaviour.

A `MongoDriverInformation` constant named `"spring-ai-alibaba"` is defined
once at class level and reused for all instances.

### Describe how to verify it

Run the new unit tests:

```
./mvnw -pl spring-ai-alibaba-graph-core test -Dtest=MongoSaverDriverInfoTest
```

Three tests are included:
- `driverInfo_hasExpectedName` — asserts the constant carries the name `"spring-ai-alibaba"`
- `constructor_silentlySkipsAppendMetadataWhenUnavailable` — verifies no exception is thrown on driver < 5.6.0 (the current resolved version, 5.5.2)
- `constructor_invokesAppendMetadataWhenAvailable` — uses a subinterface to simulate driver ≥ 5.6.0 and confirms `appendMetadata` is called with the correct `DriverInfo`

### Special notes for reviews

The change is limited to `MongoSaver.java` and one new test file. No
behaviour change occurs on driver versions < 5.6.0 — the reflection call
fails silently. No new dependencies are introduced.