### PR TITLE
refactor(graph): extract JDBC checkpoint saver base

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCache.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCache.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers.common;
+
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A bounded LRU cache that stores the latest checkpoint for each thread.
+ */
+public final class LatestCheckpointCache {
+
+	private final int maxCachedThreads;
+
+	private final Map<String, Checkpoint> checkpoints;
+
+	/**
+	 * Creates a latest-checkpoint cache with an LRU thread limit.
+	 *
+	 * @param maxCachedThreads maximum number of thread entries to keep, or 0 to
+	 * disable caching
+	 */
+	public LatestCheckpointCache(int maxCachedThreads) {
+		if (maxCachedThreads < 0) {
+			throw new IllegalArgumentException("maxCachedThreads must be greater than or equal to 0");
+		}
+		this.maxCachedThreads = maxCachedThreads;
+		this.checkpoints = createCache(maxCachedThreads);
+	}
+
+	/**
+	 * Gets the cached latest checkpoint for a thread.
+	 *
+	 * @param threadId thread name/id used by the owning saver
+	 * @return cached checkpoint when caching is enabled and the thread is present
+	 */
+	public synchronized Optional<Checkpoint> get(String threadId) {
+		if (maxCachedThreads == 0) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(checkpoints.get(threadId));
+	}
+
+	/**
+	 * Stores the latest checkpoint for a thread when caching is enabled.
+	 *
+	 * @param threadId thread name/id used by the owning saver
+	 * @param checkpoint latest checkpoint to cache
+	 */
+	public synchronized void put(String threadId, Checkpoint checkpoint) {
+		if (maxCachedThreads > 0) {
+			checkpoints.put(threadId, checkpoint);
+		}
+	}
+
+	/**
+	 * Removes one thread from the cache when caching is enabled.
+	 *
+	 * @param threadId thread name/id used by the owning saver
+	 */
+	public synchronized void remove(String threadId) {
+		if (maxCachedThreads > 0) {
+			checkpoints.remove(threadId);
+		}
+	}
+
+	/**
+	 * Creates either an empty disabled cache or an access-ordered LRU map.
+	 *
+	 * @param maxCachedThreads maximum number of thread entries to keep
+	 * @return map backing the cache
+	 */
+	private static Map<String, Checkpoint> createCache(int maxCachedThreads) {
+		if (maxCachedThreads == 0) {
+			return Collections.emptyMap();
+		}
+		return new LinkedHashMap<>(16, 0.75f, true) {
+			/**
+			 * Evicts the least recently used thread once the configured limit is
+			 * exceeded.
+			 *
+			 * @param eldest eldest entry tracked by the access-ordered map
+			 * @return true when the cache should evict the eldest entry
+			 */
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
+				return size() > maxCachedThreads;
+			}
+		};
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaver.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers.jdbc;
+
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.common.LatestCheckpointCache;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Base implementation for JDBC checkpoint savers.
+ * <p>
+ * This class owns the common saver lifecycle and latest-checkpoint cache behavior.
+ * Subclasses keep database-specific SQL, transaction details and row mapping logic.
+ */
+public abstract class AbstractJdbcCheckpointSaver implements BaseCheckpointSaver {
+
+	private final LatestCheckpointCache latestCheckpointCache;
+
+	private final ReentrantLock lock = new ReentrantLock();
+
+	/**
+	 * Creates a JDBC saver base with a bounded latest-checkpoint cache.
+	 *
+	 * @param maxCachedThreads maximum number of thread latest-checkpoint entries to
+	 * cache, or 0 to disable the cache
+	 */
+	protected AbstractJdbcCheckpointSaver(int maxCachedThreads) {
+		this.latestCheckpointCache = new LatestCheckpointCache(maxCachedThreads);
+	}
+
+	/**
+	 * Lists active checkpoints for a thread and refreshes the latest-checkpoint cache
+	 * from the first item in the returned history.
+	 *
+	 * @param config runnable config that identifies the target thread
+	 * @return immutable active checkpoint history ordered by the concrete saver
+	 */
+	@Override
+	public final Collection<Checkpoint> list(RunnableConfig config) {
+		lock.lock();
+		try {
+			String threadId = threadId(config);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadId);
+			if (!checkpoints.isEmpty()) {
+				latestCheckpointCache.put(threadId, checkpoints.peek());
+			}
+			return Collections.unmodifiableCollection(checkpoints);
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Gets a checkpoint by explicit checkpoint id, or returns the latest checkpoint
+	 * using the bounded cache before falling back to the backing database.
+	 *
+	 * @param config runnable config that identifies the thread and optional checkpoint
+	 * id
+	 * @return matching checkpoint when it exists
+	 */
+	@Override
+	public final Optional<Checkpoint> get(RunnableConfig config) {
+		lock.lock();
+		try {
+			String threadId = threadId(config);
+			if (config.checkPointId().isPresent()) {
+				return selectCheckpointById(threadId, config.checkPointId().get());
+			}
+
+			Optional<Checkpoint> cached = latestCheckpointCache.get(threadId);
+			if (cached.isPresent()) {
+				return cached;
+			}
+
+			Optional<Checkpoint> latest = selectLatestCheckpoint(threadId);
+			latest.ifPresent(checkpoint -> latestCheckpointCache.put(threadId, checkpoint));
+			return latest;
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Inserts a new checkpoint when no checkpoint id is present, otherwise updates
+	 * the configured checkpoint and keeps the cached latest entry coherent.
+	 *
+	 * @param config runnable config that identifies the thread and optional checkpoint
+	 * id
+	 * @param checkpoint checkpoint data to insert or use as the replacement value
+	 * @return config with the inserted checkpoint id, or the original config for
+	 * updates
+	 * @throws Exception when the concrete saver cannot persist the checkpoint
+	 */
+	@Override
+	public final RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+		lock.lock();
+		try {
+			String threadId = threadId(config);
+			if (config.checkPointId().isPresent()) {
+				String checkpointId = config.checkPointId().get();
+				updateCheckpoint(threadId, checkpointId, checkpoint);
+				latestCheckpointCache.get(threadId)
+						.filter(latest -> latest.getId().equals(checkpointId))
+						.ifPresent(latest -> latestCheckpointCache.put(threadId, checkpoint));
+				return config;
+			}
+
+			insertCheckpoint(threadId, checkpoint);
+			latestCheckpointCache.put(threadId, checkpoint);
+			return RunnableConfig.builder(config)
+					.checkPointId(checkpoint.getId())
+					.build();
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Releases the active thread after loading the released checkpoint history, then
+	 * removes the thread from the latest-checkpoint cache.
+	 *
+	 * @param config runnable config that identifies the target thread
+	 * @return released thread id and its checkpoint history
+	 * @throws Exception when the concrete saver cannot release the thread
+	 */
+	@Override
+	public final Tag release(RunnableConfig config) throws Exception {
+		lock.lock();
+		try {
+			String threadId = threadId(config);
+			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadId);
+			releaseThread(threadId);
+			latestCheckpointCache.remove(threadId);
+			return new Tag(threadId, checkpoints);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Selects the active checkpoint history for a thread from the backing database.
+	 *
+	 * @param threadId thread name/id used by the concrete saver schema
+	 * @return checkpoint history in latest-first order
+	 * @throws Exception when the concrete saver cannot read checkpoint history
+	 */
+	protected abstract LinkedList<Checkpoint> selectCheckpoints(String threadId) throws Exception;
+
+	/**
+	 * Selects only the latest active checkpoint for a thread.
+	 *
+	 * @param threadId thread name/id used by the concrete saver schema
+	 * @return latest checkpoint when one exists
+	 * @throws Exception when the concrete saver cannot read the latest checkpoint
+	 */
+	protected abstract Optional<Checkpoint> selectLatestCheckpoint(String threadId) throws Exception;
+
+	/**
+	 * Selects an active checkpoint by id for a thread.
+	 *
+	 * @param threadId thread name/id used by the concrete saver schema
+	 * @param checkpointId checkpoint id to look up
+	 * @return matching checkpoint when one exists
+	 * @throws Exception when the concrete saver cannot read the checkpoint
+	 */
+	protected abstract Optional<Checkpoint> selectCheckpointById(String threadId, String checkpointId) throws Exception;
+
+	/**
+	 * Inserts a new active checkpoint for a thread.
+	 *
+	 * @param threadId thread name/id used by the concrete saver schema
+	 * @param checkpoint checkpoint to persist
+	 * @throws Exception when the concrete saver cannot insert the checkpoint
+	 */
+	protected abstract void insertCheckpoint(String threadId, Checkpoint checkpoint) throws Exception;
+
+	/**
+	 * Replaces an existing active checkpoint for a thread.
+	 *
+	 * @param threadId thread name/id used by the concrete saver schema
+	 * @param checkpointId checkpoint id to replace
+	 * @param checkpoint replacement checkpoint data
+	 * @throws Exception when the concrete saver cannot update the checkpoint
+	 */
+	protected abstract void updateCheckpoint(String threadId, String checkpointId, Checkpoint checkpoint) throws Exception;
+
+	/**
+	 * Marks the active thread as released in the backing database.
+	 *
+	 * @param threadId thread name/id used by the concrete saver schema
+	 * @throws Exception when the concrete saver cannot release the thread
+	 */
+	protected abstract void releaseThread(String threadId) throws Exception;
+
+	/**
+	 * Resolves the configured thread id, falling back to the default saver thread.
+	 *
+	 * @param config runnable config supplied by graph execution
+	 * @return configured thread id or {@link BaseCheckpointSaver#THREAD_ID_DEFAULT}
+	 */
+	private String threadId(RunnableConfig config) {
+		return config.threadId().orElse(THREAD_ID_DEFAULT);
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
@@ -15,10 +15,9 @@
  */
 package com.alibaba.cloud.ai.graph.checkpoint.savers.mysql;
 
-import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
-import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.jdbc.AbstractJdbcCheckpointSaver;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 
 import java.io.IOException;
@@ -28,15 +27,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Base64;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.sql.DataSource;
 
@@ -100,7 +95,7 @@ import static java.util.Objects.requireNonNull;
  * </pre>
  * </p>
  */
-public class MysqlSaver implements BaseCheckpointSaver {
+public class MysqlSaver extends AbstractJdbcCheckpointSaver {
 
 	private static final Logger log = LoggerFactory.getLogger(MysqlSaver.class);
 
@@ -222,10 +217,6 @@ public class MysqlSaver implements BaseCheckpointSaver {
 	private final CreateOption createOption;
 	private final StateSerializer stateSerializer;
 
-	private final Map<String, Checkpoint> latestCheckpointCache;
-	private final ReentrantLock lock = new ReentrantLock();
-	private final int maxCachedThreads;
-
 	/**
 	 * Private constructor used by the builder to create a new instance of
 	 * MysqlSaver.
@@ -233,11 +224,10 @@ public class MysqlSaver implements BaseCheckpointSaver {
 	 * @param builder the builder
 	 */
 	private MysqlSaver(Builder builder) {
+		super(builder.maxCachedThreads);
 		this.dataSource = builder.dataSource;
 		this.createOption = builder.createOption;
 		this.stateSerializer = builder.stateSerializer;
-		this.maxCachedThreads = builder.maxCachedThreads;
-		this.latestCheckpointCache = createLatestCheckpointCache(builder.maxCachedThreads);
 		initTables();
 	}
 
@@ -374,7 +364,8 @@ public class MysqlSaver implements BaseCheckpointSaver {
 	/**
 	 * Loads full checkpoint history on demand without retaining it in cache.
 	 */
-	private LinkedList<Checkpoint> selectCheckpoints(String threadName) throws Exception {
+	@Override
+	protected LinkedList<Checkpoint> selectCheckpoints(String threadName) throws Exception {
 		LinkedList<Checkpoint> checkpoints = new LinkedList<>();
 		try (Connection connection = dataSource.getConnection();
 				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINTS)) {
@@ -392,7 +383,8 @@ public class MysqlSaver implements BaseCheckpointSaver {
 		return checkpoints;
 	}
 
-	private Optional<Checkpoint> selectLatestCheckpoint(String threadName) throws Exception {
+	@Override
+	protected Optional<Checkpoint> selectLatestCheckpoint(String threadName) throws Exception {
 		try (Connection connection = dataSource.getConnection();
 				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_LATEST_CHECKPOINT)) {
 
@@ -409,7 +401,8 @@ public class MysqlSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private Optional<Checkpoint> selectCheckpointById(String threadName, String checkpointId) throws Exception {
+	@Override
+	protected Optional<Checkpoint> selectCheckpointById(String threadName, String checkpointId) throws Exception {
 		try (Connection connection = dataSource.getConnection();
 				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINT_BY_ID)) {
 
@@ -427,7 +420,8 @@ public class MysqlSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void insertCheckpoint(String threadName, Checkpoint checkpoint) throws Exception {
+	@Override
+	protected void insertCheckpoint(String threadName, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 		try (Connection ignored = conn = dataSource.getConnection()) {
 			conn.setAutoCommit(false);
@@ -457,7 +451,8 @@ public class MysqlSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void updateCheckpoint(String threadName, String checkpointId, Checkpoint checkpoint) throws Exception {
+	@Override
+	protected void updateCheckpoint(String threadName, String checkpointId, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 		try (Connection ignored = conn = dataSource.getConnection()) {
 			conn.setAutoCommit(false);
@@ -486,7 +481,8 @@ public class MysqlSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void releaseThread(String threadName) throws Exception {
+	@Override
+	protected void releaseThread(String threadName) throws Exception {
 		Connection conn = null;
 		try (Connection ignored = conn = dataSource.getConnection()) {
 			conn.setAutoCommit(false);
@@ -507,137 +503,6 @@ public class MysqlSaver implements BaseCheckpointSaver {
 			log.error("Error releasing thread {}", threadName, ex);
 			rollback(conn, threadName);
 			throw new Exception("Unable to release checkpoint", ex);
-		}
-	}
-
-	/**
-	 * Lists active checkpoints for the configured thread.
-	 */
-	@Override
-	public Collection<Checkpoint> list(RunnableConfig config) {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
-			if (!checkpoints.isEmpty()) {
-				cacheLatest(threadName, checkpoints.peek());
-			}
-			return Collections.unmodifiableCollection(checkpoints);
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Gets a checkpoint for the configured thread.
-	 */
-	@Override
-	public Optional<Checkpoint> get(RunnableConfig config) {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			if (config.checkPointId().isPresent()) {
-				return selectCheckpointById(threadName, config.checkPointId().get());
-			}
-
-			Optional<Checkpoint> cached = getCachedLatest(threadName);
-			if (cached.isPresent()) {
-				return cached;
-			}
-
-			Optional<Checkpoint> latest = selectLatestCheckpoint(threadName);
-			latest.ifPresent(checkpoint -> cacheLatest(threadName, checkpoint));
-			return latest;
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Inserts or updates a checkpoint.
-	 */
-	@Override
-	public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			if (config.checkPointId().isPresent()) {
-				String checkpointId = config.checkPointId().get();
-				updateCheckpoint(threadName, checkpointId, checkpoint);
-				getCachedLatest(threadName)
-						.filter(latest -> latest.getId().equals(checkpointId))
-						.ifPresent(latest -> cacheLatest(threadName, checkpoint));
-				return config;
-			}
-
-			insertCheckpoint(threadName, checkpoint);
-			cacheLatest(threadName, checkpoint);
-			return RunnableConfig.builder(config)
-					.checkPointId(checkpoint.getId())
-					.build();
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Releases the active thread and returns the released checkpoints.
-	 */
-	@Override
-	public Tag release(RunnableConfig config) throws Exception {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
-			releaseThread(threadName);
-			removeCachedLatest(threadName);
-			return new Tag(threadName, checkpoints);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Creates a bounded LRU cache for latest checkpoints.
-	 */
-	private static Map<String, Checkpoint> createLatestCheckpointCache(int maxCachedThreads) {
-		if (maxCachedThreads == 0) {
-			return Collections.emptyMap();
-		}
-		return new LinkedHashMap<>(16, 0.75f, true) {
-			@Override
-			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
-				return size() > maxCachedThreads;
-			}
-		};
-	}
-
-	private Optional<Checkpoint> getCachedLatest(String threadName) {
-		if (maxCachedThreads == 0) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(latestCheckpointCache.get(threadName));
-	}
-
-	private void cacheLatest(String threadName, Checkpoint checkpoint) {
-		if (maxCachedThreads > 0) {
-			latestCheckpointCache.put(threadName, checkpoint);
-		}
-	}
-
-	private void removeCachedLatest(String threadName) {
-		if (maxCachedThreads > 0) {
-			latestCheckpointCache.remove(threadName);
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/oracle/OracleSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/oracle/OracleSaver.java
@@ -15,10 +15,9 @@
  */
 package com.alibaba.cloud.ai.graph.checkpoint.savers.oracle;
 
-import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
-import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.jdbc.AbstractJdbcCheckpointSaver;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 
 import java.io.IOException;
@@ -29,16 +28,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Base64;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.sql.DataSource;
 
@@ -111,7 +106,7 @@ import static java.lang.String.format;
  * </pre>
  * </p>
  */
-public class OracleSaver implements BaseCheckpointSaver {
+public class OracleSaver extends AbstractJdbcCheckpointSaver {
 
 	private static final Logger log = LoggerFactory.getLogger(OracleSaver.class);
 
@@ -228,9 +223,6 @@ public class OracleSaver implements BaseCheckpointSaver {
 	private final DataSource dataSource;
 	private final CreateOption createOption;
 	private final StateSerializer stateSerializer;
-	private final Map<String, Checkpoint> latestCheckpointCache;
-	private final ReentrantLock lock = new ReentrantLock();
-	private final int maxCachedThreads;
 
 	/**
 	 * Private constructor used by the builder to create a new instance of
@@ -239,11 +231,10 @@ public class OracleSaver implements BaseCheckpointSaver {
 	 * @param builder the builder
 	 */
 	private OracleSaver(Builder builder) {
+		super(builder.maxCachedThreads);
 		this.dataSource = builder.dataSource;
 		this.createOption = builder.createOption;
 		this.stateSerializer = Objects.requireNonNull(builder.stateSerializer, "stateSerializer cannot be null");
-		this.maxCachedThreads = builder.maxCachedThreads;
-		this.latestCheckpointCache = createLatestCheckpointCache(builder.maxCachedThreads);
 		initTables();
 	}
 
@@ -374,7 +365,8 @@ public class OracleSaver implements BaseCheckpointSaver {
 	/**
 	 * Loads full checkpoint history on demand without retaining it in cache.
 	 */
-	private LinkedList<Checkpoint> selectCheckpoints(String threadName) throws Exception {
+	@Override
+	protected LinkedList<Checkpoint> selectCheckpoints(String threadName) throws Exception {
 		LinkedList<Checkpoint> checkpoints = new LinkedList<>();
 		ObjectMapper objectMapper = osonObjectMapper();
 		try (Connection connection = dataSource.getConnection();
@@ -394,7 +386,8 @@ public class OracleSaver implements BaseCheckpointSaver {
 		return checkpoints;
 	}
 
-	private Optional<Checkpoint> selectLatestCheckpoint(String threadName) throws Exception {
+	@Override
+	protected Optional<Checkpoint> selectLatestCheckpoint(String threadName) throws Exception {
 		ObjectMapper objectMapper = osonObjectMapper();
 		try (Connection connection = dataSource.getConnection();
 				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_LATEST_CHECKPOINT)) {
@@ -413,7 +406,8 @@ public class OracleSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private Optional<Checkpoint> selectCheckpointById(String threadName, String checkpointId) throws Exception {
+	@Override
+	protected Optional<Checkpoint> selectCheckpointById(String threadName, String checkpointId) throws Exception {
 		ObjectMapper objectMapper = osonObjectMapper();
 		try (Connection connection = dataSource.getConnection();
 				PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINT_BY_ID)) {
@@ -433,7 +427,8 @@ public class OracleSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void insertCheckpoint(String threadName, Checkpoint checkpoint) throws Exception {
+	@Override
+	protected void insertCheckpoint(String threadName, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 
 		try (Connection ignored = conn = dataSource.getConnection()) {
@@ -467,7 +462,8 @@ public class OracleSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void updateCheckpoint(String threadName, String checkpointId, Checkpoint checkpoint) throws Exception {
+	@Override
+	protected void updateCheckpoint(String threadName, String checkpointId, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 
 		try (Connection ignored = conn = dataSource.getConnection()) {
@@ -499,7 +495,8 @@ public class OracleSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void releaseThread(String threadName) throws Exception {
+	@Override
+	protected void releaseThread(String threadName) throws Exception {
 		Connection conn = null;
 
 		try (Connection ignored = conn = dataSource.getConnection()) {
@@ -547,137 +544,6 @@ public class OracleSaver implements BaseCheckpointSaver {
 		}
 		catch (SQLException sqlException) {
 			throw new RuntimeException("Unable to create tables", sqlException);
-		}
-	}
-
-	/**
-	 * Lists active checkpoints for the configured thread.
-	 */
-	@Override
-	public Collection<Checkpoint> list(RunnableConfig config) {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
-			if (!checkpoints.isEmpty()) {
-				cacheLatest(threadName, checkpoints.peek());
-			}
-			return Collections.unmodifiableCollection(checkpoints);
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Gets a checkpoint for the configured thread.
-	 */
-	@Override
-	public Optional<Checkpoint> get(RunnableConfig config) {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			if (config.checkPointId().isPresent()) {
-				return selectCheckpointById(threadName, config.checkPointId().get());
-			}
-
-			Optional<Checkpoint> cached = getCachedLatest(threadName);
-			if (cached.isPresent()) {
-				return cached;
-			}
-
-			Optional<Checkpoint> latest = selectLatestCheckpoint(threadName);
-			latest.ifPresent(checkpoint -> cacheLatest(threadName, checkpoint));
-			return latest;
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Inserts or updates a checkpoint.
-	 */
-	@Override
-	public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			if (config.checkPointId().isPresent()) {
-				String checkpointId = config.checkPointId().get();
-				updateCheckpoint(threadName, checkpointId, checkpoint);
-				getCachedLatest(threadName)
-						.filter(latest -> latest.getId().equals(checkpointId))
-						.ifPresent(latest -> cacheLatest(threadName, checkpoint));
-				return config;
-			}
-
-			insertCheckpoint(threadName, checkpoint);
-			cacheLatest(threadName, checkpoint);
-			return RunnableConfig.builder(config)
-					.checkPointId(checkpoint.getId())
-					.build();
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Releases the active thread and returns the released checkpoints.
-	 */
-	@Override
-	public Tag release(RunnableConfig config) throws Exception {
-		lock.lock();
-		try {
-			String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
-			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadName);
-			releaseThread(threadName);
-			removeCachedLatest(threadName);
-			return new Tag(threadName, checkpoints);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Creates a bounded LRU cache for latest checkpoints.
-	 */
-	private static Map<String, Checkpoint> createLatestCheckpointCache(int maxCachedThreads) {
-		if (maxCachedThreads == 0) {
-			return Collections.emptyMap();
-		}
-		return new LinkedHashMap<>(16, 0.75f, true) {
-			@Override
-			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
-				return size() > maxCachedThreads;
-			}
-		};
-	}
-
-	private Optional<Checkpoint> getCachedLatest(String threadName) {
-		if (maxCachedThreads == 0) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(latestCheckpointCache.get(threadName));
-	}
-
-	private void cacheLatest(String threadName, Checkpoint checkpoint) {
-		if (maxCachedThreads > 0) {
-			latestCheckpointCache.put(threadName, checkpoint);
-		}
-	}
-
-	private void removeCachedLatest(String threadName) {
-		if (maxCachedThreads > 0) {
-			latestCheckpointCache.remove(threadName);
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/postgresql/PostgresSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/postgresql/PostgresSaver.java
@@ -15,10 +15,9 @@
  */
 package com.alibaba.cloud.ai.graph.checkpoint.savers.postgresql;
 
-import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
-import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.jdbc.AbstractJdbcCheckpointSaver;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 
 import java.io.IOException;
@@ -29,16 +28,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.Base64;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.sql.DataSource;
 
@@ -104,7 +99,7 @@ import static java.util.Objects.requireNonNull;
  * </pre>
  * </p>
  */
-public class PostgresSaver implements BaseCheckpointSaver {
+public class PostgresSaver extends AbstractJdbcCheckpointSaver {
 
 	private static final Logger log = LoggerFactory.getLogger(PostgresSaver.class);
 
@@ -242,12 +237,6 @@ public class PostgresSaver implements BaseCheckpointSaver {
 
 	private final CreateOption createOption;
 
-	private final Map<String, Checkpoint> latestCheckpointCache;
-
-	private final ReentrantLock lock = new ReentrantLock();
-
-	private final int maxCachedThreads;
-
 	/**
 	 * Private constructor used by the builder to create a new instance of
 	 * PostgresSaver.
@@ -255,11 +244,10 @@ public class PostgresSaver implements BaseCheckpointSaver {
 	 * @param builder the builder
 	 */
 	private PostgresSaver(Builder builder) throws SQLException {
+		super(builder.maxCachedThreads);
 		this.datasource = builder.datasource;
 		this.stateSerializer = builder.stateSerializer;
 		this.createOption = builder.createOption;
-		this.maxCachedThreads = builder.maxCachedThreads;
-		this.latestCheckpointCache = createLatestCheckpointCache(builder.maxCachedThreads);
 		initTable(createOption);
 	}
 
@@ -361,7 +349,8 @@ public class PostgresSaver implements BaseCheckpointSaver {
 				.build();
 	}
 
-	private LinkedList<Checkpoint> selectCheckpoints(String threadId) throws Exception {
+	@Override
+	protected LinkedList<Checkpoint> selectCheckpoints(String threadId) throws Exception {
 		LinkedList<Checkpoint> checkpoints = new LinkedList<>();
 		try (Connection conn = getConnection();
 				PreparedStatement ps = conn.prepareStatement(SELECT_CHECKPOINTS)) {
@@ -380,7 +369,8 @@ public class PostgresSaver implements BaseCheckpointSaver {
 		return checkpoints;
 	}
 
-	private Optional<Checkpoint> selectLatestCheckpoint(String threadId) throws Exception {
+	@Override
+	protected Optional<Checkpoint> selectLatestCheckpoint(String threadId) throws Exception {
 		try (Connection conn = getConnection();
 				PreparedStatement ps = conn.prepareStatement(SELECT_LATEST_CHECKPOINT)) {
 
@@ -398,7 +388,8 @@ public class PostgresSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private Optional<Checkpoint> selectCheckpointById(String threadId, String checkpointId) throws Exception {
+	@Override
+	protected Optional<Checkpoint> selectCheckpointById(String threadId, String checkpointId) throws Exception {
 		try (Connection conn = getConnection();
 				PreparedStatement ps = conn.prepareStatement(SELECT_CHECKPOINT_BY_ID)) {
 
@@ -417,7 +408,8 @@ public class PostgresSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void insertCheckpoint(String threadId, Checkpoint checkpoint) throws Exception {
+	@Override
+	protected void insertCheckpoint(String threadId, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 		try (Connection ignored = conn = getConnection()) {
 			conn.setAutoCommit(false);
@@ -485,7 +477,8 @@ public class PostgresSaver implements BaseCheckpointSaver {
 
 	}
 
-	private void updateCheckpoint(String threadId, String checkpointId, Checkpoint checkpoint) throws Exception {
+	@Override
+	protected void updateCheckpoint(String threadId, String checkpointId, Checkpoint checkpoint) throws Exception {
 		Connection conn = null;
 		try (Connection ignored = conn = getConnection()) {
 			conn.setAutoCommit(false);
@@ -517,7 +510,8 @@ public class PostgresSaver implements BaseCheckpointSaver {
 		}
 	}
 
-	private void releaseThread(String threadId) throws Exception {
+	@Override
+	protected void releaseThread(String threadId) throws Exception {
 		Connection conn = null;
 		try (Connection ignored = conn = getConnection()) {
 			conn.setAutoCommit(false);
@@ -537,137 +531,6 @@ public class PostgresSaver implements BaseCheckpointSaver {
 			log.error("Error releasing thread {}", threadId, ex);
 			rollback(conn, threadId);
 			throw new Exception("Unable to release checkpoint", ex);
-		}
-	}
-
-	/**
-	 * Lists active checkpoints for the configured thread.
-	 */
-	@Override
-	public Collection<Checkpoint> list(RunnableConfig config) {
-		lock.lock();
-		try {
-			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadId);
-			if (!checkpoints.isEmpty()) {
-				cacheLatest(threadId, checkpoints.peek());
-			}
-			return Collections.unmodifiableCollection(checkpoints);
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Gets a checkpoint for the configured thread.
-	 */
-	@Override
-	public Optional<Checkpoint> get(RunnableConfig config) {
-		lock.lock();
-		try {
-			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-			if (config.checkPointId().isPresent()) {
-				return selectCheckpointById(threadId, config.checkPointId().get());
-			}
-
-			Optional<Checkpoint> cached = getCachedLatest(threadId);
-			if (cached.isPresent()) {
-				return cached;
-			}
-
-			Optional<Checkpoint> latest = selectLatestCheckpoint(threadId);
-			latest.ifPresent(checkpoint -> cacheLatest(threadId, checkpoint));
-			return latest;
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Inserts or updates a checkpoint.
-	 */
-	@Override
-	public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
-		lock.lock();
-		try {
-			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-			if (config.checkPointId().isPresent()) {
-				String checkpointId = config.checkPointId().get();
-				updateCheckpoint(threadId, checkpointId, checkpoint);
-				getCachedLatest(threadId)
-						.filter(latest -> latest.getId().equals(checkpointId))
-						.ifPresent(latest -> cacheLatest(threadId, checkpoint));
-				return config;
-			}
-
-			insertCheckpoint(threadId, checkpoint);
-			cacheLatest(threadId, checkpoint);
-			return RunnableConfig.builder(config)
-					.checkPointId(checkpoint.getId())
-					.build();
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Releases the active thread and returns the released checkpoints.
-	 */
-	@Override
-	public Tag release(RunnableConfig config) throws Exception {
-		lock.lock();
-		try {
-			var threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
-			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadId);
-			releaseThread(threadId);
-			removeCachedLatest(threadId);
-			return new Tag(threadId, checkpoints);
-		}
-		finally {
-			lock.unlock();
-		}
-	}
-
-	/**
-	 * Creates a bounded LRU cache for latest checkpoints.
-	 */
-	private static Map<String, Checkpoint> createLatestCheckpointCache(int maxCachedThreads) {
-		if (maxCachedThreads == 0) {
-			return Collections.emptyMap();
-		}
-		return new LinkedHashMap<>(16, 0.75f, true) {
-			@Override
-			protected boolean removeEldestEntry(Map.Entry<String, Checkpoint> eldest) {
-				return size() > maxCachedThreads;
-			}
-		};
-	}
-
-	private Optional<Checkpoint> getCachedLatest(String threadId) {
-		if (maxCachedThreads == 0) {
-			return Optional.empty();
-		}
-		return Optional.ofNullable(latestCheckpointCache.get(threadId));
-	}
-
-	private void cacheLatest(String threadId, Checkpoint checkpoint) {
-		if (maxCachedThreads > 0) {
-			latestCheckpointCache.put(threadId, checkpoint);
-		}
-	}
-
-	private void removeCachedLatest(String threadId) {
-		if (maxCachedThreads > 0) {
-			latestCheckpointCache.remove(threadId);
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCacheTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCacheTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers.common;
+
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LatestCheckpointCacheTest {
+
+	private static Checkpoint checkpoint(String value) {
+		return Checkpoint.builder()
+				.nodeId("node")
+				.nextNodeId("next")
+				.state(Map.of("value", value))
+				.build();
+	}
+
+	@Test
+	void shouldDisableCacheWhenMaxCachedThreadsIsZero() {
+		LatestCheckpointCache cache = new LatestCheckpointCache(0);
+		Checkpoint checkpoint = checkpoint("v1");
+
+		cache.put("thread-1", checkpoint);
+
+		assertTrue(cache.get("thread-1").isEmpty());
+	}
+
+	@Test
+	void shouldEvictLeastRecentlyUsedThread() {
+		LatestCheckpointCache cache = new LatestCheckpointCache(1);
+		Checkpoint firstCheckpoint = checkpoint("v1");
+		Checkpoint secondCheckpoint = checkpoint("v2");
+
+		cache.put("thread-1", firstCheckpoint);
+		cache.put("thread-2", secondCheckpoint);
+
+		assertTrue(cache.get("thread-1").isEmpty());
+		assertEquals(secondCheckpoint.getId(), cache.get("thread-2").orElseThrow().getId());
+	}
+
+	@Test
+	void shouldRejectNegativeMaxCachedThreads() {
+		assertThrows(IllegalArgumentException.class, () -> new LatestCheckpointCache(-1));
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaverTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers.jdbc;
+
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractJdbcCheckpointSaverTest {
+
+	@Test
+	void shouldCacheLatestCheckpointAndReloadEvictedThread() throws Exception {
+		var saver = new FakeJdbcCheckpointSaver(2);
+		var firstCheckpoint = checkpoint("first");
+		var firstConfig = config("thread-1");
+
+		saver.put(firstConfig, firstCheckpoint);
+		saver.put(config("thread-2"), checkpoint("second"));
+		saver.put(config("thread-3"), checkpoint("third"));
+
+		var reloaded = saver.get(firstConfig);
+
+		assertTrue(reloaded.isPresent());
+		assertEquals(firstCheckpoint.getId(), reloaded.get().getId());
+		assertEquals(1, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldBypassLatestCacheWhenCheckpointIdIsProvided() throws Exception {
+		var saver = new FakeJdbcCheckpointSaver(16);
+		String threadId = "thread-by-id";
+		var firstCheckpoint = checkpoint("first");
+		var secondCheckpoint = checkpoint("second");
+
+		saver.put(config(threadId), firstCheckpoint);
+		saver.put(config(threadId), secondCheckpoint);
+
+		var first = saver.get(config(threadId, firstCheckpoint.getId()));
+
+		assertTrue(first.isPresent());
+		assertEquals(firstCheckpoint.getId(), first.get().getId());
+		assertEquals(1, saver.checkpointByIdSelects);
+		assertEquals(0, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldRefreshLatestCacheWhenLatestCheckpointIsUpdated() throws Exception {
+		var saver = new FakeJdbcCheckpointSaver(16);
+		String threadId = "thread-update";
+		var originalCheckpoint = checkpoint("original");
+		var updatedCheckpoint = checkpoint("updated");
+		var checkpointConfig = saver.put(config(threadId), originalCheckpoint);
+
+		saver.put(checkpointConfig, updatedCheckpoint);
+		var latest = saver.get(config(threadId));
+
+		assertTrue(latest.isPresent());
+		assertEquals(updatedCheckpoint.getId(), latest.get().getId());
+		assertEquals(0, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldClearLatestCacheWhenThreadIsReleased() throws Exception {
+		var saver = new FakeJdbcCheckpointSaver(16);
+		String threadId = "thread-release";
+		saver.put(config(threadId), checkpoint("released"));
+
+		var released = saver.release(config(threadId));
+		var latest = saver.get(config(threadId));
+
+		assertEquals(threadId, released.threadId());
+		assertEquals(1, released.checkpoints().size());
+		assertTrue(latest.isEmpty());
+		assertEquals(1, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldDisableLatestCacheWhenMaxCachedThreadsIsZero() throws Exception {
+		var saver = new FakeJdbcCheckpointSaver(0);
+		String threadId = "thread-no-cache";
+		var checkpoint = checkpoint("latest");
+		saver.put(config(threadId), checkpoint);
+
+		saver.get(config(threadId));
+		saver.get(config(threadId));
+
+		assertEquals(2, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldRejectNegativeMaxCachedThreads() {
+		assertThrows(IllegalArgumentException.class, () -> new FakeJdbcCheckpointSaver(-1));
+	}
+
+	private static RunnableConfig config(String threadId) {
+		return RunnableConfig.builder().threadId(threadId).build();
+	}
+
+	private static RunnableConfig config(String threadId, String checkpointId) {
+		return RunnableConfig.builder().threadId(threadId).checkPointId(checkpointId).build();
+	}
+
+	private static Checkpoint checkpoint(String value) {
+		return Checkpoint.builder()
+				.id(UUID.randomUUID().toString())
+				.nodeId("node")
+				.nextNodeId("next")
+				.state(Map.of("value", value))
+				.build();
+	}
+
+	private static final class FakeJdbcCheckpointSaver extends AbstractJdbcCheckpointSaver {
+
+		private final Map<String, LinkedList<Checkpoint>> checkpoints = new HashMap<>();
+
+		private final Set<String> releasedThreads = new HashSet<>();
+
+		private int latestCheckpointSelects;
+
+		private int checkpointByIdSelects;
+
+		private FakeJdbcCheckpointSaver(int maxCachedThreads) {
+			super(maxCachedThreads);
+		}
+
+		@Override
+		protected LinkedList<Checkpoint> selectCheckpoints(String threadId) {
+			if (releasedThreads.contains(threadId)) {
+				return new LinkedList<>();
+			}
+			return new LinkedList<>(checkpoints.getOrDefault(threadId, new LinkedList<>()));
+		}
+
+		@Override
+		protected Optional<Checkpoint> selectLatestCheckpoint(String threadId) {
+			latestCheckpointSelects++;
+			return selectCheckpoints(threadId).stream().findFirst();
+		}
+
+		@Override
+		protected Optional<Checkpoint> selectCheckpointById(String threadId, String checkpointId) {
+			checkpointByIdSelects++;
+			return selectCheckpoints(threadId).stream()
+					.filter(checkpoint -> checkpoint.getId().equals(checkpointId))
+					.findFirst();
+		}
+
+		@Override
+		protected void insertCheckpoint(String threadId, Checkpoint checkpoint) {
+			checkpoints.computeIfAbsent(threadId, key -> new LinkedList<>()).addFirst(checkpoint);
+		}
+
+		@Override
+		protected void updateCheckpoint(String threadId, String checkpointId, Checkpoint checkpoint) {
+			LinkedList<Checkpoint> history = checkpoints.getOrDefault(threadId, new LinkedList<>());
+			for (int i = 0; i < history.size(); i++) {
+				if (history.get(i).getId().equals(checkpointId)) {
+					history.set(i, checkpoint);
+					return;
+				}
+			}
+			throw new NoSuchElementException("Checkpoint with id %s not found!".formatted(checkpointId));
+		}
+
+		@Override
+		protected void releaseThread(String threadId) {
+			releasedThreads.add(threadId);
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Describe what this PR does / why we need it

跟进 #4628。

前面几个 PR 已经分别处理了 MysqlSaver、PostgresSaver、OracleSaver 和 FileSystemSaver 长期持有完整 checkpoint history 的问题。修复后的共同语义是：持久化介质作为完整 history 的数据源，JVM 内存只保留一个有上限的 latest checkpoint cache。

这个 PR 继续把这类 saver 的公共逻辑往上抽：将 latest-checkpoint cache 封装为公共组件，并把 MySQL、PostgreSQL、Oracle 三个 JDBC saver 里重复的 `list/get/put/release` 流程收敛到 `AbstractJdbcCheckpointSaver`。数据库方言、SQL、事务和行映射仍然留在各自 saver 里。

## Does this pull request fix one issue?

Related to #4608

## Describe how you did it

* 新增 `LatestCheckpointCache`，统一封装 latest checkpoint 的 bounded LRU cache 语义。
* 新增 `AbstractJdbcCheckpointSaver`，承载 JDBC saver 共有的 `list/get/put/release` 生命周期流程。
* `MysqlSaver`、`PostgresSaver`、`OracleSaver` 改为继承 `AbstractJdbcCheckpointSaver`。
* 保留各数据库自己的 SQL、transaction handling、parameter binding 和 `ResultSet` mapping，避免把方言差异抽象过度。
* 补充 `LatestCheckpointCacheTest` 和 `AbstractJdbcCheckpointSaverTest`，覆盖 cache 禁用、LRU 淘汰、显式 checkpoint id 查询、latest 更新和 release 清 cache 等边界。

## Describe how to verify it

* `JAVA_HOME=/Users/viperthanks/.sdkman/candidates/java/17.0.17-tem ./mvnw -pl spring-ai-alibaba-graph-core -Dtest=LatestCheckpointCacheTest,AbstractJdbcCheckpointSaverTest test`
* `JAVA_HOME=/Users/viperthanks/.sdkman/candidates/java/17.0.17-tem ./mvnw -pl spring-ai-alibaba-graph-core -Dtest=LatestCheckpointCacheTest,AbstractJdbcCheckpointSaverTest,FileSystemSaverCacheTest test`

## Special notes for reviews

这次不改变 MySQL、PostgreSQL、Oracle 的表结构、SQL 查询语义和持久化格式，只抽取三个 JDBC saver 已经一致的运行时流程。

完整 checkpoint history 仍然来自数据库，latest checkpoint cache 仍然只是 bounded in-memory cache。带 checkpoint id 的 `get(config)` 仍然直接查数据库，不走 latest cache。

当前进度：

* MySQL Saver: #4609
* PostgreSQL Saver: #4612
* Oracle Saver: #4621
* FileSystem Saver: #4628
* Extract shared latest-checkpoint cache and JDBC saver flow: this PR
* H2 Saver coverage
* SQL Server Saver
* Documentation and examples

如果这个抽象边界不符合项目预期，欢迎指出，我会及时调整。