### PR TITLE
fix(graph): omit full text on GRAPH_NODE_FINISHED for graph LLM streams

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -341,11 +341,9 @@ public class NodeExecutor extends BaseGraphExecutor {
 					return Flux.empty();
 				} else {
 					ChatResponse lastChatResponse = lastChatResponseRef.get();
-					// For completion status with AGENT_MODEL_NAME, create a StreamingOutput with null message to avoid chunk content
-					// This ensures that completion events don't carry the full text content in the chunk field
+					// FINISHED StreamingOutput omits message for agent/graph LLM nodes (tool/hook unchanged); full text still in done(state).
 					Message messageForCompletion = lastChatResponse.getResult().getOutput();
-					if (nodeId.startsWith(RunnableConfig.AGENT_MODEL_NAME)) {
-						// For agent model completion, use null message to prevent chunk content
+					if (shouldOmitMessageOnStreamCompletion(nodeId)) {
 						messageForCompletion = null;
 					}
 					GraphResponse<NodeOutput> aggregatedResponse = GraphResponse
@@ -494,6 +492,16 @@ public class NodeExecutor extends BaseGraphExecutor {
     private static String normalized(String value) {
         return StringUtils.hasText(value) ? value : null;
     }
+
+	/**
+	 * Whether the FINISHED {@link StreamingOutput} after a {@link ChatResponse} flux should omit
+	 * {@link Message} text (agent model and ordinary graph LLM nodes). Tool/hook streams keep the message.
+	 */
+	private static boolean shouldOmitMessageOnStreamCompletion(String nodeId) {
+		return nodeId.startsWith(RunnableConfig.AGENT_MODEL_NAME)
+				|| (!nodeId.startsWith(RunnableConfig.AGENT_TOOL_NAME)
+						&& !nodeId.startsWith(RunnableConfig.AGENT_HOOK_NAME_PREFIX));
+	}
 
 	/**
 	 * Processes a Flux<GraphResponse<NodeOutput>> with embedded flux handling logic.

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/streaming/OutputType.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/streaming/OutputType.java
@@ -48,4 +48,12 @@ public enum OutputType {
 		}
 	}
 
+	/**
+	 * True for model/graph LLM stream completion ({@link #AGENT_MODEL_FINISHED}, {@link #GRAPH_NODE_FINISHED}):
+	 * text was already streamed; do not append {@link StreamingOutput#message()} again.
+	 */
+	public boolean isStreamAggregationFinished() {
+		return this == AGENT_MODEL_FINISHED || this == GRAPH_NODE_FINISHED;
+	}
+
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/GraphNodeStreamFinishedTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/GraphNodeStreamFinishedTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.executor;
+
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.stream.LLmNodeAction;
+import com.alibaba.cloud.ai.graph.streaming.OutputType;
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link com.alibaba.cloud.ai.graph.executor.NodeExecutor} stream completion behavior for
+ * graph LLM nodes: {@link OutputType#GRAPH_NODE_FINISHED} must not repeat text already sent as
+ * {@link OutputType#GRAPH_NODE_STREAMING} deltas.
+ */
+public class GraphNodeStreamFinishedTest {
+
+	private static final String EXPECTED_FULL_TEXT = "foo bar baz";
+
+	@Test
+	void testGraphNodeFinishedDoesNotRepeatFullTextOnStream() throws Exception {
+		CompiledGraph compiledGraph = buildGraph(createIncrementalMockChatModel());
+		Map<String, Object> input = Map.of(OverAllState.DEFAULT_INPUT_KEY, "test");
+
+		StringBuilder appendAllNonEmptyChunks = new StringBuilder();
+		AtomicReference<StreamingOutput<?>> finishedOutput = new AtomicReference<>();
+
+		NodeOutput last = compiledGraph.stream(input)
+				.doOnNext(output -> {
+					if (!(output instanceof StreamingOutput<?> so)) {
+						return;
+					}
+					if (so.getOutputType() == OutputType.GRAPH_NODE_FINISHED) {
+						finishedOutput.set(so);
+					}
+					appendChunkIfPresent(appendAllNonEmptyChunks, so);
+				})
+				.blockLast(Duration.ofSeconds(10));
+
+		assertNotNull(finishedOutput.get(), "stream should emit GRAPH_NODE_FINISHED");
+		assertTrue(isEmptyText(finishedOutput.get()),
+				"GRAPH_NODE_FINISHED must not expose full text in chunk/message");
+
+		assertEquals(EXPECTED_FULL_TEXT, appendAllNonEmptyChunks.toString(),
+				"appending all non-empty stream chunks should equal full text once, not twice");
+		assertEquals(EXPECTED_FULL_TEXT, extractLastAssistantText(last),
+				"final state should still contain the full assistant message");
+	}
+
+	private static CompiledGraph buildGraph(ChatModel chatModel) throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("streaming_node", node_async(new LLmNodeAction(chatModel, "streaming_node")))
+				.addEdge(START, "streaming_node")
+				.addEdge("streaming_node", END);
+		return stateGraph.compile();
+	}
+
+	private static ChatModel createIncrementalMockChatModel() {
+		return new ChatModel() {
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				return new ChatResponse(List.of(new Generation(new AssistantMessage(EXPECTED_FULL_TEXT))));
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				return Flux.just(
+						new ChatResponse(List.of(new Generation(new AssistantMessage("foo")))),
+						new ChatResponse(List.of(new Generation(new AssistantMessage(" bar")))),
+						new ChatResponse(List.of(new Generation(new AssistantMessage(" baz")))));
+			}
+		};
+	}
+
+	/** Append whenever chunk or message text is non-empty (naive stream consumer). */
+	private static void appendChunkIfPresent(StringBuilder sink, StreamingOutput<?> so) {
+		String chunk = chunkText(so);
+		if (chunk != null && !chunk.isEmpty()) {
+			sink.append(chunk);
+		}
+	}
+
+	private static String chunkText(StreamingOutput<?> so) {
+		String chunk = so.chunk();
+		if (chunk != null) {
+			return chunk;
+		}
+		if (so.message() != null && so.message().getText() != null) {
+			return so.message().getText();
+		}
+		return null;
+	}
+
+	private static boolean isEmptyText(StreamingOutput<?> so) {
+		String chunk = chunkText(so);
+		return chunk == null || chunk.isEmpty();
+	}
+
+	private static String extractLastAssistantText(NodeOutput last) {
+		if (last == null || last.state() == null) {
+			return "";
+		}
+		Object messages = last.state().value("messages").orElse(null);
+		if (messages instanceof Iterable<?> list) {
+			AssistantMessage lastAssistant = null;
+			for (Object item : list) {
+				if (item instanceof AssistantMessage am) {
+					lastAssistant = am;
+				}
+			}
+			return lastAssistant != null && lastAssistant.getText() != null ? lastAssistant.getText() : "";
+		}
+		return "";
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/streaming/OutputTypeTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/streaming/OutputTypeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.streaming;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OutputTypeTest {
+
+	@Test
+	void streamAggregationFinishedIncludesModelAndGraphNode() {
+		assertTrue(OutputType.AGENT_MODEL_FINISHED.isStreamAggregationFinished());
+		assertTrue(OutputType.GRAPH_NODE_FINISHED.isStreamAggregationFinished());
+	}
+
+	@Test
+	void streamAggregationFinishedExcludesStreamingAndToolTypes() {
+		assertFalse(OutputType.AGENT_MODEL_STREAMING.isStreamAggregationFinished());
+		assertFalse(OutputType.GRAPH_NODE_STREAMING.isStreamAggregationFinished());
+		assertFalse(OutputType.AGENT_TOOL_FINISHED.isStreamAggregationFinished());
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Agent streaming already avoids pushing full text on the FINISHED event:
1. **Framework** (`NodeExecutor`, on `main`): for nodes whose id starts with `_AGENT_MODEL_`,
   `messageForCompletion` is set to `null` before emitting `AGENT_MODEL_FINISHED`, with an explicit
   comment that completion events must not carry full text in the chunk field. The full
   `AssistantMessage` is still written to state via `GraphResponse.done(completionResult)`.
```
// For completion status with AGENT_MODEL_NAME, create a StreamingOutput with null message to avoid chunk content
// This ensures that completion events don't carry the full text content in the chunk field
Message messageForCompletion = lastChatResponse.getResult().getOutput();
if (nodeId.startsWith(RunnableConfig.AGENT_MODEL_NAME)) {
     // For agent model completion, use null message to prevent chunk content
     messageForCompletion = null;
}
```
2. **Studio** (`ExecutionController`): `AGENT_MODEL_FINISHED` is filtered out of the Agent SSE
   stream because it "would duplicate the final message":
```
// Skip AGENT_MODEL_FINISHED: it is the framework's aggregation of AGENT_MODEL_STREAMING
// chunks; sending it to the frontend would duplicate the final message.
return agentStream
		.filter(nodeOutput -> !(nodeOutput instanceof StreamingOutput<?> so
				&& so.getOutputType() == OutputType.AGENT_MODEL_FINISHED))
		.map(nodeOutput -> {
			String node = nodeOutput.node();
			String agentName = nodeOutput.agent();
			Usage tokenUsage = nodeOutput.tokenUsage();
```
Graph LLM nodes (`GRAPH_NODE_FINISHED`) did not get the same treatment on `main`, which caused [#4631](https://github.com/alibaba/spring-ai-alibaba/issues/4631)
- style duplicate text when consumers append every non-empty chunk. This PR aligns graph LLM nodes with the existing agent convention.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #4631
### Describe how you did it
- NodeExecutor: Replaced the _AGENT_MODEL_-only null-message branch with shouldOmitMessageOnStreamCompletion(nodeId) so agent model and ordinary graph LLM nodes omit message on stream completion; _AGENT_TOOL_ / _AGENT_HOOK_ nodes are unchanged and still emit their completion payload.
- OutputType: Added isStreamAggregationFinished() to document that AGENT_MODEL_FINISHED and GRAPH_NODE_FINISHED mark the end of a streamed text segment (text already sent on *_STREAMING).
- Tests:
  - GraphNodeStreamFinishedTest — mock incremental ChatResponse flux; assert GRAPH_NODE_FINISHED has empty chunk/message and naive “append all non-empty chunks” does not double the text.
  - OutputTypeTest — covers isStreamAggregationFinished().

### Describe how to verify it
#### Unit test (no API key)

```bash
./mvnw -pl spring-ai-alibaba-graph-core -Dtest=GraphNodeStreamFinishedTest,OutputTypeTest test
```

#### Manual repro (optional, requires `AI_DASHSCOPE_API_KEY`)
before fixed：
<img width="1319" height="711" alt="4631修复前" src="https://github.com/user-attachments/assets/15f79901-95ff-47ce-9992-c5a5f0767a07" />
after fixed:
<img width="662" height="600" alt="4631修复后" src="https://github.com/user-attachments/assets/f829f3bc-ed21-4c63-9670-1d88ffdf265c" />

**Expected after this PR:**

- `GRAPH_NODE_FINISHED` → `chunkLen=0`
- Appending all non-empty chunks matches final state **once** (no ~2× length)

### Special notes for reviews
- **Scope:** `spring-ai-alibaba-graph-core` only.  `ExecutionController` / `GraphExecutionController` are cited as prior-art for agent behavior, **not modified** in this PR.
- **Tool/hook streams:** Explicitly excluded from message omission so tool results and hook outputs on `*_FINISHED` are preserved.
- **`GraphExecutionController`:** Still filters only `AGENT_MODEL_FINISHED` for SSE.  Graph Studio does not drop `GRAPH_NODE_FINISHED` events;  it relies on `NodeExecutor` to omit duplicate text on FINISHED.  When `message` is null, that event may still carry `tokenUsage` to the frontend.
- **Breaking change risk:** Low for correct consumers (only `*_STREAMING` deltas, or state/`done` for full text).  Callers that incorrectly treated `GRAPH_NODE_FINISHED` as an extra token chunk will see empty `message`/`chunk` — that is the intended fix.