### PR TITLE
fix(graph): merge parallel graph flux done state

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -727,9 +727,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 				return;
 			}
 
-			// Apply mapResult function if available
-			Map<String, Object> resultMap = new HashMap<>();
-			resultMap.put(graphFlux.getKey(), lastData);
+			// Resolve the final GraphFlux result into a graph state update.
+			Map<String, Object> resultMap = graphFluxResultState(graphFlux, lastData);
 
 			// Merge non-GraphFlux state
 			Map<String, Object> partialStateWithoutGraphFlux = partialState.entrySet()
@@ -763,6 +762,40 @@ public class NodeExecutor extends BaseGraphExecutor {
 
 		return processedFlux
 				.concatWith(updateContextMono.thenMany(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue))));
+	}
+
+	private Map<String, Object> graphFluxResultState(GraphFlux<?> graphFlux, Object lastData) {
+		if (lastData instanceof GraphResponse<?> graphResponse) {
+			Optional<Object> resultValue = graphResponse.resultValue();
+			if (resultValue.isPresent()) {
+				Object value = resultValue.get();
+				if (value instanceof Map<?, ?> resultMap) {
+					return copyStateMap(resultMap);
+				}
+				Map<String, Object> state = new HashMap<>();
+				state.put(graphFluxStateKey(graphFlux), value);
+				return state;
+			}
+		}
+
+		Map<String, Object> state = new HashMap<>();
+		state.put(graphFluxStateKey(graphFlux), lastData);
+		return state;
+	}
+
+	private static String graphFluxStateKey(GraphFlux<?> graphFlux) {
+		return StringUtils.hasText(graphFlux.getKey()) ? graphFlux.getKey() : "result";
+	}
+
+	private static Map<String, Object> copyStateMap(Map<?, ?> resultMap) {
+		Map<String, Object> state = new HashMap<>();
+		for (Map.Entry<?, ?> entry : resultMap.entrySet()) {
+			if (!(entry.getKey() instanceof String key)) {
+				throw new IllegalArgumentException("GraphFlux done result map keys must be String");
+			}
+			state.put(key, entry.getValue());
+		}
+		return state;
 	}
 
 	/**
@@ -847,7 +880,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 				String nodeId = graphFlux.getNodeId();
 				Object nodeData = nodeDataRefs.get(nodeId).get();
 
-				combinedResultMap.put(graphFlux.getKey(),nodeData);
+				combinedResultMap = OverAllState.updateState(
+						combinedResultMap, graphFluxResultState(graphFlux, nodeData), context.getKeyStrategyMap());
 			}
 
 			// Merge non-ParallelGraphFlux state
@@ -910,4 +944,3 @@ public class NodeExecutor extends BaseGraphExecutor {
 				.concatWith(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue)));
 	}
 }
-

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -772,9 +772,6 @@ public class NodeExecutor extends BaseGraphExecutor {
 				if (value instanceof Map<?, ?> resultMap) {
 					return copyStateMap(resultMap);
 				}
-				Map<String, Object> state = new HashMap<>();
-				state.put(graphFluxStateKey(graphFlux), value);
-				return state;
 			}
 		}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/ParallelGraphFluxStateMergeTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/ParallelGraphFluxStateMergeTest.java
@@ -53,6 +53,16 @@ public class ParallelGraphFluxStateMergeTest {
 		assertEquals(List.of("left", "right"), finalState.value("join_results", List.of()));
 	}
 
+	@Test
+	void testParallelGraphFluxDoneNonMapKeepsGraphResponseState() throws Exception {
+		CompiledGraph graph = buildGraphWithNonMapDoneValue();
+
+		OverAllState finalState = graph.invoke(Map.of()).orElseThrow();
+
+		assertEquals("left-token", finalState.value("join_left_payload", ""));
+		assertEquals("right", finalState.value("join_right", ""));
+	}
+
 	private static CompiledGraph buildGraph() throws Exception {
 		StateGraph stateGraph = new StateGraph(() -> {
 			Map<String, KeyStrategy> strategies = new HashMap<>();
@@ -78,6 +88,33 @@ public class ParallelGraphFluxStateMergeTest {
 						"join_left", state.value("left_result", ""),
 						"join_right", state.value("right_result", ""),
 						"join_results", state.value("parallel_results", List.of()));
+			}))
+			.addEdge(START, "left")
+			.addEdge(START, "right")
+			.addEdge("left", "join")
+			.addEdge("right", "join")
+			.addEdge("join", END);
+		return stateGraph.compile();
+	}
+
+	private static CompiledGraph buildGraphWithNonMapDoneValue() throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("left_stream", new ReplaceStrategy());
+			strategies.put("right_result", new ReplaceStrategy());
+			strategies.put("join_left_payload", new ReplaceStrategy());
+			strategies.put("join_right", new ReplaceStrategy());
+			return strategies;
+		}).addNode("left", node_async(state -> Map.of("left_stream",
+				Flux.just(GraphResponse.done("left-token")))))
+			.addNode("right", node_async(state -> Map.of("right_stream",
+					Flux.just(GraphResponse.done(Map.of("right_result", "right"))))))
+			.addNode("join", node_async(state -> {
+				GraphResponse<?> leftResponse = assertInstanceOf(
+						GraphResponse.class, state.value("left_stream", Object.class).orElseThrow());
+				return Map.of(
+						"join_left_payload", leftResponse.resultValue().orElse(""),
+						"join_right", state.value("right_result", ""));
 			}))
 			.addEdge(START, "left")
 			.addEdge(START, "right")

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/ParallelGraphFluxStateMergeTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/ParallelGraphFluxStateMergeTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.executor;
+
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.GraphResponse;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import reactor.core.publisher.Flux;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Verifies that parallel streaming branches merge their {@link GraphResponse#done(Object)}
+ * state updates before the converged node runs.
+ */
+public class ParallelGraphFluxStateMergeTest {
+
+	@Test
+	void testParallelGraphFluxDoneMapIsMergedBeforeJoinNode() throws Exception {
+		CompiledGraph graph = buildGraph();
+
+		OverAllState finalState = graph.invoke(Map.of()).orElseThrow();
+
+		assertEquals("left", finalState.value("join_left", ""));
+		assertEquals("right", finalState.value("join_right", ""));
+		assertEquals(List.of("left", "right"), finalState.value("join_results", List.of()));
+	}
+
+	private static CompiledGraph buildGraph() throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("left_result", new ReplaceStrategy());
+			strategies.put("right_result", new ReplaceStrategy());
+			strategies.put("parallel_results", new AppendStrategy());
+			strategies.put("join_left", new ReplaceStrategy());
+			strategies.put("join_right", new ReplaceStrategy());
+			strategies.put("join_results", new ReplaceStrategy());
+			return strategies;
+		}).addNode("left", node_async(state -> Map.of("left_stream", Flux.just(
+				GraphResponse.done(Map.of(
+						"left_result", "left",
+						"parallel_results", List.of("left")))))))
+			.addNode("right", node_async(state -> Map.of("right_stream", Flux.just(
+					GraphResponse.done(Map.of(
+							"right_result", "right",
+							"parallel_results", List.of("right")))))))
+			.addNode("join", node_async(state -> {
+				assertInstanceOf(String.class, state.value("left_result", ""));
+				assertInstanceOf(String.class, state.value("right_result", ""));
+				return Map.of(
+						"join_left", state.value("left_result", ""),
+						"join_right", state.value("right_result", ""),
+						"join_results", state.value("parallel_results", List.of()));
+			}))
+			.addEdge(START, "left")
+			.addEdge(START, "right")
+			.addEdge("left", "join")
+			.addEdge("right", "join")
+			.addEdge("join", END);
+		return stateGraph.compile();
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Parallel graph streams can finish with `GraphResponse.done(Map<String, Object>)` to publish final state updates from a streaming branch. `NodeExecutor` currently stores the last `GraphResponse` object under the `GraphFlux` key when handling `GraphFlux` and `ParallelGraphFlux`, so the done-state map is not merged into graph state before the converged node runs.

This PR unwraps done-state maps from graph flux results and merges them through the configured key strategies, while preserving the existing fallback behavior for non-map result values.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Unwrap `GraphResponse.done(Map<String, Object>)` results from `GraphFlux` before merging state.
- Apply the same result normalization to both single `GraphFlux` and `ParallelGraphFlux` handling.
- Merge parallel branch done-state maps with the graph key strategies, so shared keys still honor strategies such as `AppendStrategy`.
- Keep non-map graph flux results under the existing graph flux state key.
- Add unit coverage for parallel streaming branches whose done maps must be visible to the converged node.

### Describe how to verify it

- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=ParallelGraphFluxStateMergeTest test`
- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=ParallelGraphFluxStateMergeTest,GraphNodeStreamFinishedTest test`
- `./mvnw -pl spring-ai-alibaba-graph-core test`
- `git diff --check`

### Special notes for reviews

The change only unwraps explicit `GraphResponse.done(Map)` completion state. Streaming chunks are still forwarded as before, and non-map completion values continue to be stored under the graph flux key.