### PR TITLE
fix(graph): fail fast for divergent conditional parallel successors (#4601)

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -176,13 +176,16 @@ public class CompiledGraph {
 						}
 
 						var parallelNodeTargets = findParallelNodeTargets(mappedNodeIds);
-						if (!parallelNodeTargets.isEmpty()) {
-							// Set edge from ConditionalParallelNode to the next node
-							// All parallel nodes point to the same target, use that target
-							edges.put(conditionalParallelNode.id(), new EdgeValue(parallelNodeTargets.iterator().next()));
-						} else {
+						if (parallelNodeTargets.size() > 1) {
+							throw Errors.illegalMultipleTargetsOnParallelNode
+									.exception(e.sourceId(), parallelNodeTargets);
+						}
+						if (parallelNodeTargets.isEmpty()) {
 							throw Errors.illegalMultipleTargetsOnParallelNode.exception(e.sourceId(), 0);
 						}
+						// Set edge from ConditionalParallelNode to the next node.
+						// Conditional parallel branches currently require a single converged target.
+						edges.put(conditionalParallelNode.id(), new EdgeValue(parallelNodeTargets.iterator().next()));
 						// The ConditionalParallelNode will handle parallel execution internally
 					} else {
 						// Single Command action - same as regular single target edge

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
@@ -1760,6 +1760,45 @@ public class StateGraphTest {
 	}
 
 	/**
+	 * Tests addParallelConditionalEdges with divergent successors.
+	 * Verifies that compile fails fast when conditional parallel branches do not
+	 * converge to one immediate target.
+	 */
+	@Test
+	public void testAddParallelConditionalEdgesWithDifferentImmediateSuccessors() throws Exception {
+		StateGraph workflow = new StateGraph(() -> {
+			Map<String, KeyStrategy> keyStrategyMap = new HashMap<>();
+			keyStrategyMap.put("messages", new AppendStrategy());
+			return keyStrategyMap;
+		});
+
+		workflow.addNode("start", node_async(state -> Map.of("messages", "start")))
+				.addNode("conditional_node", node_async(state -> Map.of("messages", "conditional")))
+				.addNode("B", node_async(state -> Map.of("messages", "B")))
+				.addNode("C", node_async(state -> Map.of("messages", "C")))
+				.addNode("D", node_async(state -> Map.of("messages", "D")))
+				.addNode("C1", node_async(state -> Map.of("messages", "C1")))
+				.addNode("E", node_async(state -> Map.of("messages", "E")));
+
+		workflow.addParallelConditionalEdges(
+				"conditional_node",
+				AsyncMultiCommandAction.node_async((state, config) -> new MultiCommand(List.of("route_b", "route_c"))),
+				Map.of("route_b", "B", "route_c", "C"));
+
+		workflow.addEdge(START, "start")
+				.addEdge("start", "conditional_node")
+				.addEdge("B", "D")
+				.addEdge("D", "E")
+				.addEdge("C", "C1")
+				.addEdge("C1", "E")
+				.addEdge("E", END);
+
+		GraphStateException exception = assertThrows(GraphStateException.class, () -> workflow.compile());
+		assertTrue(exception.getMessage().contains("parallel node [conditional_node] must have only one target"),
+				"Expected compile error for divergent immediate successors, but got: " + exception.getMessage());
+	}
+
+	/**
 	 * Tests a simple A->B->C graph flow with Long type value in overall state.
 	 * NodeA increments the counter by 100, NodeB multiplies it by 2.
 	 * NodeC implements InterruptableAction to check if result exceeds threshold.


### PR DESCRIPTION
Fixes issue #4601 by removing non-deterministic routing in CompiledGraph for addParallelConditionalEdges.

Previously, when conditional parallel branches mapped to nodes with different immediate successors (for example B -> D and C -> C1), compilation collected multiple targets and used iterator().next() to pick one arbitrarily, causing one branch to be silently skipped.

Now, compilation validates this explicitly:

if multiple immediate successors are found, it throws GraphStateException (illegalMultipleTargetsOnParallelNode);
only a single immediate successor is allowed.
Added regression test:

StateGraphTest.testAddParallelConditionalEdgesWithDifferentImmediateSuccessors
verifies compile() fails fast with a clear error message for divergent successors.
Verification:

StateGraphTest#testAddParallelConditionalEdgesWithDifferentImmediateSuccessors passed.
StateGraphTest#testAddParallelConditionalEdgesWithSingleNode passed (no regression).