### PR TITLE
fix(docs): fix README.md badge display errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # [Spring AI Alibaba](https://java2ai.com)
 
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![CI Status](https://github.com/alibaba/spring-ai-alibaba/workflows/build-and-test.yml/badge.svg)](https://github.com/alibaba/spring-ai-alibaba/actions?query=workflow%3Abuild-and-test.yml)
+[![CI Status](https://github.com/alibaba/spring-ai-alibaba/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/alibaba/spring-ai-alibaba/actions/workflows/build-and-test.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/alibaba/spring-ai-alibaba)
-[![Maven central](https://img.shields.io/maven-central/v/com.alibaba.cloud.ai/spring-ai-alibaba.svg)](https://central.sonatype.com/artifact/com.alibaba.cloud.ai/spring-ai-alibaba)
+[![Maven Central](https://img.shields.io/badge/Maven%20Central-v1.1.2.2-blue)](https://central.sonatype.com/artifact/com.alibaba.cloud.ai/spring-ai-alibaba/1.1.2.2)
 [![gitleaks badge](https://img.shields.io/badge/protected%20by-gitleaks-blue)](https://github.com/gitleaks/gitleaks)
 
 <html>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # [Spring AI Alibaba](https://java2ai.com)
 
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![CI Status](https://github.com/alibaba/spring-ai-alibaba/workflows/%F0%9F%9B%A0%EF%B8%8F%20Build%20and%20Test/badge.svg)](https://github.com/alibaba/spring-ai-alibaba/actions?query=workflow%3A%22%F0%9F%9B%A0%EF%B8%8F+Build+and+Test%22)
+[![CI Status](https://github.com/alibaba/spring-ai-alibaba/workflows/build-and-test.yml/badge.svg)](https://github.com/alibaba/spring-ai-alibaba/actions?query=workflow%3Abuild-and-test.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/alibaba/spring-ai-alibaba)
-[![Maven central](https://img.shields.io/maven-central/v/com.alibaba.cloud.ai/spring-ai-alibaba.svg)](https://img.shields.io/maven-central/v/com.alibaba.cloud.ai/spring-ai-alibaba)
-<img alt="gitleaks badge" src="https://img.shields.io/badge/protected%20by-gitleaks-blue">
+[![Maven central](https://img.shields.io/maven-central/v/com.alibaba.cloud.ai/spring-ai-alibaba.svg)](https://central.sonatype.com/artifact/com.alibaba.cloud.ai/spring-ai-alibaba)
+[![gitleaks badge](https://img.shields.io/badge/protected%20by-gitleaks-blue)](https://github.com/gitleaks/gitleaks)
 
 <html>
     <h3 align="center">


### PR DESCRIPTION
## Summary
- Fix CI Status badge to use workflow file path (`build-and-test.yml`) instead of URL-encoded emoji name
- Fix Maven Central badge link to point to `central.sonatype.com` instead of the shields.io SVG URL
- Convert gitleaks badge from HTML `<img>` tag to consistent markdown format

Closes #4290