### PR TITLE
feat(agent): add streaming model interceptor for per-chunk LLM output

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/Builder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/Builder.java
@@ -30,6 +30,7 @@ import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.agent.hook.Hook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.Interceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.StreamingModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
 import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
@@ -94,6 +95,7 @@ public abstract class Builder {
 	protected List<Interceptor> interceptors = new ArrayList<>();
 	protected List<ModelInterceptor> modelInterceptors = new ArrayList<>();
 	protected List<ToolInterceptor> toolInterceptors = new ArrayList<>();
+	protected List<StreamingModelInterceptor> streamingInterceptors = new ArrayList<>();
 
 	protected boolean includeContents = true;
 	protected boolean returnReasoningContents;
@@ -302,6 +304,20 @@ public abstract class Builder {
 		Assert.notNull(interceptors, "interceptors cannot be null");
 		Assert.noNullElements(interceptors, "interceptors cannot contain null elements");
 		this.interceptors.addAll(List.of(interceptors));
+		return this;
+	}
+
+	public Builder streamingInterceptors(List<StreamingModelInterceptor> streamingInterceptors) {
+		Assert.notNull(streamingInterceptors, "streamingInterceptors cannot be null");
+		Assert.noNullElements(streamingInterceptors, "streamingInterceptors cannot contain null elements");
+		this.streamingInterceptors.addAll(streamingInterceptors);
+		return this;
+	}
+
+	public Builder streamingInterceptors(StreamingModelInterceptor... streamingInterceptors) {
+		Assert.notNull(streamingInterceptors, "streamingInterceptors cannot be null");
+		Assert.noNullElements(streamingInterceptors, "streamingInterceptors cannot contain null elements");
+		this.streamingInterceptors.addAll(List.of(streamingInterceptors));
 		return this;
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -42,6 +42,7 @@ import com.alibaba.cloud.ai.graph.agent.hook.ModelHook;
 import com.alibaba.cloud.ai.graph.agent.hook.ToolInjection;
 import com.alibaba.cloud.ai.graph.agent.hook.hip.HumanInTheLoopHook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.StreamingModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
 import com.alibaba.cloud.ai.graph.agent.node.AgentLlmNode;
 import com.alibaba.cloud.ai.graph.agent.node.AgentToolNode;
@@ -108,6 +109,8 @@ public class ReactAgent extends BaseAgent {
 
 	private List<ToolInterceptor> toolInterceptors;
 
+	private List<StreamingModelInterceptor> streamingInterceptors;
+
 	private String instruction;
 
 	private StateSerializer stateSerializer;
@@ -125,6 +128,7 @@ public class ReactAgent extends BaseAgent {
 		this.hooks = builder.hooks;
 		this.modelInterceptors = builder.modelInterceptors;
 		this.toolInterceptors = builder.toolInterceptors;
+		this.streamingInterceptors = builder.streamingInterceptors;
 		this.includeContents = builder.includeContents;
 		this.inputSchema = builder.inputSchema;
 		this.inputType = builder.inputType;
@@ -148,6 +152,9 @@ public class ReactAgent extends BaseAgent {
 		}
 		if (mergedToolInterceptors != null && !mergedToolInterceptors.isEmpty()) {
 			this.toolNode.setToolInterceptors(mergedToolInterceptors);
+		}
+		if (this.streamingInterceptors != null && !this.streamingInterceptors.isEmpty()) {
+			this.llmNode.setStreamingInterceptors(this.streamingInterceptors);
 		}
 
         // Set tools flag if tool interceptors are present.

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
@@ -17,6 +17,11 @@ package com.alibaba.cloud.ai.graph.agent.interceptor;
 
 import java.util.List;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+
+import reactor.core.publisher.Flux;
+
 /**
  * Utility class for chaining model and tool interceptors.
  *
@@ -88,6 +93,64 @@ public class InterceptorChain {
 
 			// Create a wrapper that calls the interceptor's wrap method
 			current = request -> interceptor.interceptToolCall(request, nextHandler);
+		}
+
+		return current;
+	}
+
+	/**
+	 * Apply streaming interceptors to a {@link Flux} of {@link ChatResponse}.
+	 *
+	 * <p>Each interceptor is applied in order (first to last). For each interceptor:
+	 * <ol>
+	 *   <li>{@link StreamingModelInterceptor#beforeStreamCall} is called once before subscription</li>
+	 *   <li>{@link StreamingModelInterceptor#onStreamChunk} is called for each chunk</li>
+	 *   <li>{@link StreamingModelInterceptor#afterStreamComplete} is called when the stream completes</li>
+	 *   <li>{@link StreamingModelInterceptor#onStreamError} is called if an error occurs</li>
+	 * </ol>
+	 *
+	 * @param interceptors List of StreamingModelInterceptors to apply
+	 * @param flux The original Flux of ChatResponse chunks
+	 * @param request The model request (for context)
+	 * @return The transformed Flux with all interceptors applied
+	 */
+	public static Flux<ChatResponse> applyStreamingInterceptors(
+			List<StreamingModelInterceptor> interceptors,
+			Flux<ChatResponse> flux,
+			ModelRequest request) {
+
+		if (interceptors == null || interceptors.isEmpty()) {
+			return flux;
+		}
+
+		// Apply beforeStreamCall for all interceptors (first to last)
+		ModelRequest currentRequest = request;
+		for (StreamingModelInterceptor interceptor : interceptors) {
+			currentRequest = interceptor.beforeStreamCall(currentRequest);
+		}
+
+		// Apply onStreamChunk, afterStreamComplete, and onStreamError for each interceptor
+		final ModelRequest finalRequest = currentRequest;
+		Flux<ChatResponse> current = flux;
+
+		for (StreamingModelInterceptor interceptor : interceptors) {
+			// Aggregate text from all chunks so afterStreamComplete sees the full message,
+			// not just the final delta chunk's text.
+			final StringBuilder aggregator = new StringBuilder();
+
+			current = current
+					.map(chunk -> {
+						ChatResponse transformed = interceptor.onStreamChunk(chunk, finalRequest);
+						if (transformed != null && transformed.getResult() != null
+								&& transformed.getResult().getOutput() != null
+								&& transformed.getResult().getOutput().getText() != null) {
+							aggregator.append(transformed.getResult().getOutput().getText());
+						}
+						return transformed;
+					})
+					.doOnComplete(() -> interceptor.afterStreamComplete(
+							new AssistantMessage(aggregator.toString()), finalRequest))
+					.doOnError(error -> interceptor.onStreamError(error, finalRequest));
 		}
 
 		return current;

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
@@ -101,13 +101,29 @@ public class InterceptorChain {
 	/**
 	 * Apply streaming interceptors to a {@link Flux} of {@link ChatResponse}.
 	 *
-	 * <p>Each interceptor is applied in order (first to last). For each interceptor:
+	 * <p>The full pipeline is wrapped in {@link Flux#defer(java.util.function.Supplier)} so
+	 * that every subscription (including reactor-driven retries) gets its own
+	 * {@code beforeStreamCall} pass and its own per-interceptor aggregator buffer. Nothing
+	 * runs at composition time.
+	 *
+	 * <p>Per subscription, for each interceptor in registration order (first to last):
 	 * <ol>
-	 *   <li>{@link StreamingModelInterceptor#beforeStreamCall} is called once before subscription</li>
-	 *   <li>{@link StreamingModelInterceptor#onStreamChunk} is called for each chunk</li>
-	 *   <li>{@link StreamingModelInterceptor#afterStreamComplete} is called when the stream completes</li>
-	 *   <li>{@link StreamingModelInterceptor#onStreamError} is called if an error occurs</li>
+	 *   <li>{@link StreamingModelInterceptor#beforeStreamCall} is invoked, threading the
+	 *       (possibly mutated) request to the next interceptor</li>
+	 *   <li>{@link StreamingModelInterceptor#onStreamChunk} is invoked per chunk via
+	 *       {@link Flux#handle}: returning the original/transformed chunk emits it
+	 *       downstream; returning {@code null} drops it (filter)</li>
+	 *   <li>{@link StreamingModelInterceptor#afterStreamComplete} receives an
+	 *       {@link AssistantMessage} built by concatenating each emitted chunk's text
+	 *       (per-subscription, per-interceptor)</li>
+	 *   <li>{@link StreamingModelInterceptor#onStreamError} is invoked on error</li>
 	 * </ol>
+	 *
+	 * <p><b>Wrapping order:</b> the first registered interceptor is the <i>innermost</i>
+	 * operator, i.e. it sees raw model chunks first; later interceptors see whatever the
+	 * previous one returned. This differs from the synchronous {@code chainXxxInterceptors}
+	 * methods above (where the first interceptor is outermost) because chunk-level
+	 * interceptors typically want to observe untransformed model output.
 	 *
 	 * @param interceptors List of StreamingModelInterceptors to apply
 	 * @param flux The original Flux of ChatResponse chunks
@@ -123,41 +139,44 @@ public class InterceptorChain {
 			return flux;
 		}
 
-		// Apply beforeStreamCall for all interceptors (first to last)
-		ModelRequest currentRequest = request;
-		for (StreamingModelInterceptor interceptor : interceptors) {
-			currentRequest = interceptor.beforeStreamCall(currentRequest);
-		}
+		return Flux.defer(() -> {
+			// Per-subscription: thread request through beforeStreamCall (first to last)
+			ModelRequest threaded = request;
+			for (StreamingModelInterceptor interceptor : interceptors) {
+				threaded = interceptor.beforeStreamCall(threaded);
+			}
+			final ModelRequest finalRequest = threaded;
 
-		// Apply onStreamChunk, afterStreamComplete, and onStreamError for each interceptor
-		final ModelRequest finalRequest = currentRequest;
-		Flux<ChatResponse> current = flux;
+			Flux<ChatResponse> current = flux;
+			for (StreamingModelInterceptor interceptor : interceptors) {
+				// Per-subscription, per-interceptor aggregator buffer
+				final StringBuilder aggregator = new StringBuilder();
 
-		for (StreamingModelInterceptor interceptor : interceptors) {
-			// Aggregate text from all chunks so afterStreamComplete sees the full message,
-			// not just the final delta chunk's text.
-			final StringBuilder aggregator = new StringBuilder();
+				current = current
+						.handle((ChatResponse chunk, reactor.core.publisher.SynchronousSink<ChatResponse> sink) -> {
+							ChatResponse transformed = interceptor.onStreamChunk(chunk, finalRequest);
+							if (transformed == null) {
+								// null = drop this chunk (filter); next interceptors won't see it
+								return;
+							}
+							if (transformed.getResult() != null
+									&& transformed.getResult().getOutput() != null
+									&& transformed.getResult().getOutput().getText() != null) {
+								aggregator.append(transformed.getResult().getOutput().getText());
+							}
+							sink.next(transformed);
+						})
+						.doOnComplete(() -> interceptor.afterStreamComplete(
+								new AssistantMessage(aggregator.toString()), finalRequest))
+						.doOnError(error -> interceptor.onStreamError(error, finalRequest));
+			}
 
-			current = current
-					.map(chunk -> {
-						ChatResponse transformed = interceptor.onStreamChunk(chunk, finalRequest);
-						if (transformed != null && transformed.getResult() != null
-								&& transformed.getResult().getOutput() != null
-								&& transformed.getResult().getOutput().getText() != null) {
-							aggregator.append(transformed.getResult().getOutput().getText());
-						}
-						return transformed;
-					})
-					.doOnComplete(() -> interceptor.afterStreamComplete(
-							new AssistantMessage(aggregator.toString()), finalRequest))
-					.doOnError(error -> interceptor.onStreamError(error, finalRequest));
-		}
-
-		return current;
+			return current;
+		});
 	}
 
 	/**
-	 * Example of how interceptors are chained:
+	 * Example of how synchronous (model/tool) interceptors are chained:
 	 *
 	 * Given interceptors [auth, retry, cache] and baseHandler:
 	 *
@@ -166,10 +185,14 @@ public class InterceptorChain {
 	 * 3. Wrap with retry: current = req -> retry.wrap(req, cache.wrap(...))
 	 * 4. Wrap with auth: current = req -> auth.wrap(req, retry.wrap(...))
 	 *
-	 * Final call flow:
+	 * Final call flow (first interceptor is outermost):
 	 * request -> auth -> retry -> cache -> baseHandler
 	 *
 	 * Response flow:
 	 * baseHandler -> cache -> retry -> auth -> response
+	 *
+	 * Note: streaming interceptors use the opposite convention — the first registered
+	 * interceptor is the innermost operator and sees raw chunks first. See
+	 * {@link #applyStreamingInterceptors}.
 	 */
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
@@ -119,6 +119,15 @@ public class InterceptorChain {
 	 *   <li>{@link StreamingModelInterceptor#onStreamError} is invoked on error</li>
 	 * </ol>
 	 *
+	 * <p><b>Request threading:</b> the {@code request} parameter passed to every
+	 * {@code onStreamChunk} / {@code afterStreamComplete} / {@code onStreamError}
+	 * invocation is the request as it stands <i>after every interceptor's
+	 * {@code beforeStreamCall} has run</i>, not the original {@code request} argument
+	 * to this method. This means {@code beforeStreamCall} is purely a context-propagation
+	 * hook between interceptors; it cannot influence the outbound model call (the chunk
+	 * Flux has already been built from the original request). To modify what is sent to
+	 * the model, use {@link ModelInterceptor}.
+	 *
 	 * <p><b>Wrapping order:</b> the first registered interceptor is the <i>innermost</i>
 	 * operator, i.e. it sees raw model chunks first; later interceptors see whatever the
 	 * previous one returned. This differs from the synchronous {@code chainXxxInterceptors}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/InterceptorChain.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.graph.agent.interceptor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -149,10 +150,30 @@ public class InterceptorChain {
 		}
 
 		return Flux.defer(() -> {
-			// Per-subscription: thread request through beforeStreamCall (first to last)
-			ModelRequest threaded = request;
-			for (StreamingModelInterceptor interceptor : interceptors) {
-				threaded = interceptor.beforeStreamCall(threaded);
+			// Defensive copy: each subscription starts from its own ModelRequest so an
+			// interceptor that mutates context/messages/options in-place inside
+			// beforeStreamCall does not leak state across retries / multi-subscribe.
+			ModelRequest scopedRequest = copyForSubscription(request);
+
+			// Thread request through beforeStreamCall (first to last). Wrapped in try/catch
+			// because we are inside the defer supplier — if we let the exception escape
+			// before any doOnError operator is attached below, per-interceptor onStreamError
+			// callbacks would never fire and startup failures would be invisible to users.
+			ModelRequest threaded = scopedRequest;
+			try {
+				for (StreamingModelInterceptor interceptor : interceptors) {
+					threaded = interceptor.beforeStreamCall(threaded);
+				}
+			} catch (Throwable startupError) {
+				for (StreamingModelInterceptor interceptor : interceptors) {
+					try {
+						interceptor.onStreamError(startupError, scopedRequest);
+					} catch (Throwable cbThrown) {
+						// Don't let one buggy callback hide the original failure
+						startupError.addSuppressed(cbThrown);
+					}
+				}
+				return Flux.error(startupError);
 			}
 			final ModelRequest finalRequest = threaded;
 
@@ -182,6 +203,32 @@ public class InterceptorChain {
 
 			return current;
 		});
+	}
+
+	/**
+	 * Build a per-subscription copy of {@link ModelRequest} so concurrent / retried
+	 * subscriptions of the same wrapped {@link Flux} do not share mutable state.
+	 *
+	 * <p>{@link ModelRequest#builder(ModelRequest)} already shallow-copies
+	 * {@code tools}, {@code dynamicToolCallbacks}, {@code toolDescriptions}, and
+	 * {@code context}, but reuses the {@code messages} list and {@code options} object.
+	 * This helper additionally wraps {@code messages} in a fresh {@link ArrayList} and
+	 * invokes {@code options.copy()} so an interceptor that does e.g.
+	 * {@code request.getOptions().setTemperature(0.0)} or
+	 * {@code request.getMessages().add(...)} mutates only this subscription's copy.
+	 *
+	 * <p>Note: individual {@link org.springframework.ai.chat.messages.Message} elements
+	 * are treated as effectively immutable (Spring AI uses immutable message types in
+	 * practice); we do not deep-copy them.
+	 */
+	private static ModelRequest copyForSubscription(ModelRequest src) {
+		if (src == null) {
+			return null;
+		}
+		return ModelRequest.builder(src)
+				.messages(src.getMessages() != null ? new ArrayList<>(src.getMessages()) : null)
+				.options(src.getOptions() != null ? src.getOptions().copy() : null)
+				.build();
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/StreamingModelInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/StreamingModelInterceptor.java
@@ -77,7 +77,10 @@ public interface StreamingModelInterceptor {
 	 *
 	 * @param chunk the current streaming chunk
 	 * @param request the original model request (for context)
-	 * @return the (possibly modified) chunk; return the original chunk if no modification is needed
+	 * @return the (possibly modified) chunk to keep emitting, or {@code null} to drop this
+	 *         chunk from the stream entirely. When dropped, downstream interceptors and
+	 *         subscribers will not see this chunk, and its text will not be included in
+	 *         the aggregated message passed to {@link #afterStreamComplete}.
 	 */
 	default ChatResponse onStreamChunk(ChatResponse chunk, ModelRequest request) {
 		return chunk;

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/StreamingModelInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/StreamingModelInterceptor.java
@@ -24,11 +24,18 @@ import org.springframework.ai.chat.model.ChatResponse;
  * <p>Unlike {@link ModelInterceptor} which intercepts the entire model call (request/response),
  * this interceptor provides fine-grained control over individual streaming chunks.</p>
  *
- * <p>Lifecycle:</p>
+ * <p>Lifecycle (per subscription — see
+ * {@link InterceptorChain#applyStreamingInterceptors}):</p>
  * <ol>
- *   <li>{@link #beforeStreamCall} - Called once before the streaming call starts, can modify the request</li>
- *   <li>{@link #onStreamChunk} - Called for each {@link ChatResponse} chunk during streaming</li>
- *   <li>{@link #afterStreamComplete} - Called once after all chunks have been received</li>
+ *   <li>{@link #beforeStreamCall} - Called once before the chunk Flux is subscribed.
+ *       The returned {@link ModelRequest} is threaded into <i>subsequent callbacks</i>
+ *       of this and later interceptors as the {@code request} parameter; it does
+ *       <b>not</b> alter the actual outbound model call (the Flux has already been
+ *       constructed). To modify the outbound request use {@link ModelInterceptor}.</li>
+ *   <li>{@link #onStreamChunk} - Called for each {@link ChatResponse} chunk; can
+ *       transform, observe, or drop ({@code return null}) the chunk</li>
+ *   <li>{@link #afterStreamComplete} - Called once after all chunks have been received,
+ *       with the aggregated {@link AssistantMessage} built from emitted chunk text</li>
  *   <li>{@link #onStreamError} - Called if an error occurs during streaming</li>
  * </ol>
  *
@@ -61,11 +68,22 @@ import org.springframework.ai.chat.model.ChatResponse;
 public interface StreamingModelInterceptor {
 
 	/**
-	 * Called once before the streaming call starts.
-	 * Can be used to modify or enrich the request before it is sent to the model.
+	 * Called once per subscription, before the chunk Flux is subscribed to.
 	 *
-	 * @param request the original model request
-	 * @return the (possibly modified) model request
+	 * <p>The returned {@link ModelRequest} is propagated as the {@code request} parameter
+	 * to this and later interceptors' {@link #onStreamChunk}, {@link #afterStreamComplete},
+	 * and {@link #onStreamError} callbacks. Use this hook to attach context (correlation
+	 * IDs, trace metadata, computed state) that downstream callbacks need to read.
+	 *
+	 * <p><b>Important:</b> the returned request does <i>not</i> alter the outbound model
+	 * call — by the time this method runs, the chunk Flux has already been built from the
+	 * original request. To modify what is sent to the model (messages, options, tools),
+	 * use {@link ModelInterceptor} instead.
+	 *
+	 * @param request the model request as threaded through earlier interceptors'
+	 *                {@code beforeStreamCall} (or the original request for the first
+	 *                interceptor in the chain)
+	 * @return the (possibly enriched) model request to pass to subsequent callbacks
 	 */
 	default ModelRequest beforeStreamCall(ModelRequest request) {
 		return request;
@@ -76,7 +94,9 @@ public interface StreamingModelInterceptor {
 	 * Can be used to inspect, transform, or filter individual chunks.
 	 *
 	 * @param chunk the current streaming chunk
-	 * @param request the original model request (for context)
+	 * @param request the model request as it stands after every interceptor's
+	 *                {@link #beforeStreamCall} has run (i.e. the fully-threaded request,
+	 *                not necessarily the original one passed to the model)
 	 * @return the (possibly modified) chunk to keep emitting, or {@code null} to drop this
 	 *         chunk from the stream entirely. When dropped, downstream interceptors and
 	 *         subscribers will not see this chunk, and its text will not be included in
@@ -90,8 +110,12 @@ public interface StreamingModelInterceptor {
 	 * Called once after all streaming chunks have been received successfully.
 	 * Can be used for logging, metrics collection, or post-processing.
 	 *
-	 * @param aggregatedMessage the aggregated assistant message from all chunks
-	 * @param request the original model request (for context)
+	 * @param aggregatedMessage an {@link AssistantMessage} built by concatenating the
+	 *                          {@code text} of every chunk this interceptor emitted
+	 *                          downstream (chunks dropped via {@link #onStreamChunk}
+	 *                          returning {@code null} are excluded)
+	 * @param request the model request as it stands after every interceptor's
+	 *                {@link #beforeStreamCall} has run
 	 */
 	default void afterStreamComplete(AssistantMessage aggregatedMessage, ModelRequest request) {
 	}
@@ -101,7 +125,8 @@ public interface StreamingModelInterceptor {
 	 * Can be used for error logging, alerting, or fallback logic.
 	 *
 	 * @param error the error that occurred
-	 * @param request the original model request (for context)
+	 * @param request the model request as it stands after every interceptor's
+	 *                {@link #beforeStreamCall} has run
 	 */
 	default void onStreamError(Throwable error, ModelRequest request) {
 	}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/StreamingModelInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/StreamingModelInterceptor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptor;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+
+/**
+ * Streaming model interceptor that provides per-chunk interception for streaming model calls.
+ *
+ * <p>Unlike {@link ModelInterceptor} which intercepts the entire model call (request/response),
+ * this interceptor provides fine-grained control over individual streaming chunks.</p>
+ *
+ * <p>Lifecycle:</p>
+ * <ol>
+ *   <li>{@link #beforeStreamCall} - Called once before the streaming call starts, can modify the request</li>
+ *   <li>{@link #onStreamChunk} - Called for each {@link ChatResponse} chunk during streaming</li>
+ *   <li>{@link #afterStreamComplete} - Called once after all chunks have been received</li>
+ *   <li>{@link #onStreamError} - Called if an error occurs during streaming</li>
+ * </ol>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * StreamingModelInterceptor interceptor = new StreamingModelInterceptor() {
+ *     @Override
+ *     public ChatResponse onStreamChunk(ChatResponse chunk, ModelRequest request) {
+ *         System.out.println("Chunk: " + chunk.getResult().getOutput().getText());
+ *         return chunk;
+ *     }
+ *
+ *     @Override
+ *     public void afterStreamComplete(AssistantMessage aggregatedMessage, ModelRequest request) {
+ *         System.out.println("Complete: " + aggregatedMessage.getText());
+ *     }
+ * };
+ *
+ * ReactAgent agent = ReactAgent.builder()
+ *     .name("my-agent")
+ *     .model(chatModel)
+ *     .streamingInterceptors(interceptor)
+ *     .build();
+ * }</pre>
+ *
+ * @author haojunpan
+ * @since 1.0.0
+ * @see ModelInterceptor
+ */
+public interface StreamingModelInterceptor {
+
+	/**
+	 * Called once before the streaming call starts.
+	 * Can be used to modify or enrich the request before it is sent to the model.
+	 *
+	 * @param request the original model request
+	 * @return the (possibly modified) model request
+	 */
+	default ModelRequest beforeStreamCall(ModelRequest request) {
+		return request;
+	}
+
+	/**
+	 * Called for each {@link ChatResponse} chunk during streaming.
+	 * Can be used to inspect, transform, or filter individual chunks.
+	 *
+	 * @param chunk the current streaming chunk
+	 * @param request the original model request (for context)
+	 * @return the (possibly modified) chunk; return the original chunk if no modification is needed
+	 */
+	default ChatResponse onStreamChunk(ChatResponse chunk, ModelRequest request) {
+		return chunk;
+	}
+
+	/**
+	 * Called once after all streaming chunks have been received successfully.
+	 * Can be used for logging, metrics collection, or post-processing.
+	 *
+	 * @param aggregatedMessage the aggregated assistant message from all chunks
+	 * @param request the original model request (for context)
+	 */
+	default void afterStreamComplete(AssistantMessage aggregatedMessage, ModelRequest request) {
+	}
+
+	/**
+	 * Called if an error occurs during streaming.
+	 * Can be used for error logging, alerting, or fallback logic.
+	 *
+	 * @param error the error that occurred
+	 * @param request the original model request (for context)
+	 */
+	default void onStreamError(Throwable error, ModelRequest request) {
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
@@ -26,6 +26,7 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
 import com.alibaba.cloud.ai.graph.agent.interceptor.InterceptorChain;
 import com.alibaba.cloud.ai.graph.agent.tool.ToolCallbackUtils;
+import com.alibaba.cloud.ai.graph.agent.interceptor.StreamingModelInterceptor;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.DefaultChatClient;
@@ -75,6 +76,8 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 	private List<ModelInterceptor> modelInterceptors = new ArrayList<>();
 
+	private List<StreamingModelInterceptor> streamingInterceptors = new ArrayList<>();
+
 	private String outputKey;
 
 	private String outputSchema;
@@ -107,6 +110,9 @@ public class AgentLlmNode implements NodeActionWithConfig {
 		if (builder.modelInterceptors != null) {
 			this.modelInterceptors = builder.modelInterceptors;
 		}
+		if (builder.streamingInterceptors != null) {
+			this.streamingInterceptors = builder.streamingInterceptors;
+		}
 		this.chatClient = builder.chatClient;
 		this.chatOptions = buildChatOptions(builder.chatOptions, this.toolCallbacks);
 		this.enableReasoningLog = builder.enableReasoningLog;
@@ -122,6 +128,10 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 	public void setModelInterceptors(List<ModelInterceptor> modelInterceptors) {
 		this.modelInterceptors = modelInterceptors;
+	}
+
+	public void setStreamingInterceptors(List<StreamingModelInterceptor> streamingInterceptors) {
+		this.streamingInterceptors = streamingInterceptors;
 	}
 
 	public void setInstruction(String instruction) {
@@ -226,6 +236,10 @@ public class AgentLlmNode implements NodeActionWithConfig {
 								}
 							}
 						});
+					}
+					if (streamingInterceptors != null && !streamingInterceptors.isEmpty()) {
+						chatResponseFlux = InterceptorChain.applyStreamingInterceptors(
+								streamingInterceptors, chatResponseFlux, request);
 					}
 					return ModelResponse.of(chatResponseFlux);
 				} catch (Exception e) {
@@ -549,6 +563,8 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 		private List<ModelInterceptor> modelInterceptors;
 
+		private List<StreamingModelInterceptor> streamingInterceptors;
+
 		private String instruction;
 
 		private boolean enableReasoningLog;
@@ -592,6 +608,11 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 		public Builder modelInterceptors(List<ModelInterceptor> modelInterceptors) {
 			this.modelInterceptors = modelInterceptors;
+			return this;
+		}
+
+		public Builder streamingInterceptors(List<StreamingModelInterceptor> streamingInterceptors) {
+			this.streamingInterceptors = streamingInterceptors;
 			return this;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/AbstractDashscopeChatModelTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/AbstractDashscopeChatModelTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptors;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+
+/**
+ * 共享 base class：通过 OpenAI 兼容接口初始化 DashScope ChatModel。
+ * 子类用 {@link #chatModel} 字段直接拿到注入好的实例。
+ *
+ * <p>运行前需设置以下环境变量：
+ * <ul>
+ *   <li>{@code AI_DASHSCOPE_API_KEY}  - DashScope API 密钥（必填，缺失时测试自动跳过）</li>
+ *   <li>{@code AI_DASHSCOPE_BASE_URL} - API 地址（可选，默认 DashScope 公网兼容端点）</li>
+ *   <li>{@code AI_DASHSCOPE_MODEL}    - 模型名称（可选，默认 qwen-plus）</li>
+ * </ul>
+ */
+abstract class AbstractDashscopeChatModelTest {
+
+	private static final String DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+
+	private static final String DEFAULT_MODEL = "qwen-plus";
+
+	protected ChatModel chatModel;
+
+	@BeforeEach
+	void initChatModel() {
+		final String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+		Assumptions.assumeTrue(apiKey != null && !apiKey.isBlank(),
+				"Skipping: AI_DASHSCOPE_API_KEY environment variable is not set");
+
+		final String baseUrl = System.getenv().getOrDefault("AI_DASHSCOPE_BASE_URL", DEFAULT_BASE_URL);
+		final String model = System.getenv().getOrDefault("AI_DASHSCOPE_MODEL", DEFAULT_MODEL);
+
+		OpenAiApi openAiApi = OpenAiApi.builder()
+				.baseUrl(baseUrl)
+				.apiKey(apiKey)
+				.build();
+		chatModel = OpenAiChatModel.builder()
+				.openAiApi(openAiApi)
+				.defaultOptions(OpenAiChatOptions.builder().model(model).build())
+				.build();
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/AbstractDashscopeChatModelTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/AbstractDashscopeChatModelTest.java
@@ -35,7 +35,8 @@ import org.springframework.ai.openai.api.OpenAiApi;
  */
 abstract class AbstractDashscopeChatModelTest {
 
-	private static final String DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+	// Base URL only — OpenAiApi appends "/v1/chat/completions" itself; do NOT include /v1 here.
+	private static final String DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode";
 
 	private static final String DEFAULT_MODEL = "qwen-plus";
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/InterceptorChainStreamingTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/InterceptorChainStreamingTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptors;
+
+import com.alibaba.cloud.ai.graph.agent.interceptor.InterceptorChain;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.StreamingModelInterceptor;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import reactor.core.publisher.Flux;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Deterministic unit tests for {@link InterceptorChain#applyStreamingInterceptors}.
+ *
+ * <p>Pin down the lifecycle guarantees that the streaming interceptor extension point
+ * relies on:
+ * <ul>
+ *   <li>Per-subscription isolation of aggregator state and {@link ModelRequest} copies
+ *       (so retries / multi-subscribe don't cross-contaminate)</li>
+ *   <li>{@code onStreamChunk} returning {@code null} drops the chunk from downstream
+ *       and from the aggregated message</li>
+ *   <li>Exceptions thrown from {@code beforeStreamCall} fan out to every interceptor's
+ *       {@code onStreamError} and surface as an upstream error to the subscriber</li>
+ *   <li>In-place mutation of the request inside {@code beforeStreamCall} does not
+ *       affect later subscriptions of the same wrapped Flux</li>
+ * </ul>
+ *
+ * <p>These tests use mock chunks (not a real ChatModel) so they run in CI without
+ * any DashScope credentials.
+ */
+class InterceptorChainStreamingTest {
+
+	// ---------- helpers ----------
+
+	private static ChatResponse chunk(String text) {
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+	}
+
+	private static ModelRequest newRequest() {
+		return ModelRequest.builder()
+				.messages(new ArrayList<>(List.of(new UserMessage("hi"))))
+				.options(ToolCallingChatOptions.builder().build())
+				.build();
+	}
+
+	// ---------- tests ----------
+
+	@Test
+	void multiSubscribe_aggregatorIsPerSubscription() {
+		AtomicInteger completeCount = new AtomicInteger();
+		AtomicReference<String> lastAggregated = new AtomicReference<>();
+
+		StreamingModelInterceptor i = new StreamingModelInterceptor() {
+			@Override
+			public void afterStreamComplete(AssistantMessage m, ModelRequest r) {
+				completeCount.incrementAndGet();
+				lastAggregated.set(m.getText());
+			}
+		};
+
+		Flux<ChatResponse> wrapped = InterceptorChain.applyStreamingInterceptors(
+				List.of(i), Flux.just(chunk("a"), chunk("b")), newRequest());
+
+		wrapped.blockLast();
+		wrapped.blockLast();
+
+		assertEquals(2, completeCount.get(), "afterStreamComplete should fire once per subscription");
+		assertEquals("ab", lastAggregated.get(),
+				"second subscription must see 'ab' (its own buffer), not 'abab' (shared buffer)");
+	}
+
+	@Test
+	void onStreamChunkReturningNull_dropsChunkAndExcludesFromAggregate() {
+		StreamingModelInterceptor dropAllB = new StreamingModelInterceptor() {
+			@Override
+			public ChatResponse onStreamChunk(ChatResponse c, ModelRequest r) {
+				if ("b".equals(c.getResult().getOutput().getText())) {
+					return null;
+				}
+				return c;
+			}
+		};
+
+		AtomicReference<String> aggregated = new AtomicReference<>();
+		StreamingModelInterceptor capture = new StreamingModelInterceptor() {
+			@Override
+			public void afterStreamComplete(AssistantMessage m, ModelRequest r) {
+				aggregated.set(m.getText());
+			}
+		};
+
+		Flux<ChatResponse> wrapped = InterceptorChain.applyStreamingInterceptors(
+				List.of(dropAllB, capture),
+				Flux.just(chunk("a"), chunk("b"), chunk("c")),
+				newRequest());
+
+		List<String> emitted = wrapped
+				.map(c -> c.getResult().getOutput().getText())
+				.collectList()
+				.block();
+
+		assertEquals(List.of("a", "c"), emitted, "dropped chunk must not reach downstream");
+		assertEquals("ac", aggregated.get(),
+				"aggregator must not include text from dropped chunks");
+	}
+
+	@Test
+	void beforeStreamCallThrows_fansOutOnStreamErrorToAllInterceptors_andSignalsErrorDownstream() {
+		AtomicInteger errorCalls = new AtomicInteger();
+		AtomicReference<Throwable> errorSeen = new AtomicReference<>();
+
+		RuntimeException boom = new RuntimeException("boom");
+		StreamingModelInterceptor exploding = new StreamingModelInterceptor() {
+			@Override
+			public ModelRequest beforeStreamCall(ModelRequest r) {
+				throw boom;
+			}
+
+			@Override
+			public void onStreamError(Throwable t, ModelRequest r) {
+				errorCalls.incrementAndGet();
+				errorSeen.set(t);
+			}
+		};
+		StreamingModelInterceptor neverInvoked = new StreamingModelInterceptor() {
+			@Override
+			public void onStreamError(Throwable t, ModelRequest r) {
+				errorCalls.incrementAndGet();
+			}
+		};
+
+		Flux<ChatResponse> wrapped = InterceptorChain.applyStreamingInterceptors(
+				List.of(exploding, neverInvoked), Flux.just(chunk("x")), newRequest());
+
+		RuntimeException thrown = assertThrows(RuntimeException.class, wrapped::blockLast,
+				"the original exception must propagate to the subscriber");
+		assertSame(boom, thrown, "downstream subscriber should observe the original throwable");
+
+		assertEquals(2, errorCalls.get(),
+				"every interceptor's onStreamError should fire when beforeStreamCall fails");
+		assertSame(boom, errorSeen.get(), "onStreamError should receive the originating exception");
+	}
+
+	@Test
+	void inPlaceContextMutation_doesNotLeakAcrossSubscriptions() {
+		StreamingModelInterceptor mutator = new StreamingModelInterceptor() {
+			@Override
+			public ModelRequest beforeStreamCall(ModelRequest r) {
+				r.getContext().put("counter",
+						(int) r.getContext().getOrDefault("counter", 0) + 1);
+				return r;
+			}
+		};
+
+		AtomicReference<Object> seenCounter = new AtomicReference<>();
+		StreamingModelInterceptor reader = new StreamingModelInterceptor() {
+			@Override
+			public ModelRequest beforeStreamCall(ModelRequest r) {
+				seenCounter.set(r.getContext().get("counter"));
+				return r;
+			}
+		};
+
+		ModelRequest shared = newRequest();
+		Flux<ChatResponse> wrapped = InterceptorChain.applyStreamingInterceptors(
+				List.of(mutator, reader), Flux.just(chunk("a")), shared);
+
+		wrapped.blockLast();
+		Object firstSeen = seenCounter.get();
+		wrapped.blockLast();
+		Object secondSeen = seenCounter.get();
+
+		assertEquals(1, firstSeen, "first subscription's mutator should bump counter to 1");
+		assertEquals(1, secondSeen,
+				"second subscription must start fresh — counter must be 1 again, not 2");
+		assertNotNull(shared.getContext(),
+				"original request's context should remain (and never grow) across subscriptions");
+		assertEquals(0, shared.getContext().size(),
+				"original request must not be mutated by interceptor in-place changes");
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ParallelAgentToolContextLossTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ParallelAgentToolContextLossTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptors;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+import com.alibaba.cloud.ai.graph.agent.hook.AgentHook;
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+
+import static com.alibaba.cloud.ai.graph.agent.tools.ToolContextConstants.AGENT_STATE_FOR_UPDATE_CONTEXT_KEY;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+@EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+class ParallelAgentToolContextLossTest extends AbstractDashscopeChatModelTest {
+
+	/** 用于在 afterHook 中记录检查结果 */
+	private static final ConcurrentHashMap<String, Object> HOOK_CAPTURED_DATA = new ConcurrentHashMap<>();
+
+	@BeforeEach
+	void clearHookCapturedData() {
+		HOOK_CAPTURED_DATA.clear();
+	}
+
+
+	// ==================== 商品查询工具 ====================
+
+	/**
+	 * 查询商品1的工具：返回商品信息，并通过 ToolContext 写入额外数据
+	 */
+	static class QueryProduct1Tool implements BiFunction<QueryProduct1Tool.Request, ToolContext, String> {
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public String apply(Request request, ToolContext toolContext) {
+			// 通过 ToolContext 写入额外状态数据
+			Map<String, Object> updateMap = (Map<String, Object>) toolContext.getContext()
+					.get(AGENT_STATE_FOR_UPDATE_CONTEXT_KEY);
+			if (updateMap != null) {
+				updateMap.put("product_1_extra", "苹果手机");
+				System.out.println("[Tool query_product_1] 已写入 product_1_extra=苹果手机 到 ToolContext");
+			} else {
+				System.out.println("[Tool query_product_1] ⚠️ updateMap 为 null，无法写入额外数据");
+			}
+			return "商品1: id=1, name=苹果";
+		}
+
+		public record Request(
+				@JsonProperty(required = true, value = "query")
+				@JsonPropertyDescription("查询关键词") String query,
+
+				@JsonProperty(required = true, value = "thought")
+				@JsonPropertyDescription("思考为什么要调用这个工具") String thought
+				) {
+		}
+
+		static ToolCallback createCallback() {
+			return FunctionToolCallback.builder("query_product_1", new QueryProduct1Tool())
+					.description("查询商品1的信息，返回id=1的苹果商品")
+					.inputType(Request.class)
+					.build();
+		}
+	}
+
+	/**
+	 * 查询商品2的工具：返回商品信息，并通过 ToolContext 写入额外数据
+	 */
+	static class QueryProduct2Tool implements BiFunction<QueryProduct2Tool.Request, ToolContext, String> {
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public String apply(Request request, ToolContext toolContext) {
+			Map<String, Object> updateMap = (Map<String, Object>) toolContext.getContext()
+					.get(AGENT_STATE_FOR_UPDATE_CONTEXT_KEY);
+			if (updateMap != null) {
+				updateMap.put("product_2_extra", "华为平板");
+				System.out.println("[Tool query_product_2] 已写入 product_2_extra=华为平板 到 ToolContext");
+			} else {
+				System.out.println("[Tool query_product_2] ⚠️ updateMap 为 null，无法写入额外数据");
+			}
+			return "商品2: id=2, name=香蕉";
+		}
+
+		public record Request(
+				@JsonProperty(required = true, value = "query")
+				@JsonPropertyDescription("查询关键词") String query) {
+		}
+
+		static ToolCallback createCallback() {
+			return FunctionToolCallback.builder("query_product_2", new QueryProduct2Tool())
+					.description("查询商品2的信息，返回id=2的香蕉商品")
+					.inputType(Request.class)
+					.build();
+		}
+	}
+
+	// ==================== AfterHook：验证数据可见性 ====================
+
+	/**
+	 * 在 SequentialAgent 执行完成后检查 ToolContext 写入的额外数据是否可见
+	 */
+	static class DataVerificationHook extends AgentHook {
+
+		@Override
+		public String getName() {
+			return "data_verification_hook";
+		}
+
+		@Override
+		public CompletableFuture<Map<String, Object>> afterAgent(OverAllState state, RunnableConfig config) {
+			System.out.println("\n╔══════════════════════════════════════════════════╗");
+			System.out.println("║  [afterHook] 验证子Agent ToolContext 数据可见性    ║");
+			System.out.println("╠══════════════════════════════════════════════════╣");
+
+			Optional<Object> extra1 = state.value("product_1_extra");
+			Optional<Object> extra2 = state.value("product_2_extra");
+
+			System.out.println("║  product_1_extra: " + (extra1.isPresent() ? extra1.get() : "❌ 缺失"));
+			System.out.println("║  product_2_extra: " + (extra2.isPresent() ? extra2.get() : "❌ 缺失"));
+
+			// 记录到静态 map，供断言使用
+			HOOK_CAPTURED_DATA.put("product_1_extra_present", extra1.isPresent());
+			HOOK_CAPTURED_DATA.put("product_2_extra_present", extra2.isPresent());
+			extra1.ifPresent(value -> HOOK_CAPTURED_DATA.put("product_1_extra_value", value));
+			extra2.ifPresent(value -> HOOK_CAPTURED_DATA.put("product_2_extra_value", value));
+
+			// 打印所有 state keys 帮助调试
+			System.out.println("║  所有 state keys: " + state.data().keySet());
+			System.out.println("╚══════════════════════════════════════════════════╝\n");
+
+			return CompletableFuture.completedFuture(Map.of());
+		}
+	}
+
+	// ==================== 测试用例 ====================
+
+	/**
+	 * 复现：SequentialAgent(afterHook) → ParallelAgent(2个子Agent并发查询商品)
+	 * 验证 afterHook 能否获取到子Agent通过 ToolContext 写入的额外数据
+	 */
+	@Test
+	void testToolContextDataLossInParallelSubAgents() throws Exception {
+		// 子Agent1：查询商品1
+		ReactAgent productAgent1 = ReactAgent.builder()
+				.name("product_agent_1")
+				.model(chatModel)
+				.description("查询商品1")
+				.instruction("请调用 query_product_1 工具查询商品信息,并输出500字的商品结构化解读")
+				.tools(List.of(QueryProduct1Tool.createCallback()))
+				.outputKey("product_1_result")
+				.build();
+
+		// 子Agent2：查询商品2
+		ReactAgent productAgent2 = ReactAgent.builder()
+				.name("product_agent_2")
+				.model(chatModel)
+				.description("查询商品2")
+				.instruction("请调用 query_product_2 工具查询商品信息,并输出500字的商品结构化解读")
+				.tools(List.of(QueryProduct2Tool.createCallback()))
+				.outputKey("product_2_result")
+				.build();
+
+		// ParallelAgent：并发执行两个商品查询
+//		ParallelAgent parallelAgent = ParallelAgent.builder()
+//				.name("parallel_product_query")
+//				.description("并发查询两个商品")
+//				.subAgents(List.of(productAgent1, productAgent2))
+//				.build();
+
+		// SequentialAgent：包含 ParallelAgent + afterHook 验证数据
+		SequentialAgent sequentialAgent = SequentialAgent.builder()
+				.name("product_query_workflow")
+				.description("商品查询工作流")
+				.subAgents(List.of(productAgent1, productAgent2))
+				.hooks(List.of(new DataVerificationHook()))
+				.build();
+
+		try {
+			// 收集所有输出数据
+			StringBuffer allOutput = new StringBuffer();
+
+			sequentialAgent
+					.stream("查询所有商品")
+					.doOnNext(data -> {
+						try {
+							if (data instanceof StreamingOutput<?> streamingOutput) {
+								String chunk = streamingOutput.chunk();
+								if (chunk != null) {
+									System.out.println("sse: " + chunk);
+									allOutput.append(chunk);
+								}
+							}
+							Thread.sleep(200); // 停顿 200ms，方便观测输出
+						} catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
+						}
+					})
+					.doOnComplete(() -> {
+						System.out.println("\n\n===== 完整输出结果 =====");
+						System.out.println(allOutput);
+						System.out.println("========================");
+					})
+					.blockLast();
+
+//			assertTrue(result.isPresent(), "执行结果不应为空");
+
+//			OverAllState finalState = result.get();
+			System.out.println("\n===== 最终 State =====");
+//			System.out.println("所有 keys: " + finalState.data().keySet());
+//			finalState.data().forEach((key, value) ->
+//					System.out.println("  " + key + " = " + value));
+
+			// 验证 afterHook 是否捕获到了数据
+			Boolean extra1Present = (Boolean) HOOK_CAPTURED_DATA.get("product_1_extra_present");
+			Boolean extra2Present = (Boolean) HOOK_CAPTURED_DATA.get("product_2_extra_present");
+
+			System.out.println("\n===== 验证结果 =====");
+			System.out.println("afterHook 中 product_1_extra 是否存在: " + extra1Present);
+			System.out.println("afterHook 中 product_2_extra 是否存在: " + extra2Present);
+
+			// 这两个断言预期会失败，从而复现问题
+			assertTrue(extra1Present != null && extra1Present,
+					"afterHook 应该能获取到 product_1_extra（通过 ToolContext 写入的数据），但实际获取不到");
+			assertTrue(extra2Present != null && extra2Present,
+					"afterHook 应该能获取到 product_2_extra（通过 ToolContext 写入的数据），但实际获取不到");
+
+		} catch (java.util.concurrent.CompletionException completionException) {
+			completionException.printStackTrace();
+			fail("执行失败: " + completionException.getMessage());
+		}
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ParallelAgentToolContextLossTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ParallelAgentToolContextLossTest.java
@@ -24,6 +24,7 @@ import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.model.ToolContext;
@@ -167,8 +168,15 @@ class ParallelAgentToolContextLossTest extends AbstractDashscopeChatModelTest {
 
 	/**
 	 * 复现：SequentialAgent(afterHook) → ParallelAgent(2个子Agent并发查询商品)
-	 * 验证 afterHook 能否获取到子Agent通过 ToolContext 写入的额外数据
+	 * 验证 afterHook 能否获取到子Agent通过 ToolContext 写入的额外数据。
+	 *
+	 * <p>这个测试是为了**复现一个已知 bug**：子 agent 通过 {@link ToolContext} 写入
+	 * {@code AGENT_STATE_FOR_UPDATE_CONTEXT_KEY} 的数据在父层 afterHook 中不可见。
+	 * 在底层修复落地之前，断言会失败，所以暂时 {@link Disabled}，避免污染
+	 * integration test 套件。修复合入后请移除此注解。
 	 */
+	@Disabled("Reproduction-style test for a known ToolContext propagation bug; "
+			+ "re-enable after the underlying fix is merged")
 	@Test
 	void testToolContextDataLossInParallelSubAgents() throws Exception {
 		// 子Agent1：查询商品1

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/StreamingModelInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/StreamingModelInterceptorTest.java
@@ -28,6 +28,7 @@ import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -145,8 +146,10 @@ class StreamingModelInterceptorTest extends AbstractDashscopeChatModelTest {
 				.build();
 
 		try {
+			// Bounded wait so a hung upstream stream surfaces as a deterministic failure
+			// instead of blocking the test runner forever.
 			agent.stream("查询商品1并简要解读")
-					.blockLast();
+					.blockLast(Duration.ofMinutes(2));
 
 			System.out.println();
 			System.out.println("===== Interceptor 计数 =====");

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/StreamingModelInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/StreamingModelInterceptorTest.java
@@ -164,7 +164,7 @@ class StreamingModelInterceptorTest extends AbstractDashscopeChatModelTest {
 					"每轮成功完成时都应触发 afterStreamComplete，实际=" + completeCount.get());
 			assertEquals(0, errorCount.get(), "正常路径不应触发 onStreamError");
 			assertNotNull(lastAggregatedText.get(), "聚合文本不应为 null");
-            assertFalse(lastAggregatedText.get().isEmpty(), "最后一轮聚合文本不应为空（说明 chunk text 累加生效）");
+			assertFalse(lastAggregatedText.get().isEmpty(), "最后一轮聚合文本不应为空（说明 chunk text 累加生效）");
 
 		} catch (Exception ex) {
 			ex.printStackTrace();

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/StreamingModelInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/StreamingModelInterceptorTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptors;
+
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.StreamingModelInterceptor;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+
+import static com.alibaba.cloud.ai.graph.agent.tools.ToolContextConstants.AGENT_STATE_FOR_UPDATE_CONTEXT_KEY;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
+class StreamingModelInterceptorTest extends AbstractDashscopeChatModelTest {
+
+	/**
+	 * 查询商品1的工具：触发 ReactAgent 走两轮模型调用（首轮决定调工具，第二轮基于工具返回作答）。
+	 */
+	static class QueryProduct1Tool implements BiFunction<QueryProduct1Tool.Request, ToolContext, String> {
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public String apply(Request request, ToolContext toolContext) {
+			Map<String, Object> updateMap = (Map<String, Object>) toolContext.getContext()
+					.get(AGENT_STATE_FOR_UPDATE_CONTEXT_KEY);
+			if (updateMap != null) {
+				updateMap.put("product_1_extra", "苹果手机");
+			}
+			return "商品1: id=1, name=苹果";
+		}
+
+		public record Request(
+				@JsonProperty(required = true, value = "query")
+				@JsonPropertyDescription("查询关键词") String query,
+
+				@JsonProperty(required = true, value = "thought")
+				@JsonPropertyDescription("思考为什么要调用这个工具") String thought
+				) {
+		}
+
+		static ToolCallback createCallback() {
+			return FunctionToolCallback.builder("query_product_1", new QueryProduct1Tool())
+					.description("查询商品1的信息，返回id=1的苹果商品")
+					.inputType(Request.class)
+					.build();
+		}
+	}
+
+	/**
+	 * 验证 StreamingModelInterceptor 扩展点端到端工作：
+	 * - 复用 QueryProduct1Tool，让 agent 至少触发两轮模型调用（首轮决定调用工具，第二轮基于工具返回作答）
+	 * - 注册一个计数 interceptor，断言 beforeStreamCall / onStreamChunk / afterStreamComplete 全部被触发
+	 * - 断言 onStreamChunk 累计 chunk 数 ≥ beforeStreamCall 次数（每轮至少 1 个 chunk）
+	 * - 断言 afterStreamComplete 收到的聚合文本非空
+	 */
+	@Test
+	void streamingModelInterceptor_shouldReceivePerChunkCallbacks() throws Exception {
+		AtomicInteger beforeCount = new AtomicInteger(0);
+		AtomicInteger chunkCount = new AtomicInteger(0);
+		AtomicInteger completeCount = new AtomicInteger(0);
+		AtomicInteger errorCount = new AtomicInteger(0);
+		AtomicReference<String> lastAggregatedText = new AtomicReference<>("");
+
+		StreamingModelInterceptor counting = new StreamingModelInterceptor() {
+			@Override
+			public ModelRequest beforeStreamCall(ModelRequest request) {
+				int round = beforeCount.incrementAndGet();
+				System.out.println("\n[interceptor] >>> beforeStreamCall round=" + round
+						+ ", messages=" + (request.getMessages() == null ? 0 : request.getMessages().size())
+						+ ", tools=" + request.getTools());
+				return request;
+			}
+
+			@Override
+			public ChatResponse onStreamChunk(ChatResponse chunk, ModelRequest request) {
+				int idx = chunkCount.incrementAndGet();
+				String text = null;
+				boolean hasToolCalls = false;
+				if (chunk != null && chunk.getResult() != null && chunk.getResult().getOutput() != null) {
+					text = chunk.getResult().getOutput().getText();
+					hasToolCalls = chunk.getResult().getOutput().hasToolCalls();
+				}
+				if (hasToolCalls) {
+					System.out.println("[interceptor] chunk#" + idx + " toolCalls="
+							+ chunk.getResult().getOutput().getToolCalls());
+				} else {
+					System.out.println("[interceptor] chunk#" + idx + " text=" + (text == null ? "<null>" : text));
+				}
+				return chunk;
+			}
+
+			@Override
+			public void afterStreamComplete(AssistantMessage aggregatedMessage, ModelRequest request) {
+				int round = completeCount.incrementAndGet();
+				String aggregated = aggregatedMessage != null ? aggregatedMessage.getText() : null;
+				System.out.println("[interceptor] <<< afterStreamComplete round=" + round
+						+ ", aggregatedText=" + aggregated);
+				if (aggregated != null) {
+					lastAggregatedText.set(aggregated);
+				}
+			}
+
+			@Override
+			public void onStreamError(Throwable error, ModelRequest request) {
+				errorCount.incrementAndGet();
+				System.out.println("[interceptor] !!! onStreamError: " + error);
+			}
+		};
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("streaming_interceptor_agent")
+				.model(chatModel)
+				.description("用于测试 StreamingModelInterceptor")
+				.instruction("请调用 query_product_1 工具查询商品信息，并基于返回结果用 500 字内说明这是什么商品，有什么特点等。")
+				.tools(List.of(QueryProduct1Tool.createCallback()))
+				.streamingInterceptors(counting)
+				.build();
+
+		try {
+			agent.stream("查询商品1并简要解读")
+					.blockLast();
+
+			System.out.println();
+			System.out.println("===== Interceptor 计数 =====");
+			System.out.println("beforeStreamCall   : " + beforeCount.get());
+			System.out.println("onStreamChunk      : " + chunkCount.get());
+			System.out.println("afterStreamComplete: " + completeCount.get());
+			System.out.println("onStreamError      : " + errorCount.get());
+			System.out.println("最后一轮聚合文本    : " + lastAggregatedText.get());
+
+			assertTrue(beforeCount.get() >= 2,
+					"agent 调用了工具，至少应触发 2 轮模型调用，beforeStreamCall 实际=" + beforeCount.get());
+			assertTrue(chunkCount.get() >= beforeCount.get(),
+					"每轮至少应有 1 个 chunk；chunkCount=" + chunkCount.get() + ", beforeCount=" + beforeCount.get());
+			assertTrue(completeCount.get() >= 2,
+					"每轮成功完成时都应触发 afterStreamComplete，实际=" + completeCount.get());
+			assertEquals(0, errorCount.get(), "正常路径不应触发 onStreamError");
+			assertNotNull(lastAggregatedText.get(), "聚合文本不应为 null");
+            assertFalse(lastAggregatedText.get().isEmpty(), "最后一轮聚合文本不应为空（说明 chunk text 累加生效）");
+
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			fail("流式拦截器测试失败: " + ex.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

新增 `StreamingModelInterceptor` —— 面向 `ReactAgent` 流式调用的扩展点，让用户在 `agent.stream(...)` 过程中按 `ChatResponse` chunk 粒度进行拦截。

当前框架已有四种拦截层：`Flux<NodeOutput>.doOnNext`（节点级）、`AgentHook`/`ModelHook`（模型调用边界）、`ModelInterceptor`（整次调用）、Spring AI `Advisor`（ChatClient 层），但**没有任何一个提供干净的、官方支持的 chunk 级回调**。要在今天实现按 chunk 处理，只能在 `ModelInterceptor` 内部把 `ModelResponse.getMessage()` 强转成 `Flux<ChatResponse>` 再 `.map()`，写法别扭、且把流式与阻塞语义混在一起。

本 PR 把这个空缺补上，让 chunk 级需求（逐 chunk 日志/指标、流式敏感词过滤、SSE 转换、内容审核、实时埋点等）成为一等公民 API：

```java
ReactAgent agent = ReactAgent.builder()
        .name("my-agent")
        .model(chatModel)
        .streamingInterceptors(myInterceptor)
        .build();
```

### Does this pull request fix one issue?

NONE

### Describe how you did it

**1. 新增 `StreamingModelInterceptor` 接口**（`spring-ai-alibaba-agent-framework/.../interceptor/StreamingModelInterceptor.java`），含四个 `default` 生命周期回调：

| 方法 | 触发时机 | 用途 |
|---|---|---|
| `beforeStreamCall(ModelRequest)` | 每次订阅前调用一次 | 在拦截器之间传递 context（返回的 request 作为后续回调的参数）。**不影响外发模型调用**——要改外发请求请用 `ModelInterceptor` |
| `onStreamChunk(ChatResponse, ModelRequest)` | 每个 chunk | 检视、转换或过滤 chunk（返回 `null` 即丢弃） |
| `afterStreamComplete(AssistantMessage, ModelRequest)` | 每次成功完成时调用一次 | 拿到**聚合后**的完整 AssistantMessage 用于日志/指标 |
| `onStreamError(Throwable, ModelRequest)` | 流出错时 | 错误日志 / 告警 |

**2. 链式实现** `InterceptorChain.applyStreamingInterceptors(...)` 把多个拦截器组合到 `Flux<ChatResponse>` 上。**注册顺序里第一个 = 最内层包装**——它最先看到模型原始 chunk，后面的拦截器看到的是上一个返回的 chunk。这个顺序与同步的 `chainModelInterceptors` / `chainToolInterceptors` 相反（那两个是 first = outermost），因为 chunk 级拦截器的核心价值是观察模型原始输出，源头优先更直觉。整条管道用 `Flux.defer(...)` 包裹，每次订阅都会跑一遍 `beforeStreamCall` 并拿到独立的聚合缓冲，避免 retry / 多订阅者的状态串扰与多线程 race。`onStreamChunk` 改用 `Flux.handle(...)`，用户返回 `null` 即可丢弃该 chunk（filter 语义）。

**3. 聚合语义修复** —— 之前的 `applyStreamingInterceptors` 把**最后一个 chunk** 的 `AssistantMessage` 传给 `afterStreamComplete`。对 DashScope / OpenAI 这类 delta 风格的 provider 而言，最后一个 chunk 只是末尾增量，并不是完整文本。修复后的链路改为对所有 chunk 累加 `chunk.getResult().getOutput().getText()`，再用完整文本构造一个 `AssistantMessage` 传出。

**4. 接线**（让拦截器真正被调用的"最后一公里"）：
- `Builder.java`：新增字段 `streamingInterceptors` + 两个 `streamingInterceptors(...)` 重载
- `ReactAgent.java`：读取 `builder.streamingInterceptors`，在已有的 model/tool 拦截器接线旁调用 `llmNode.setStreamingInterceptors(...)`
- `AgentLlmNode.java`：新增字段 + `setStreamingInterceptors(...)`；在流式 `baseHandler` 内，`enableReasoningLog` 之后、`ModelResponse.of(chatResponseFlux)` 之前调用 `InterceptorChain.applyStreamingInterceptors(...)` 把 Flux 包一层。挂在 base handler **内部**（相对 `ModelInterceptor` 是最内层），意味着 streaming 拦截器看到的是模型的原始 chunk；外层 `ModelInterceptor` 仍可对结果 Flux 做整次调用层面的处理（retry、fallback 等）。

**5. 测试重构**：
- 新增 `AbstractDashscopeChatModelTest` base —— 提供共享的 `protected ChatModel chatModel`，用环境变量驱动 OpenAI 兼容 DashScope 端点初始化；当 `AI_DASHSCOPE_API_KEY` 缺失时自动跳过。
- 新增 `StreamingModelInterceptorTest` —— 本扩展点的端到端测试（用 `QueryProduct1Tool` 强制走两轮流式：一轮决定调用工具 + 一轮基于工具结果作答）。

### Describe how to verify it

```bash
# 设置 DashScope 凭据（任意非空 AI_DASHSCOPE_API_KEY 即可启用受控测试）
export AI_DASHSCOPE_API_KEY=<your_dashscope_key>

# 跑新增的流式拦截器端到端测试
./mvnw -pl spring-ai-alibaba-agent-framework -am test \
  -Dtest='StreamingModelInterceptorTest#streamingModelInterceptor_shouldReceivePerChunkCallbacks'
```

预期运行输出（计数随模型详尽程度浮动）：

```
[interceptor] >>> beforeStreamCall round=1, messages=2, tools=[query_product_1]
[interceptor] chunk#1 toolCalls=[ToolCall[id=..., name=query_product_1, arguments=...]]
[interceptor] <<< afterStreamComplete round=1, aggregatedText=
[interceptor] >>> beforeStreamCall round=2, messages=4, tools=[query_product_1]
[interceptor] chunk#3 text=商品
[interceptor] chunk#4 text=1是编号
... (per-chunk delta text continues) ...
[interceptor] <<< afterStreamComplete round=2, aggregatedText=<完整最终回答>

===== Interceptor 计数 =====
beforeStreamCall   : 2
onStreamChunk      : 39       (≥ beforeStreamCall，随模型而异)
afterStreamComplete: 2
onStreamError      : 0
```

测试断言：`beforeStreamCall ≥ 2`、`chunkCount ≥ beforeCount`、`completeCount ≥ 2`、`errorCount == 0`，并且聚合文本非空（验证 chunk text 累加修复生效）。

### Special notes for reviews

- **兼容性**：纯加法改动。已有 `ModelInterceptor` / `ToolInterceptor` / `Hook` 链路完全不动；用户如仍想用 `ModelInterceptor` 自行包装流式响应也可以照旧。未改动任何已有公开类型的方法签名。
- **挂载点选择**：streaming 拦截器挂在 `baseHandler` **内部**（最内层），而不是 `chainedHandler.call()` 之后。原因：chunk 级拦截器应观察模型的原始输出；如果某个 `ModelInterceptor`（比如 retry）重新调用 handler，每次重试都会自然地重新走一遍 streaming 链，符合直觉。
- **`StreamingModelInterceptor` 没有 `extends Interceptor`** —— 故意保持独立，因为它语义上和现有 `Interceptor`（chunk 级 vs 整次调用）不同，注册入口也独立成 `streamingInterceptors(...)`，与 `interceptors(...)` 平级。如果后续想统一，挂到 `Interceptor` 体系下做 follow-up 也很干净。
- **`Builder.chatClient(...)` + Spring AI `StreamAroundAdvisor`** 仍是想直接复用 Spring AI advisor 生态的现有逃生通道。
- **`beforeStreamCall` 的 request 是 context-only**：返回值仅串到本拦截器与后续拦截器的 `onStreamChunk`/`afterStreamComplete`/`onStreamError` 回调，**不会改写实际发到模型的请求**（chunk Flux 在拦截器跑之前已经构造好）。要改外发 request 请用 `ModelInterceptor`。这一限制已在 `StreamingModelInterceptor` 的 Javadoc 里写明。
- **测试环境**：`StreamingModelInterceptorTest` 属于集成测试（真实调用 DashScope），由 `AI_DASHSCOPE_API_KEY` 控制；CI 不配 secret 时会被 `Assumptions.assumeTrue` 干净跳过。
