### PR TITLE
fix(graph): prevent MysqlSaver checkpoint history cache growth

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
@@ -17,8 +17,8 @@ package com.alibaba.cloud.ai.graph.checkpoint.savers.mysql;
 
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
-import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 
 import java.io.IOException;
@@ -28,9 +28,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.sql.DataSource;
 
@@ -42,8 +48,8 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * <p>
- * MysqlSaver is an extension of MemorySaver that enables persistent,
- * reliable storage of Graph state in a MySQL database.
+ * MysqlSaver stores Graph state in a MySQL database and keeps only a bounded
+ * latest-checkpoint cache in memory.
  * </p>
  * <p>
  * Two tables are used to store the workflow state:
@@ -79,6 +85,7 @@ import static java.util.Objects.requireNonNull;
  * to the database
  * - CreateOption : indicates whether the tables should be created or
  * existing tables should be used.
+ * - MaxCachedThreads: indicates how many latest checkpoints are kept in memory.
  * </p>
  * <p>
  * Ex:
@@ -92,7 +99,7 @@ import static java.util.Objects.requireNonNull;
  * </pre>
  * </p>
  */
-public class MysqlSaver extends MemorySaver {
+public class MysqlSaver implements BaseCheckpointSaver {
 
 	private static final Logger log = LoggerFactory.getLogger(MysqlSaver.class);
 
@@ -142,13 +149,15 @@ public class MysqlSaver extends MemorySaver {
 			""";
 
 	private static final String UPDATE_CHECKPOINT = """
-			UPDATE GRAPH_CHECKPOINT
+			UPDATE GRAPH_CHECKPOINT c
+			INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
 			SET
-			  checkpoint_id = ?,
-			  node_id = ?,
-			  next_node_id = ?,
-			  state_data = ?
-			WHERE checkpoint_id = ?
+			  c.checkpoint_id = ?,
+			  c.node_id = ?,
+			  c.next_node_id = ?,
+			  c.state_data = ?
+			WHERE t.thread_name = ? AND t.is_released != TRUE
+			  AND c.checkpoint_id = ?
 			""";
 
 	private static final String SELECT_CHECKPOINTS = """
@@ -163,18 +172,43 @@ public class MysqlSaver extends MemorySaver {
 			ORDER BY c.saved_at DESC
 			""";
 
-	private static final String DELETE_CHECKPOINTS = """
-			    DELETE FROM GRAPH_CHECKPOINT WHERE checkpoint_id = ?
-			""";
-
 	private static final String RELEASE_THREAD = """
 			UPDATE GRAPH_THREAD SET is_released = TRUE WHERE thread_name = ? AND is_released = FALSE
+			""";
+
+	private static final String SELECT_LATEST_CHECKPOINT = """
+			SELECT
+			  c.checkpoint_id,
+			  c.node_id,
+			  c.next_node_id,
+			  JSON_UNQUOTE(JSON_EXTRACT(c.state_data, '$.binaryPayload')) AS base64_data
+			FROM GRAPH_CHECKPOINT c
+			  INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
+			WHERE t.thread_name = ? AND t.is_released != TRUE
+			ORDER BY c.saved_at DESC
+			LIMIT 1
+			""";
+
+	private static final String SELECT_CHECKPOINT_BY_ID = """
+			SELECT
+			  c.checkpoint_id,
+			  c.node_id,
+			  c.next_node_id,
+			  JSON_UNQUOTE(JSON_EXTRACT(c.state_data, '$.binaryPayload')) AS base64_data
+			FROM GRAPH_CHECKPOINT c
+			  INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
+			WHERE t.thread_name = ? AND t.is_released != TRUE
+			  AND c.checkpoint_id = ?
 			""";
 
 	// Configuration
 	private final DataSource dataSource;
 	private final CreateOption createOption;
 	private final StateSerializer stateSerializer;
+
+	private final Map<String, Checkpoint> latestCheckpointCache;
+	private final ReentrantLock lock = new ReentrantLock();
+	private final int maxCachedThreads;
 
 	/**
 	 * Private constructor used by the builder to create a new instance of
@@ -186,6 +220,8 @@ public class MysqlSaver extends MemorySaver {
 		this.dataSource = builder.dataSource;
 		this.createOption = builder.createOption;
 		this.stateSerializer = builder.stateSerializer;
+		this.maxCachedThreads = builder.maxCachedThreads;
+		this.latestCheckpointCache = createLatestCheckpointCache(builder.maxCachedThreads);
 		initTables();
 	}
 
@@ -259,188 +295,6 @@ public class MysqlSaver extends MemorySaver {
 	}
 
 	/**
-	 * If the list of checkpoints is empty, loads the checkpoints from the database.
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the list of checkpoints
-	 * @return a list of checkpoints
-	 * @throws Exception if an error occurs while the checkpoints are being
-	 *                   loaded from the database.
-	 */
-	@Override
-	protected LinkedList<Checkpoint> loadedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints)
-			throws Exception {
-		if (!checkpoints.isEmpty()) {
-			return checkpoints;
-		}
-
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-
-		try (Connection connection = dataSource.getConnection();
-			 PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINTS)) {
-
-			preparedStatement.setString(1, threadName);
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					Checkpoint checkpoint = Checkpoint.builder()
-							.id(resultSet.getString(1))
-							.nodeId(resultSet.getString(2))
-							.nextNodeId(resultSet.getString(3))
-							.state(decodeState(resultSet.getBytes(4)))
-							.build();
-					checkpoints.add(checkpoint);
-				}
-			}
-		}
-		catch (SQLException | IOException | ClassNotFoundException sqlException) {
-			throw new Exception("Unable to load checkpoints", sqlException);
-		}
-		return checkpoints;
-	}
-
-	/**
-	 * Inserts a checkpoint to the database
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the list of checkpoints
-	 * @param checkpoint  the checkpoint to insert
-	 * @throws Exception if an error occurs while inserting the checkpoint in the
-	 *                   database.
-	 */
-	@Override
-	protected void insertedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
-			throws Exception {
-
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-		Connection conn = null;
-		try (Connection ignored = conn = dataSource.getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
-
-			try (PreparedStatement upsertStatement = conn.prepareStatement(UPSERT_THREAD);
-				 PreparedStatement insertCheckpointStatement = conn.prepareStatement(INSERT_CHECKPOINT)) {
-
-				upsertStatement.setString(1, UUID.randomUUID().toString());
-				upsertStatement.setString(2, threadName);
-				upsertStatement.execute();
-
-				insertCheckpointStatement.setString(1, checkpoint.getId());
-				insertCheckpointStatement.setString(2, checkpoint.getNodeId());
-				insertCheckpointStatement.setString(3, checkpoint.getNextNodeId());
-				insertCheckpointStatement.setString(4, encodeState(checkpoint.getState()));
-				insertCheckpointStatement.setString(5, threadName);
-
-				insertCheckpointStatement.execute();
-			}
-
-			conn.commit();
-			log.debug("Checkpoint {} for thread {} inserted successfully.", checkpoint.getId(), threadName);
-		}
-		catch (SQLException | IOException e) {
-			log.error("Error inserting checkpoint with id {} in thread {}", checkpoint.getId(), threadName, e);
-			rollback(conn, checkpoint, threadName);
-			throw new Exception("Unable to insert checkpoint", e);
-		}
-
-	}
-
-	/**
-	 * Marks the checkpoints as released
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the checkpoints
-	 * @param releaseTag  the release tag
-	 * @throws Exception if an error occurs while marking the checkpoints as
-	 *                   released
-	 */
-	@Override
-	protected void releasedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Tag releaseTag)
-			throws Exception {
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-
-		Connection conn = null;
-		try (Connection ignored = conn = dataSource.getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
-
-			try (PreparedStatement preparedStatement = conn.prepareStatement(RELEASE_THREAD)) {
-				preparedStatement.setString(1, threadName);
-				int rowsAffected = preparedStatement.executeUpdate();
-				
-				if (rowsAffected == 0) {
-					conn.rollback();
-					throw new IllegalStateException(
-							format("Thread '%s' not found or already released", threadName));
-				}
-			}
-
-			conn.commit();
-			log.debug("Thread {} released successfully.", threadName);
-		}
-		catch (SQLException e) {
-			log.error("Error releasing thread {}", threadName, e);
-			rollback(conn, threadName);
-			throw new Exception("Unable to release checkpoint", e);
-		}
-	}
-
-	/**
-	 * If the checkpoint exists, updates the checkpoint, otherwise it inserts it.
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the list of checkpoints
-	 * @param checkpoint  the checkpoint
-	 * @throws Exception if an error occurs while inserting or updating the
-	 *                   checkpoint.
-	 */
-	@Override
-	protected void updatedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
-			throws Exception {
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-		Connection conn = null;
-
-		try (Connection ignored = conn = dataSource.getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
-
-			if (config.checkPointId().isPresent()) {
-				// Update existing checkpoint
-				try (PreparedStatement preparedStatement = conn.prepareStatement(UPDATE_CHECKPOINT)) {
-					preparedStatement.setString(1, checkpoint.getId());
-					preparedStatement.setString(2, checkpoint.getNodeId());
-					preparedStatement.setString(3, checkpoint.getNextNodeId());
-					preparedStatement.setString(4, encodeState(checkpoint.getState()));
-					preparedStatement.setString(5, config.checkPointId().get());
-					preparedStatement.execute();
-				}
-			}
-			else {
-				// Insert new checkpoint (within same transaction)
-				try (PreparedStatement upsertStatement = conn.prepareStatement(UPSERT_THREAD);
-					 PreparedStatement insertCheckpointStatement = conn.prepareStatement(INSERT_CHECKPOINT)) {
-
-					upsertStatement.setString(1, UUID.randomUUID().toString());
-					upsertStatement.setString(2, threadName);
-					upsertStatement.execute();
-
-					insertCheckpointStatement.setString(1, checkpoint.getId());
-					insertCheckpointStatement.setString(2, checkpoint.getNodeId());
-					insertCheckpointStatement.setString(3, checkpoint.getNextNodeId());
-					insertCheckpointStatement.setString(4, encodeState(checkpoint.getState()));
-					insertCheckpointStatement.setString(5, threadName);
-
-					insertCheckpointStatement.execute();
-				}
-			}
-
-			conn.commit();
-			log.debug("Checkpoint with id {} for thread {} updated successfully.", checkpoint.getId(), threadName);
-		}
-		catch (SQLException | IOException e) {
-			log.error("Error updating checkpoint with id {} in thread {}", checkpoint.getId(), threadName, e);
-			rollback(conn, checkpoint, threadName);
-			throw new Exception("Unable to update checkpoint", e);
-		}
-	}
-
-	/**
 	 * Initializes the database according the create options.
 	 */
 	protected void initTables() {
@@ -474,13 +328,308 @@ public class MysqlSaver extends MemorySaver {
 		}
 	}
 
+	private Checkpoint readCheckpoint(ResultSet resultSet)
+			throws SQLException, IOException, ClassNotFoundException {
+		return Checkpoint.builder()
+				.id(resultSet.getString(1))
+				.nodeId(resultSet.getString(2))
+				.nextNodeId(resultSet.getString(3))
+				.state(decodeState(resultSet.getBytes(4)))
+				.build();
+	}
+
+	/**
+	 * Loads full checkpoint history on demand without retaining it in cache.
+	 */
+	private LinkedList<Checkpoint> selectCheckpoints(String threadName) throws Exception {
+		LinkedList<Checkpoint> checkpoints = new LinkedList<>();
+		try (Connection connection = dataSource.getConnection();
+				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINTS)) {
+
+			preparedStatement.setString(1, threadName);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					checkpoints.add(readCheckpoint(resultSet));
+				}
+			}
+		}
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load checkpoints", ex);
+		}
+		return checkpoints;
+	}
+
+	private Optional<Checkpoint> selectLatestCheckpoint(String threadName) throws Exception {
+		try (Connection connection = dataSource.getConnection();
+				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_LATEST_CHECKPOINT)) {
+
+			preparedStatement.setString(1, threadName);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return Optional.of(readCheckpoint(resultSet));
+				}
+				return Optional.empty();
+			}
+		}
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load latest checkpoint", ex);
+		}
+	}
+
+	private Optional<Checkpoint> selectCheckpointById(String threadName, String checkpointId) throws Exception {
+		try (Connection connection = dataSource.getConnection();
+				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINT_BY_ID)) {
+
+			preparedStatement.setString(1, threadName);
+			preparedStatement.setString(2, checkpointId);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return Optional.of(readCheckpoint(resultSet));
+				}
+				return Optional.empty();
+			}
+		}
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load checkpoint", ex);
+		}
+	}
+
+	private void insertCheckpoint(String threadName, Checkpoint checkpoint) throws Exception {
+		Connection conn = null;
+		try (Connection ignored = conn = dataSource.getConnection()) {
+			conn.setAutoCommit(false);
+
+			try (PreparedStatement upsertStatement = conn.prepareStatement(UPSERT_THREAD);
+					PreparedStatement insertCheckpointStatement = conn.prepareStatement(INSERT_CHECKPOINT)) {
+
+				upsertStatement.setString(1, UUID.randomUUID().toString());
+				upsertStatement.setString(2, threadName);
+				upsertStatement.execute();
+
+				insertCheckpointStatement.setString(1, checkpoint.getId());
+				insertCheckpointStatement.setString(2, checkpoint.getNodeId());
+				insertCheckpointStatement.setString(3, checkpoint.getNextNodeId());
+				insertCheckpointStatement.setString(4, encodeState(checkpoint.getState()));
+				insertCheckpointStatement.setString(5, threadName);
+				insertCheckpointStatement.execute();
+			}
+
+			conn.commit();
+			log.debug("Checkpoint {} for thread {} inserted successfully.", checkpoint.getId(), threadName);
+		}
+		catch (SQLException | IOException ex) {
+			log.error("Error inserting checkpoint with id {} in thread {}", checkpoint.getId(), threadName, ex);
+			rollback(conn, checkpoint, threadName);
+			throw new Exception("Unable to insert checkpoint", ex);
+		}
+	}
+
+	private void updateCheckpoint(String threadName, String checkpointId, Checkpoint checkpoint) throws Exception {
+		Connection conn = null;
+		try (Connection ignored = conn = dataSource.getConnection()) {
+			conn.setAutoCommit(false);
+
+			try (PreparedStatement preparedStatement = conn.prepareStatement(UPDATE_CHECKPOINT)) {
+				preparedStatement.setString(1, checkpoint.getId());
+				preparedStatement.setString(2, checkpoint.getNodeId());
+				preparedStatement.setString(3, checkpoint.getNextNodeId());
+				preparedStatement.setString(4, encodeState(checkpoint.getState()));
+				preparedStatement.setString(5, threadName);
+				preparedStatement.setString(6, checkpointId);
+				int rowsAffected = preparedStatement.executeUpdate();
+				if (rowsAffected == 0) {
+					conn.rollback();
+					throw new NoSuchElementException(format("Checkpoint with id %s not found!", checkpointId));
+				}
+			}
+
+			conn.commit();
+			log.debug("Checkpoint with id {} for thread {} updated successfully.", checkpoint.getId(), threadName);
+		}
+		catch (SQLException | IOException ex) {
+			log.error("Error updating checkpoint with id {} in thread {}", checkpoint.getId(), threadName, ex);
+			rollback(conn, checkpoint, threadName);
+			throw new Exception("Unable to update checkpoint", ex);
+		}
+	}
+
+	private void releaseThread(String threadName) throws Exception {
+		Connection conn = null;
+		try (Connection ignored = conn = dataSource.getConnection()) {
+			conn.setAutoCommit(false);
+
+			try (PreparedStatement preparedStatement = conn.prepareStatement(RELEASE_THREAD)) {
+				preparedStatement.setString(1, threadName);
+				int rowsAffected = preparedStatement.executeUpdate();
+				if (rowsAffected == 0) {
+					conn.rollback();
+					throw new IllegalStateException(format("Thread '%s' not found or already released", threadName));
+				}
+			}
+
+			conn.commit();
+			log.debug("Thread {} released successfully.", threadName);
+		}
+		catch (SQLException ex) {
+			log.error("Error releasing thread {}", threadName, ex);
+			rollback(conn, threadName);
+			throw new Exception("Unable to release checkpoint", ex);
+		}
+	}
+
+	/**
+	 * Lists active checkpoints for the configured thread.
+	 */
+	@Override
+	public Collection<Checkpoint> list(RunnableConfig config) {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
+			if (!checkpoints.isEmpty()) {
+				cacheLatest(threadName, checkpoints.peek());
+			}
+			return Collections.unmodifiableCollection(checkpoints);
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Gets a checkpoint for the configured thread.
+	 */
+	@Override
+	public Optional<Checkpoint> get(RunnableConfig config) {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			if (config.checkPointId().isPresent()) {
+				return selectCheckpointById(threadName, config.checkPointId().get());
+			}
+
+			Optional<Checkpoint> cached = getCachedLatest(threadName);
+			if (cached.isPresent()) {
+				return cached;
+			}
+
+			Optional<Checkpoint> latest = selectLatestCheckpoint(threadName);
+			latest.ifPresent(checkpoint -> cacheLatest(threadName, checkpoint));
+			return latest;
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Inserts or updates a checkpoint.
+	 */
+	@Override
+	public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			if (config.checkPointId().isPresent()) {
+				String checkpointId = config.checkPointId().get();
+				updateCheckpoint(threadName, checkpointId, checkpoint);
+				getCachedLatest(threadName)
+						.filter(latest -> latest.getId().equals(checkpointId))
+						.ifPresent(latest -> cacheLatest(threadName, checkpoint));
+				return config;
+			}
+
+			insertCheckpoint(threadName, checkpoint);
+			cacheLatest(threadName, checkpoint);
+			return RunnableConfig.builder(config)
+					.checkPointId(checkpoint.getId())
+					.build();
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Releases the active thread and returns the released checkpoints.
+	 */
+	@Override
+	public Tag release(RunnableConfig config) throws Exception {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
+			releaseThread(threadName);
+			removeCachedLatest(threadName);
+			return new Tag(threadName, checkpoints);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Creates a bounded LRU cache for latest checkpoints.
+	 */
+	private static Map<String, Checkpoint> createLatestCheckpointCache(int maxCachedThreads) {
+		if (maxCachedThreads == 0) {
+			return Collections.emptyMap();
+		}
+		return new LinkedHashMap<>(16, 0.75f, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
+				return size() > maxCachedThreads;
+			}
+		};
+	}
+
+	private Optional<Checkpoint> getCachedLatest(String threadName) {
+		if (maxCachedThreads == 0) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(latestCheckpointCache.get(threadName));
+	}
+
+	private void cacheLatest(String threadName, Checkpoint checkpoint) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.put(threadName, checkpoint);
+		}
+	}
+
+	private void removeCachedLatest(String threadName) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.remove(threadName);
+		}
+	}
+
 	/**
 	 * A builder for MysqlSaver.
 	 */
-	public static class Builder extends MemorySaver.Builder {
+	public static class Builder {
 		private DataSource dataSource;
 		private CreateOption createOption = CreateOption.CREATE_IF_NOT_EXISTS;
 		private StateSerializer stateSerializer;
+		private int maxCachedThreads = 1024;
+
+		/**
+		 * Sets the maximum number of latest checkpoints retained in memory.
+		 *
+		 * @param maxCachedThreads max cached threads, or 0 to disable the cache
+		 * @return this builder
+		 */
+		public Builder maxCachedThreads(int maxCachedThreads) {
+			if (maxCachedThreads < 0) {
+				throw new IllegalArgumentException("maxCachedThreads must be greater than or equal to 0");
+			}
+			this.maxCachedThreads = maxCachedThreads;
+			return this;
+		}
 
 		/**
 		 * Sets the state serializer
@@ -521,9 +670,9 @@ public class MysqlSaver extends MemorySaver {
 		 * @return the new instance of MysqlSaver.
 		 */
 		public MysqlSaver build() {
-			if(stateSerializer == null) {
-                this.stateSerializer = StateGraph.DEFAULT_JACKSON_SERIALIZER;
-            }
+			if (stateSerializer == null) {
+				this.stateSerializer = StateGraph.DEFAULT_JACKSON_SERIALIZER;
+			}
 			return new MysqlSaver(this);
 		}
 	}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
@@ -23,13 +23,24 @@ import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.mysql.CreateOption;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.mysql.MysqlSaver;
 
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
+import javax.sql.DataSource;
 import com.mysql.cj.jdbc.MysqlDataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -111,6 +122,22 @@ public class MysqlSaverTest {
         dataSource.setURL(url);
         dataSource.setUser(username);
         dataSource.setPassword(password);
+    }
+
+    private static RunnableConfig config(String threadId) {
+        return RunnableConfig.builder().threadId(threadId).build();
+    }
+
+    private static RunnableConfig config(String threadId, String checkpointId) {
+        return RunnableConfig.builder().threadId(threadId).checkPointId(checkpointId).build();
+    }
+
+    private static Checkpoint checkpoint(String value) {
+        return Checkpoint.builder()
+                .nodeId("agent_1")
+                .nextNodeId(END)
+                .state(Map.of("value", value))
+                .build();
     }
 
     @Test
@@ -231,6 +258,159 @@ public class MysqlSaverTest {
 
         saver.release(runnableConfig);
 
+    }
+
+    @Test
+    public void testLatestCheckpointCacheIsBoundedByThreadCount() throws Exception {
+        var countingDataSource = new CountingDataSource(DATA_SOURCE);
+        var saver = MysqlSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(countingDataSource)
+                .maxCachedThreads(2)
+                .build();
+
+        var firstCheckpoint = checkpoint("first");
+        var firstConfig = config("mysql-cache-thread-1");
+        saver.put(firstConfig, firstCheckpoint);
+        saver.put(config("mysql-cache-thread-2"), checkpoint("second"));
+        saver.put(config("mysql-cache-thread-3"), checkpoint("third"));
+
+        countingDataSource.reset();
+        var reloaded = saver.get(firstConfig);
+        assertTrue(reloaded.isPresent());
+        assertEquals(firstCheckpoint.getId(), reloaded.get().getId());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+    }
+
+    @Test
+    public void testMysqlSaverKeepsOnlyLatestCheckpointInMemory() throws Exception {
+        var countingDataSource = new CountingDataSource(DATA_SOURCE);
+        var saver = MysqlSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(countingDataSource)
+                .maxCachedThreads(16)
+                .build();
+
+        String threadId = "mysql-cache-single-thread";
+        var firstCheckpoint = checkpoint("first");
+        var secondCheckpoint = checkpoint("second");
+        var thirdCheckpoint = checkpoint("third");
+
+        saver.put(config(threadId), firstCheckpoint);
+        saver.put(config(threadId), secondCheckpoint);
+        saver.put(config(threadId), thirdCheckpoint);
+
+        countingDataSource.reset();
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isPresent());
+        assertEquals(thirdCheckpoint.getId(), latest.get().getId());
+        assertEquals(0, countingDataSource.latestCheckpointSelects());
+
+        Collection<Checkpoint> history = saver.list(config(threadId));
+        assertEquals(3, history.size());
+
+        countingDataSource.reset();
+        var firstFromDatabase = saver.get(config(threadId, firstCheckpoint.getId()));
+        assertTrue(firstFromDatabase.isPresent());
+        assertEquals(firstCheckpoint.getId(), firstFromDatabase.get().getId());
+        assertEquals(1, countingDataSource.checkpointByIdSelects());
+    }
+
+    private static final class CountingDataSource implements DataSource {
+
+        private final DataSource delegate;
+
+        private final AtomicInteger latestCheckpointSelects = new AtomicInteger();
+
+        private final AtomicInteger checkpointByIdSelects = new AtomicInteger();
+
+        private CountingDataSource(DataSource delegate) {
+            this.delegate = delegate;
+        }
+
+        void reset() {
+            latestCheckpointSelects.set(0);
+            checkpointByIdSelects.set(0);
+        }
+
+        int latestCheckpointSelects() {
+            return latestCheckpointSelects.get();
+        }
+
+        int checkpointByIdSelects() {
+            return checkpointByIdSelects.get();
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return countPreparedStatements(delegate.getConnection());
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return countPreparedStatements(delegate.getConnection(username, password));
+        }
+
+        private Connection countPreparedStatements(Connection connection) {
+            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class<?>[] { Connection.class },
+                    (proxy, method, args) -> {
+                        countQuery(method, args);
+                        try {
+                            return method.invoke(connection, args);
+                        }
+                        catch (InvocationTargetException ex) {
+                            throw ex.getCause();
+                        }
+                    });
+        }
+
+        private void countQuery(java.lang.reflect.Method method, Object[] args) {
+            if (!"prepareStatement".equals(method.getName()) || args == null || args.length == 0
+                    || !(args[0] instanceof String sql)) {
+                return;
+            }
+            if (sql.contains("LIMIT 1")) {
+                latestCheckpointSelects.incrementAndGet();
+            }
+            if (sql.contains("AND c.checkpoint_id = ?")) {
+                checkpointByIdSelects.incrementAndGet();
+            }
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return delegate.unwrap(iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return delegate.isWrapperFor(iface);
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return delegate.getLogWriter();
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {
+            delegate.setLogWriter(out);
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {
+            delegate.setLoginTimeout(seconds);
+        }
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return delegate.getLoginTimeout();
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return delegate.getParentLogger();
+        }
     }
 
 }


### PR DESCRIPTION
## 背景

关联：#4608

`MysqlSaver` 原先继承 `MemorySaver`，父类会通过 `_checkpointsByThread` 为每个 thread 持有完整 checkpoint 列表。这个实现可以减少读取最新 checkpoint 时的 MySQL RTT，但也让 MySQL 持久化存储和内存全量缓存同时存在：当 thread 的 checkpoint history 持续增长时，内存占用也会跟着历史长度增长。

这个 PR 的修复方向不是关闭 checkpoint 语义，也不是移除历史读取能力，而是拆开两类访问路径：最新 checkpoint 保留一个有界内存缓存，完整 checkpoint history 仍以 MySQL 为准并按需读取。

## 修改内容

- `MysqlSaver` 改为直接实现 `BaseCheckpointSaver`，不再继承 `MemorySaver` 的全量 checkpoint history 缓存。
- 新增有界 latest-checkpoint LRU cache，默认最多缓存 1024 个 thread 的最新 checkpoint，可通过 `maxCachedThreads(0)` 关闭。
- `get(config)` 未指定 checkpoint id 时优先读取 latest cache，cache miss 时只从 MySQL 查询最新一条。
- `get(config)` 指定 checkpoint id 时直接从 MySQL 查询对应 checkpoint，不把历史 checkpoint 放进内存缓存。
- `list(config)` 和 `release(config)` 保留完整历史语义，但改为按需从 MySQL 加载，不长期驻留内存。
- update checkpoint 时绑定当前 active thread，并在目标 checkpoint 不存在时保持原先的异常语义。
- 为 MySQL saver 增加测试，覆盖 latest cache 有界、历史 checkpoint 不进入内存缓存、按 checkpoint id 走 MySQL 查询。

## 语义说明

这个修改保留了原先为了避免最新 checkpoint 频繁访问 MySQL 的优化意图：常见的 latest checkpoint 读取仍然可以命中内存缓存。区别在于不再把完整 checkpoint history 常驻内存，避免内存占用和历史 checkpoint 数量线性绑定。

也就是说：

- 最新 checkpoint：可以缓存，但缓存有上限。
- 历史 checkpoint：仍可查询，但以 MySQL 为数据源。
- release/list：仍返回完整 active history，但只在调用时加载。

## 验证

- `JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.10-amzn PATH=$HOME/.sdkman/candidates/java/21.0.10-amzn/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core -am -DskipTests compile`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.10-amzn PATH=$HOME/.sdkman/candidates/java/21.0.10-amzn/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core -am -Dtest=MysqlSaverTest test`

本地环境没有可用 Docker socket，`MysqlSaverTest` 被 Testcontainers 跳过；命令整体构建通过，CI 环境有 Docker 时会实际执行该测试。
