### PR TITLE
fix(graph): resolve null message in StreamingOutput for HITL partial …

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -464,11 +464,15 @@ public class GraphRunnerContext {
 			// Check if "messages" key exists and is a List
 			Object messagesObj = updateStates.get("messages");
 			if (messagesObj instanceof List<?> messagesList && !messagesList.isEmpty()) {
-				// Get the last element
-				Object lastElement = messagesList.get(messagesList.size() - 1);
-				// Check if it's a Message type
-				if (lastElement instanceof Message) {
-					message = (Message) lastElement;
+				// Iterate backwards to find the last Message, skipping non-Message
+				// markers such as RemoveByHash that may be appended after the actual
+				// message (e.g. in HITL partial tool-response handling).
+				for (int i = messagesList.size() - 1; i >= 0; i--) {
+					Object element = messagesList.get(i);
+					if (element instanceof Message msg) {
+						message = msg;
+						break;
+					}
 				}
 			} else if (messagesObj instanceof Message singleMessage) {
 				// If it's a single Message instance


### PR DESCRIPTION
…tool responses (#4595)

When AgentToolNode handles partial ToolResponseMessage (e.g. some tool calls approved and others denied via HITL), it puts a List into the "messages" state where the last element is a RemoveByHash marker rather than a Message. GraphRunnerContext.buildNodeOutput previously took only the very last list element as the StreamingOutput message, so the instanceof Message check failed and the AGENT_TOOL_FINISHED event was emitted with a null message even though the ToolResponseMessage was present in state.

Iterate the messages list backwards and pick the last actual Message instance, skipping non-Message markers like RemoveByHash. This keeps the original "last message" semantics while being robust to additional marker types.

Fixes #4595


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
