### PR TITLE
fix(agent): retry streaming model responses safely

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelretry/ModelRetryInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelretry/ModelRetryInterceptor.java
@@ -20,12 +20,19 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+
+import reactor.core.publisher.Flux;
 
 /**
  * The model calls a retry interceptor to handle retryable exceptions such as network errors.
@@ -74,7 +81,13 @@ public class ModelRetryInterceptor extends ModelInterceptor {
 				}
 
 				ModelResponse modelResponse = handler.call(request);
-				Message message = (Message) modelResponse.getMessage();
+				Object messagePayload = modelResponse.getMessage();
+				if (messagePayload instanceof Flux<?> responseFlux) {
+					return ModelResponse.of(withStreamingRetry(request, handler, castChatResponseFlux(responseFlux), attempt, currentDelay));
+				}
+				if (!(messagePayload instanceof Message message)) {
+					return modelResponse;
+				}
 
 				// Check if the response contains any exception information (exceptions captured from AgentLlmNode).
 				if (message != null && message.getText() != null && message.getText().startsWith("Exception:")) {
@@ -145,6 +158,99 @@ public class ModelRetryInterceptor extends ModelInterceptor {
 
 		// All retries failed.
 		throw new RuntimeException("Model call failed, maximum number of retries reached. " + maxAttempts, lastException);
+	}
+
+	private Flux<ChatResponse> withStreamingRetry(ModelRequest request, ModelCallHandler handler, Flux<ChatResponse> responseFlux,
+			int attempt, long currentDelay) {
+		return Flux.defer(() -> {
+			AtomicBoolean chunkEmitted = new AtomicBoolean(false);
+			return responseFlux.doOnNext(response -> chunkEmitted.set(true)).onErrorResume(error -> {
+				if (chunkEmitted.get()) {
+					// Retrying after partial output would duplicate chunks downstream.
+					return Flux.error(error);
+				}
+				return retryStreamingModelCall(request, handler, attempt, currentDelay, error);
+			});
+		});
+	}
+
+	private Flux<ChatResponse> retryStreamingModelCall(ModelRequest request, ModelCallHandler handler, int failedAttempt,
+			long currentDelay, Throwable error) {
+		Exception exception = toException(error);
+		log.warn("Streaming model call failed (attempted {}/{}): {}", failedAttempt, maxAttempts, exception.getMessage());
+
+		if (failedAttempt >= maxAttempts) {
+			log.error("The maximum number of retries has been reached {}, and the streaming model call has failed.", maxAttempts);
+			return Flux.error(new RuntimeException("Model call failed, maximum number of retries reached.", exception));
+		}
+
+		if (!retryableExceptionPredicate.test(exception)) {
+			log.warn("Exceptions cannot be retried and are thrown immediately: {}", exception.getMessage());
+			return Flux.error(new RuntimeException("Model call failed (non-retryable exception)", exception));
+		}
+
+		int nextAttempt = failedAttempt + 1;
+		long nextDelay = nextDelay(currentDelay);
+		return delay(currentDelay).thenMany(Flux.defer(() -> {
+			log.info("Retry model call, on the {}th attempt (out of {} attempts).", nextAttempt, maxAttempts);
+			try {
+				ModelResponse retryResponse = handler.call(request);
+				return toStreamingFlux(request, handler, retryResponse, nextAttempt, nextDelay);
+			}
+			catch (Exception retryError) {
+				return retryStreamingModelCall(request, handler, nextAttempt, nextDelay, retryError);
+			}
+		}));
+	}
+
+	private Flux<ChatResponse> toStreamingFlux(ModelRequest request, ModelCallHandler handler, ModelResponse modelResponse,
+			int attempt, long currentDelay) {
+		Object messagePayload = modelResponse.getMessage();
+		if (messagePayload instanceof Flux<?> responseFlux) {
+			return withStreamingRetry(request, handler, castChatResponseFlux(responseFlux), attempt, currentDelay);
+		}
+		if (messagePayload instanceof Message message) {
+			if (isExceptionMessage(message)) {
+				return retryStreamingModelCall(request, handler, attempt, currentDelay,
+						new RuntimeException(message.getText()));
+			}
+			if (message instanceof AssistantMessage assistantMessage) {
+				return Flux.just(new ChatResponse(List.of(new Generation(assistantMessage))));
+			}
+		}
+		return Flux.error(new IllegalStateException(
+				"Streaming model call returned unsupported response type: " + responseTypeName(messagePayload)));
+	}
+
+	@SuppressWarnings("unchecked")
+	private Flux<ChatResponse> castChatResponseFlux(Flux<?> responseFlux) {
+		return (Flux<ChatResponse>) responseFlux;
+	}
+
+	private Flux<ChatResponse> delay(long currentDelay) {
+		if (currentDelay <= 0) {
+			return Flux.empty();
+		}
+		return Flux.<ChatResponse>empty().delaySubscription(Duration.ofMillis(currentDelay));
+	}
+
+	private long nextDelay(long currentDelay) {
+		return Math.min((long) (currentDelay * backoffMultiplier), maxDelay);
+	}
+
+	private Exception toException(Throwable error) {
+		if (error instanceof Exception exception) {
+			return exception;
+		}
+		return new RuntimeException(error);
+	}
+
+	private boolean isExceptionMessage(Message message) {
+		return message != null && message.getText() != null && message.getText().startsWith("Exception:");
+	}
+
+	private String responseTypeName(Object messagePayload) {
+		return messagePayload != null ? messagePayload.getClass().getName() : "null";
 	}
 
 	/**
@@ -279,4 +385,3 @@ public class ModelRetryInterceptor extends ModelInterceptor {
 		}
 	}
 }
-

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelretry/ModelRetryInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/modelretry/ModelRetryInterceptor.java
@@ -184,7 +184,7 @@ public class ModelRetryInterceptor extends ModelInterceptor {
 			return Flux.error(new RuntimeException("Model call failed, maximum number of retries reached.", exception));
 		}
 
-		if (!retryableExceptionPredicate.test(exception)) {
+		if (!isRetryableStreamingException(exception)) {
 			log.warn("Exceptions cannot be retried and are thrown immediately: {}", exception.getMessage());
 			return Flux.error(new RuntimeException("Model call failed (non-retryable exception)", exception));
 		}
@@ -246,7 +246,19 @@ public class ModelRetryInterceptor extends ModelInterceptor {
 	}
 
 	private boolean isExceptionMessage(Message message) {
-		return message != null && message.getText() != null && message.getText().startsWith("Exception:");
+		return message != null && isExceptionMessageText(message.getText());
+	}
+
+	private boolean isExceptionMessageText(String text) {
+		return text != null && text.startsWith("Exception:");
+	}
+
+	private boolean isRetryableStreamingException(Exception exception) {
+		String message = exception.getMessage();
+		if (isExceptionMessageText(message)) {
+			return isRetryableExceptionMessage(message);
+		}
+		return retryableExceptionPredicate.test(exception);
 	}
 
 	private String responseTypeName(Object messagePayload) {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRetryInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRetryInterceptorTest.java
@@ -22,7 +22,13 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import com.alibaba.cloud.ai.graph.agent.interceptor.modelretry.ModelRetryInterceptor;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import reactor.core.publisher.Flux;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -146,6 +152,120 @@ class ModelRetryInterceptorTest {
 
 		assertEquals(3, attemptCount.get(), "应该重试直到成功");
 		assertEquals("Success after retry", ((AssistantMessage) response.getMessage()).getText());
+	}
+
+	@Test
+	void testStreamingSuccessOnSecondAttempt() {
+		ModelRetryInterceptor interceptor = ModelRetryInterceptor.builder()
+				.maxAttempts(3)
+				.initialDelay(0)
+				.build();
+
+		AtomicInteger attemptCount = new AtomicInteger(0);
+
+		ModelCallHandler handler = request -> {
+			int count = attemptCount.incrementAndGet();
+			if (count == 1) {
+				return ModelResponse.of(Flux.error(new RuntimeException("I/O error on streaming response")));
+			}
+			return ModelResponse.of(Flux.just(chatResponse("Success after streaming retry")));
+		};
+
+		ModelResponse response = interceptor.interceptModel(ModelRequest.builder().build(), handler);
+
+		assertInstanceOf(Flux.class, response.getMessage());
+		@SuppressWarnings("unchecked")
+		Flux<ChatResponse> responseFlux = (Flux<ChatResponse>) response.getMessage();
+		List<ChatResponse> responses = responseFlux.collectList().block(Duration.ofSeconds(2));
+
+		assertEquals(2, attemptCount.get(), "应该重试流式模型调用");
+		assertNotNull(responses);
+		assertEquals("Success after streaming retry", responses.get(0).getResult().getOutput().getText());
+	}
+
+	@Test
+	void testStreamingExceptionMessageRetry() {
+		ModelRetryInterceptor interceptor = ModelRetryInterceptor.builder()
+				.maxAttempts(3)
+				.initialDelay(0)
+				.build();
+
+		AtomicInteger attemptCount = new AtomicInteger(0);
+
+		ModelCallHandler handler = request -> {
+			int count = attemptCount.incrementAndGet();
+			if (count == 1) {
+				return ModelResponse.of(new AssistantMessage("Exception: I/O error before streaming starts"));
+			}
+			return ModelResponse.of(Flux.just(chatResponse("Streaming recovered")));
+		};
+
+		ModelResponse response = interceptor.interceptModel(ModelRequest.builder().build(), handler);
+
+		assertInstanceOf(Flux.class, response.getMessage());
+		@SuppressWarnings("unchecked")
+		Flux<ChatResponse> responseFlux = (Flux<ChatResponse>) response.getMessage();
+		List<ChatResponse> responses = responseFlux.collectList().block(Duration.ofSeconds(2));
+
+		assertEquals(2, attemptCount.get(), "应该重试流式启动阶段异常");
+		assertNotNull(responses);
+		assertEquals("Streaming recovered", responses.get(0).getResult().getOutput().getText());
+	}
+
+	@Test
+	void testStreamingNonRetryableException() {
+		ModelRetryInterceptor interceptor = ModelRetryInterceptor.builder()
+				.maxAttempts(3)
+				.initialDelay(0)
+				.build();
+
+		AtomicInteger attemptCount = new AtomicInteger(0);
+
+		ModelCallHandler handler = request -> {
+			attemptCount.incrementAndGet();
+			return ModelResponse.of(Flux.error(new RuntimeException("Authentication failed")));
+		};
+
+		ModelResponse response = interceptor.interceptModel(ModelRequest.builder().build(), handler);
+
+		assertInstanceOf(Flux.class, response.getMessage());
+		@SuppressWarnings("unchecked")
+		Flux<ChatResponse> responseFlux = (Flux<ChatResponse>) response.getMessage();
+
+		RuntimeException exception = assertThrows(RuntimeException.class,
+				() -> responseFlux.collectList().block(Duration.ofSeconds(2)));
+		assertEquals(1, attemptCount.get(), "不可重试的流式异常应该只尝试一次");
+		assertTrue(exception.getMessage().contains("non-retryable exception"));
+	}
+
+	@Test
+	void testStreamingErrorAfterFirstChunkIsNotRetried() {
+		ModelRetryInterceptor interceptor = ModelRetryInterceptor.builder()
+				.maxAttempts(3)
+				.initialDelay(0)
+				.build();
+
+		AtomicInteger attemptCount = new AtomicInteger(0);
+
+		ModelCallHandler handler = request -> {
+			attemptCount.incrementAndGet();
+			return ModelResponse.of(Flux.just(chatResponse("partial response"))
+					.concatWith(Flux.error(new RuntimeException("I/O error after streaming started"))));
+		};
+
+		ModelResponse response = interceptor.interceptModel(ModelRequest.builder().build(), handler);
+
+		assertInstanceOf(Flux.class, response.getMessage());
+		@SuppressWarnings("unchecked")
+		Flux<ChatResponse> responseFlux = (Flux<ChatResponse>) response.getMessage();
+		List<ChatResponse> emittedResponses = new ArrayList<>();
+
+		RuntimeException exception = assertThrows(RuntimeException.class,
+				() -> responseFlux.doOnNext(emittedResponses::add).collectList().block(Duration.ofSeconds(2)));
+		assertEquals(1, attemptCount.get(), "已经输出部分流式结果后不应该重试，避免重复输出");
+		assertEquals(1, emittedResponses.size());
+		assertEquals("partial response", emittedResponses.get(0).getResult().getOutput().getText());
+		assertTrue(exception.getMessage().contains("I/O error after streaming started"));
 	}
 
 	@Test
@@ -288,5 +408,8 @@ class ModelRetryInterceptorTest {
 			ModelRetryInterceptor.builder().backoffMultiplier(0.5).build();
 		}, "backoffMultiplier 必须 >= 1.0");
 	}
-}
 
+	private ChatResponse chatResponse(String text) {
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRetryInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRetryInterceptorTest.java
@@ -213,6 +213,38 @@ class ModelRetryInterceptorTest {
 	}
 
 	@Test
+	void testStreamingRetryUsesCapturedExceptionMessageClassifier() {
+		ModelRetryInterceptor interceptor = ModelRetryInterceptor.builder()
+				.maxAttempts(3)
+				.initialDelay(0)
+				.build();
+
+		AtomicInteger attemptCount = new AtomicInteger(0);
+
+		ModelCallHandler handler = request -> {
+			int count = attemptCount.incrementAndGet();
+			if (count == 1) {
+				return ModelResponse.of(Flux.error(new RuntimeException("I/O error on streaming response")));
+			}
+			if (count == 2) {
+				return ModelResponse.of(new AssistantMessage("Exception: network reset before streaming starts"));
+			}
+			return ModelResponse.of(Flux.just(chatResponse("Recovered after captured network exception")));
+		};
+
+		ModelResponse response = interceptor.interceptModel(ModelRequest.builder().build(), handler);
+
+		assertInstanceOf(Flux.class, response.getMessage());
+		@SuppressWarnings("unchecked")
+		Flux<ChatResponse> responseFlux = (Flux<ChatResponse>) response.getMessage();
+		List<ChatResponse> responses = responseFlux.collectList().block(Duration.ofSeconds(2));
+
+		assertEquals(3, attemptCount.get(), "流式重试中的 Exception: network 消息应该继续按可重试异常处理");
+		assertNotNull(responses);
+		assertEquals("Recovered after captured network exception", responses.get(0).getResult().getOutput().getText());
+	}
+
+	@Test
 	void testStreamingNonRetryableException() {
 		ModelRetryInterceptor interceptor = ModelRetryInterceptor.builder()
 				.maxAttempts(3)

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
@@ -64,6 +64,7 @@ import static java.util.Objects.requireNonNull;
  *          ON GRAPH_THREAD(thread_name, is_released)
  *
  *     CREATE TABLE GRAPH_CHECKPOINT (
+ *          checkpoint_seq BIGINT NOT NULL AUTO_INCREMENT UNIQUE,
  *          checkpoint_id VARCHAR(36) PRIMARY KEY,
  *          thread_id VARCHAR(36) NOT NULL,
  *          node_id VARCHAR(255),
@@ -118,6 +119,7 @@ public class MysqlSaver implements BaseCheckpointSaver {
 
 	private static final String CREATE_CHECKPOINT_TABLE = """
 			CREATE TABLE IF NOT EXISTS GRAPH_CHECKPOINT (
+			   checkpoint_seq BIGINT NOT NULL AUTO_INCREMENT UNIQUE,
 			   checkpoint_id VARCHAR(36) PRIMARY KEY,
 			   thread_id VARCHAR(36) NOT NULL,
 			   node_id VARCHAR(255),
@@ -133,6 +135,20 @@ public class MysqlSaver implements BaseCheckpointSaver {
 
 	private static final String DROP_CHECKPOINT_TABLE = "DROP TABLE IF EXISTS GRAPH_CHECKPOINT";
 	private static final String DROP_THREAD_TABLE = "DROP TABLE IF EXISTS GRAPH_THREAD";
+
+	private static final String INDEX_CHECKPOINT_THREAD_SEQUENCE = """
+			CREATE INDEX IDX_GRAPH_CHECKPOINT_THREAD_SEQUENCE
+			  ON GRAPH_CHECKPOINT(thread_id, checkpoint_seq)
+			""";
+
+	private static final String ADD_CHECKPOINT_SEQUENCE_COLUMN = """
+			ALTER TABLE GRAPH_CHECKPOINT
+			ADD COLUMN checkpoint_seq BIGINT NOT NULL AUTO_INCREMENT UNIQUE
+			""";
+
+	private static final String HAS_CHECKPOINT_SEQUENCE_COLUMN = """
+			SHOW COLUMNS FROM GRAPH_CHECKPOINT LIKE 'checkpoint_seq'
+			""";
 
 	// DML statements
 	private static final String UPSERT_THREAD = """
@@ -169,7 +185,7 @@ public class MysqlSaver implements BaseCheckpointSaver {
 			FROM GRAPH_CHECKPOINT c
 			  INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
 			WHERE t.thread_name = ? AND t.is_released != TRUE
-			ORDER BY c.saved_at DESC
+			ORDER BY c.checkpoint_seq DESC
 			""";
 
 	private static final String RELEASE_THREAD = """
@@ -185,7 +201,7 @@ public class MysqlSaver implements BaseCheckpointSaver {
 			FROM GRAPH_CHECKPOINT c
 			  INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
 			WHERE t.thread_name = ? AND t.is_released != TRUE
-			ORDER BY c.saved_at DESC
+			ORDER BY c.checkpoint_seq DESC
 			LIMIT 1
 			""";
 
@@ -310,21 +326,38 @@ public class MysqlSaver implements BaseCheckpointSaver {
 					createOption == CreateOption.CREATE_IF_NOT_EXISTS) {
 				statement.execute(CREATE_THREAD_TABLE);
 				statement.execute(CREATE_CHECKPOINT_TABLE);
-
-				// Try to create index, ignore error if it already exists
-				try {
-					statement.execute(INDEX_THREAD_TABLE);
-				}
-				catch (SQLException e) {
-					// Ignore "Duplicate key name" error (error code 1061)
-					if (e.getErrorCode() != 1061) {
-						throw e;
-					}
-				}
+				ensureCheckpointSequenceColumn(connection);
+				createIndexIfAbsent(statement, INDEX_THREAD_TABLE);
+				createIndexIfAbsent(statement, INDEX_CHECKPOINT_THREAD_SEQUENCE);
 			}
 		}
 		catch (SQLException sqlException) {
 			throw new RuntimeException("Unable to create tables", sqlException);
+		}
+	}
+
+	private void createIndexIfAbsent(Statement statement, String indexSql) throws SQLException {
+		try {
+			statement.execute(indexSql);
+		}
+		catch (SQLException e) {
+			// Ignore "Duplicate key name" error (error code 1061)
+			if (e.getErrorCode() != 1061) {
+				throw e;
+			}
+		}
+	}
+
+	private void ensureCheckpointSequenceColumn(Connection connection) throws SQLException {
+		try (Statement statement = connection.createStatement();
+			 ResultSet resultSet = statement.executeQuery(HAS_CHECKPOINT_SEQUENCE_COLUMN)) {
+			if (resultSet.next()) {
+				return;
+			}
+		}
+
+		try (Statement statement = connection.createStatement()) {
+			statement.execute(ADD_CHECKPOINT_SEQUENCE_COLUMN);
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Collection;
@@ -133,11 +134,64 @@ public class MysqlSaverTest {
     }
 
     private static Checkpoint checkpoint(String value) {
-        return Checkpoint.builder()
+        return checkpoint(null, value);
+    }
+
+    private static Checkpoint checkpoint(String id, String value) {
+        Checkpoint.Builder builder = Checkpoint.builder()
                 .nodeId("agent_1")
                 .nextNodeId(END)
-                .state(Map.of("value", value))
+                .state(Map.of("value", value));
+        if (id != null) {
+            builder.id(id);
+        }
+        return builder.build();
+    }
+
+    private static void forceSameSavedAt(String threadId) throws SQLException {
+        try (Connection connection = DATA_SOURCE.getConnection();
+                PreparedStatement statement = connection.prepareStatement("""
+                        UPDATE GRAPH_CHECKPOINT c
+                        INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
+                        SET c.saved_at = TIMESTAMP('2026-01-01 00:00:00')
+                        WHERE t.thread_name = ? AND t.is_released != TRUE
+                        """)) {
+            statement.setString(1, threadId);
+            assertEquals(2, statement.executeUpdate());
+        }
+    }
+
+    private static String firstCheckpointId() {
+        return "00000000-0000-0000-0000-000000000001";
+    }
+
+    private static String secondCheckpointId() {
+        return "00000000-0000-0000-0000-000000000002";
+    }
+
+    @Test
+    public void testMysqlSaverOrdersCheckpointsByInsertSequenceWhenSavedAtTies() throws Exception {
+        var saver = MysqlSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(DATA_SOURCE)
+                .maxCachedThreads(0)
                 .build();
+
+        String threadId = "mysql-checkpoint-sequence-thread";
+        var firstCheckpoint = checkpoint(firstCheckpointId(), "first");
+        var secondCheckpoint = checkpoint(secondCheckpointId(), "second");
+
+        saver.put(config(threadId), firstCheckpoint);
+        saver.put(config(threadId), secondCheckpoint);
+        forceSameSavedAt(threadId);
+
+        Collection<Checkpoint> history = saver.list(config(threadId));
+        assertEquals(2, history.size());
+        assertEquals(secondCheckpoint.getId(), history.iterator().next().getId());
+
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isPresent());
+        assertEquals(secondCheckpoint.getId(), latest.get().getId());
     }
 
     @Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

`ModelRetryInterceptor` currently assumes `ModelResponse#getMessage()` is always a Spring AI `Message`. In the agent streaming path, the response payload is `Flux<ChatResponse>`, so the interceptor can throw a `ClassCastException` before the stream is consumed.

This PR makes model retry handling safe for streaming responses while preserving the existing non-streaming behavior.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Detect `Flux<ChatResponse>` payloads before casting to `Message`.
- Wrap streaming responses with retry handling for retryable errors that happen before the first chunk is emitted.
- Keep partial streaming output safe by not retrying after at least one chunk has already been emitted, avoiding duplicated downstream chunks.
- Reuse the existing retry predicate, max-attempts, and backoff settings.
- Add unit coverage for streaming retry success, retryable startup exception messages, non-retryable stream errors, and post-chunk stream errors.

### Describe how to verify it

- `./mvnw -pl spring-ai-alibaba-agent-framework -am -Dtest=ModelRetryInterceptorTest test`
- `./mvnw -pl spring-ai-alibaba-agent-framework -am -Dtest=ModelRetryInterceptorTest,InterceptorChainStreamingTest test`
- `git diff --check`

### Special notes for reviews

The streaming retry intentionally only retries before any stream chunk is emitted. Once partial output has reached downstream consumers, retrying the whole model call could duplicate chunks in the same response stream.