### PR TITLE
fix(graph): prevent OracleSaver checkpoint history cache growth

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/oracle/OracleSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/oracle/OracleSaver.java
@@ -17,22 +17,28 @@ package com.alibaba.cloud.ai.graph.checkpoint.savers.oracle;
 
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
-import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.sql.DataSource;
 
@@ -52,8 +58,8 @@ import static java.lang.String.format;
 
 /**
  * <p>
- * OracleSaver is an extension of MemorySaver that enables persistent,
- * reliable storage of workflow state in an Oracle database.
+ * OracleSaver stores Graph state in an Oracle database and keeps only a bounded
+ * latest-checkpoint cache in memory.
  * </p>
  * <p>
  * Two tables are used to store the workflow state:
@@ -91,6 +97,7 @@ import static java.lang.String.format;
  * - CreateOption : indicates whether the tables should be created or
  * existing tables should be used.
  * - StateSerializer: the serializer used to serialize/deserialize state data
+ * - MaxCachedThreads: indicates how many latest checkpoints are kept in memory.
  * </p>
  * <p>
  * Ex:
@@ -104,7 +111,7 @@ import static java.lang.String.format;
  * </pre>
  * </p>
  */
-public class OracleSaver extends MemorySaver {
+public class OracleSaver implements BaseCheckpointSaver {
 
 	private static final Logger log = LoggerFactory.getLogger(OracleSaver.class);
 
@@ -157,14 +164,20 @@ public class OracleSaver extends MemorySaver {
 			""";
 
 	private static final String UPDATE_CHECKPOINT = """
-			UPDATE GRAPH_CHECKPOINT
+			UPDATE GRAPH_CHECKPOINT c
 			SET
 			  checkpoint_id = ?,
 			  node_id = ?,
 			  next_node_id = ?,
 			  state_data = ?,
 			  state_content_type = ?
-			WHERE checkpoint_id = ?
+			WHERE c.checkpoint_id = ?
+			  AND EXISTS (
+			    SELECT 1 FROM GRAPH_THREAD t
+			    WHERE t.thread_id = c.thread_id
+			      AND t.thread_name = ?
+			      AND t.is_released != TRUE
+			  )
 			""";
 
 	private static final String SELECT_CHECKPOINTS = """
@@ -180,8 +193,31 @@ public class OracleSaver extends MemorySaver {
 			ORDER BY c.saved_at DESC
 			""";
 
-	private static final String DELETE_CHECKPOINTS = """
-			    DELETE FROM GRAPH_CHECKPOINT WHERE checkpoint_id = ?
+	private static final String SELECT_LATEST_CHECKPOINT = """
+			SELECT
+			  c.checkpoint_id,
+			  c.node_id,
+			  c.next_node_id,
+			  c.state_data,
+			  c.state_content_type
+			FROM GRAPH_CHECKPOINT c
+			  INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
+			WHERE t.thread_name = ? AND t.is_released != TRUE
+			ORDER BY c.saved_at DESC
+			FETCH FIRST 1 ROW ONLY
+			""";
+
+	private static final String SELECT_CHECKPOINT_BY_ID = """
+			SELECT
+			  c.checkpoint_id,
+			  c.node_id,
+			  c.next_node_id,
+			  c.state_data,
+			  c.state_content_type
+			FROM GRAPH_CHECKPOINT c
+			  INNER JOIN GRAPH_THREAD t ON c.thread_id = t.thread_id
+			WHERE t.thread_name = ? AND t.is_released != TRUE
+			  AND c.checkpoint_id = ?
 			""";
 
 	private static final String RELEASE_THREAD = """
@@ -192,19 +228,22 @@ public class OracleSaver extends MemorySaver {
 	private final DataSource dataSource;
 	private final CreateOption createOption;
 	private final StateSerializer stateSerializer;
+	private final Map<String, Checkpoint> latestCheckpointCache;
+	private final ReentrantLock lock = new ReentrantLock();
+	private final int maxCachedThreads;
 
 	/**
 	 * Private constructor used by the builder to create a new instance of
 	 * OracleSaver.
 	 *
-	 * @param dataSource      the data source
-	 * @param createOption    the create options
-	 * @param stateSerializer the state serializer
+	 * @param builder the builder
 	 */
-	private OracleSaver(DataSource dataSource, CreateOption createOption, StateSerializer stateSerializer) {
-		this.dataSource = dataSource;
-		this.createOption = createOption;
-		this.stateSerializer = Objects.requireNonNull(stateSerializer, "stateSerializer cannot be null");
+	private OracleSaver(Builder builder) {
+		this.dataSource = builder.dataSource;
+		this.createOption = builder.createOption;
+		this.stateSerializer = Objects.requireNonNull(builder.stateSerializer, "stateSerializer cannot be null");
+		this.maxCachedThreads = builder.maxCachedThreads;
+		this.latestCheckpointCache = createLatestCheckpointCache(builder.maxCachedThreads);
 		initTables();
 	}
 
@@ -301,96 +340,104 @@ public class OracleSaver extends MemorySaver {
 		return stateSerializer.dataFromBytes(bytes);
 	}
 
-	/**
-	 * If the list of checkpoints is empty, loads the checkpoints from the database.
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the list of checkpoints
-	 * @return a list of checkpoints
-	 * @throws Exception if an error occurs while the checkpoints are being
-	 *                   loaded from the database.
-	 */
-	@Override
-	protected LinkedList<Checkpoint> loadedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints)
-			throws Exception {
-		if (!checkpoints.isEmpty()) {
-			return checkpoints;
-		}
-
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+	private ObjectMapper osonObjectMapper() {
 		JsonFactory osonFactory = new OsonFactory();
-		ObjectMapper objectMapper = new ObjectMapper(osonFactory);
+		return new ObjectMapper(osonFactory);
+	}
 
+	private void defineCheckpointColumns(PreparedStatement preparedStatement) throws SQLException {
+		// Defining JSON columns up front avoids an additional Oracle JDBC metadata round trip.
+		OracleStatement oracleStatement = preparedStatement.unwrap(OracleStatement.class);
+		oracleStatement.defineColumnType(1, OracleTypes.VARCHAR);
+		oracleStatement.defineColumnType(2, OracleTypes.VARCHAR);
+		oracleStatement.defineColumnType(3, OracleTypes.VARCHAR);
+		oracleStatement.defineColumnType(4, OracleTypes.JSON, Integer.MAX_VALUE);
+		oracleStatement.defineColumnType(5, OracleTypes.VARCHAR);
+		oracleStatement.setLobPrefetchSize(Integer.MAX_VALUE);
+	}
+
+	private Checkpoint readCheckpoint(ResultSet resultSet, ObjectMapper objectMapper)
+			throws SQLException, IOException, ClassNotFoundException {
+		byte[] osonBytes = resultSet.getObject(4, OracleJsonDatum.class).shareBytes();
+		Map<String, Object> jsonMap = objectMapper.readValue(osonBytes, Map.class);
+		String base64Data = (String) jsonMap.get("binaryPayload");
+		byte[] binaryPayload = base64Data.getBytes(StandardCharsets.UTF_8);
+
+		return Checkpoint.builder()
+				.id(resultSet.getString(1))
+				.nodeId(resultSet.getString(2))
+				.nextNodeId(resultSet.getString(3))
+				.state(decodeState(binaryPayload, resultSet.getString(5)))
+				.build();
+	}
+
+	/**
+	 * Loads full checkpoint history on demand without retaining it in cache.
+	 */
+	private LinkedList<Checkpoint> selectCheckpoints(String threadName) throws Exception {
+		LinkedList<Checkpoint> checkpoints = new LinkedList<>();
+		ObjectMapper objectMapper = osonObjectMapper();
 		try (Connection connection = dataSource.getConnection();
-			 PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINTS)) {
+				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINTS)) {
 
-			// Calls to defineColumnType reduce the number of network requests. When Oracle
-			// JDBC knows that it is
-			// fetching VECTOR, CLOB, and/or JSON columns, the first request it sends to the
-			// database can include a LOB
-			// prefetch size (VECTOR and JSON are value-based-lobs). If defineColumnType is
-			// not called, then JDBC needs
-			// to send an additional request with the LOB prefetch size, after the first
-			// request has the database
-			// respond with the column data types. To request all data, the prefetch size is
-			// Integer.MAX_VALUE.
-			OracleStatement oracleStatement = preparedStatement.unwrap(OracleStatement.class);
-			oracleStatement.defineColumnType(1, OracleTypes.VARCHAR); // checkpoint_id
-			oracleStatement.defineColumnType(2, OracleTypes.VARCHAR); // node_id
-			oracleStatement.defineColumnType(3, OracleTypes.VARCHAR); // next_node_id
-			oracleStatement.defineColumnType(4, OracleTypes.JSON, Integer.MAX_VALUE); // state_data
-			oracleStatement.defineColumnType(5, OracleTypes.VARCHAR); // state_content_type
-			oracleStatement.setLobPrefetchSize(Integer.MAX_VALUE); // Workaround for Oracle JDBC bug 37030121
-
+			defineCheckpointColumns(preparedStatement);
 			preparedStatement.setString(1, threadName);
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					byte[] osonBytes = resultSet.getObject(4, OracleJsonDatum.class).shareBytes();
-					String contentType = resultSet.getString(5);
-
-					// Parse JSON to extract binaryPayload
-					Map<String, Object> jsonMap = objectMapper.readValue(osonBytes, Map.class);
-					String base64Data = (String) jsonMap.get("binaryPayload");
-					// Convert base64 string to bytes (don't decode yet, decodeState will do that)
-					byte[] binaryPayload = base64Data.getBytes(StandardCharsets.UTF_8);
-
-					Checkpoint checkpoint = Checkpoint.builder()
-							.id(resultSet.getString(1))
-							.nodeId(resultSet.getString(2))
-							.nextNodeId(resultSet.getString(3))
-							.state(decodeState(binaryPayload, contentType))
-							.build();
-					checkpoints.add(checkpoint);
+					checkpoints.add(readCheckpoint(resultSet, objectMapper));
 				}
 			}
 		}
-		catch (SQLException sqlException) {
-			throw new Exception("Unable to load checkpoints", sqlException);
-		}
-		catch (ClassNotFoundException e) {
-			throw new Exception("Unable to deserialize checkpoint state", e);
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load checkpoints", ex);
 		}
 		return checkpoints;
 	}
 
-	/**
-	 * Inserts a checkpoint to the database
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the list of checkpoints
-	 * @param checkpoint  the checkpoint to insert
-	 * @throws Exception if an error occurs while inserting the checkpoint in the
-	 *                   database.
-	 */
-	@Override
-	protected void insertedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
-			throws Exception {
+	private Optional<Checkpoint> selectLatestCheckpoint(String threadName) throws Exception {
+		ObjectMapper objectMapper = osonObjectMapper();
+		try (Connection connection = dataSource.getConnection();
+				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_LATEST_CHECKPOINT)) {
 
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			defineCheckpointColumns(preparedStatement);
+			preparedStatement.setString(1, threadName);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return Optional.of(readCheckpoint(resultSet, objectMapper));
+				}
+				return Optional.empty();
+			}
+		}
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load latest checkpoint", ex);
+		}
+	}
+
+	private Optional<Checkpoint> selectCheckpointById(String threadName, String checkpointId) throws Exception {
+		ObjectMapper objectMapper = osonObjectMapper();
+		try (Connection connection = dataSource.getConnection();
+				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINT_BY_ID)) {
+
+			defineCheckpointColumns(preparedStatement);
+			preparedStatement.setString(1, threadName);
+			preparedStatement.setString(2, checkpointId);
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return Optional.of(readCheckpoint(resultSet, objectMapper));
+				}
+				return Optional.empty();
+			}
+		}
+		catch (SQLException | IOException | ClassNotFoundException ex) {
+			throw new Exception("Unable to load checkpoint", ex);
+		}
+	}
+
+	private void insertCheckpoint(String threadName, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 
 		try (Connection ignored = conn = dataSource.getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
+			conn.setAutoCommit(false);
 
 			try (PreparedStatement upsertStatement = conn.prepareStatement(UPSERT_THREAD);
 				 PreparedStatement insertCheckpointStatement = conn.prepareStatement(INSERT_CHECKPOINT)) {
@@ -413,31 +460,50 @@ public class OracleSaver extends MemorySaver {
 			conn.commit();
 			log.debug("Checkpoint {} for thread {} inserted successfully.", checkpoint.getId(), threadName);
 		}
-		catch (SQLException | IOException e) {
-			log.error("Error inserting checkpoint with id {} in thread {}", checkpoint.getId(), threadName, e);
+		catch (SQLException | IOException ex) {
+			log.error("Error inserting checkpoint with id {} in thread {}", checkpoint.getId(), threadName, ex);
 			rollback(conn, checkpoint, threadName);
-			throw new Exception("Unable to insert checkpoint", e);
+			throw new Exception("Unable to insert checkpoint", ex);
 		}
-
 	}
 
-	/**
-	 * Marks the checkpoints as released
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the checkpoints
-	 * @param releaseTag  the release tab
-	 * @throws Exception if an error occurs while marking the checkpoints as
-	 *                   released
-	 */
-	@Override
-	protected void releasedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Tag releaseTag)
-			throws Exception {
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+	private void updateCheckpoint(String threadName, String checkpointId, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 
 		try (Connection ignored = conn = dataSource.getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
+			conn.setAutoCommit(false);
+
+			try (PreparedStatement preparedStatement = conn.prepareStatement(UPDATE_CHECKPOINT)) {
+				String encodedState = encodeState(checkpoint.getState());
+				preparedStatement.setString(1, checkpoint.getId());
+				preparedStatement.setString(2, checkpoint.getNodeId());
+				preparedStatement.setString(3, checkpoint.getNextNodeId());
+				preparedStatement.setObject(4, encodedState, OracleType.JSON);
+				preparedStatement.setString(5, stateSerializer.contentType());
+				preparedStatement.setString(6, checkpointId);
+				preparedStatement.setString(7, threadName);
+				int rowsAffected = preparedStatement.executeUpdate();
+				if (rowsAffected == 0) {
+					conn.rollback();
+					throw new NoSuchElementException(format("Checkpoint with id %s not found!", checkpointId));
+				}
+			}
+
+			conn.commit();
+			log.debug("Checkpoint with id {} for thread {} updated successfully.", checkpoint.getId(), threadName);
+		}
+		catch (SQLException | IOException ex) {
+			log.error("Error updating checkpoint with id {} in thread {}", checkpoint.getId(), threadName, ex);
+			rollback(conn, checkpoint, threadName);
+			throw new Exception("Unable to update checkpoint", ex);
+		}
+	}
+
+	private void releaseThread(String threadName) throws Exception {
+		Connection conn = null;
+
+		try (Connection ignored = conn = dataSource.getConnection()) {
+			conn.setAutoCommit(false);
 
 			try (PreparedStatement preparedStatement = conn.prepareStatement(RELEASE_THREAD)) {
 				preparedStatement.setString(1, threadName);
@@ -453,72 +519,10 @@ public class OracleSaver extends MemorySaver {
 			conn.commit();
 			log.debug("Thread {} released successfully.", threadName);
 		}
-		catch (SQLException e) {
-			log.error("Error releasing thread {}", threadName, e);
+		catch (SQLException ex) {
+			log.error("Error releasing thread {}", threadName, ex);
 			rollback(conn, threadName);
-			throw new Exception("Unable to release checkpoint", e);
-		}
-	}
-
-	/**
-	 * If the checkpoint exists, updates the checkpoint, otherwise it inserts it.
-	 *
-	 * @param config      the configuration
-	 * @param checkpoints the list of checkpoints
-	 * @param checkpoint  the checkpoint
-	 * @throws Exception if an error occurs while inserting or updating the
-	 *                   checkpoint.
-	 */
-	@Override
-	protected void updatedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
-			throws Exception {
-		final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-		Connection conn = null;
-
-		try (Connection ignored = conn = dataSource.getConnection()) {
-			conn.setAutoCommit(false); // Start transaction
-
-			if (config.checkPointId().isPresent()) {
-				// Update existing checkpoint
-				try (PreparedStatement preparedStatement = conn.prepareStatement(UPDATE_CHECKPOINT)) {
-					String encodedState = encodeState(checkpoint.getState());
-					preparedStatement.setString(1, checkpoint.getId());
-					preparedStatement.setString(2, checkpoint.getNodeId());
-					preparedStatement.setString(3, checkpoint.getNextNodeId());
-					preparedStatement.setObject(4, encodedState, OracleType.JSON);
-					preparedStatement.setString(5, stateSerializer.contentType());
-					preparedStatement.setString(6, config.checkPointId().get());
-					preparedStatement.execute();
-				}
-			}
-			else {
-				// Insert new checkpoint (within same transaction)
-				try (PreparedStatement upsertStatement = conn.prepareStatement(UPSERT_THREAD);
-					 PreparedStatement insertCheckpointStatement = conn.prepareStatement(INSERT_CHECKPOINT)) {
-
-					upsertStatement.setString(1, UUID.randomUUID().toString());
-					upsertStatement.setString(2, threadName);
-					upsertStatement.execute();
-
-					String encodedState = encodeState(checkpoint.getState());
-					insertCheckpointStatement.setString(1, checkpoint.getId());
-					insertCheckpointStatement.setString(2, checkpoint.getNodeId());
-					insertCheckpointStatement.setString(3, checkpoint.getNextNodeId());
-					insertCheckpointStatement.setObject(4, encodedState, OracleType.JSON);
-					insertCheckpointStatement.setString(5, stateSerializer.contentType());
-					insertCheckpointStatement.setString(6, threadName);
-
-					insertCheckpointStatement.execute();
-				}
-			}
-
-			conn.commit();
-			log.debug("Checkpoint with id {} for thread {} updated successfully.", checkpoint.getId(), threadName);
-		}
-		catch (SQLException | IOException e) {
-			log.error("Error updating checkpoint with id {} in thread {}", checkpoint.getId(), threadName, e);
-			rollback(conn, checkpoint, threadName);
-			throw new Exception("Unable to update checkpoint", e);
+			throw new Exception("Unable to release checkpoint", ex);
 		}
 	}
 
@@ -547,12 +551,144 @@ public class OracleSaver extends MemorySaver {
 	}
 
 	/**
+	 * Lists active checkpoints for the configured thread.
+	 */
+	@Override
+	public Collection<Checkpoint> list(RunnableConfig config) {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
+			if (!checkpoints.isEmpty()) {
+				cacheLatest(threadName, checkpoints.peek());
+			}
+			return Collections.unmodifiableCollection(checkpoints);
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Gets a checkpoint for the configured thread.
+	 */
+	@Override
+	public Optional<Checkpoint> get(RunnableConfig config) {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			if (config.checkPointId().isPresent()) {
+				return selectCheckpointById(threadName, config.checkPointId().get());
+			}
+
+			Optional<Checkpoint> cached = getCachedLatest(threadName);
+			if (cached.isPresent()) {
+				return cached;
+			}
+
+			Optional<Checkpoint> latest = selectLatestCheckpoint(threadName);
+			latest.ifPresent(checkpoint -> cacheLatest(threadName, checkpoint));
+			return latest;
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Inserts or updates a checkpoint.
+	 */
+	@Override
+	public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			if (config.checkPointId().isPresent()) {
+				String checkpointId = config.checkPointId().get();
+				updateCheckpoint(threadName, checkpointId, checkpoint);
+				getCachedLatest(threadName)
+						.filter(latest -> latest.getId().equals(checkpointId))
+						.ifPresent(latest -> cacheLatest(threadName, checkpoint));
+				return config;
+			}
+
+			insertCheckpoint(threadName, checkpoint);
+			cacheLatest(threadName, checkpoint);
+			return RunnableConfig.builder(config)
+					.checkPointId(checkpoint.getId())
+					.build();
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Releases the active thread and returns the released checkpoints.
+	 */
+	@Override
+	public Tag release(RunnableConfig config) throws Exception {
+		lock.lock();
+		try {
+			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
+			releaseThread(threadName);
+			removeCachedLatest(threadName);
+			return new Tag(threadName, checkpoints);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Creates a bounded LRU cache for latest checkpoints.
+	 */
+	private static Map<String, Checkpoint> createLatestCheckpointCache(int maxCachedThreads) {
+		if (maxCachedThreads == 0) {
+			return Collections.emptyMap();
+		}
+		return new LinkedHashMap<>(16, 0.75f, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
+				return size() > maxCachedThreads;
+			}
+		};
+	}
+
+	private Optional<Checkpoint> getCachedLatest(String threadName) {
+		if (maxCachedThreads == 0) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(latestCheckpointCache.get(threadName));
+	}
+
+	private void cacheLatest(String threadName, Checkpoint checkpoint) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.put(threadName, checkpoint);
+		}
+	}
+
+	private void removeCachedLatest(String threadName) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.remove(threadName);
+		}
+	}
+
+	/**
 	 * A builder for OracleSaver.
 	 */
-	public static class Builder extends MemorySaver.Builder {
+	public static class Builder {
 		private DataSource dataSource;
 		private CreateOption createOption = CreateOption.CREATE_IF_NOT_EXISTS;
 		private StateSerializer stateSerializer;
+		private int maxCachedThreads = 1024;
 
 		/**
 		 * Sets the datasource
@@ -588,16 +724,30 @@ public class OracleSaver extends MemorySaver {
 		}
 
 		/**
+		 * Sets the maximum number of latest checkpoints retained in memory.
+		 *
+		 * @param maxCachedThreads max cached threads, or 0 to disable the cache
+		 * @return this builder
+		 */
+		public Builder maxCachedThreads(int maxCachedThreads) {
+			if (maxCachedThreads < 0) {
+				throw new IllegalArgumentException("maxCachedThreads must be greater than or equal to 0");
+			}
+			this.maxCachedThreads = maxCachedThreads;
+			return this;
+		}
+
+		/**
 		 * Creates a new instance of OracleSaver
 		 *
 		 * @return the new instance of OracleSaver.
 		 */
 		public OracleSaver build() {
 			Objects.requireNonNull(dataSource, "dataSource cannot be null");
-            if (stateSerializer == null) {
-                this.stateSerializer = StateGraph.DEFAULT_JACKSON_SERIALIZER;
-            }
-            return new OracleSaver(dataSource, createOption, stateSerializer);
+			if (stateSerializer == null) {
+				this.stateSerializer = StateGraph.DEFAULT_JACKSON_SERIALIZER;
+			}
+			return new OracleSaver(this);
 		}
 	}
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/OracleSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/OracleSaverTest.java
@@ -21,15 +21,26 @@ import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.oracle.CreateOption;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.oracle.OracleSaver;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
 
 import oracle.jdbc.OracleConnection;
 import oracle.jdbc.datasource.OracleDataSource;
@@ -124,6 +135,22 @@ public class OracleSaverTest {
         dataSource.setURL(url + "?oracle.jdbc.provider.json=jackson-json-provider");
         dataSource.setUser(username);
         dataSource.setPassword(password);
+    }
+
+    private static RunnableConfig config(String threadId) {
+        return RunnableConfig.builder().threadId(threadId).build();
+    }
+
+    private static RunnableConfig config(String threadId, String checkpointId) {
+        return RunnableConfig.builder().threadId(threadId).checkPointId(checkpointId).build();
+    }
+
+    private static Checkpoint checkpoint(String value) {
+        return Checkpoint.builder()
+                .nodeId("agent_1")
+                .nextNodeId(END)
+                .state(Map.of("value", value))
+                .build();
     }
 
     @Test
@@ -243,6 +270,227 @@ public class OracleSaverTest {
 
         saver.release(runnableConfig);
 
+    }
+
+    @Test
+    public void testLatestCheckpointCacheIsBoundedByThreadCount() throws Exception {
+        var countingDataSource = new CountingDataSource(DATA_SOURCE);
+        var saver = OracleSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(countingDataSource)
+                .maxCachedThreads(2)
+                .build();
+
+        var firstCheckpoint = checkpoint("first");
+        var firstConfig = config("oracle-cache-thread-1");
+        saver.put(firstConfig, firstCheckpoint);
+        saver.put(config("oracle-cache-thread-2"), checkpoint("second"));
+        saver.put(config("oracle-cache-thread-3"), checkpoint("third"));
+
+        countingDataSource.reset();
+        var reloaded = saver.get(firstConfig);
+        assertTrue(reloaded.isPresent());
+        assertEquals(firstCheckpoint.getId(), reloaded.get().getId());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+    }
+
+    @Test
+    public void testOracleSaverKeepsOnlyLatestCheckpointInMemory() throws Exception {
+        var countingDataSource = new CountingDataSource(DATA_SOURCE);
+        var saver = OracleSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(countingDataSource)
+                .maxCachedThreads(16)
+                .build();
+
+        String threadId = "oracle-cache-single-thread";
+        var firstCheckpoint = checkpoint("first");
+        var secondCheckpoint = checkpoint("second");
+        var thirdCheckpoint = checkpoint("third");
+
+        saver.put(config(threadId), firstCheckpoint);
+        saver.put(config(threadId), secondCheckpoint);
+        saver.put(config(threadId), thirdCheckpoint);
+
+        countingDataSource.reset();
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isPresent());
+        assertEquals(thirdCheckpoint.getId(), latest.get().getId());
+        assertEquals(0, countingDataSource.latestCheckpointSelects());
+
+        Collection<Checkpoint> history = saver.list(config(threadId));
+        assertEquals(3, history.size());
+
+        countingDataSource.reset();
+        var firstFromDatabase = saver.get(config(threadId, firstCheckpoint.getId()));
+        assertTrue(firstFromDatabase.isPresent());
+        assertEquals(firstCheckpoint.getId(), firstFromDatabase.get().getId());
+        assertEquals(1, countingDataSource.checkpointByIdSelects());
+    }
+
+    @Test
+    public void testOracleSaverRefreshesLatestCacheWhenLatestCheckpointIsUpdated() throws Exception {
+        var countingDataSource = new CountingDataSource(DATA_SOURCE);
+        var saver = OracleSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(countingDataSource)
+                .maxCachedThreads(16)
+                .build();
+
+        String threadId = "oracle-cache-update-latest-thread";
+        var originalCheckpoint = checkpoint("original");
+        var updatedCheckpoint = checkpoint("updated");
+        var checkpointConfig = saver.put(config(threadId), originalCheckpoint);
+
+        saver.put(checkpointConfig, updatedCheckpoint);
+
+        countingDataSource.reset();
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isPresent());
+        assertEquals(updatedCheckpoint.getId(), latest.get().getId());
+        assertEquals(0, countingDataSource.latestCheckpointSelects());
+    }
+
+    @Test
+    public void testOracleSaverClearsLatestCacheWhenThreadIsReleased() throws Exception {
+        var countingDataSource = new CountingDataSource(DATA_SOURCE);
+        var saver = OracleSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(countingDataSource)
+                .maxCachedThreads(16)
+                .build();
+
+        String threadId = "oracle-cache-release-thread";
+        saver.put(config(threadId), checkpoint("released"));
+
+        countingDataSource.reset();
+        saver.release(config(threadId));
+        var latest = saver.get(config(threadId));
+        assertTrue(latest.isEmpty());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+    }
+
+    @Test
+    public void testOracleSaverCanDisableLatestCheckpointCache() throws Exception {
+        var countingDataSource = new CountingDataSource(DATA_SOURCE);
+        var saver = OracleSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(countingDataSource)
+                .maxCachedThreads(0)
+                .build();
+
+        String threadId = "oracle-cache-disabled-thread";
+        var latestCheckpoint = checkpoint("latest");
+        saver.put(config(threadId), latestCheckpoint);
+
+        countingDataSource.reset();
+        var firstRead = saver.get(config(threadId));
+        assertTrue(firstRead.isPresent());
+        assertEquals(latestCheckpoint.getId(), firstRead.get().getId());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+
+        countingDataSource.reset();
+        var secondRead = saver.get(config(threadId));
+        assertTrue(secondRead.isPresent());
+        assertEquals(latestCheckpoint.getId(), secondRead.get().getId());
+        assertEquals(1, countingDataSource.latestCheckpointSelects());
+    }
+
+    private static final class CountingDataSource implements DataSource {
+
+        private final DataSource delegate;
+
+        private final AtomicInteger latestCheckpointSelects = new AtomicInteger();
+
+        private final AtomicInteger checkpointByIdSelects = new AtomicInteger();
+
+        private CountingDataSource(DataSource delegate) {
+            this.delegate = delegate;
+        }
+
+        void reset() {
+            latestCheckpointSelects.set(0);
+            checkpointByIdSelects.set(0);
+        }
+
+        int latestCheckpointSelects() {
+            return latestCheckpointSelects.get();
+        }
+
+        int checkpointByIdSelects() {
+            return checkpointByIdSelects.get();
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return countPreparedStatements(delegate.getConnection());
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return countPreparedStatements(delegate.getConnection(username, password));
+        }
+
+        private Connection countPreparedStatements(Connection connection) {
+            return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(), new Class<?>[] { Connection.class },
+                    (proxy, method, args) -> {
+                        countQuery(method, args);
+                        try {
+                            return method.invoke(connection, args);
+                        }
+                        catch (InvocationTargetException ex) {
+                            throw ex.getCause();
+                        }
+                    });
+        }
+
+        private void countQuery(java.lang.reflect.Method method, Object[] args) {
+            if (!"prepareStatement".equals(method.getName()) || args == null || args.length == 0
+                    || !(args[0] instanceof String sql)) {
+                return;
+            }
+            if (sql.contains("FETCH FIRST 1 ROW ONLY")) {
+                latestCheckpointSelects.incrementAndGet();
+            }
+            if (sql.contains("AND c.checkpoint_id = ?")) {
+                checkpointByIdSelects.incrementAndGet();
+            }
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return delegate.unwrap(iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return delegate.isWrapperFor(iface);
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return delegate.getLogWriter();
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {
+            delegate.setLogWriter(out);
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {
+            delegate.setLoginTimeout(seconds);
+        }
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return delegate.getLoginTimeout();
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            return delegate.getParentLogger();
+        }
     }
 
 }


### PR DESCRIPTION
## 背景

关联 #4608，跟进 #4609 和 #4612。

#4609 已经修复了 MysqlSaver 继承 MemorySaver 后长期持有完整 checkpoint history 的问题。#4612 也按同一方向修复了 PostgresSaver。

OracleSaver 同样属于持久化 Saver，也不应该把 MemorySaver 的 `_checkpointsByThread` 当作长期主存储。这个 PR 只处理 OracleSaver，继续保持最小改动面：完整 checkpoint history 仍以 Oracle 为准，内存只保留 latest checkpoint cache。

## 修改内容

- `OracleSaver` 改为直接实现 `BaseCheckpointSaver`，不再继承 `MemorySaver` 的全量 checkpoint history 缓存。
- 新增有界 latest-checkpoint LRU cache，默认最多缓存 1024 个 thread 的最新 checkpoint，可通过 `maxCachedThreads(0)` 关闭。
- `get(config)` 未指定 checkpoint id 时优先读取 latest cache，cache miss 时只从 Oracle 查询最新一条。
- `get(config)` 指定 checkpoint id 时直接从 Oracle 查询对应 checkpoint，不把历史 checkpoint 放进内存缓存。
- `list(config)` 和 `release(config)` 保留完整历史语义，但改为按需从 Oracle 加载，不长期驻留内存。
- release thread 后清理对应 latest checkpoint cache，避免返回已 release thread 的缓存数据。
- 为 OracleSaver 增加测试，覆盖 latest cache 有界、历史 checkpoint 不进入内存缓存、latest update 后缓存刷新、release 后缓存清理、关闭 cache 后直接读库。

## 语义说明

这个修改保留了原先为了避免最新 checkpoint 频繁访问 Oracle 的优化意图：常见的 latest checkpoint 读取仍然可以命中内存缓存。区别在于不再把完整 checkpoint history 常驻内存，避免内存占用和历史 checkpoint 数量线性绑定。

也就是说：

- 最新 checkpoint：可以缓存，但缓存有上限。
- 历史 checkpoint：仍可查询，但以 Oracle 为数据源。
- release/list：仍返回完整 active history，但只在调用时加载。

## 后续计划

这个 PR 是持续收敛 JDBC 持久化 checkpoint saver 行为一致性的一部分。

当前进度：

- [x] MySQL Saver: #4609
- [x] PostgreSQL Saver: #4612
- [x] Oracle Saver: this PR
- [ ] SQL Server Saver / H2 coverage, if applicable
- [ ] Documentation and examples
- [ ] Additional regression coverage if gaps are found

我会继续用小的 PR 推进，尽量保持 review scope 可控。
如果这个方向和项目预期不一致，欢迎指出，我会及时调整。

## 验证

- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.17-tem PATH=$JAVA_HOME/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core -DskipTests compile`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.17-tem PATH=$JAVA_HOME/bin:$PATH CI=true ./mvnw -pl spring-ai-alibaba-graph-core -Dtest=OracleSaverTest test`

本地 Testcontainers 已连接 OrbStack 实际启动 `gvenzl/oracle-free:23.7-slim-faststart` 容器，`OracleSaverTest` 真实执行通过：

- `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`
