### PR TITLE
fix(graph): prevent PostgresSaver checkpoint history cache growth

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/postgresql/PostgresSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/postgresql/PostgresSaver.java
@@ -17,8 +17,8 @@ package com.alibaba.cloud.ai.graph.checkpoint.savers.postgresql;
 
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
-import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 
 import java.io.IOException;
@@ -29,10 +29,16 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.sql.DataSource;
 
@@ -43,8 +49,190 @@ import org.slf4j.LoggerFactory;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class PostgresSaver extends MemorySaver {
+/**
+ * <p>
+ * PostgresSaver stores Graph state in a PostgreSQL database and keeps only a bounded
+ * latest-checkpoint cache in memory.
+ * </p>
+ * <p>
+ * Two tables are used to store the workflow state:
+ *
+ * <pre>
+ *     CREATE TABLE GraphThread (
+ *          thread_id UUID PRIMARY KEY,
+ *          thread_name VARCHAR(255),
+ *          is_released BOOLEAN DEFAULT FALSE NOT NULL
+ *     )
+ *     CREATE UNIQUE INDEX idx_unique_lg4jthread_thread_name_unreleased
+ *          ON GraphThread(thread_name) WHERE is_released = FALSE
+ *
+ *     CREATE TABLE GraphCheckpoint (
+ *          checkpoint_id UUID PRIMARY KEY,
+ *          parent_checkpoint_id UUID,
+ *          thread_id UUID NOT NULL,
+ *          node_id VARCHAR(255),
+ *          next_node_id VARCHAR(255),
+ *          state_data JSONB NOT NULL,
+ *          state_content_type VARCHAR(100) NOT NULL,
+ *          saved_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+ *
+ *          CONSTRAINT fk_thread
+ *              FOREIGN KEY(thread_id)
+ *              REFERENCES GraphThread(thread_id)
+ *              ON DELETE CASCADE
+ *     )
+ * </pre>
+ * </p>
+ * <p>
+ * A builder can be used to create an instance of PostgresSaver. The builder
+ * allows to configure the following options:
+ * - DataSource: indicates which data source should be used to connect
+ * to the database
+ * - CreateOption : indicates whether the tables should be created or
+ * existing tables should be used.
+ * - MaxCachedThreads: indicates how many latest checkpoints are kept in memory.
+ * </p>
+ * <p>
+ * Ex:
+ *
+ * <pre>
+ * var saver = PostgresSaver.builder()
+ *         .stateSerializer(STATE_SERIALIZER)
+ *         .createOption(CreateOption.CREATE_OR_REPLACE)
+ *         .datasource(DATA_SOURCE)
+ *         .build();
+ * </pre>
+ * </p>
+ */
+public class PostgresSaver implements BaseCheckpointSaver {
+
 	private static final Logger log = LoggerFactory.getLogger(PostgresSaver.class);
+
+	// DDL statements
+	private static final String DROP_TABLES = """
+			DROP TABLE IF EXISTS GraphCheckpoint CASCADE;
+			DROP TABLE IF EXISTS GraphThread CASCADE;
+			""";
+
+	private static final String CREATE_TABLES = """
+			CREATE TABLE IF NOT EXISTS GraphThread (
+			     thread_id UUID PRIMARY KEY,
+			     thread_name VARCHAR(255),
+			     is_released BOOLEAN DEFAULT FALSE NOT NULL
+			 );
+
+			 CREATE TABLE IF NOT EXISTS GraphCheckpoint (
+			     checkpoint_id UUID PRIMARY KEY,
+			     parent_checkpoint_id UUID,
+			     thread_id UUID NOT NULL,
+			     node_id VARCHAR(255),
+			     next_node_id VARCHAR(255),
+			     state_data JSONB NOT NULL,
+			     state_content_type VARCHAR(100) NOT NULL,
+			     saved_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+			     CONSTRAINT fk_thread
+			         FOREIGN KEY(thread_id)
+			         REFERENCES GraphThread(thread_id)
+			         ON DELETE CASCADE
+			 );
+			""";
+
+	private static final String CREATE_INDEXES = """
+			CREATE INDEX IF NOT EXISTS idx_lg4jcheckpoint_thread_id ON GraphCheckpoint(thread_id);
+			CREATE INDEX IF NOT EXISTS idx_lg4jcheckpoint_thread_id_saved_at_desc ON GraphCheckpoint(thread_id, saved_at DESC);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_lg4jthread_thread_name_unreleased ON GraphThread(thread_name) WHERE is_released = FALSE;
+			""";
+
+	// DML statements
+	private static final String UPSERT_THREAD = """
+			WITH inserted AS (
+			    INSERT INTO GraphThread (thread_id, thread_name, is_released)
+			    VALUES (?, ?, FALSE)
+			    ON CONFLICT (thread_name)
+			    WHERE is_released = FALSE
+			    DO NOTHING
+			    RETURNING thread_id
+			)
+			SELECT thread_id FROM inserted
+			UNION ALL
+			SELECT thread_id FROM GraphThread
+			WHERE thread_name = ? AND is_released = FALSE
+			LIMIT 1;
+			""";
+
+	private static final String INSERT_CHECKPOINT = """
+			INSERT INTO GraphCheckpoint(
+			checkpoint_id,
+			parent_checkpoint_id,
+			thread_id,
+			node_id,
+			next_node_id,
+			state_data,
+			state_content_type)
+			VALUES (?, ?, ?, ?, ?, ?::jsonb, ?)
+			""";
+
+	private static final String UPDATE_CHECKPOINT = """
+			UPDATE GraphCheckpoint c
+			SET
+			  checkpoint_id = ?,
+			  node_id = ?,
+			  next_node_id = ?,
+			  state_data = ?::jsonb,
+			  state_content_type = ?
+			FROM GraphThread t
+			WHERE c.thread_id = t.thread_id
+			  AND t.thread_name = ? AND t.is_released = FALSE
+			  AND c.checkpoint_id = ?
+			""";
+
+	private static final String SELECT_CHECKPOINTS = """
+			SELECT
+			  c.checkpoint_id,
+			  c.node_id,
+			  c.next_node_id,
+			  c.state_data->>'binaryPayload' AS base64_data,
+			  c.state_content_type
+			FROM GraphCheckpoint c
+			  JOIN GraphThread t ON c.thread_id = t.thread_id
+			WHERE t.thread_name = ? AND t.is_released = FALSE
+			ORDER BY c.saved_at DESC
+			""";
+
+	private static final String SELECT_LATEST_CHECKPOINT = """
+			SELECT
+			  c.checkpoint_id,
+			  c.node_id,
+			  c.next_node_id,
+			  c.state_data->>'binaryPayload' AS base64_data,
+			  c.state_content_type
+			FROM GraphCheckpoint c
+			  JOIN GraphThread t ON c.thread_id = t.thread_id
+			WHERE t.thread_name = ? AND t.is_released = FALSE
+			ORDER BY c.saved_at DESC
+			LIMIT 1
+			""";
+
+	private static final String SELECT_CHECKPOINT_BY_ID = """
+			SELECT
+			  c.checkpoint_id,
+			  c.node_id,
+			  c.next_node_id,
+			  c.state_data->>'binaryPayload' AS base64_data,
+			  c.state_content_type
+			FROM GraphCheckpoint c
+			  JOIN GraphThread t ON c.thread_id = t.thread_id
+			WHERE t.thread_name = ? AND t.is_released = FALSE
+			  AND c.checkpoint_id = ?
+			""";
+
+	private static final String RELEASE_THREAD = """
+			UPDATE GraphThread
+			SET is_released = TRUE
+			WHERE thread_name = ? AND is_released = FALSE
+			""";
+
 	/**
 	 * Datasource used to create the store
 	 */
@@ -54,19 +242,41 @@ public class PostgresSaver extends MemorySaver {
 
 	private final CreateOption createOption;
 
-	protected PostgresSaver(Builder builder) throws SQLException {
+	private final Map<String, Checkpoint> latestCheckpointCache;
+
+	private final ReentrantLock lock = new ReentrantLock();
+
+	private final int maxCachedThreads;
+
+	/**
+	 * Private constructor used by the builder to create a new instance of
+	 * PostgresSaver.
+	 *
+	 * @param builder the builder
+	 */
+	private PostgresSaver(Builder builder) throws SQLException {
 		this.datasource = builder.datasource;
 		this.stateSerializer = builder.stateSerializer;
 		this.createOption = builder.createOption;
+		this.maxCachedThreads = builder.maxCachedThreads;
+		this.latestCheckpointCache = createLatestCheckpointCache(builder.maxCachedThreads);
 		initTable(createOption);
 	}
 
+	/**
+	 * Creates an instance of a builder that allows to configure and create a new
+	 * instance of PostgresSaver.
+	 *
+	 * @return a new instance of the builder.
+	 */
 	public static Builder builder() {
 		return new Builder();
 	}
 
 	private void rollback(Connection conn, Checkpoint checkpoint, String threadId) {
-		if (conn == null) return;
+		if (conn == null) {
+			return;
+		}
 
 		requireNonNull(checkpoint, "checkpoint cannot be null");
 
@@ -79,6 +289,20 @@ public class PostgresSaver extends MemorySaver {
 					checkpoint.getId(),
 					threadId,
 					exRollback);
+		}
+	}
+
+	private void rollback(Connection conn, String threadId) {
+		if (conn == null) {
+			return;
+		}
+
+		try {
+			conn.rollback();
+			log.warn("Transaction rolled back for thread {}", threadId);
+		}
+		catch (SQLException exRollback) {
+			log.error("Failed to rollback transaction for thread {}", threadId, exRollback);
 		}
 	}
 
@@ -103,57 +327,21 @@ public class PostgresSaver extends MemorySaver {
 	}
 
 	protected void initTable(CreateOption createOption) throws SQLException {
-		var sqlDropTables = """
-				DROP TABLE IF EXISTS GraphCheckpoint CASCADE;
-				DROP TABLE IF EXISTS GraphThread CASCADE;
-				""";
-
-		var sqlCreateTables = """
-				CREATE TABLE IF NOT EXISTS GraphThread (
-				     thread_id UUID PRIMARY KEY,
-				     thread_name VARCHAR(255),
-				     is_released BOOLEAN DEFAULT FALSE NOT NULL
-				 );
-
-				 CREATE TABLE IF NOT EXISTS GraphCheckpoint (
-				     checkpoint_id UUID PRIMARY KEY,
-				     parent_checkpoint_id UUID,
-				     thread_id UUID NOT NULL,
-				     node_id VARCHAR(255),
-				     next_node_id VARCHAR(255),
-				     state_data JSONB NOT NULL,
-				     state_content_type VARCHAR(100) NOT NULL,
-				     saved_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-
-				     CONSTRAINT fk_thread
-				         FOREIGN KEY(thread_id)
-				         REFERENCES GraphThread(thread_id)
-				         ON DELETE CASCADE
-				 );
-				""";
-
-		var sqlCreateIndexes = """
-				CREATE INDEX IF NOT EXISTS idx_lg4jcheckpoint_thread_id ON GraphCheckpoint(thread_id);
-				CREATE INDEX IF NOT EXISTS idx_lg4jcheckpoint_thread_id_saved_at_desc ON GraphCheckpoint(thread_id, saved_at DESC);
-				CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_lg4jthread_thread_name_unreleased ON GraphThread(thread_name) WHERE is_released = FALSE;
-				""";
-
-
 		String sqlCommand = null;
 		try (Connection connection = getConnection(); Statement statement = connection.createStatement()) {
 			if (createOption == CreateOption.CREATE_OR_REPLACE) {
-				log.trace("Executing drop tables:\n---\n{}---", sqlDropTables);
-				sqlCommand = sqlDropTables;
+				log.trace("Executing drop tables:\n---\n{}---", DROP_TABLES);
+				sqlCommand = DROP_TABLES;
 				statement.executeUpdate(sqlCommand);
 			}
 			if (createOption == CreateOption.CREATE_OR_REPLACE ||
 				createOption == CreateOption.CREATE_IF_NOT_EXISTS) {
-				log.trace("Executing create tables:\n---\n{}---", sqlCreateTables);
-				sqlCommand = sqlCreateTables;
+				log.trace("Executing create tables:\n---\n{}---", CREATE_TABLES);
+				sqlCommand = CREATE_TABLES;
 				statement.executeUpdate(sqlCommand);
 
-				log.trace("Executing create indexes:\n---\n{}---", sqlCreateIndexes);
-				sqlCommand = sqlCreateIndexes;
+				log.trace("Executing create indexes:\n---\n{}---", CREATE_INDEXES);
+				sqlCommand = CREATE_INDEXES;
 				statement.executeUpdate(sqlCommand);
 			}
 		}
@@ -163,110 +351,98 @@ public class PostgresSaver extends MemorySaver {
 		}
 	}
 
-	@Override
-	protected LinkedList<Checkpoint> loadedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints) throws Exception {
+	private Checkpoint readCheckpoint(ResultSet resultSet)
+			throws SQLException, IOException, ClassNotFoundException {
+		return Checkpoint.builder()
+				.id(resultSet.getString(1))
+				.nodeId(resultSet.getString(2))
+				.nextNodeId(resultSet.getString(3))
+				.state(decodeState(resultSet.getBytes(4), resultSet.getString(5)))
+				.build();
+	}
 
-		if (!checkpoints.isEmpty()) return checkpoints;
+	private LinkedList<Checkpoint> selectCheckpoints(String threadId) throws Exception {
+		LinkedList<Checkpoint> checkpoints = new LinkedList<>();
+		try (Connection conn = getConnection();
+				PreparedStatement ps = conn.prepareStatement(SELECT_CHECKPOINTS)) {
 
-		var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-
-		var sqlCheckThread = """
-				SELECT COUNT(*)
-				FROM GraphThread
-				WHERE thread_name = ? AND is_released = FALSE
-				""";
-		var sqlQueryCheckpoints = """
-				WITH matched_thread AS (
-				    SELECT thread_id
-				    FROM GraphThread
-				    WHERE thread_name = ? AND is_released = FALSE
-				)
-				SELECT  c.checkpoint_id,
-				        c.node_id,
-				        c.next_node_id,
-				        c.state_data->>'binaryPayload' AS base64_data,
-				        c.state_content_type,
-				        c.parent_checkpoint_id
-				FROM matched_thread t
-				JOIN GraphCheckpoint c ON c.thread_id = t.thread_id
-				ORDER BY c.saved_at DESC
-				""";
-		try (Connection conn = getConnection()) {
-
-			try (PreparedStatement ps = conn.prepareStatement(sqlCheckThread)) {
-				ps.setString(1, threadId);
-				var resultSet = ps.executeQuery();
-				resultSet.next();
-				var count = resultSet.getInt(1);
-
-				if (count == 0) {
-					return checkpoints;
-				}
-				if (count > 1) {
-					throw new IllegalStateException(format("there are more than one Thread '%s' open (not released yet)", threadId));
-				}
-			}
-
-			log.trace("Executing select checkpoints:\n---\n{}---", sqlQueryCheckpoints);
-			try (PreparedStatement ps = conn.prepareStatement(sqlQueryCheckpoints)) {
-				ps.setString(1, threadId);
-				var rs = ps.executeQuery();
+			log.trace("Executing select checkpoints:\n---\n{}---", SELECT_CHECKPOINTS);
+			ps.setString(1, threadId);
+			try (ResultSet rs = ps.executeQuery()) {
 				while (rs.next()) {
-					var checkpoint = Checkpoint.builder()
-							.id(rs.getString(1))
-							.nodeId(rs.getString(2))
-							.nextNodeId(rs.getString(3))
-							.state(decodeState(rs.getBytes(4), rs.getString(5)))
-							.build();
-					checkpoints.add(checkpoint);
+					checkpoints.add(readCheckpoint(rs));
 				}
 			}
-
 		}
-
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load checkpoints", ex);
+		}
 		return checkpoints;
 	}
 
-	private void insertCheckpoint(Connection conn, RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint) throws Exception {
-		var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
+	private Optional<Checkpoint> selectLatestCheckpoint(String threadId) throws Exception {
+		try (Connection conn = getConnection();
+				PreparedStatement ps = conn.prepareStatement(SELECT_LATEST_CHECKPOINT)) {
 
-		var upsertThreadSql = """
-				WITH inserted AS (
-				    INSERT INTO GraphThread (thread_id, thread_name, is_released)
-				    VALUES (?, ?, FALSE)
-				    ON CONFLICT (thread_name)
-				    WHERE is_released = FALSE
-				    DO NOTHING
-				    RETURNING thread_id
-				)
-				SELECT thread_id FROM inserted
-				UNION ALL
-				SELECT thread_id FROM GraphThread
-				WHERE thread_name = ? AND is_released = FALSE
-				LIMIT 1;
-				""";
+			log.trace("Executing select latest checkpoint:\n---\n{}---", SELECT_LATEST_CHECKPOINT);
+			ps.setString(1, threadId);
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					return Optional.of(readCheckpoint(rs));
+				}
+				return Optional.empty();
+			}
+		}
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load latest checkpoint", ex);
+		}
+	}
 
-		var insertCheckpointSql = """
-				INSERT INTO GraphCheckpoint(
-				checkpoint_id,
-				parent_checkpoint_id,
-				thread_id,
-				node_id,
-				next_node_id,
-				state_data,
-				state_content_type)
-				VALUES (?, ?, ?, ?, ?, ?::jsonb, ?)
-				""";
+	private Optional<Checkpoint> selectCheckpointById(String threadId, String checkpointId) throws Exception {
+		try (Connection conn = getConnection();
+				PreparedStatement ps = conn.prepareStatement(SELECT_CHECKPOINT_BY_ID)) {
+
+			log.trace("Executing select checkpoint by id:\n---\n{}---", SELECT_CHECKPOINT_BY_ID);
+			ps.setString(1, threadId);
+			ps.setObject(2, UUID.fromString(checkpointId), Types.OTHER);
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					return Optional.of(readCheckpoint(rs));
+				}
+				return Optional.empty();
+			}
+		}
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load checkpoint", ex);
+		}
+	}
+
+	private void insertCheckpoint(String threadId, Checkpoint checkpoint) throws Exception {
+		Connection conn = null;
+		try (Connection ignored = conn = getConnection()) {
+			conn.setAutoCommit(false);
+			insertCheckpoint(conn, threadId, checkpoint);
+			conn.commit();
+			log.debug("Checkpoint {} for thread {} inserted successfully.", checkpoint.getId(), threadId);
+		}
+		catch (SQLException | IOException ex) {
+			log.error("Error inserting checkpoint with id {} in thread {}", checkpoint.getId(), threadId, ex);
+			rollback(conn, checkpoint, threadId);
+			throw new Exception("Unable to insert checkpoint", ex);
+		}
+	}
+
+	private void insertCheckpoint(Connection conn, String threadId, Checkpoint checkpoint) throws Exception {
 		UUID threadUUID = null;
 
 		// 1. Upsert thread information
-		try (PreparedStatement ps = conn.prepareStatement(upsertThreadSql)) {
+		try (PreparedStatement ps = conn.prepareStatement(UPSERT_THREAD)) {
 			var field = 0;
 			ps.setObject(++field, UUID.randomUUID(), Types.OTHER);
 			ps.setString(++field, threadId);
 			ps.setString(++field, threadId);
 
-			log.trace("Executing upsert thread:\n---\n{}---", upsertThreadSql);
+			log.trace("Executing upsert thread:\n---\n{}---", UPSERT_THREAD);
 
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
@@ -277,7 +453,7 @@ public class PostgresSaver extends MemorySaver {
 
 
 		// 2. Insert checkpoint data
-		try (PreparedStatement ps = conn.prepareStatement(insertCheckpointSql)) {
+		try (PreparedStatement ps = conn.prepareStatement(INSERT_CHECKPOINT)) {
 			var field = 0;
 			// checkpoint_id
 			ps.setObject(++field,
@@ -303,138 +479,200 @@ public class PostgresSaver extends MemorySaver {
 			// To use DB default, one would typically omit the column or pass NULL if the column definition allows it to trigger default.
 			// OffsetDateTime savedAt = checkpoint.getSavedAt().orElse(OffsetDateTime.now());
 			// psCheckpoint.setObject(8, savedAt);
-			log.trace("Executing insert checkpoint:\n---\n{}---", insertCheckpointSql);
+			log.trace("Executing insert checkpoint:\n---\n{}---", INSERT_CHECKPOINT);
 			ps.executeUpdate();
 		}
 
 	}
 
-	@Override
-	protected void insertedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint) throws Exception {
-		var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-
+	private void updateCheckpoint(String threadId, String checkpointId, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 		try (Connection ignored = conn = getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
-
-			insertCheckpoint(conn, config, checkpoints, checkpoint);
-
-			conn.commit();
-			log.debug("Checkpoint {} for thread {} inserted successfully.", checkpoint.getId(), threadId);
-
-		}
-		catch (SQLException | IOException e) { // IOException from convertStateToJson
-			log.error("Error inserting checkpoint with id {} in thread {}", checkpoint.getId(), threadId, e);
-			rollback(conn, checkpoint, threadId);
-			throw e;
-		}
-
-	}
-
-	@Override
-	protected void updatedCheckpoint(RunnableConfig config,
-			LinkedList<Checkpoint> checkpoints,
-			Checkpoint checkpoint) throws Exception {
-
-		final var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-
-		var deletePreviousCheckpointSql = """
-				DELETE FROM GraphCheckpoint
-				WHERE checkpoint_id = ?;
-				""";
-
-		Connection conn = null;
-
-		try (Connection ignored = conn = getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
-
-			if (config.checkPointId().isPresent()) {
-
-				try (PreparedStatement ps = conn.prepareStatement(deletePreviousCheckpointSql)) {
-					var field = 0;
-					ps.setObject(++field,
-							UUID.fromString(config.checkPointId().get()),
-							Types.OTHER); // nullable
-					log.trace("Executing deleting previous checkpoint with id {} in thread {}:\n---\n{}---",
-							config.checkPointId().get(),
-							threadId,
-							deletePreviousCheckpointSql);
-					ps.executeUpdate();
+			conn.setAutoCommit(false);
+			try (PreparedStatement ps = conn.prepareStatement(UPDATE_CHECKPOINT)) {
+				var field = 0;
+				ps.setObject(++field, UUID.fromString(checkpoint.getId()), Types.OTHER);
+				ps.setString(++field, checkpoint.getNodeId());
+				ps.setString(++field, checkpoint.getNextNodeId());
+				ps.setString(++field, encodeState(checkpoint.getState()));
+				ps.setString(++field, stateSerializer.contentType());
+				ps.setString(++field, threadId);
+				ps.setObject(++field, UUID.fromString(checkpointId), Types.OTHER);
+				log.trace("Executing update checkpoint:\n---\n{}---", UPDATE_CHECKPOINT);
+				int rowsAffected = ps.executeUpdate();
+				if (rowsAffected == 0) {
+					conn.rollback();
+					throw new NoSuchElementException(format("Checkpoint with id %s not found!", checkpointId));
 				}
 			}
-
-			insertCheckpoint(conn, config, checkpoints, checkpoint);
-
 			conn.commit();
-
-			log.debug("Checkpoint with id {} for thread {} inserted successfully.",
+			log.debug("Checkpoint with id {} for thread {} updated successfully.",
 					checkpoint.getId(),
 					threadId);
-
 		}
-		catch (SQLException | IOException e) { // IOException from convertStateToJson
-			log.error("Error inserting checkpoint with id {} in thread {}",
-					checkpoint.getId(),
-					threadId,
-					e);
+		catch (SQLException | IOException ex) {
+			log.error("Error updating checkpoint with id {} in thread {}", checkpoint.getId(), threadId, ex);
 			rollback(conn, checkpoint, threadId);
-			throw e;
+			throw new Exception("Unable to update checkpoint", ex);
 		}
 	}
 
-	@Override
-	protected void releasedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Tag releaseTag) throws Exception {
-		var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-
-		var selectThreadSql = """
-				SELECT thread_id FROM GraphThread
-				WHERE thread_name = ? AND is_released = FALSE
-				""";
-		var releaseThreadSql = """
-				UPDATE GraphThread
-				SET
-				    is_released = TRUE
-				WHERE thread_id = ?;
-				""";
-		try (Connection conn = getConnection()) {
-
-			UUID threadUUID = null;
-			try (PreparedStatement ps = conn.prepareStatement(selectThreadSql)) {
-				var field = 0;
-				ps.setString(++field, threadId);
-
-				try (ResultSet rs = ps.executeQuery()) {
-					var rows = 0;
-					while (rs.next()) {
-						threadUUID = rs.getObject("thread_id", UUID.class);
-						++rows;
-					}
-					if (rows == 0) {
-						throw new IllegalStateException(format("active Thread '%s' not found", threadId));
-					}
-					if (rows > 1) {
-						throw new IllegalStateException(format("duplicate active Thread '%s' found", threadId));
-					}
+	private void releaseThread(String threadId) throws Exception {
+		Connection conn = null;
+		try (Connection ignored = conn = getConnection()) {
+			conn.setAutoCommit(false);
+			log.trace("Executing release Thread:\n---\n{}---", RELEASE_THREAD);
+			try (PreparedStatement ps = conn.prepareStatement(RELEASE_THREAD)) {
+				ps.setString(1, threadId);
+				int rowsAffected = ps.executeUpdate();
+				if (rowsAffected == 0) {
+					conn.rollback();
+					throw new IllegalStateException(format("Thread '%s' not found or already released", threadId));
 				}
 			}
-
-			log.trace("Executing release Thread:\n---\n{}---", releaseThreadSql);
-			try (PreparedStatement ps = conn.prepareStatement(releaseThreadSql)) {
-				var field = 0;
-				ps.setObject(++field,
-						Objects.requireNonNull(threadUUID, "threadUUID cannot be null"),
-						Types.OTHER); // nullable
-				ps.executeUpdate();
-
-			}
+			conn.commit();
+			log.debug("Thread {} released successfully.", threadId);
 		}
+		catch (SQLException ex) {
+			log.error("Error releasing thread {}", threadId, ex);
+			rollback(conn, threadId);
+			throw new Exception("Unable to release checkpoint", ex);
+		}
+	}
 
+	/**
+	 * Lists active checkpoints for the configured thread.
+	 */
+	@Override
+	public Collection<Checkpoint> list(RunnableConfig config) {
+		lock.lock();
+		try {
+			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadId);
+			if (!checkpoints.isEmpty()) {
+				cacheLatest(threadId, checkpoints.peek());
+			}
+			return Collections.unmodifiableCollection(checkpoints);
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Gets a checkpoint for the configured thread.
+	 */
+	@Override
+	public Optional<Checkpoint> get(RunnableConfig config) {
+		lock.lock();
+		try {
+			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
+			if (config.checkPointId().isPresent()) {
+				return selectCheckpointById(threadId, config.checkPointId().get());
+			}
+
+			Optional<Checkpoint> cached = getCachedLatest(threadId);
+			if (cached.isPresent()) {
+				return cached;
+			}
+
+			Optional<Checkpoint> latest = selectLatestCheckpoint(threadId);
+			latest.ifPresent(checkpoint -> cacheLatest(threadId, checkpoint));
+			return latest;
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Inserts or updates a checkpoint.
+	 */
+	@Override
+	public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+		lock.lock();
+		try {
+			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
+			if (config.checkPointId().isPresent()) {
+				String checkpointId = config.checkPointId().get();
+				updateCheckpoint(threadId, checkpointId, checkpoint);
+				getCachedLatest(threadId)
+						.filter(latest -> latest.getId().equals(checkpointId))
+						.ifPresent(latest -> cacheLatest(threadId, checkpoint));
+				return config;
+			}
+
+			insertCheckpoint(threadId, checkpoint);
+			cacheLatest(threadId, checkpoint);
+			return RunnableConfig.builder(config)
+					.checkPointId(checkpoint.getId())
+					.build();
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Releases the active thread and returns the released checkpoints.
+	 */
+	@Override
+	public Tag release(RunnableConfig config) throws Exception {
+		lock.lock();
+		try {
+			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadId);
+			releaseThread(threadId);
+			removeCachedLatest(threadId);
+			return new Tag(threadId, checkpoints);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Creates a bounded LRU cache for latest checkpoints.
+	 */
+	private static Map<String, Checkpoint> createLatestCheckpointCache(int maxCachedThreads) {
+		if (maxCachedThreads == 0) {
+			return Collections.emptyMap();
+		}
+		return new LinkedHashMap<>(16, 0.75f, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
+				return size() > maxCachedThreads;
+			}
+		};
+	}
+
+	private Optional<Checkpoint> getCachedLatest(String threadId) {
+		if (maxCachedThreads == 0) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(latestCheckpointCache.get(threadId));
+	}
+
+	private void cacheLatest(String threadId, Checkpoint checkpoint) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.put(threadId, checkpoint);
+		}
+	}
+
+	private void removeCachedLatest(String threadId) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.remove(threadId);
+		}
 	}
 
 	/**
 	 * Datasource connection
-	 * Creates the vector extension and add the vector type if it does not exist.
-	 * Could be overridden in case extension creation and adding type is done at datasource initialization step.
 	 *
 	 * @return Datasource connection
 	 * @throws SQLException exception
@@ -443,7 +681,10 @@ public class PostgresSaver extends MemorySaver {
 		return datasource.getConnection();
 	}
 
-	public static class Builder extends MemorySaver.Builder {
+	/**
+	 * A builder for PostgresSaver.
+	 */
+	public static class Builder {
 		public StateSerializer stateSerializer;
 		private String host;
 		private Integer port;
@@ -455,9 +696,24 @@ public class PostgresSaver extends MemorySaver {
 		// New CreateOption field with default value
 		private CreateOption createOption = CreateOption.CREATE_IF_NOT_EXISTS;
 
+		private int maxCachedThreads = 1024;
+
 		// Legacy fields for backward compatibility
 		private boolean createTables;
 		private boolean dropTablesFirst;
+
+		/**
+		 * Sets the maximum number of latest checkpoints retained in memory.
+		 * @param maxCachedThreads max cached threads, or 0 to disable the cache
+		 * @return this builder
+		 */
+		public Builder maxCachedThreads(int maxCachedThreads) {
+			if (maxCachedThreads < 0) {
+				throw new IllegalArgumentException("maxCachedThreads must be greater than or equal to 0");
+			}
+			this.maxCachedThreads = maxCachedThreads;
+			return this;
+		}
 
 		public Builder stateSerializer(StateSerializer stateSerializer) {
 			this.stateSerializer = stateSerializer;

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/PostgresSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/PostgresSaverTest.java
@@ -17,22 +17,35 @@ package com.alibaba.cloud.ai.graph.checkpoint.savers;
 
 import com.alibaba.cloud.ai.graph.*;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.postgresql.CreateOption;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.postgresql.PostgresSaver;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.postgresql.ds.PGSimpleDataSource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -103,6 +116,32 @@ public class PostgresSaverTest {
                 .database(DATABASE_NAME)
                 .stateSerializer(serializer)
                 ;
+    }
+
+    private static DataSource dataSource() {
+        var dataSource = new PGSimpleDataSource();
+        dataSource.setServerNames(new String[] {postgres.getHost()});
+        dataSource.setPortNumbers(new int[] {postgres.getFirstMappedPort()});
+        dataSource.setDatabaseName(DATABASE_NAME);
+        dataSource.setUser(postgres.getUsername());
+        dataSource.setPassword(postgres.getPassword());
+        return dataSource;
+    }
+
+    private static RunnableConfig config(String threadId) {
+        return RunnableConfig.builder().threadId(threadId).build();
+    }
+
+    private static RunnableConfig config(String threadId, String checkpointId) {
+        return RunnableConfig.builder().threadId(threadId).checkPointId(checkpointId).build();
+    }
+
+    private static Checkpoint checkpoint(String value) {
+        return Checkpoint.builder()
+                .nodeId("agent_1")
+                .nextNodeId(END)
+                .state(Map.of("value", value))
+                .build();
     }
 
     @Test
@@ -226,6 +265,135 @@ public class PostgresSaverTest {
 
         saver.release( runnableConfig );
 
+    }
+
+    @Test
+    public void testLatestCheckpointCacheIsBoundedByThreadCount() throws Exception {
+        var countingDataSource = new CountingDataSource(dataSource());
+        var saver = PostgresSaver.builder()
+                .datasource(countingDataSource)
+                .stateSerializer(serializer)
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .maxCachedThreads(2)
+                .build();
+
+        var firstCheckpoint = checkpoint("first");
+        var firstConfig = config("postgres-cache-thread-1");
+        saver.put(firstConfig, firstCheckpoint);
+        saver.put(config("postgres-cache-thread-2"), checkpoint("second"));
+        saver.put(config("postgres-cache-thread-3"), checkpoint("third"));
+
+        countingDataSource.reset();
+        var reloaded = saver.get(firstConfig);
+        assertTrue(reloaded.isPresent());
+        assertEquals(firstCheckpoint.getId(), reloaded.get().getId());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+    }
+
+    @Test
+    public void testPostgresSaverKeepsOnlyLatestCheckpointInMemory() throws Exception {
+        var countingDataSource = new CountingDataSource(dataSource());
+        var saver = PostgresSaver.builder()
+                .datasource(countingDataSource)
+                .stateSerializer(serializer)
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .maxCachedThreads(16)
+                .build();
+
+        String threadId = "postgres-cache-single-thread";
+        var firstCheckpoint = checkpoint("first");
+        var secondCheckpoint = checkpoint("second");
+        var thirdCheckpoint = checkpoint("third");
+
+        saver.put(config(threadId), firstCheckpoint);
+        saver.put(config(threadId), secondCheckpoint);
+        saver.put(config(threadId), thirdCheckpoint);
+
+        countingDataSource.reset();
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isPresent());
+        assertEquals(thirdCheckpoint.getId(), latest.get().getId());
+        assertEquals(0, countingDataSource.latestCheckpointSelects());
+
+        Collection<Checkpoint> history = saver.list(config(threadId));
+        assertEquals(3, history.size());
+
+        countingDataSource.reset();
+        var firstFromDatabase = saver.get(config(threadId, firstCheckpoint.getId()));
+        assertTrue(firstFromDatabase.isPresent());
+        assertEquals(firstCheckpoint.getId(), firstFromDatabase.get().getId());
+        assertEquals(1, countingDataSource.checkpointByIdSelects());
+    }
+
+    @Test
+    public void testPostgresSaverRefreshesLatestCacheWhenLatestCheckpointIsUpdated() throws Exception {
+        var countingDataSource = new CountingDataSource(dataSource());
+        var saver = PostgresSaver.builder()
+                .datasource(countingDataSource)
+                .stateSerializer(serializer)
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .maxCachedThreads(16)
+                .build();
+
+        String threadId = "postgres-cache-update-latest-thread";
+        var originalCheckpoint = checkpoint("original");
+        var updatedCheckpoint = checkpoint("updated");
+        var checkpointConfig = saver.put(config(threadId), originalCheckpoint);
+
+        saver.put(checkpointConfig, updatedCheckpoint);
+
+        countingDataSource.reset();
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isPresent());
+        assertEquals(updatedCheckpoint.getId(), latest.get().getId());
+        assertEquals(0, countingDataSource.latestCheckpointSelects());
+    }
+
+    @Test
+    public void testPostgresSaverClearsLatestCacheWhenThreadIsReleased() throws Exception {
+        var countingDataSource = new CountingDataSource(dataSource());
+        var saver = PostgresSaver.builder()
+                .datasource(countingDataSource)
+                .stateSerializer(serializer)
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .maxCachedThreads(16)
+                .build();
+
+        String threadId = "postgres-cache-release-thread";
+        saver.put(config(threadId), checkpoint("released"));
+
+        countingDataSource.reset();
+        saver.release(config(threadId));
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isEmpty());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+    }
+
+    @Test
+    public void testPostgresSaverCanDisableLatestCheckpointCache() throws Exception {
+        var countingDataSource = new CountingDataSource(dataSource());
+        var saver = PostgresSaver.builder()
+                .datasource(countingDataSource)
+                .stateSerializer(serializer)
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .maxCachedThreads(0)
+                .build();
+
+        String threadId = "postgres-cache-disabled-thread";
+        var latestCheckpoint = checkpoint("latest");
+        saver.put(config(threadId), latestCheckpoint);
+
+        countingDataSource.reset();
+        var firstRead = saver.get(config(threadId));
+        assertTrue(firstRead.isPresent());
+        assertEquals(latestCheckpoint.getId(), firstRead.get().getId());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+
+        countingDataSource.reset();
+        var secondRead = saver.get(config(threadId));
+        assertTrue(secondRead.isPresent());
+        assertEquals(latestCheckpoint.getId(), secondRead.get().getId());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
     }
 
 
@@ -429,5 +597,102 @@ public class PostgresSaverTest {
 			saver.release(config);
 		}
 	}
+
+    private static final class CountingDataSource implements DataSource {
+
+        private final DataSource delegate;
+
+        private final AtomicInteger latestCheckpointSelects = new AtomicInteger();
+
+        private final AtomicInteger checkpointByIdSelects = new AtomicInteger();
+
+        private CountingDataSource(DataSource delegate) {
+            this.delegate = delegate;
+        }
+
+        void reset() {
+            latestCheckpointSelects.set(0);
+            checkpointByIdSelects.set(0);
+        }
+
+        int latestCheckpointSelects() {
+            return latestCheckpointSelects.get();
+        }
+
+        int checkpointByIdSelects() {
+            return checkpointByIdSelects.get();
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return countPreparedStatements(delegate.getConnection());
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return countPreparedStatements(delegate.getConnection(username, password));
+        }
+
+        private Connection countPreparedStatements(Connection connection) {
+            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class<?>[] { Connection.class },
+                    (proxy, method, args) -> {
+                        countQuery(method, args);
+                        try {
+                            return method.invoke(connection, args);
+                        }
+                        catch (InvocationTargetException ex) {
+                            throw ex.getCause();
+                        }
+                    });
+        }
+
+        private void countQuery(java.lang.reflect.Method method, Object[] args) {
+            if (!"prepareStatement".equals(method.getName()) || args == null || args.length == 0
+                    || !(args[0] instanceof String sql)) {
+                return;
+            }
+            if (sql.contains("ORDER BY c.saved_at DESC") && sql.contains("LIMIT 1")) {
+                latestCheckpointSelects.incrementAndGet();
+            }
+            if (sql.contains("AND c.checkpoint_id = ?")) {
+                checkpointByIdSelects.incrementAndGet();
+            }
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return delegate.unwrap(iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return delegate.isWrapperFor(iface);
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return delegate.getLogWriter();
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {
+            delegate.setLogWriter(out);
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {
+            delegate.setLoginTimeout(seconds);
+        }
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return delegate.getLoginTimeout();
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return delegate.getParentLogger();
+        }
+    }
 
 }


### PR DESCRIPTION
## 背景

关联 #4608，跟进 #4609。

#4609 已经修复了 MysqlSaver 继承 MemorySaver 后长期持有完整 checkpoint history 的问题。PostgresSaver 也属于持久化 Saver，同样不应该把 MemorySaver 的 `_checkpointsByThread` 当作长期主存储。

这个 PR 只处理 PostgresSaver，和之前的 MySQLSaver pr 一样保持最小改动面。完整 checkpoint history 仍以 PostgreSQL 为准，内存只保留 latest checkpoint cache。

## 修改内容

- `PostgresSaver` 改为直接实现 `BaseCheckpointSaver`，不再继承 `MemorySaver` 的全量 checkpoint history 缓存。
- 新增有界 latest-checkpoint LRU cache，默认最多缓存 1024 个 thread 的最新 checkpoint，可通过 `maxCachedThreads(0)` 关闭。
- `get(config)` 未指定 checkpoint id 时优先读取 latest cache，cache miss 时只从 PostgreSQL 查询最新一条。
- `get(config)` 指定 checkpoint id 时直接从 PostgreSQL 查询对应 checkpoint，不把历史 checkpoint 放进内存缓存。
- `list(config)` 和 `release(config)` 保留完整历史语义，但改为按需从 PostgreSQL 加载，不长期驻留内存。
- update checkpoint 时改为更新原 checkpoint 行，保留原 `saved_at`，更接近 `MemorySaver` 中 `checkpoints.set(index, checkpoint)` 的替换语义。
- 为 PostgresSaver 增加测试，覆盖 latest cache 有界、历史 checkpoint 不进入内存缓存、latest update 后缓存刷新、release 后缓存清理、关闭 cache 后直接读库。

## 语义说明

这个修改保留了原先为了避免最新 checkpoint 频繁访问 PostgreSQL 的优化意图：常见的 latest checkpoint 读取仍然可以命中内存缓存。区别在于不再把完整 checkpoint history 常驻内存，避免内存占用和历史 checkpoint 数量线性绑定。

也就是说：

- 最新 checkpoint：可以缓存，但缓存有上限。
- 历史 checkpoint：仍可查询，但以 PostgreSQL 为数据源。
- release/list：仍返回完整 active history，但只在调用时加载。

另外，PostgresSaver 原先更新 checkpoint 时是 delete + insert，会刷新 `saved_at`，导致被替换的 checkpoint 在历史列表里重新排到最前面。本 PR 改为 UPDATE 原 checkpoint 行，保留原 `saved_at`，更接近 MemorySaver 的替换语义。

## 验证

- `JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.10-amzn PATH=$HOME/.sdkman/candidates/java/21.0.10-amzn/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core -am -DskipTests compile`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.10-amzn PATH=$HOME/.sdkman/candidates/java/21.0.10-amzn/bin:$PATH CI=true ./mvnw -pl spring-ai-alibaba-graph-core -am -Dtest=PostgresSaverTest test`

本地 Testcontainers 已连接 OrbStack 实际启动 `pgvector/pgvector:pg16` 容器，`PostgresSaverTest` 真实执行通过：

- `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0`
