### PR TITLE
fix(agent): Drain completed A2A generator futures iteratively

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
@@ -144,54 +144,67 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 	}
 
 	private <E> void drainGenerator(AsyncGenerator<E> generator, FluxSink<GraphResponse<E>> sink) {
-		if (sink.isCancelled()) {
-			return;
-		}
+		while (!sink.isCancelled()) {
+			final AsyncGenerator.Data<E> data;
+			try {
+				data = generator.next();
+			}
+			catch (Exception ex) {
+				sink.error(ex);
+				return;
+			}
 
-		final AsyncGenerator.Data<E> data;
-		try {
-			data = generator.next();
-		}
-		catch (Exception ex) {
-			sink.error(ex);
-			return;
-		}
-
-		if (data.isDone()) {
-			data.resultValue().ifPresent(result -> {
+			if (data.isDone()) {
+				data.resultValue().ifPresent(result -> {
+					if (!sink.isCancelled()) {
+						sink.next(GraphResponse.done(result));
+					}
+				});
 				if (!sink.isCancelled()) {
-					sink.next(GraphResponse.done(result));
+					sink.complete();
 				}
+				return;
+			}
+
+			var future = data.getData();
+			if (future == null) {
+				sink.error(new IllegalStateException("AsyncGenerator data is null without completion signal"));
+				return;
+			}
+
+			if (future.isDone()) {
+				try {
+					E value = future.join();
+					if (!sink.isCancelled()) {
+						sink.next(GraphResponse.of(value));
+					}
+				}
+				catch (Exception ex) {
+					sink.error(unwrapCompletionException(ex));
+					return;
+				}
+				continue;
+			}
+
+			future.whenComplete((value, throwable) -> {
+				if (sink.isCancelled()) {
+					return;
+				}
+
+				if (throwable != null) {
+					Throwable actual = unwrapCompletionException(throwable);
+					sink.error(actual);
+					return;
+				}
+
+				if (!sink.isCancelled()) {
+					sink.next(GraphResponse.of(value));
+				}
+
+				drainGenerator(generator, sink);
 			});
-			if (!sink.isCancelled()) {
-				sink.complete();
-			}
 			return;
 		}
-
-		var future = data.getData();
-		if (future == null) {
-			sink.error(new IllegalStateException("AsyncGenerator data is null without completion signal"));
-			return;
-		}
-
-		future.whenComplete((value, throwable) -> {
-			if (sink.isCancelled()) {
-				return;
-			}
-
-			if (throwable != null) {
-				Throwable actual = unwrapCompletionException(throwable);
-				sink.error(actual);
-				return;
-			}
-
-			if (!sink.isCancelled()) {
-				sink.next(GraphResponse.of(value));
-			}
-
-			drainGenerator(generator, sink);
-		});
 	}
 
 	private Throwable unwrapCompletionException(Throwable throwable) {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfigTests.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfigTests.java
@@ -87,6 +87,33 @@ class A2aNodeActionWithConfigTests {
 	}
 
 	@Test
+	void toFluxDrainsCompletedFuturesWithoutRecursiveStackGrowth() throws Exception {
+		int count = 20_000;
+		AsyncGenerator<NodeOutput> generator = new AsyncGenerator<>() {
+			private final AtomicInteger index = new AtomicInteger();
+
+			@Override
+			public Data<NodeOutput> next() {
+				int step = index.getAndIncrement();
+				if (step < count) {
+					return Data.of(NodeOutput.of("node-" + step, "", new OverAllState(), new EmptyUsage()));
+				}
+				return Data.done(Map.of("result", "ok"));
+			}
+		};
+
+		Flux<GraphResponse<NodeOutput>> flux = invokeToFlux(generator);
+
+		List<GraphResponse<NodeOutput>> responses = flux.collectList().block(Duration.ofSeconds(5));
+
+		assertNotNull(responses);
+		assertEquals(count + 1, responses.size());
+		assertEquals("node-0", responses.get(0).getOutput().getNow(null).node());
+		assertEquals("node-" + (count - 1), responses.get(count - 1).getOutput().getNow(null).node());
+		assertTrue(responses.get(count).isDone());
+	}
+
+	@Test
 	void toFluxPropagatesErrors() throws Exception {
 		AsyncGenerator<NodeOutput> generator = new AsyncGenerator<>() {
 			private final AtomicInteger index = new AtomicInteger();


### PR DESCRIPTION
### Describe what this PR does / why we need it

`A2aNodeActionWithConfig#drainGenerator` currently calls itself again from the `CompletableFuture.whenComplete` callback after each emitted item. When an `AsyncGenerator` returns many already-completed futures, each `whenComplete` callback is invoked immediately, so the recursive drain can grow the call stack with the number of ready chunks.

This PR drains already-completed futures with a loop and only keeps the callback path for futures that are still pending.

### Does this pull request fix one issue?

Fixes #4624

### Describe how you did it

- Changed `drainGenerator` to loop while the next future is already completed.
- Preserved the existing async callback behavior when the next future is still pending.
- Kept cancellation, error propagation, and completion handling aligned with the previous behavior.
- Added a regression test that drains 20,000 completed futures through `toFlux`.

### Describe how to verify it

```bash
./mvnw -pl spring-ai-alibaba-agent-framework -am -Dtest=A2aNodeActionWithConfigTests test
git diff --check
```

### Special notes for reviews

The first focused test attempt without `-am` failed during module compilation because `spring-ai-alibaba-agent-framework` resolved stale `spring-ai-alibaba-graph-core` APIs from the local Maven cache. Running the same focused test with `-am` builds the dependent graph-core module from the current checkout and passes.
