### PR TITLE
fix: support copying lib jars from jar protocol resources

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/utils/FileUtils.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/utils/FileUtils.java
@@ -17,9 +17,15 @@
 package com.alibaba.cloud.ai.graph.utils;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.Enumeration;
 
 /**
  * @author HeYQ
@@ -71,36 +77,71 @@ public class FileUtils {
 	 * @param workDir The target working directory where the JAR files will be copied.
 	 */
 	public static void copyResourceJarToWorkDir(String workDir) {
-		try {
-			// Get the JAR files from resources/lib directory
-			ClassLoader classLoader = FileUtils.class.getClassLoader();
-			URL libUrl = classLoader.getResource("lib");
-			if (libUrl == null) {
-				throw new RuntimeException("Could not find lib directory in resources");
-			}
+		copyResourceJarToWorkDir(workDir, FileUtils.class.getClassLoader());
+	}
 
-			// Create target directory if it doesn't exist
+	/**
+	 * Copies all JAR files from the resources/lib directory (including resources packaged
+	 * inside dependency JARs) to the specified working directory.
+	 * @param workDir The target working directory where the JAR files will be copied.
+	 * @param classLoader The class loader used to locate lib resources.
+	 */
+	static void copyResourceJarToWorkDir(String workDir, ClassLoader classLoader) {
+		try {
 			Path targetDir = Path.of(workDir);
 			if (!Files.exists(targetDir)) {
 				Files.createDirectories(targetDir);
 			}
 
-			// Get all JAR files from lib directory
-			Path libPath = Path.of(libUrl.toURI());
-			try (var stream = Files.walk(libPath)) {
-				stream.filter(path -> path.toString().endsWith(".jar")).forEach(jarPath -> {
-					try {
-						Path targetPath = targetDir.resolve(jarPath.getFileName());
-						Files.copy(jarPath, targetPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+			Enumeration<URL> libUrls = classLoader.getResources("lib");
+			if (!libUrls.hasMoreElements()) {
+				return;
+			}
+
+			while (libUrls.hasMoreElements()) {
+				URL libUrl = libUrls.nextElement();
+				if ("file".equals(libUrl.getProtocol())) {
+					copyJarFilesFromDir(Path.of(libUrl.toURI()), targetDir);
+					continue;
+				}
+				if ("jar".equals(libUrl.getProtocol())) {
+					String jarUrl = libUrl.toString();
+					int separatorIndex = jarUrl.indexOf("!/");
+					if (separatorIndex <= 0) {
+						continue;
 					}
-					catch (IOException e) {
-						throw new RuntimeException("Failed to copy JAR file: " + jarPath, e);
+					URI jarFileUri = URI.create(jarUrl.substring(0, separatorIndex));
+					try (FileSystem fs = FileSystems.newFileSystem(jarFileUri, Collections.emptyMap())) {
+						copyJarFilesFromDir(fs.getPath("/lib"), targetDir);
 					}
-				});
+				}
 			}
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Failed to copy JAR files to working directory", e);
+		}
+	}
+
+	/**
+	 * Copies all JAR files under the source directory to the target directory.
+	 * @param sourceDir The source directory containing JAR files.
+	 * @param targetDir The target directory where JAR files will be copied.
+	 * @throws IOException if I/O operations fail while scanning or copying files.
+	 */
+	private static void copyJarFilesFromDir(Path sourceDir, Path targetDir) throws IOException {
+		if (!Files.exists(sourceDir)) {
+			return;
+		}
+		try (var stream = Files.walk(sourceDir)) {
+			stream.filter(path -> path.toString().endsWith(".jar")).forEach(jarPath -> {
+				try {
+					Path targetPath = targetDir.resolve(jarPath.getFileName().toString());
+					Files.copy(jarPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+				}
+				catch (IOException e) {
+					throw new RuntimeException("Failed to copy JAR file: " + jarPath, e);
+				}
+			});
 		}
 	}
 

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/utils/FileUtilsTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/utils/FileUtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author 014-code
+ * @since 2026-05-05
+ */
+class FileUtilsTest {
+
+	@TempDir
+	Path tempDir;
+
+	/**
+	 * Verify that JAR files under lib/ can be copied successfully when the resource is
+	 * loaded via jar protocol.
+	 */
+	@Test
+	void testCopyResourceJarToWorkDirFromJarProtocol() throws Exception {
+		Path resourceJar = tempDir.resolve("resource-bundle.jar");
+		createJarWithLibEntry(resourceJar, "lib/mock-dependency.jar");
+
+		Path workDir = tempDir.resolve("work");
+		try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[] { resourceJar.toUri().toURL() },
+				null)) {
+			FileUtils.copyResourceJarToWorkDir(workDir.toString(), classLoader);
+		}
+
+		assertTrue(Files.exists(workDir.resolve("mock-dependency.jar")));
+	}
+
+	/**
+	 * Creates a temporary JAR file containing the given lib entry for resource loading
+	 * tests.
+	 * @param jarPath The output JAR path.
+	 * @param entryName The entry path inside JAR.
+	 * @throws IOException if writing JAR entries fails.
+	 */
+	private static void createJarWithLibEntry(Path jarPath, String entryName) throws IOException {
+		try (JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jarPath))) {
+			jarOutputStream.putNextEntry(new JarEntry("lib/"));
+			jarOutputStream.closeEntry();
+			jarOutputStream.putNextEntry(new JarEntry(entryName));
+			jarOutputStream.write(new byte[] { 0x01, 0x02, 0x03 });
+			jarOutputStream.closeEntry();
+		}
+	}
+
+}


### PR DESCRIPTION
## Related Issue
Fixes #3987

## Problem
`FileUtils.copyResourceJarToWorkDir` assumed `resources/lib` is a filesystem directory.
When this starter is consumed as a dependency, `lib` is inside a JAR (`jar:` URL), so `Path.of(libUrl.toURI())` fails and throws:
`Failed to copy JAR files to working directory`.

## Solution
- Keep the public API unchanged.
- Add an internal overload `copyResourceJarToWorkDir(String workDir, ClassLoader classLoader)` for testability.
- Support both resource protocols:
  - `file:` -> walk directory directly.
  - `jar:` -> open JAR filesystem via `FileSystems.newFileSystem(...)` and walk `/lib`.
- Return safely when no `lib` resource is present.

## Tests
Added `FileUtilsTest.testCopyResourceJarToWorkDirFromJarProtocol`:
- Creates a temporary JAR containing `lib/mock-dependency.jar`.
- Loads it via `URLClassLoader`.
- Verifies the JAR is copied to work directory.

Also re-ran:
- `CodeActionTest#testExecuteJavaGlobalDictStyleWithLocalExecutor`