### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 **Spring AI Alibaba Admin** is a one-stop Agent platform that supports visualized Agent development, observability, evaluation, and MCP management, etc. It also integrates with open-source low-code platforms like Dify, enabling rapid migration from DSL to Spring AI Alibaba project.
 
-**Spring AI Alibaba Agent Framework** is an agent development framework that can quickly develop agents with builtin **Context Engineering** and **Human In The Loop** support. For scenarios requiring more complex process control, Agent Framework offers built-in workflows like `SequentialAgent`, `ParallelAgent`, `RoutingAgent`, `LoopAgent`.
+**Spring AI Alibaba Agent Framework** is an agent development framework that can quickly develop agents with built-in **Context Engineering** and **Human In The Loop** support. For scenarios requiring more complex process control, Agent Framework offers built-in workflows like `SequentialAgent`, `ParallelAgent`, `RoutingAgent`, `LoopAgent`.
 
 **Spring AI Alibaba Graph** serves as the underlying runtime of the Agent Framework, providing essential capabilities such as persistence, workflow orchestration, and streaming required for long-running stateful agents. Compared to the Agent Framework, users can build more flexible multi-agent workflows based on the Graph API.
 

--- a/examples/deepresearch/README.md
+++ b/examples/deepresearch/README.md
@@ -73,7 +73,7 @@ DeepResearch implements an agentic architecture that goes beyond simple tool-cal
 - `Hook`: Event hooks for human approval, summarization, tool call limits
 - `MemorySaver`: In-memory state management with conversation history
 
-**Builtin Interceptors**
+**Built-in Interceptors**
 - `TodoListInterceptor`: Task list management and tracking
 - `FilesystemInterceptor`: File system access control with sandboxing
 - `SubAgentInterceptor`: Subagent spawning and coordination
@@ -81,7 +81,7 @@ DeepResearch implements an agentic architecture that goes beyond simple tool-cal
 - `LargeResultEvictionInterceptor`: Auto-dump large results to files
 - `ToolRetryInterceptor`: Retry logic for failed tool calls
 
-**Builtin Hooks**
+**Built-in Hooks**
 - `SummarizationHook`: Conversation history summarization (triggers at 120K tokens)
 - `HumanInTheLoopHook`: Human approval for critical operations
 - `ToolCallLimitHook`: Limit tool calls per run (default: 25)

--- a/spring-ai-alibaba-graph-core/README.md
+++ b/spring-ai-alibaba-graph-core/README.md
@@ -6,7 +6,7 @@ Spring AI Alibaba Graph is a **workflow and multi-agent framework** for Java dev
 
 Spring AI Alibaba Graph serves as the underlying core engine of the Agent Framework. It provides atomic components for building intelligent agents with interruptible and orchestratable capabilities, offering high flexibility but also relatively high learning costs. In contrast, the Agent Framework is built atop Graph, abstracting away the underlying complexities through concepts like ReactAgent and SequentialAgent.
 
-Please check [the documentation](https://java2ai.com/docs/frameworks/graph-core/quick-start) on official website for mote details
+Please check [the documentation](https://java2ai.com/docs/frameworks/graph-core/quick-start) on official website for more details
 
 ## Core Concepts & Classes
 


### PR DESCRIPTION
  ## Summary
  Fix documentation typos:

  - `builtin` → `built-in` in README.md
  - `Builtin Interceptors/Hooks` → `Built-in Interceptors/Hooks` in deepresearch README
  - `mote` → `more` in spring-ai-alibaba-graph-core/README.md

  ## Test plan
  - [x] Verified no functional code changes
  - [x] Only documentation formatting/text corrections