### PR TITLE
fix(graph): prevent FileSystemSaver checkpoint cache growth

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaver.java
@@ -17,8 +17,8 @@ package com.alibaba.cloud.ai.graph.checkpoint.savers.file;
 
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
-import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.serializer.Serializer;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 import com.alibaba.cloud.ai.graph.serializer.check_point.CheckPointSerializer;
@@ -31,10 +31,18 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 import static java.lang.String.format;
 
@@ -45,8 +53,12 @@ import static java.lang.String.format;
  * named "thread-<i>threadId</i>.saver" if the RunnableConfig has a threadId, or
  * "thread-$default.saver" if it doesn't.
  * </p>
+ * <p>
+ * Full checkpoint history is loaded from the file on demand. In memory this saver keeps
+ * only a bounded latest-checkpoint cache.
+ * </p>
  */
-public class FileSystemSaver extends MemorySaver {
+public class FileSystemSaver implements BaseCheckpointSaver {
 
 	public static final String EXTENSION = ".saver";
 	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FileSystemSaver.class);
@@ -54,23 +66,43 @@ public class FileSystemSaver extends MemorySaver {
 
 	private final Serializer<Checkpoint> serializer;
 
-	@SuppressWarnings("unchecked")
+	private final Map<String, Checkpoint> latestCheckpointCache;
+	private final ReentrantLock lock = new ReentrantLock();
+	private final int maxCachedThreads;
+
+	/**
+	 * Protected constructor for FileSystemSaver.
+	 * Use {@link #builder()} to create instances.
+	 * @param targetFolder the directory where checkpoint files are stored
+	 * @param stateSerializer the serializer used to persist checkpoint state
+	 */
 	protected FileSystemSaver(Path targetFolder, StateSerializer stateSerializer) {
-		if(stateSerializer == null) {
+		this(new Builder()
+				.targetFolder(targetFolder)
+				.stateSerializer(stateSerializer));
+	}
+
+	@SuppressWarnings("unchecked")
+	protected FileSystemSaver(Builder builder) {
+		StateSerializer stateSerializer = builder.stateSerializer;
+		if (stateSerializer == null) {
 			this.serializer = new CheckPointSerializer(StateGraph.DEFAULT_JACKSON_SERIALIZER);
-		} else {
+		}
+		else {
 			this.serializer = new CheckPointSerializer(stateSerializer);
 		}
-		this.targetFolder = Objects.requireNonNull(targetFolder, "targetFolder cannot be null");
+		this.targetFolder = Objects.requireNonNull(builder.targetFolder, "targetFolder cannot be null");
+		this.maxCachedThreads = builder.maxCachedThreads;
+		this.latestCheckpointCache = createLatestCheckpointCache(builder.maxCachedThreads);
 
 		try {
-			if (Files.exists(targetFolder) && !Files.isDirectory(targetFolder)) {
-				throw new IllegalArgumentException(format("targetFolder '%s' must be a directory", targetFolder));
+			if (Files.exists(this.targetFolder) && !Files.isDirectory(this.targetFolder)) {
+				throw new IllegalArgumentException(format("targetFolder '%s' must be a directory", this.targetFolder));
 			}
-			Files.createDirectories(targetFolder);
+			Files.createDirectories(this.targetFolder);
 		}
 		catch (IOException ex) {
-			throw new IllegalArgumentException(format("targetFolder '%s' cannot be created", targetFolder), ex);
+			throw new IllegalArgumentException(format("targetFolder '%s' cannot be created", this.targetFolder), ex);
 		}
 
 	}
@@ -94,6 +126,10 @@ public class FileSystemSaver extends MemorySaver {
 
 	private File getFile(RunnableConfig config) {
 		return getPath(config).toFile();
+	}
+
+	private String getThreadId(RunnableConfig config) {
+		return config.threadId().orElse(THREAD_ID_DEFAULT);
 	}
 
 	private void serialize(LinkedList<Checkpoint> checkpoints, File outFile) throws IOException {
@@ -120,29 +156,162 @@ public class FileSystemSaver extends MemorySaver {
 		}
 	}
 
-	@Override
-	protected LinkedList<Checkpoint> loadedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints)
-			throws Exception {
-
-		File targetFile = getFile(config);
-		if (targetFile.exists() && checkpoints.isEmpty()) {
-			deserialize(targetFile, checkpoints);
+	private LinkedList<Checkpoint> deserialize(File file) throws IOException, ClassNotFoundException {
+		LinkedList<Checkpoint> checkpoints = new LinkedList<>();
+		if (file.exists()) {
+			deserialize(file, checkpoints);
 		}
 		return checkpoints;
-
 	}
 
-	@Override
-	protected void insertedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
-			throws Exception {
+	private Optional<Checkpoint> deserializeLatest(File file) throws IOException, ClassNotFoundException {
+		if (!file.exists()) {
+			return Optional.empty();
+		}
+
+		try (ObjectInputStream ois = new ObjectInputStream(Files.newInputStream(file.toPath()))) {
+			int size = ois.readInt();
+			if (size == 0) {
+				return Optional.empty();
+			}
+			return Optional.of(serializer.read(ois));
+		}
+	}
+
+	private Optional<Checkpoint> deserializeCheckpoint(File file, String checkpointId)
+			throws IOException, ClassNotFoundException {
+		if (!file.exists()) {
+			return Optional.empty();
+		}
+
+		try (ObjectInputStream ois = new ObjectInputStream(Files.newInputStream(file.toPath()))) {
+			int size = ois.readInt();
+			for (int i = 0; i < size; i++) {
+				Checkpoint checkpoint = serializer.read(ois);
+				if (checkpoint.getId().equals(checkpointId)) {
+					return Optional.of(checkpoint);
+				}
+			}
+			return Optional.empty();
+		}
+	}
+
+	private LinkedList<Checkpoint> loadCheckpoints(RunnableConfig config) throws IOException, ClassNotFoundException {
+		return deserialize(getFile(config));
+	}
+
+	private void insertCheckpoint(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+		LinkedList<Checkpoint> checkpoints = loadCheckpoints(config);
+		checkpoints.push(checkpoint);
 		File targetFile = getFile(config);
 		serialize(checkpoints, targetFile);
 	}
 
+	private void updateCheckpoint(RunnableConfig config, String checkpointId, Checkpoint checkpoint) throws Exception {
+		LinkedList<Checkpoint> checkpoints = loadCheckpoints(config);
+		int index = IntStream.range(0, checkpoints.size())
+				.filter(i -> checkpoints.get(i).getId().equals(checkpointId))
+				.findFirst()
+				.orElseThrow(() -> new NoSuchElementException(format("Checkpoint with id %s not found!", checkpointId)));
+		checkpoints.set(index, checkpoint);
+		serialize(checkpoints, getFile(config));
+	}
+
+	/**
+	 * Lists active checkpoints for the configured thread.
+	 */
 	@Override
-	protected void updatedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
-			throws Exception {
-		insertedCheckpoint(config, checkpoints, checkpoint);
+	public Collection<Checkpoint> list(RunnableConfig config) {
+		lock.lock();
+		try {
+			LinkedList<Checkpoint> checkpoints = loadCheckpoints(config);
+			if (!checkpoints.isEmpty()) {
+				cacheLatest(getThreadId(config), checkpoints.peek());
+			}
+			return Collections.unmodifiableCollection(checkpoints);
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Gets a checkpoint for the configured thread.
+	 */
+	@Override
+	public Optional<Checkpoint> get(RunnableConfig config) {
+		lock.lock();
+		try {
+			String threadId = getThreadId(config);
+			File targetFile = getFile(config);
+			if (config.checkPointId().isPresent()) {
+				return deserializeCheckpoint(targetFile, config.checkPointId().get());
+			}
+
+			Optional<Checkpoint> cached = getCachedLatest(threadId);
+			if (cached.isPresent()) {
+				return cached;
+			}
+
+			Optional<Checkpoint> latest = deserializeLatest(targetFile);
+			latest.ifPresent(checkpoint -> cacheLatest(threadId, checkpoint));
+			return latest;
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Inserts or updates a checkpoint.
+	 */
+	@Override
+	public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+		lock.lock();
+		try {
+			String threadId = getThreadId(config);
+			if (config.checkPointId().isPresent()) {
+				String checkpointId = config.checkPointId().get();
+				updateCheckpoint(config, checkpointId, checkpoint);
+				getCachedLatest(threadId)
+						.filter(latest -> latest.getId().equals(checkpointId))
+						.ifPresent(latest -> cacheLatest(threadId, checkpoint));
+				return config;
+			}
+
+			insertCheckpoint(config, checkpoint);
+			cacheLatest(threadId, checkpoint);
+			return RunnableConfig.builder(config)
+					.checkPointId(checkpoint.getId())
+					.build();
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Releases the active thread and returns the released checkpoints.
+	 */
+	@Override
+	public Tag release(RunnableConfig config) throws Exception {
+		lock.lock();
+		try {
+			String threadId = getThreadId(config);
+			LinkedList<Checkpoint> checkpoints = loadCheckpoints(config);
+			releaseFile(config);
+			removeCachedLatest(threadId);
+			return new Tag(threadId, checkpoints);
+		}
+		finally {
+			lock.unlock();
+		}
 	}
 
 	/**
@@ -152,14 +321,10 @@ public class FileSystemSaver extends MemorySaver {
 	 * existing versioned files, deleting the original unversioned file, and then clearing
 	 * the in-memory checkpoints.
 	 * @param config The configuration for which to release checkpoints.
-	 * @param checkpoints released checkpoints
-	 * @param releaseTag released Tag
 	 * @throws Exception If an error occurs during file operations or releasing from
 	 * memory.
 	 */
-	@Override
-	protected void releasedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Tag releaseTag)
-			throws Exception {
+	private void releaseFile(RunnableConfig config) throws Exception {
 		var currentPath = getPath(config);
 
 		if (!Files.exists(currentPath)) {
@@ -172,11 +337,11 @@ public class FileSystemSaver extends MemorySaver {
 		int maxVersion = 0;
 		try (var stream = Files.list(targetFolder)) {
 			maxVersion = stream.map(path -> path.getFileName().toString())
-					.map(versionPattern::matcher)
-					.filter(Matcher::matches)
-					.mapToInt(matcher -> Integer.parseInt(matcher.group(1)))
-					.max()
-					.orElse(0); // Default to 0 if no versioned files found
+				.map(versionPattern::matcher)
+				.filter(Matcher::matches)
+				.mapToInt(matcher -> Integer.parseInt(matcher.group(1)))
+				.max()
+				.orElse(0); // Default to 0 if no versioned files found
 		}
 		catch (IOException e) {
 			log.error(
@@ -203,7 +368,9 @@ public class FileSystemSaver extends MemorySaver {
 	public boolean deleteFile(RunnableConfig config) {
 		Path path = getPath(config);
 		try {
-			return Files.deleteIfExists(path);
+			boolean deleted = Files.deleteIfExists(path);
+			removeCachedLatest(getThreadId(config));
+			return deleted;
 		}
 		catch (IOException e) {
 			log.warn("Failed to delete checkpoint file {}", path, e);
@@ -212,11 +379,46 @@ public class FileSystemSaver extends MemorySaver {
 	}
 
 	/**
+	 * Creates a bounded LRU cache for latest checkpoints.
+	 */
+	private static Map<String, Checkpoint> createLatestCheckpointCache(int maxCachedThreads) {
+		if (maxCachedThreads == 0) {
+			return Collections.emptyMap();
+		}
+		return new LinkedHashMap<>(16, 0.75f, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
+				return size() > maxCachedThreads;
+			}
+		};
+	}
+
+	private Optional<Checkpoint> getCachedLatest(String threadId) {
+		if (maxCachedThreads == 0) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(latestCheckpointCache.get(threadId));
+	}
+
+	private void cacheLatest(String threadId, Checkpoint checkpoint) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.put(threadId, checkpoint);
+		}
+	}
+
+	private void removeCachedLatest(String threadId) {
+		if (maxCachedThreads > 0) {
+			latestCheckpointCache.remove(threadId);
+		}
+	}
+
+	/**
 	 * Builder class for FileSystemSaver.
 	 */
-	public static class Builder extends MemorySaver.Builder {
+	public static class Builder {
 		private Path targetFolder;
 		private StateSerializer stateSerializer;
+		private int maxCachedThreads = 1024;
 
 		public Builder targetFolder(Path targetFolder) {
 			this.targetFolder = targetFolder;
@@ -229,12 +431,25 @@ public class FileSystemSaver extends MemorySaver {
 		}
 
 		/**
+		 * Sets the maximum number of latest checkpoints retained in memory.
+		 * @param maxCachedThreads max cached threads, or 0 to disable the cache
+		 * @return this builder
+		 */
+		public Builder maxCachedThreads(int maxCachedThreads) {
+			if (maxCachedThreads < 0) {
+				throw new IllegalArgumentException("maxCachedThreads must be greater than or equal to 0");
+			}
+			this.maxCachedThreads = maxCachedThreads;
+			return this;
+		}
+
+		/**
 		 * Builds a new FileSystemSaver instance.
 		 * @return a new FileSystemSaver instance
-		 * @throws IllegalArgumentException if targetFolder or stateSerializer is null
+		 * @throws IllegalArgumentException if targetFolder is null
 		 */
 		public FileSystemSaver build() {
-			return new FileSystemSaver(targetFolder, stateSerializer);
+			return new FileSystemSaver(this);
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphFileSystemSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphFileSystemSaverTest.java
@@ -103,14 +103,14 @@ public class StateGraphFileSystemSaverTest {
 				Optional<OverAllState> state = app.invoke(Map.of(), runnableConfig_1);
 
 				assertTrue(state.isPresent());
-				assertEquals(expectedSteps + (execution * 2), (int) state.get().data().get("steps"));
+				assertEquals(expectedSteps, (int) state.get().data().get("steps"));
 
 				List<String> messages = (List<String>) state.get().data().get("messages");
 				assertFalse(messages.isEmpty());
 
 				log.info("thread_1: execution: {} messages:\n{}\n", execution, messages);
 
-				assertEquals(expectedSteps + execution * 2, messages.size());
+				assertEquals(expectedSteps, messages.size());
 				for (int i = 0; i < messages.size(); i++) {
 					assertEquals(format("agent_1:step %d", (i + 1)), messages.get(i));
 				}
@@ -125,23 +125,23 @@ public class StateGraphFileSystemSaverTest {
 				state = app.invoke(emptyMap(), runnableConfig_2);
 
 				assertTrue(state.isPresent());
-				assertEquals(expectedSteps + execution, (int) state.get().data().get("steps"));
+				assertEquals(expectedSteps, (int) state.get().data().get("steps"));
 				messages = (List<String>) state.get().data().get("messages");
 
 				log.info("thread_2: execution: {} messages:\n{}\n", execution, messages);
 
-				assertEquals(expectedSteps + execution, messages.size());
+				assertEquals(expectedSteps, messages.size());
 
 				// RE-SUBMIT THREAD 1
 				state = app.invoke(Map.of(), runnableConfig_1);
 
 				assertTrue(state.isPresent());
-				assertEquals(expectedSteps + 1 + execution * 2, (int) state.get().data().get("steps"));
+				assertEquals(expectedSteps + 1, (int) state.get().data().get("steps"));
 				messages = (List<String>) state.get().data().get("messages");
 
 				log.info("thread_1: execution: {} messages:\n{}\n", execution, messages);
 
-				assertEquals(expectedSteps + 1 + execution * 2, messages.size());
+				assertEquals(expectedSteps + 1, messages.size());
 
 			}
 		}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaverCacheTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaverCacheTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers.file;
+
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FileSystemSaverCacheTest {
+
+	@TempDir
+	Path tempDir;
+
+	private static RunnableConfig config(String threadId) {
+		return RunnableConfig.builder().threadId(threadId).build();
+	}
+
+	private static Checkpoint checkpoint(String value) {
+		return Checkpoint.builder()
+				.nodeId("node")
+				.nextNodeId("next")
+				.state(Map.of("value", value))
+				.build();
+	}
+
+	@Test
+	public void shouldLoadLatestCheckpointWhenCacheDisabled() throws Exception {
+		FileSystemSaver saver = FileSystemSaver.builder()
+				.targetFolder(tempDir)
+				.maxCachedThreads(0)
+				.build();
+		RunnableConfig config = config("thread-1");
+		Checkpoint checkpoint = checkpoint("v1");
+
+		RunnableConfig checkpointConfig = saver.put(config, checkpoint);
+
+		assertEquals(checkpoint.getId(), saver.get(config).orElseThrow().getId());
+		assertEquals(checkpoint.getId(), saver.get(checkpointConfig).orElseThrow().getId());
+		assertEquals(1, saver.list(config).size());
+	}
+
+	@Test
+	public void shouldLoadEvictedLatestCheckpointFromFile() throws Exception {
+		FileSystemSaver saver = FileSystemSaver.builder()
+				.targetFolder(tempDir)
+				.maxCachedThreads(1)
+				.build();
+		RunnableConfig firstThread = config("thread-1");
+		RunnableConfig secondThread = config("thread-2");
+		Checkpoint firstCheckpoint = checkpoint("v1");
+		Checkpoint secondCheckpoint = checkpoint("v2");
+
+		saver.put(firstThread, firstCheckpoint);
+		saver.put(secondThread, secondCheckpoint);
+
+		assertEquals(firstCheckpoint.getId(), saver.get(firstThread).orElseThrow().getId());
+		assertEquals(secondCheckpoint.getId(), saver.get(secondThread).orElseThrow().getId());
+	}
+
+	@Test
+	public void releaseShouldReturnHistoryAndClearLatestCache() throws Exception {
+		FileSystemSaver saver = FileSystemSaver.builder()
+				.targetFolder(tempDir)
+				.build();
+		RunnableConfig config = config("thread-1");
+		Checkpoint firstCheckpoint = checkpoint("v1");
+		Checkpoint secondCheckpoint = checkpoint("v2");
+
+		saver.put(config, firstCheckpoint);
+		saver.put(config, secondCheckpoint);
+
+		assertEquals(secondCheckpoint.getId(), saver.get(config).orElseThrow().getId());
+
+		var tag = saver.release(config);
+
+		assertEquals("thread-1", tag.threadId());
+		assertEquals(2, tag.checkpoints().size());
+		assertTrue(saver.get(config).isEmpty());
+		assertFalse(Files.exists(tempDir.resolve("thread-thread-1.saver")));
+		assertTrue(Files.exists(tempDir.resolve("thread-thread-1-v1.saver")));
+	}
+
+	@Test
+	public void deleteFileShouldClearLatestCache() throws Exception {
+		FileSystemSaver saver = FileSystemSaver.builder()
+				.targetFolder(tempDir)
+				.build();
+		RunnableConfig config = config("thread-1");
+		Checkpoint checkpoint = checkpoint("v1");
+
+		saver.put(config, checkpoint);
+		assertEquals(checkpoint.getId(), saver.get(config).orElseThrow().getId());
+
+		assertTrue(saver.deleteFile(config));
+		assertTrue(saver.get(config).isEmpty());
+	}
+
+}


### PR DESCRIPTION
## Describe what this PR does / why we need it

关联 #4608，跟进 #4609、#4612 和 #4621。

前面几个 PR 已经分别处理了 MysqlSaver、PostgresSaver、OracleSaver 继承 `MemorySaver` 后长期持有完整 checkpoint history 的问题。FileSystemSaver 这里是同一类问题：checkpoint 已经持久化到文件了，但因为继承了 `MemorySaver`，运行时仍然会把完整 history 留在 `_checkpointsByThread` 里。

这个 PR 只处理 FileSystemSaver。修复后的语义是：checkpoint file 继续作为完整 history 的数据源，JVM 内存只保留一个有上限的 latest checkpoint cache，避免内存占用随着 checkpoint history 持续增长。

## Does this pull request fix one issue?

Related to #4608

## Describe how you did it

- 将 `FileSystemSaver` 从继承 `MemorySaver` 改为直接实现 `BaseCheckpointSaver`。
- 新增 latest-checkpoint LRU cache，默认最多缓存 1024 个 thread，可通过 `maxCachedThreads(0)` 关闭。
- `get(config)` 不带 checkpoint id 时，优先读 latest cache；cache miss 时只从 checkpoint file 读取最新一条。
- `get(config)` 带 checkpoint id 时，直接从 checkpoint file 查对应 checkpoint，不把完整 history 放进内存。
- `list(config)` 和 `release(config)` 仍然保留完整 history 语义，但只在调用时从文件加载。
- release thread 后清理 latest cache，避免 release 后继续返回旧缓存。
- delete checkpoint file 后同步清理 latest cache，避免文件已删除但内存里还能返回 checkpoint。
- 补充 FileSystemSaver 回归测试，覆盖关闭 cache、cache 淘汰后回源文件、release 清缓存、delete file 清缓存这些边界。

## Describe how to verify it

- `JAVA_HOME=/Users/viperthanks/Env/JDKs/JDK17/Contents/Home PATH=$JAVA_HOME/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core -Dtest=FileSystemSaverCacheTest,FileSystemSaverDeleteFileTest,StateGraphFileSystemSaverTest test`
- `JAVA_HOME=/Users/viperthanks/Env/JDKs/JDK17/Contents/Home PATH=$JAVA_HOME/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core test`

本地 `spring-ai-alibaba-graph-core` 全模块测试通过：

- `Tests run: 308, Failures: 0, Errors: 0, Skipped: 64`

## Special notes for reviews

这次没有改变 FileSystemSaver 的文件格式，也没有移除 checkpoint history 能力。完整 history 仍然在 checkpoint file 里，`list/release` 仍然会返回完整 active history，只是不再长期驻留 JVM 内存。

当前进度：

- [x] MySQL Saver: #4609
- [x] PostgreSQL Saver: #4612
- [x] Oracle Saver: #4621
- [x] FileSystem Saver: this PR
- [ ] Extract shared latest-checkpoint cache
- [ ] Introduce AbstractJdbcCheckpointSaver
- [ ] H2 Saver coverage
- [ ] SQL Server Saver
- [ ] Documentation and examples
- [ ] Additional regression coverage if gaps are found

我会继续按小 PR 推进。下一个 PR 先把 latest-checkpoint cache 和 JDBC saver 的公共流程抽出来，后面再做 H2、SQL Server 这类新的 JdbcSaver 时就可以少重复很多逻辑。

如果这个方向和项目预期不一致，欢迎指出，我会及时调整。