### PR TITLE
fix: PersistenceExample use resolved checkpoint id in PersistenceExample#getState

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/core/PersistenceExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/core/PersistenceExample.java
@@ -108,10 +108,13 @@ public class PersistenceExample {
 		System.out.println("Current state: " + stateSnapshot.state());
 		System.out.println("Current node: " + stateSnapshot.node());
 
-		// 获取特定 checkpoint_id 的状态快照
+		// 使用本次运行产生的 checkpoint id
+		String checkpointId = stateSnapshot.config()
+				.checkPointId()
+				.orElseThrow(() -> new IllegalStateException("latest snapshot has no checkpoint id"));
 		RunnableConfig configWithCheckpoint = RunnableConfig.builder()
 				.threadId("1")
-				.checkPointId("1ef663ba-28fe-6528-8002-5a559208592c")
+				.checkPointId(checkpointId)
 				.build();
 		StateSnapshot specificSnapshot = graph.getState(configWithCheckpoint);
 		System.out.println("Specific checkpoint state: " + specificSnapshot.state());


### PR DESCRIPTION
### Describe what this PR does / why we need it
`PersistenceExample` is meant to show checkpoint-backed persistence. Example 2 calls `CompiledGraph.getState` twice: first with only `threadId` (works), then with a **hard-coded** `checkPointId` that does not exist in `MemorySaver` for that run. `BaseCheckpointSaver.get` returns empty, so `getState` throws `java.lang.IllegalStateException: Missing Checkpoint!` and the sample cannot finish.
<img width="1107" height="330" alt="image" src="https://github.com/user-attachments/assets/bf4d9372-a83b-4bfa-bff3-dd11980abee0" />

This PR keeps the same teaching goal (“fetch state for a specific checkpoint id”) but wires the second call to a **real** checkpoint id produced by the current execution, so the documentation example runs reliably for anyone copying or running the class.

When running `com.alibaba.cloud.ai.examples.documentation.graph.core.PersistenceExample`, execution used to fail during **Example 2: get state** with:

```text
java.lang.IllegalStateException: Missing Checkpoint!
```

The stack trace pointed to the second `getState` call inside `PersistenceExample.getStateExample` → `CompiledGraph.getState`.

### Does this pull request fix one issue?
NONE

<!-- No GitHub issue filed; no existing issue to link. -->

### Describe how you did it
In `PersistenceExample.getStateExample`:

- Removed the hard-coded `checkPointId` string on the second `RunnableConfig`.
- After the first `graph.getState(config)`, take `stateSnapshot.config().checkPointId()` and pass it into `RunnableConfig.builder().threadId(...).checkPointId(checkpointId)` for the second `graph.getState(...)`.
- If `checkPointId()` is empty, throw `IllegalStateException` with a short message.

### Describe how to verify it
Just run the verification directly.
<img width="1155" height="597" alt="image" src="https://github.com/user-attachments/assets/6cbd6e9c-f0d9-44be-b62e-8f97c7ab7cf1" />


### Special notes for reviews
It's a simple fix，so I didn't create an issue but directly submitted the pull request.
