### PR TITLE
fix(agent): parent-thread resume for ReactAgent / SubCompiled / A2a s…

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -50,12 +50,12 @@ import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.internal.node.Node;
 import com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction;
+import com.alibaba.cloud.ai.graph.internal.node.SubGraphRunnableConfigBridge;
 import com.alibaba.cloud.ai.graph.serializer.AgentInstructionMessage;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
 import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
-import com.alibaba.cloud.ai.graph.utils.TypeRef;
 
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -91,7 +91,6 @@ import static com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig.node_a
 import static com.alibaba.cloud.ai.graph.agent.hook.InterruptionHook.INTERRUPTION_FEEDBACK_KEY;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
-import static java.lang.String.format;
 
 
 public class ReactAgent extends BaseAgent {
@@ -1001,28 +1000,27 @@ public class ReactAgent extends BaseAgent {
 
 		@Override
 		public Map<String, Object> apply(OverAllState parentState, RunnableConfig config) throws Exception {
-			final boolean resumeSubgraph = config.metadata(resumeSubGraphId(nodeId), new TypeRef<Boolean>() {}).orElse(false);
-
-			RunnableConfig subGraphRunnableConfig = getSubGraphRunnableConfig(config);
-			Flux<GraphResponse<NodeOutput>> subGraphResult;
-			Object parentMessages = null;
-
 			// Instruction is always injected by InstructionAgentHook in beforeAgent; do not add here
+			Map<String, Object> stateForChild;
 			if (includeContents) {
-				Map<String, Object> stateForChild = new HashMap<>(parentState.data());
+				stateForChild = new HashMap<>(parentState.data());
 				List<Object> newMessages;
 				if (stateForChild.get("messages") != null) {
-					newMessages = new ArrayList<>((List<Object>)stateForChild.remove("messages"));
-				} else {
+					newMessages = new ArrayList<>((List<Object>) stateForChild.remove("messages"));
+				}
+				else {
 					newMessages = new ArrayList<>();
 				}
 				stateForChild.put("messages", newMessages);
-				subGraphResult = childGraph.graphResponseStream(stateForChild, subGraphRunnableConfig);
-			} else {
-				Map<String, Object> stateForChild = new HashMap<>(parentState.data());
-				parentMessages = stateForChild.remove("messages");
-				subGraphResult = childGraph.graphResponseStream(stateForChild, subGraphRunnableConfig);
 			}
+			else {
+				stateForChild = new HashMap<>(parentState.data());
+				stateForChild.remove("messages");
+			}
+
+			RunnableConfig subGraphRunnableConfig = resolveSubGraphRunnableConfig(config, stateForChild);
+			Flux<GraphResponse<NodeOutput>> subGraphResult = childGraph.graphResponseStream(stateForChild,
+					subGraphRunnableConfig);
 
 			Map<String, Object> result = new HashMap<>();
 
@@ -1102,35 +1100,30 @@ public class ReactAgent extends BaseAgent {
 			return lastResponse;
 		}
 
+		/**
+		 * Bridges parent resume into the child Agent graph. {@link #getSubGraphRunnableConfig} strips
+		 * parent resume markers; {@link SubGraphRunnableConfigBridge#resolveForCompiledChildResume}
+		 * restores child position only when a child checkpoint exists; {@link SubGraphRunnableConfigBridge#withInterruptionMetadataForHooks}
+		 * forwards {@link com.alibaba.cloud.ai.graph.action.InterruptionMetadata} for HITL hooks only
+		 * (not {@code resume()} placeholder).
+		 */
+		private RunnableConfig resolveSubGraphRunnableConfig(RunnableConfig parentConfig,
+				Map<String, Object> stateForChild) throws Exception {
+			RunnableConfig subGraphRunnableConfig = getSubGraphRunnableConfig(parentConfig);
+			subGraphRunnableConfig = SubGraphRunnableConfigBridge.resolveForCompiledChildResume(stateForChild, childGraph,
+					subGraphRunnableConfig);
+			return SubGraphRunnableConfigBridge.withInterruptionMetadataForHooks(parentConfig,
+					subGraphRunnableConfig);
+		}
+
 		private RunnableConfig getSubGraphRunnableConfig(RunnableConfig config) {
-			RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config)
-					.checkPointId(null)
-					.nextNode(null)
-					.addMetadata("_AGENT_", subGraphId(nodeId)) // subGraphId is the same as the name of the agent that created it
+			RunnableConfig subGraphRunnableConfig = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(config,
+					nodeId, parentCompileConfig, childGraph.compileConfig);
+			RunnableConfig withAgentName = RunnableConfig.builder(subGraphRunnableConfig)
+					.addMetadata(RunnableConfig.AGENT_NAME_KEY, subGraphId(nodeId))
 					.build();
-			subGraphRunnableConfig.clearContext();
-			var parentSaver = parentCompileConfig.checkpointSaver();
-			var subGraphSaver = childGraph.compileConfig.checkpointSaver();
-
-			if (subGraphSaver.isPresent()) {
-				if (parentSaver.isEmpty()) {
-					throw new IllegalStateException("Missing CheckpointSaver in parent graph!");
-				}
-
-				// Check saver are the same instance
-				if (parentSaver.get() == subGraphSaver.get()) {
-					subGraphRunnableConfig = RunnableConfig.builder(config)
-							.threadId(config.threadId()
-									.map(threadId -> format("%s_%s", threadId, subGraphId(nodeId)))
-									.orElseGet(() -> subGraphId(nodeId)))
-							.nextNode(null)
-							.checkPointId(null)
-							.addMetadata("_AGENT_", subGraphId(nodeId)) // subGraphId is the same as the name of the agent that created it
-							.build();
-					subGraphRunnableConfig.clearContext();
-				}
-			}
-			return subGraphRunnableConfig;
+			withAgentName.clearContext();
+			return withAgentName;
 		}
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -50,12 +50,12 @@ import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.internal.node.Node;
 import com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction;
+import com.alibaba.cloud.ai.graph.internal.node.SubGraphRunnableConfigBridge;
 import com.alibaba.cloud.ai.graph.serializer.AgentInstructionMessage;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
 import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
-import com.alibaba.cloud.ai.graph.utils.TypeRef;
 
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -91,7 +91,6 @@ import static com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig.node_a
 import static com.alibaba.cloud.ai.graph.agent.hook.InterruptionHook.INTERRUPTION_FEEDBACK_KEY;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
-import static java.lang.String.format;
 
 
 public class ReactAgent extends BaseAgent {
@@ -1001,28 +1000,27 @@ public class ReactAgent extends BaseAgent {
 
 		@Override
 		public Map<String, Object> apply(OverAllState parentState, RunnableConfig config) throws Exception {
-			final boolean resumeSubgraph = config.metadata(resumeSubGraphId(nodeId), new TypeRef<Boolean>() {}).orElse(false);
-
-			RunnableConfig subGraphRunnableConfig = getSubGraphRunnableConfig(config);
-			Flux<GraphResponse<NodeOutput>> subGraphResult;
-			Object parentMessages = null;
-
 			// Instruction is always injected by InstructionAgentHook in beforeAgent; do not add here
+			Map<String, Object> stateForChild;
 			if (includeContents) {
-				Map<String, Object> stateForChild = new HashMap<>(parentState.data());
+				stateForChild = new HashMap<>(parentState.data());
 				List<Object> newMessages;
 				if (stateForChild.get("messages") != null) {
-					newMessages = new ArrayList<>((List<Object>)stateForChild.remove("messages"));
-				} else {
+					newMessages = new ArrayList<>((List<Object>) stateForChild.remove("messages"));
+				}
+				else {
 					newMessages = new ArrayList<>();
 				}
 				stateForChild.put("messages", newMessages);
-				subGraphResult = childGraph.graphResponseStream(stateForChild, subGraphRunnableConfig);
-			} else {
-				Map<String, Object> stateForChild = new HashMap<>(parentState.data());
-				parentMessages = stateForChild.remove("messages");
-				subGraphResult = childGraph.graphResponseStream(stateForChild, subGraphRunnableConfig);
 			}
+			else {
+				stateForChild = new HashMap<>(parentState.data());
+				stateForChild.remove("messages");
+			}
+
+			RunnableConfig subGraphRunnableConfig = resolveSubGraphRunnableConfig(config, stateForChild);
+			Flux<GraphResponse<NodeOutput>> subGraphResult = childGraph.graphResponseStream(stateForChild,
+					subGraphRunnableConfig);
 
 			Map<String, Object> result = new HashMap<>();
 
@@ -1102,35 +1100,30 @@ public class ReactAgent extends BaseAgent {
 			return lastResponse;
 		}
 
+		/**
+		 * Bridges parent resume into the child Agent graph. {@link #getSubGraphRunnableConfig}
+		 * strips parent resume markers; {@link SubGraphRunnableConfigBridge#resolveForCompiledChildResume}
+		 * restores child position only when parent is resuming and a child checkpoint exists, and
+		 * forwards {@link com.alibaba.cloud.ai.graph.action.InterruptionMetadata} only in that case
+		 * (never the {@code resume()} placeholder onto a cold child).
+		 */
+		private RunnableConfig resolveSubGraphRunnableConfig(RunnableConfig parentConfig,
+				Map<String, Object> stateForChild) throws Exception {
+			RunnableConfig subGraphRunnableConfig = getSubGraphRunnableConfig(parentConfig);
+			return SubGraphRunnableConfigBridge.resolveForCompiledChildResume(stateForChild, childGraph,
+					subGraphRunnableConfig, parentConfig, nodeId);
+		}
+
 		private RunnableConfig getSubGraphRunnableConfig(RunnableConfig config) {
-			RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config)
-					.checkPointId(null)
-					.nextNode(null)
-					.addMetadata("_AGENT_", subGraphId(nodeId)) // subGraphId is the same as the name of the agent that created it
+			RunnableConfig subGraphRunnableConfig = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(config,
+					nodeId, parentCompileConfig, childGraph.compileConfig);
+			// React path clears run-scoped context; compiled SubCompiled path keeps the
+			// parent context copy (#4645) — do not move clearContext into the Bridge.
+			RunnableConfig withAgentName = RunnableConfig.builder(subGraphRunnableConfig)
+					.addMetadata(RunnableConfig.AGENT_NAME_KEY, subGraphId(nodeId))
 					.build();
-			subGraphRunnableConfig.clearContext();
-			var parentSaver = parentCompileConfig.checkpointSaver();
-			var subGraphSaver = childGraph.compileConfig.checkpointSaver();
-
-			if (subGraphSaver.isPresent()) {
-				if (parentSaver.isEmpty()) {
-					throw new IllegalStateException("Missing CheckpointSaver in parent graph!");
-				}
-
-				// Check saver are the same instance
-				if (parentSaver.get() == subGraphSaver.get()) {
-					subGraphRunnableConfig = RunnableConfig.builder(config)
-							.threadId(config.threadId()
-									.map(threadId -> format("%s_%s", threadId, subGraphId(nodeId)))
-									.orElseGet(() -> subGraphId(nodeId)))
-							.nextNode(null)
-							.checkPointId(null)
-							.addMetadata("_AGENT_", subGraphId(nodeId)) // subGraphId is the same as the name of the agent that created it
-							.build();
-					subGraphRunnableConfig.clearContext();
-				}
-			}
-			return subGraphRunnableConfig;
+			withAgentName.clearContext();
+			return withAgentName;
 		}
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph.agent.a2a;
 
 import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.GraphResponse;
+import com.alibaba.cloud.ai.graph.internal.node.SubGraphRunnableConfigBridge;
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
@@ -77,6 +78,8 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 
 	private CompileConfig parentCompileConfig;
 
+	private CompileConfig childCompileConfig;
+
 
 	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents, String outputKeyToParent, String instruction, boolean streaming) {
 		this.agentName = agentName;
@@ -88,9 +91,19 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 		this.shareState = false;
 	}
 
-	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents, String outputKeyToParent, String instruction, boolean streaming, boolean shareState, CompileConfig compileConfig) {
+	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents,
+			String outputKeyToParent, String instruction, boolean streaming, boolean shareState,
+			CompileConfig compileConfig) {
+		this(agentCard, agentName, includeContents, outputKeyToParent, instruction, streaming, shareState,
+				compileConfig, compileConfig);
+	}
+
+	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents,
+			String outputKeyToParent, String instruction, boolean streaming, boolean shareState,
+			CompileConfig parentCompileConfig, CompileConfig childCompileConfig) {
 		this(agentCard, agentName, includeContents, outputKeyToParent, instruction, streaming);
-		this.parentCompileConfig = compileConfig;
+		this.parentCompileConfig = parentCompileConfig;
+		this.childCompileConfig = childCompileConfig;
 		this.shareState = shareState;
 	}
 
@@ -117,13 +130,18 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 		if (shareState) {
 			return config;
 		}
-		return RunnableConfig.builder(config)
-				.threadId(config.threadId()
-						.map(threadId -> format("%s_%s", threadId, subGraphId()))
-						.orElseGet(this::subGraphId))
-				.nextNode(null)
-				.checkPointId(null)
-				.build();
+		if (parentCompileConfig == null) {
+			return RunnableConfig.builder(config)
+					.threadId(config.threadId()
+							.map(threadId -> format("%s_%s", threadId, subGraphId()))
+							.orElseGet(this::subGraphId))
+					.nextNode(null)
+					.checkPointId(null)
+					.build();
+		}
+		CompileConfig childConfig = childCompileConfig != null ? childCompileConfig : parentCompileConfig;
+		return SubGraphRunnableConfigBridge.prepareChildRunnableConfig(config, agentName, subGraphId(),
+				parentCompileConfig, childConfig);
 	}
 
 	public String subGraphId() {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph.agent.a2a;
 
 import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.GraphResponse;
+import com.alibaba.cloud.ai.graph.internal.node.SubGraphRunnableConfigBridge;
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
@@ -79,6 +80,8 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 
 	private CompileConfig parentCompileConfig;
 
+	private CompileConfig childCompileConfig;
+
 
 	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents, String outputKeyToParent, String instruction, boolean streaming) {
 		this.agentName = agentName;
@@ -90,9 +93,19 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 		this.shareState = false;
 	}
 
-	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents, String outputKeyToParent, String instruction, boolean streaming, boolean shareState, CompileConfig compileConfig) {
+	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents,
+			String outputKeyToParent, String instruction, boolean streaming, boolean shareState,
+			CompileConfig compileConfig) {
+		this(agentCard, agentName, includeContents, outputKeyToParent, instruction, streaming, shareState,
+				compileConfig, compileConfig);
+	}
+
+	public A2aNodeActionWithConfig(AgentCardWrapper agentCard, String agentName, boolean includeContents,
+			String outputKeyToParent, String instruction, boolean streaming, boolean shareState,
+			CompileConfig parentCompileConfig, CompileConfig childCompileConfig) {
 		this(agentCard, agentName, includeContents, outputKeyToParent, instruction, streaming);
-		this.parentCompileConfig = compileConfig;
+		this.parentCompileConfig = parentCompileConfig;
+		this.childCompileConfig = childCompileConfig;
 		this.shareState = shareState;
 	}
 
@@ -119,13 +132,21 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 		if (shareState) {
 			return config;
 		}
-		return RunnableConfig.builder(config)
-				.threadId(config.threadId()
-						.map(threadId -> format("%s_%s", threadId, subGraphId()))
-						.orElseGet(this::subGraphId))
-				.nextNode(null)
-				.checkPointId(null)
-				.build();
+		if (parentCompileConfig == null) {
+			RunnableConfig childConfig = RunnableConfig.builder(config)
+					.threadId(config.threadId()
+							.map(threadId -> format("%s_%s", threadId, subGraphId()))
+							.orElseGet(this::subGraphId))
+					.nextNode(null)
+					.checkPointId(null)
+					.build();
+			SubGraphRunnableConfigBridge.stripParentResumeMetadata(childConfig, agentName);
+			return childConfig;
+		}
+		CompileConfig childConfig = childCompileConfig != null ? childCompileConfig : parentCompileConfig;
+		// shareState=false: always isolate remote conversation thread, even when savers differ
+		return SubGraphRunnableConfigBridge.prepareChildRunnableConfig(config, agentName, subGraphId(),
+				parentCompileConfig, childConfig, true);
 	}
 
 	public String subGraphId() {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
@@ -69,7 +69,7 @@ public class A2aRemoteAgent extends BaseAgent {
 		StateGraph graph = new StateGraph(name, this.keyStrategyFactory);
 		graph.addNode("A2aNode", AsyncNodeActionWithConfig.node_async(
 				new A2aNodeActionWithConfig(agentCard, name, includeContents, outputKey, instruction, streaming,
-						this.shareState, this.compileConfig)));
+						this.shareState, this.compileConfig, this.compileConfig)));
 		graph.addEdge(StateGraph.START, "A2aNode");
 		graph.addEdge("A2aNode", StateGraph.END);
 		return graph;
@@ -100,7 +100,9 @@ public class A2aRemoteAgent extends BaseAgent {
 
 		public A2aRemoteAgentNode(String id, boolean includeContents, boolean returnReasoningContents, String instruction, AgentCardWrapper agentCard, boolean streaming, boolean shareState, CompiledGraph subGraph) {
 			super(Objects.requireNonNull(id, "id cannot be null"),
-					(config) -> AsyncNodeActionWithConfig.node_async(new A2aNodeActionWithConfig(agentCard, subGraph.stateGraph.getName(), includeContents, A2aRemoteAgent.this.outputKey, instruction, streaming, shareState, config)));
+					(config) -> AsyncNodeActionWithConfig.node_async(new A2aNodeActionWithConfig(agentCard,
+							subGraph.stateGraph.getName(), includeContents, A2aRemoteAgent.this.outputKey, instruction,
+							streaming, shareState, config, subGraph.compileConfig)));
 			this.subGraph = subGraph;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
@@ -75,7 +75,7 @@ public class A2aRemoteAgent extends BaseAgent {
 		StateGraph graph = new StateGraph(name, this.keyStrategyFactory);
 		graph.addNode("A2aNode", AsyncNodeActionWithConfig.node_async(
 				new A2aNodeActionWithConfig(agentCard, name, includeContents, outputKey, instruction, streaming,
-						this.shareState, this.compileConfig)));
+						this.shareState, this.compileConfig, this.compileConfig)));
 		graph.addEdge(StateGraph.START, "A2aNode");
 		graph.addEdge("A2aNode", StateGraph.END);
 		return graph;
@@ -106,7 +106,9 @@ public class A2aRemoteAgent extends BaseAgent {
 
 		public A2aRemoteAgentNode(String id, boolean includeContents, boolean returnReasoningContents, String instruction, AgentCardWrapper agentCard, boolean streaming, boolean shareState, CompiledGraph subGraph) {
 			super(Objects.requireNonNull(id, "id cannot be null"),
-					(config) -> AsyncNodeActionWithConfig.node_async(new A2aNodeActionWithConfig(agentCard, subGraph.stateGraph.getName(), includeContents, A2aRemoteAgent.this.outputKey, instruction, streaming, shareState, config)));
+					(config) -> AsyncNodeActionWithConfig.node_async(new A2aNodeActionWithConfig(agentCard,
+							subGraph.stateGraph.getName(), includeContents, A2aRemoteAgent.this.outputKey, instruction,
+							streaming, shareState, config, subGraph.compileConfig)));
 			this.subGraph = subGraph;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentResumeCheckpointTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentResumeCheckpointTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.OverAllStateBuilder;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Offline regression for
+ * <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4639">#4639</a>:
+ * {@link ReactAgent#asNode()} parent-thread resume before the child namespace has a
+ * checkpoint. Intentionally not gated on {@code AI_DASHSCOPE_API_KEY}.
+ */
+class ReactAgentResumeCheckpointTest {
+
+	private static final String AGENT_NAME = "qa_agent";
+
+	@Test
+	void parentInterruptBeforeAgent_resumeWithParentThreadId_succeeds() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		StubChatModel stubModel = new StubChatModel();
+
+		ReactAgent qaAgent = ReactAgent.builder()
+				.name(AGENT_NAME)
+				.model(stubModel)
+				.outputKey("qa_result")
+				.saver(saver)
+				.build();
+
+		CompiledGraph parentGraph = buildParentGraph(qaAgent, saver);
+
+		String threadId = "conv-001-" + System.nanoTime();
+		RunnableConfig invokeConfig = RunnableConfig.builder().threadId(threadId).build();
+
+		AtomicReference<NodeOutput> last = new AtomicReference<>();
+		parentGraph.stream(Map.of("input", "x"), invokeConfig).doOnNext(last::set).blockLast();
+
+		assertInstanceOf(InterruptionMetadata.class, last.get(), "应在进入 qa_agent 前中断");
+		assertEquals(0, stubModel.callCount(), "首次中断前子图模型不应被调用");
+
+		RunnableConfig resumeConfig = RunnableConfig.builder().threadId(threadId).resume().build();
+		AtomicReference<NodeOutput> resumeLast = new AtomicReference<>();
+		parentGraph.stream(null, resumeConfig).doOnNext(resumeLast::set).blockLast();
+
+		assertTrue(stubModel.callCount() >= 1, "resume 后应真正跑进子 Agent 并调用模型");
+		OverAllState state = resumeLast.get().state();
+		assertEquals("ok", state.value("prep_marker").orElse(null), "父终态应保留 prep 结果");
+		assertNotNull(state.value("qa_result").orElse(null), "父终态应包含子 Agent 输出");
+	}
+
+	@Test
+	void parentInterruptionMetadata_beforeUnstartedChild_coldStartsSuccessfully() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		StubChatModel stubModel = new StubChatModel();
+
+		ReactAgent qaAgent = ReactAgent.builder()
+				.name(AGENT_NAME)
+				.model(stubModel)
+				.outputKey("qa_result")
+				.saver(saver)
+				.build();
+
+		CompiledGraph parentGraph = buildParentGraph(qaAgent, saver);
+		String threadId = "conv-hitl-cold-" + System.nanoTime();
+
+		AtomicReference<NodeOutput> last = new AtomicReference<>();
+		parentGraph.stream(Map.of("input", "x"), RunnableConfig.builder().threadId(threadId).build())
+				.doOnNext(last::set)
+				.blockLast();
+		assertInstanceOf(InterruptionMetadata.class, last.get());
+		assertEquals(0, stubModel.callCount());
+
+		// Real InterruptionMetadata on parent (HITL-style), child never ran — must not
+		// reintroduce invalid-child-checkpoint failure (#4639 / review opinion #3).
+		InterruptionMetadata feedback = InterruptionMetadata.builder(AGENT_NAME, OverAllStateBuilder.builder().build())
+				.build();
+		RunnableConfig resumeConfig = RunnableConfig.builder()
+				.threadId(threadId)
+				.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, feedback)
+				.build();
+
+		AtomicReference<NodeOutput> resumeLast = new AtomicReference<>();
+		parentGraph.stream(null, resumeConfig).doOnNext(resumeLast::set).blockLast();
+
+		assertTrue(stubModel.callCount() >= 1, "冷子图应成功执行");
+		assertEquals("ok", resumeLast.get().state().value("prep_marker").orElse(null));
+	}
+
+	private static CompiledGraph buildParentGraph(ReactAgent qaAgent, MemorySaver saver) throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("prep_marker", new ReplaceStrategy());
+			strategies.put("messages", new AppendStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			return strategies;
+		};
+
+		StateGraph workflow = new StateGraph(keyStrategyFactory)
+				.addNode("prep", node_async(state -> Map.of("prep_marker", "ok")))
+				.addNode(AGENT_NAME, qaAgent.asNode(true, false))
+				.addEdge(START, "prep")
+				.addEdge("prep", AGENT_NAME)
+				.addEdge(AGENT_NAME, END);
+
+		return workflow.compile(CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build())
+				.interruptBefore(AGENT_NAME)
+				.build());
+	}
+
+	private static final class StubChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			callCount.incrementAndGet();
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		int callCount() {
+			return callCount.get();
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentTest.java
@@ -18,16 +18,24 @@ package com.alibaba.cloud.ai.graph.agent;
 import com.alibaba.cloud.ai.dashscope.api.DashScopeApi;
 import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatModel;
 import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
 import com.alibaba.cloud.ai.graph.GraphRepresentation;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.agent.hook.AgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
 import com.alibaba.cloud.ai.graph.agent.hook.ModelHook;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
 import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
 import com.alibaba.cloud.ai.graph.serializer.std.SpringAIStateSerializer;
@@ -37,6 +45,9 @@ import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.ListOutputConverter;
 import org.springframework.ai.converter.MapOutputConverter;
@@ -52,6 +63,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,8 +71,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import reactor.core.publisher.Flux;
@@ -71,6 +86,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @EnabledIfEnvironmentVariable(named = "AI_DASHSCOPE_API_KEY", matches = ".+")
@@ -1080,6 +1098,143 @@ class ReactAgentTest {
 
 		assertNotNull(agent1);
 		assertNotNull(agent2);
+	}
+
+	/**
+	 * <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4639">#4639</a> 回归：父图在 Agent 节点前中断后，
+	 * 用<strong>父 threadId</strong> resume 不应因子 namespace 无 checkpoint 而失败。
+	 *
+	 * <p><b>前提</b>：父图与子 {@link ReactAgent} 共用同一个 {@link MemorySaver}；
+	 * 子 Agent 通过 {@link ReactAgent#asNode()} 嵌进父图（图里套图，不是拍平子图）。
+	 *
+	 * @see <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4639">issue #4639</a>
+	 */
+	@Nested
+	class ResumeCheckpointRegression {
+
+		private static final String AGENT_NAME = "qa_agent";
+
+		@Test
+		void parentInterruptBeforeAgent_resumeWithParentThreadId_succeeds() throws Exception {
+			// 父子共享的 checkpoint 存储（对应业务里同一个 MemorySaver 实例）
+			MemorySaver saver = MemorySaver.builder().build();
+			StubChatModel stubModel = new StubChatModel();
+
+			// --- 步骤 1：构造子 Agent，并作为父图的一个节点 ---
+			// 建 ReactAgent（名为 qa_agent），子 Agent 也挂同一个 MemorySaver；
+			// 后面用 asNode() 挂到父图（在 buildParentGraph 里），不是拍平子图。
+			ReactAgent qaAgent = ReactAgent.builder()
+					.name(AGENT_NAME)
+					.model(stubModel)
+					.outputKey("qa_result")
+					.saver(saver)
+					.build();
+
+			// --- 步骤 2：构造父图（StateGraph）---
+			// 流程：开始 → prep → qa_agent → 结束；interruptBefore("qa_agent")：
+			// 跑完 prep、还没进 Agent 就停，等人处理。
+			CompiledGraph parentGraph = buildParentGraph(qaAgent, saver);
+
+			// 父图会话 id（对应业务里的 conv-001）；子图实际会用 conv-001_subgraph_qa_agent
+			String threadId = "conv-001-" + System.nanoTime();
+			RunnableConfig invokeConfig = RunnableConfig.builder().threadId(threadId).build();
+
+			// --- 步骤 3：第一次执行父图（模拟用户第一次跑 workflow）---
+			// stream：跑 prep → 准备进 qa_agent 时中断 → 返回 InterruptionMetadata。
+			// checkpoint 写在父 threadId；子 Agent 还没跑，子 threadId 下尚无 checkpoint。
+			AtomicReference<NodeOutput> last = new AtomicReference<>();
+			parentGraph.stream(Map.of("input", "x"), invokeConfig).doOnNext(last::set).blockLast();
+
+			assertInstanceOf(InterruptionMetadata.class, last.get(), "应在进入 qa_agent 前中断");
+			assertEquals(0, stubModel.callCount(), "首次中断前子图模型不应被调用");
+
+			// --- 步骤 4：第二次执行 —— 用父 threadId 恢复（规范写法）---
+			// 同一个父 threadId + resume()，再 stream(null, resumeConfig)，模拟「接着往下跑」。
+			RunnableConfig resumeConfig = RunnableConfig.builder().threadId(threadId).resume().build();
+
+			// --- 步骤 5：父图恢复后进入 qa_agent，子图在 xxx_subgraph_qa_agent 上执行 resume（修复前/后对比）---
+			// xxx_subgraph_qa_agent：父图 resume 成功 → 执行 qa_agent 节点 → 子图 threadId 改为
+			//   {父threadId}_subgraph_qa_agent（共享 MemorySaver 时的命名规则）。
+			//
+			// 修复前：
+			//   · 子图 RunnableConfig 从父 config 拷贝了 HUMAN_FEEDBACK（父 resume 的占位标记）
+			//   · 子图 GraphRunner 当成「在子 namespace 里恢复」→ initializeFromResume
+			//   · 在 xxx_subgraph_qa_agent 下 saver.get() → 无 CP（子 Agent 一直未运行）
+			//   → Resume request without a valid checkpoint!
+			//
+			// 修复后（AgentToSubCompiledGraphNodeAdapter，与「子 namespace 无 CP」对齐）：
+			//   · 检测到子 threadId 下无 checkpoint → 不把父 HUMAN_FEEDBACK 传给子图（避免子图 initializeFromResume）
+			//   · 不调 childGraph.updateState（无 CP 时 updateState 也会 Missing Checkpoint）
+			//   · 用父 state（prep_marker、input 等）调用 graphResponseStream → 子图 initializeFromStart（冷启动）
+			//   · 子 Agent 第一次真正执行，模型被调用 → 下列断言通过。
+			assertFalse(throwsValidCheckpoint(parentGraph, resumeConfig),
+					"父 threadId resume 不应因子 namespace 无 checkpoint 失败");
+			assertTrue(stubModel.callCount() >= 1, "resume 后应真正跑进子 Agent 并调用模型");
+		}
+
+		private static boolean throwsValidCheckpoint(CompiledGraph graph, RunnableConfig resumeConfig) {
+			try {
+				graph.stream(null, resumeConfig).blockLast();
+				return false;
+			}
+			catch (Exception ex) {
+				Throwable root = ex;
+				while (root.getCause() != null && root.getCause() != root) {
+					root = root.getCause();
+				}
+				return root.getMessage() != null && root.getMessage().contains("valid checkpoint");
+			}
+		}
+
+		/**
+		 * 步骤 2 的父图：prep 普通节点 + {@code qa_agent} 子图节点（{@link ReactAgent#asNode()}）。
+		 */
+		private static CompiledGraph buildParentGraph(ReactAgent qaAgent, MemorySaver saver) throws Exception {
+			KeyStrategyFactory keyStrategyFactory = () -> {
+				Map<String, KeyStrategy> strategies = new HashMap<>();
+				strategies.put("input", new ReplaceStrategy());
+				strategies.put("prep_marker", new ReplaceStrategy());
+				strategies.put("messages", new AppendStrategy());
+				strategies.put("qa_result", new ReplaceStrategy());
+				return strategies;
+			};
+
+			StateGraph workflow = new StateGraph(keyStrategyFactory)
+					.addNode("prep", node_async(state -> Map.of("prep_marker", "ok")))
+					// 图里套图：qa_agent 节点 = 整棵 ReactAgent 子图，不是拍平
+					.addNode(AGENT_NAME, qaAgent.asNode(true, false))
+					.addEdge(START, "prep")
+					.addEdge("prep", AGENT_NAME)
+					.addEdge(AGENT_NAME, END);
+
+			return workflow.compile(CompileConfig.builder()
+					.saverConfig(SaverConfig.builder().register(saver).build())
+					// 在 qa_agent 执行前先中断：prep 跑完、Agent 还没进就停
+					.interruptBefore(AGENT_NAME)
+					.build());
+		}
+
+		private static final class StubChatModel implements ChatModel {
+
+			private final AtomicInteger callCount = new AtomicInteger();
+
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				callCount.incrementAndGet();
+				return new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				return Flux.just(call(prompt));
+			}
+
+			int callCount() {
+				return callCount.get();
+			}
+
+		}
+
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentTest.java
@@ -1148,4 +1148,5 @@ class ReactAgentTest {
 		assertNotNull(results);
         assertFalse(results.isEmpty());
 	}
+
 }

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgentResumeCheckpointTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgentResumeCheckpointTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.a2a;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4639">#4639</a> regression for
+ * {@link A2aRemoteAgent#asNode()} / {@link A2aNodeActionWithConfig#getSubGraphRunnableConfig}.
+ */
+class A2aRemoteAgentResumeCheckpointTest {
+
+	@Nested
+	class ResumeCheckpointRegression {
+
+		private static final String AGENT_NAME = "qa_agent";
+
+		@Test
+		void parentInterruptBeforeA2aNode_resumeWithParentThreadId_succeeds() throws Exception {
+			try (StubHttpServer http = new StubHttpServer()) {
+				MemorySaver saver = MemorySaver.builder().build();
+				AgentCard agentCard = buildStubAgentCard(http.baseUrl());
+
+				A2aRemoteAgent a2aAgent = A2aRemoteAgent.builder()
+						.name(AGENT_NAME)
+						.description("a2a agent for #4639")
+						.agentCard(agentCard)
+						.instruction("echo: {input}")
+						.streaming(false)
+						.shareState(false)
+						.compileConfig(CompileConfig.builder()
+								.saverConfig(SaverConfig.builder().register(saver).build())
+								.build())
+						.build();
+
+				CompiledGraph parentGraph = buildParentGraph(a2aAgent, saver);
+				String threadId = "conv-a2a-" + System.nanoTime();
+				RunnableConfig invokeConfig = RunnableConfig.builder().threadId(threadId).build();
+
+				AtomicReference<NodeOutput> last = new AtomicReference<>();
+				parentGraph.stream(Map.of("input", "x"), invokeConfig).doOnNext(last::set).blockLast();
+
+				assertInstanceOf(InterruptionMetadata.class, last.get(), "应在进入 A2a 节点前中断");
+
+				RunnableConfig resumeConfig = RunnableConfig.builder().threadId(threadId).resume().build();
+
+				assertFalse(throwsCheckpointFailure(parentGraph, resumeConfig),
+						"父 threadId resume 不应失败");
+				assertFalse(innerGraphProbeThrowsCheckpoint(a2aAgent, agentCard, threadId, saver),
+						"inner-graph probe 不应触发子图 checkpoint 错误");
+			}
+		}
+
+		private static boolean innerGraphProbeThrowsCheckpoint(A2aRemoteAgent a2aAgent, AgentCard agentCard,
+				String parentThreadId, MemorySaver saver) throws Exception {
+			CompileConfig parentCompileConfig = CompileConfig.builder()
+					.saverConfig(SaverConfig.builder().register(saver).build())
+					.build();
+			RunnableConfig parentResume = RunnableConfig.builder().threadId(parentThreadId).resume().build();
+
+			A2aNodeActionWithConfig action = new A2aNodeActionWithConfig(new AgentCardWrapper(agentCard), AGENT_NAME,
+					false, "qa_result", "echo: {input}", false, false, parentCompileConfig,
+					a2aAgent.getAndCompileGraph().compileConfig);
+
+			Method method = A2aNodeActionWithConfig.class.getDeclaredMethod("getSubGraphRunnableConfig",
+					RunnableConfig.class);
+			method.setAccessible(true);
+			RunnableConfig childConfig = (RunnableConfig) method.invoke(action, parentResume);
+
+			try {
+				a2aAgent.getAndCompileGraph().graphResponseStream(Map.of("input", "probe"), childConfig).blockLast();
+				return false;
+			}
+			catch (Exception ex) {
+				Throwable root = ex;
+				while (root.getCause() != null && root.getCause() != root) {
+					root = root.getCause();
+				}
+				String message = root.getMessage();
+				return message != null
+						&& (message.contains("valid checkpoint") || message.contains("Missing Checkpoint"));
+			}
+		}
+
+		private static CompiledGraph buildParentGraph(A2aRemoteAgent a2aAgent, MemorySaver saver) throws Exception {
+			KeyStrategyFactory keyStrategyFactory = () -> {
+				Map<String, KeyStrategy> strategies = new HashMap<>();
+				strategies.put("input", new ReplaceStrategy());
+				strategies.put("prep_marker", new ReplaceStrategy());
+				strategies.put("qa_result", new ReplaceStrategy());
+				return strategies;
+			};
+
+			StateGraph workflow = new StateGraph(keyStrategyFactory)
+					.addNode("prep", node_async(state -> Map.of("prep_marker", "ok")))
+					.addNode(AGENT_NAME, a2aAgent.asNode(true, false))
+					.addEdge(START, "prep")
+					.addEdge("prep", AGENT_NAME)
+					.addEdge(AGENT_NAME, END);
+
+			return workflow.compile(CompileConfig.builder()
+					.saverConfig(SaverConfig.builder().register(saver).build())
+					.interruptBefore(AGENT_NAME)
+					.build());
+		}
+
+		private static AgentCard buildStubAgentCard(String url) {
+			return new AgentCard.Builder()
+					.name(AGENT_NAME)
+					.description("stub a2a for #4639 test")
+					.url(url)
+					.version("1.0.0")
+					.protocolVersion("0.2.5")
+					.preferredTransport("JSONRPC")
+					.capabilities(new AgentCapabilities.Builder().streaming(false).build())
+					.defaultInputModes(List.of("text"))
+					.defaultOutputModes(List.of("text"))
+					.skills(List.of())
+					.build();
+		}
+
+		private static boolean throwsCheckpointFailure(CompiledGraph graph, RunnableConfig resumeConfig) {
+			try {
+				graph.stream(null, resumeConfig).blockLast();
+				return false;
+			}
+			catch (Exception ex) {
+				Throwable root = ex;
+				while (root.getCause() != null && root.getCause() != root) {
+					root = root.getCause();
+				}
+				String message = root.getMessage();
+				return message != null
+						&& (message.contains("valid checkpoint") || message.contains("Missing Checkpoint"));
+			}
+		}
+
+	}
+
+	private static final class StubHttpServer implements AutoCloseable {
+
+		private final HttpServer server;
+
+		StubHttpServer() throws IOException {
+			this.server = HttpServer.create(new InetSocketAddress(0), 0);
+			this.server.createContext("/", this::handle);
+			this.server.start();
+		}
+
+		String baseUrl() {
+			return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+		}
+
+		private void handle(HttpExchange exchange) throws IOException {
+			String body = """
+					{"jsonrpc":"2.0","id":"1","result":{"kind":"message","role":"agent","parts":[{"kind":"text","text":"ok"}]}}
+					""";
+			byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+			exchange.getResponseHeaders().add("Content-Type", "application/json");
+			exchange.sendResponseHeaders(200, bytes.length);
+			try (OutputStream os = exchange.getResponseBody()) {
+				os.write(bytes);
+			}
+		}
+
+		@Override
+		public void close() {
+			server.stop(0);
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgentResumeCheckpointTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgentResumeCheckpointTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.a2a;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4639">#4639</a> regression for
+ * {@link A2aRemoteAgent#asNode()} production entry point.
+ */
+class A2aRemoteAgentResumeCheckpointTest {
+
+	private static final String AGENT_NAME = "qa_agent";
+
+	@Test
+	void parentInterruptBeforeA2aNode_resumeWithParentThreadId_succeeds() throws Exception {
+		try (StubHttpServer http = new StubHttpServer()) {
+			MemorySaver saver = MemorySaver.builder().build();
+			AgentCard agentCard = buildStubAgentCard(http.baseUrl());
+
+			A2aRemoteAgent a2aAgent = A2aRemoteAgent.builder()
+					.name(AGENT_NAME)
+					.description("a2a agent for #4639")
+					.agentCard(agentCard)
+					.instruction("echo: {input}")
+					.outputKey("qa_result")
+					.streaming(false)
+					.shareState(false)
+					.compileConfig(CompileConfig.builder()
+							.saverConfig(SaverConfig.builder().register(saver).build())
+							.build())
+					.build();
+
+			CompiledGraph parentGraph = buildParentGraph(a2aAgent, saver);
+			String threadId = "conv-a2a-" + System.nanoTime();
+			RunnableConfig invokeConfig = RunnableConfig.builder().threadId(threadId).build();
+
+			AtomicReference<NodeOutput> last = new AtomicReference<>();
+			parentGraph.stream(Map.of("input", "x"), invokeConfig).doOnNext(last::set).blockLast();
+
+			assertInstanceOf(InterruptionMetadata.class, last.get(), "应在进入 A2a 节点前中断");
+
+			RunnableConfig resumeConfig = RunnableConfig.builder().threadId(threadId).resume().build();
+			AtomicReference<NodeOutput> resumeLast = new AtomicReference<>();
+			parentGraph.stream(null, resumeConfig).doOnNext(resumeLast::set).blockLast();
+
+			OverAllState state = resumeLast.get().state();
+			assertEquals("ok", state.value("prep_marker").orElse(null));
+			assertEquals("ok", state.value("qa_result").orElse(null));
+
+			String expectedThread = threadId + "_subgraph_" + AGENT_NAME;
+			assertTrue(http.lastRequestBody().contains(expectedThread),
+					"远端应收到隔离后的 threadId: " + expectedThread + ", body=" + http.lastRequestBody());
+		}
+	}
+
+	@Test
+	void shareStateFalse_differentSavers_stillNamespacesRemoteThreadId() throws Exception {
+		try (StubHttpServer http = new StubHttpServer()) {
+			MemorySaver parentSaver = MemorySaver.builder().build();
+			MemorySaver childSaver = MemorySaver.builder().build();
+			AgentCard agentCard = buildStubAgentCard(http.baseUrl());
+
+			A2aRemoteAgent a2aAgent = A2aRemoteAgent.builder()
+					.name(AGENT_NAME)
+					.description("a2a agent different saver")
+					.agentCard(agentCard)
+					.instruction("echo: {input}")
+					.outputKey("qa_result")
+					.streaming(false)
+					.shareState(false)
+					.compileConfig(CompileConfig.builder()
+							.saverConfig(SaverConfig.builder().register(childSaver).build())
+							.build())
+					.build();
+
+			CompiledGraph parentGraph = buildParentGraph(a2aAgent, parentSaver);
+			String threadId = "conv-a2a-diff-" + System.nanoTime();
+
+			parentGraph.stream(Map.of("input", "x"), RunnableConfig.builder().threadId(threadId).build()).blockLast();
+			parentGraph.stream(null, RunnableConfig.builder().threadId(threadId).resume().build()).blockLast();
+
+			String expectedThread = threadId + "_subgraph_" + AGENT_NAME;
+			assertTrue(http.lastRequestBody().contains(expectedThread),
+					"异 saver 时仍应隔离 threadId, body=" + http.lastRequestBody());
+		}
+	}
+
+	@Test
+	void shareStateFalse_parentWithoutSaver_childWithSaver_stillNamespaces() throws Exception {
+		try (StubHttpServer http = new StubHttpServer()) {
+			MemorySaver childSaver = MemorySaver.builder().build();
+			AgentCard agentCard = buildStubAgentCard(http.baseUrl());
+
+			A2aRemoteAgent a2aAgent = A2aRemoteAgent.builder()
+					.name(AGENT_NAME)
+					.description("a2a agent parent without saver")
+					.agentCard(agentCard)
+					.instruction("echo: {input}")
+					.outputKey("qa_result")
+					.streaming(false)
+					.shareState(false)
+					.compileConfig(CompileConfig.builder()
+							.saverConfig(SaverConfig.builder().register(childSaver).build())
+							.build())
+					.build();
+
+			// Parent graph has no CheckpointSaver — pre-bridge A2A still namespaced threadId.
+			CompiledGraph parentGraph = buildParentGraphWithoutSaver(a2aAgent);
+			String threadId = "conv-a2a-nosaver-" + System.nanoTime();
+
+			AtomicReference<NodeOutput> last = new AtomicReference<>();
+			parentGraph.stream(Map.of("input", "x"), RunnableConfig.builder().threadId(threadId).build())
+					.doOnNext(last::set)
+					.blockLast();
+
+			assertEquals("ok", last.get().state().value("qa_result").orElse(null));
+			String expectedThread = threadId + "_subgraph_" + AGENT_NAME;
+			assertTrue(http.lastRequestBody().contains(expectedThread),
+					"父无 saver 时 A2A 仍应隔离 threadId, body=" + http.lastRequestBody());
+		}
+	}
+
+	private static CompiledGraph buildParentGraph(A2aRemoteAgent a2aAgent, MemorySaver saver) throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("prep_marker", new ReplaceStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			return strategies;
+		};
+
+		StateGraph workflow = new StateGraph(keyStrategyFactory)
+				.addNode("prep", node_async(state -> Map.of("prep_marker", "ok")))
+				.addNode(AGENT_NAME, a2aAgent.asNode(true, false))
+				.addEdge(START, "prep")
+				.addEdge("prep", AGENT_NAME)
+				.addEdge(AGENT_NAME, END);
+
+		return workflow.compile(CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build())
+				.interruptBefore(AGENT_NAME)
+				.build());
+	}
+
+	private static CompiledGraph buildParentGraphWithoutSaver(A2aRemoteAgent a2aAgent) throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("prep_marker", new ReplaceStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			return strategies;
+		};
+
+		return new StateGraph(keyStrategyFactory)
+				.addNode("prep", node_async(state -> Map.of("prep_marker", "ok")))
+				.addNode(AGENT_NAME, a2aAgent.asNode(true, false))
+				.addEdge(START, "prep")
+				.addEdge("prep", AGENT_NAME)
+				.addEdge(AGENT_NAME, END)
+				// Explicit empty SaverConfig: CompileConfig.builder().build() still defaults to MemorySaver
+				.compile(CompileConfig.builder().saverConfig(new SaverConfig()).build());
+	}
+
+	private static AgentCard buildStubAgentCard(String url) {
+		return new AgentCard.Builder()
+				.name(AGENT_NAME)
+				.description("stub a2a for #4639 test")
+				.url(url)
+				.version("1.0.0")
+				.protocolVersion("0.2.5")
+				.preferredTransport("JSONRPC")
+				.capabilities(new AgentCapabilities.Builder().streaming(false).build())
+				.defaultInputModes(List.of("text"))
+				.defaultOutputModes(List.of("text"))
+				.skills(List.of())
+				.build();
+	}
+
+	private static final class StubHttpServer implements AutoCloseable {
+
+		private final HttpServer server;
+
+		private final AtomicReference<String> lastRequestBody = new AtomicReference<>("");
+
+		StubHttpServer() throws IOException {
+			this.server = HttpServer.create(new InetSocketAddress(0), 0);
+			this.server.createContext("/", this::handle);
+			this.server.start();
+		}
+
+		String baseUrl() {
+			return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+		}
+
+		String lastRequestBody() {
+			return lastRequestBody.get();
+		}
+
+		private void handle(HttpExchange exchange) throws IOException {
+			byte[] requestBytes = exchange.getRequestBody().readAllBytes();
+			lastRequestBody.set(new String(requestBytes, StandardCharsets.UTF_8));
+			String body = """
+					{"jsonrpc":"2.0","id":"1","result":{"kind":"message","role":"agent","parts":[{"kind":"text","text":"ok"}]}}
+					""";
+			byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+			exchange.getResponseHeaders().add("Content-Type", "application/json");
+			exchange.sendResponseHeaders(200, bytes.length);
+			try (OutputStream os = exchange.getResponseBody()) {
+				os.write(bytes);
+			}
+		}
+
+		@Override
+		public void close() {
+			server.stop(0);
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -21,15 +21,11 @@ import com.alibaba.cloud.ai.graph.CompiledGraph;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
-import com.alibaba.cloud.ai.graph.utils.TypeRef;
-
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
-import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
-import static java.lang.String.format;
 
 /**
  * Represents an action to perform a subgraph on a given state with a specific
@@ -65,40 +61,13 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 	 */
 	@Override
 	public CompletableFuture<Map<String, Object>> apply(OverAllState state, RunnableConfig config) {
-		final boolean resumeSubgraph = config.metadata(resumeSubGraphId(nodeId), new TypeRef<Boolean>() {
-		}).orElse(false);
-
-		RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config).checkPointId(null).nextNode(null).build();
-		subGraphRunnableConfig.clearContext();
-
-		var parentSaver = parentCompileConfig.checkpointSaver();
-		var subGraphSaver = subGraph.compileConfig.checkpointSaver();
-
-		if (subGraphSaver.isPresent()) {
-			if (parentSaver.isEmpty()) {
-				return CompletableFuture
-					.failedFuture(new IllegalStateException("Missing CheckpointSaver in parent graph!"));
-			}
-
-			// Check saver are the same instance
-			if (parentSaver.get() == subGraphSaver.get()) {
-				subGraphRunnableConfig = RunnableConfig.builder(config)
-					.threadId(config.threadId()
-						.map(threadId -> format("%s_%s", threadId, subGraphId(nodeId)))
-						.orElseGet(() -> subGraphId(nodeId)))
-					.nextNode(null)
-					.checkPointId(null)
-					.build();
-				subGraphRunnableConfig.clearContext();
-			}
-		}
-
 		final CompletableFuture<Map<String, Object>> future = new CompletableFuture<>();
 
 		try {
-			if (resumeSubgraph) {
-				subGraphRunnableConfig = subGraph.updateState(subGraphRunnableConfig, state.data());
-			}
+			RunnableConfig subGraphRunnableConfig = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(config,
+					nodeId, parentCompileConfig, subGraph.compileConfig);
+			subGraphRunnableConfig = SubGraphRunnableConfigBridge.resolveForCompiledChildResume(state.data(), subGraph,
+					subGraphRunnableConfig);
 
 			var fluxStream = subGraph.graphResponseStream(state, subGraphRunnableConfig);
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -21,15 +21,11 @@ import com.alibaba.cloud.ai.graph.CompiledGraph;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
-import com.alibaba.cloud.ai.graph.utils.TypeRef;
-
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
-import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
-import static java.lang.String.format;
 
 /**
  * Represents an action to perform a subgraph on a given state with a specific
@@ -65,40 +61,13 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 	 */
 	@Override
 	public CompletableFuture<Map<String, Object>> apply(OverAllState state, RunnableConfig config) {
-		final boolean resumeSubgraph = config.metadata(resumeSubGraphId(nodeId), new TypeRef<Boolean>() {
-		}).orElse(false);
-
-		// Build from the parent config so the subgraph receives run-scoped context,
-		// while RunnableConfig.Builder keeps the child context isolated.
-		RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config).checkPointId(null).nextNode(null).build();
-
-		var parentSaver = parentCompileConfig.checkpointSaver();
-		var subGraphSaver = subGraph.compileConfig.checkpointSaver();
-
-		if (subGraphSaver.isPresent()) {
-			if (parentSaver.isEmpty()) {
-				return CompletableFuture
-					.failedFuture(new IllegalStateException("Missing CheckpointSaver in parent graph!"));
-			}
-
-			// Check saver are the same instance
-			if (parentSaver.get() == subGraphSaver.get()) {
-				subGraphRunnableConfig = RunnableConfig.builder(config)
-					.threadId(config.threadId()
-						.map(threadId -> format("%s_%s", threadId, subGraphId(nodeId)))
-						.orElseGet(() -> subGraphId(nodeId)))
-					.nextNode(null)
-					.checkPointId(null)
-					.build();
-			}
-		}
-
 		final CompletableFuture<Map<String, Object>> future = new CompletableFuture<>();
 
 		try {
-			if (resumeSubgraph) {
-				subGraphRunnableConfig = subGraph.updateState(subGraphRunnableConfig, state.data());
-			}
+			RunnableConfig subGraphRunnableConfig = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(config,
+					nodeId, parentCompileConfig, subGraph.compileConfig);
+			subGraphRunnableConfig = SubGraphRunnableConfigBridge.resolveForCompiledChildResume(state.data(), subGraph,
+					subGraphRunnableConfig, config, nodeId);
 
 			var fluxStream = subGraph.graphResponseStream(state, subGraphRunnableConfig);
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubGraphRunnableConfigBridge.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubGraphRunnableConfigBridge.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.internal.node;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
+import static java.lang.String.format;
+
+/**
+ * Shared parent→child {@link RunnableConfig} bridging for embedded compiled subgraphs.
+ */
+public final class SubGraphRunnableConfigBridge {
+
+	private SubGraphRunnableConfigBridge() {
+	}
+
+	/**
+	 * Builds a child-namespace config: copies parent metadata (except resume markers), clears
+	 * checkpoint cursor, and rewrites {@code threadId} when parent/child share a saver.
+	 */
+	public static RunnableConfig prepareChildRunnableConfig(RunnableConfig parentConfig, String nodeId,
+			CompileConfig parentCompileConfig, CompileConfig childCompileConfig) {
+		RunnableConfig childConfig = RunnableConfig.builder(parentConfig)
+			.checkPointId(null)
+			.nextNode(null)
+			.build();
+		childConfig.clearContext();
+		stripParentResumeMetadata(childConfig, nodeId);
+
+		var parentSaver = parentCompileConfig.checkpointSaver();
+		var childSaver = childCompileConfig.checkpointSaver();
+		if (childSaver.isPresent()) {
+			if (parentSaver.isEmpty()) {
+				throw new IllegalStateException("Missing CheckpointSaver in parent graph!");
+			}
+			if (parentSaver.get() == childSaver.get()) {
+				String namespace = subGraphId(nodeId);
+				childConfig = RunnableConfig.builder(parentConfig)
+					.threadId(parentConfig.threadId()
+						.map(threadId -> namespacedThreadId(threadId, namespace))
+						.orElse(namespace))
+					.nextNode(null)
+					.checkPointId(null)
+					.build();
+				childConfig.clearContext();
+				stripParentResumeMetadata(childConfig, nodeId);
+			}
+		}
+		return childConfig;
+	}
+
+	/**
+	 * Same as {@link #prepareChildRunnableConfig} but uses a custom subgraph namespace key
+	 * (e.g. A2A {@code subgraph_<agentCardName>}).
+	 */
+	public static RunnableConfig prepareChildRunnableConfig(RunnableConfig parentConfig, String nodeId,
+			String subGraphNamespaceKey, CompileConfig parentCompileConfig,
+			CompileConfig childCompileConfig) {
+		if (subGraphNamespaceKey.equals(subGraphId(nodeId))) {
+			return prepareChildRunnableConfig(parentConfig, nodeId, parentCompileConfig, childCompileConfig);
+		}
+		RunnableConfig childConfig = RunnableConfig.builder(parentConfig)
+			.checkPointId(null)
+			.nextNode(null)
+			.build();
+		childConfig.clearContext();
+		stripParentResumeMetadata(childConfig, nodeId);
+
+		var parentSaver = parentCompileConfig.checkpointSaver();
+		var childSaver = childCompileConfig.checkpointSaver();
+		if (childSaver.isPresent()) {
+			if (parentSaver.isEmpty()) {
+				throw new IllegalStateException("Missing CheckpointSaver in parent graph!");
+			}
+			if (parentSaver.get() == childSaver.get()) {
+				childConfig = RunnableConfig.builder(parentConfig)
+					.threadId(parentConfig.threadId()
+						.map(threadId -> namespacedThreadId(threadId, subGraphNamespaceKey))
+						.orElse(subGraphNamespaceKey))
+					.nextNode(null)
+					.checkPointId(null)
+					.build();
+				childConfig.clearContext();
+				stripParentResumeMetadata(childConfig, nodeId);
+			}
+		}
+		return childConfig;
+	}
+
+	/**
+	 * Restores child execution from checkpoint only when the child namespace already has one.
+	 * Parent {@code resume_subgraph_*} without a child checkpoint must cold-start.
+	 */
+	public static RunnableConfig resolveForCompiledChildResume(Map<String, Object> stateForChild,
+			CompiledGraph childGraph, RunnableConfig preparedChildConfig) throws Exception {
+		// Use the child graph's saver: checkpoints after a child interrupt live in the child
+		// namespace (or namespaced threadId when parent/child share the same saver instance).
+		var childSaver = childGraph.compileConfig.checkpointSaver();
+		boolean childCheckpointExists = childSaver.isPresent()
+				&& childSaver.get().get(preparedChildConfig).isPresent();
+		if (!childCheckpointExists) {
+			return preparedChildConfig;
+		}
+		return childGraph.updateState(preparedChildConfig, stateForChild);
+	}
+
+	/**
+	 * Forwards {@link InterruptionMetadata} for agent hooks; does not forward {@code resume()}
+	 * placeholder.
+	 */
+	public static RunnableConfig withInterruptionMetadataForHooks(RunnableConfig parentConfig,
+			RunnableConfig childConfig) {
+		Optional<Object> feedback = parentConfig.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY);
+		if (feedback.isEmpty() || !(feedback.get() instanceof InterruptionMetadata metadata)) {
+			return childConfig;
+		}
+		RunnableConfig withFeedback = RunnableConfig.builder(childConfig)
+			.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, metadata)
+			.build();
+		withFeedback.clearContext();
+		return withFeedback;
+	}
+
+	public static void stripParentResumeMetadata(RunnableConfig childConfig, String nodeId) {
+		childConfig.metadata().ifPresent(m -> {
+			m.remove(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY);
+			m.remove(resumeSubGraphId(nodeId));
+		});
+	}
+
+	/** Avoid double suffix when config is prepared more than once (e.g. A2a inner graph re-entry). */
+	static String namespacedThreadId(String threadId, String namespaceKey) {
+		String suffix = "_" + namespaceKey;
+		if (threadId.equals(namespaceKey) || threadId.endsWith(suffix)) {
+			return threadId;
+		}
+		return format("%s_%s", threadId, namespaceKey);
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubGraphRunnableConfigBridge.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubGraphRunnableConfigBridge.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.internal.node;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.utils.TypeRef;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
+import static java.lang.String.format;
+
+/**
+ * Shared parent→child {@link RunnableConfig} bridging for embedded compiled subgraphs.
+ *
+ * <p>
+ * Resume intent is read from the <strong>parent</strong> config only. Child configs are
+ * stripped of resume markers immediately so paths that only call
+ * {@link #prepareChildRunnableConfig} (e.g. A2A) never leak parent
+ * {@code HUMAN_FEEDBACK}/{@code resume_subgraph_*} into the child namespace.
+ * </p>
+ */
+public final class SubGraphRunnableConfigBridge {
+
+	/**
+	 * Per-namespace provenance: set when this bridge has already applied
+	 * {@code _<namespaceKey>} to the thread id. Nested embeddings use different keys and
+	 * still append; same-key re-entry does not double-suffix.
+	 */
+	static final String NS_APPLIED_METADATA_PREFIX = "_saa_ns_applied:";
+
+	private SubGraphRunnableConfigBridge() {
+	}
+
+	/**
+	 * Builds a child-namespace config: copies parent metadata (except resume markers),
+	 * clears the checkpoint cursor, and rewrites {@code threadId} when parent/child share
+	 * a saver (or {@code forceNamespace}).
+	 *
+	 * <p>
+	 * Run-scoped {@linkplain RunnableConfig#context() context} is copied (not shared) so
+	 * the child can read parent values without leaking writes back (#4645). This method
+	 * does <strong>not</strong> call {@code clearContext()}; callers that need an empty
+	 * child context (e.g. ReactAgent adapter) must clear on their own path.
+	 * </p>
+	 */
+	public static RunnableConfig prepareChildRunnableConfig(RunnableConfig parentConfig, String nodeId,
+			CompileConfig parentCompileConfig, CompileConfig childCompileConfig) {
+		return prepareChildRunnableConfig(parentConfig, nodeId, subGraphId(nodeId), parentCompileConfig,
+				childCompileConfig, false);
+	}
+
+	/**
+	 * Same as {@link #prepareChildRunnableConfig(RunnableConfig, String, CompileConfig, CompileConfig)}
+	 * but uses a custom subgraph namespace key (e.g. A2A {@code subgraph_<agentCardName>}).
+	 */
+	public static RunnableConfig prepareChildRunnableConfig(RunnableConfig parentConfig, String nodeId,
+			String subGraphNamespaceKey, CompileConfig parentCompileConfig, CompileConfig childCompileConfig) {
+		return prepareChildRunnableConfig(parentConfig, nodeId, subGraphNamespaceKey, parentCompileConfig,
+				childCompileConfig, false);
+	}
+
+	/**
+	 * @param forceNamespace when {@code true}, always rewrite threadId with the namespace
+	 * key (A2A {@code shareState=false}), even if parent/child savers differ or the parent
+	 * has no saver at all. When {@code false}, a child saver without a parent saver is
+	 * rejected (shared-saver embedding requires both).
+	 */
+	public static RunnableConfig prepareChildRunnableConfig(RunnableConfig parentConfig, String nodeId,
+			String subGraphNamespaceKey, CompileConfig parentCompileConfig, CompileConfig childCompileConfig,
+			boolean forceNamespace) {
+		var parentSaver = parentCompileConfig.checkpointSaver();
+		var childSaver = childCompileConfig.checkpointSaver();
+
+		boolean shareSaver = childSaver.isPresent() && parentSaver.isPresent() && parentSaver.get() == childSaver.get();
+		// Shared-saver namespacing requires a parent saver. forceNamespace (A2A shareState=false)
+		// only rewrites threadId for remote isolation and must not demand a parent saver —
+		// that embedding worked before the bridge (child can keep its own saver alone).
+		if (childSaver.isPresent() && parentSaver.isEmpty() && !forceNamespace) {
+			throw new IllegalStateException("Missing CheckpointSaver in parent graph!");
+		}
+
+		boolean shouldNamespace = forceNamespace || shareSaver;
+		RunnableConfig.Builder builder = RunnableConfig.builder(parentConfig).checkPointId(null).nextNode(null);
+		if (shouldNamespace) {
+			if (!alreadyAppliedNamespace(parentConfig, subGraphNamespaceKey)) {
+				builder.threadId(parentConfig.threadId()
+						.map(threadId -> format("%s_%s", threadId, subGraphNamespaceKey))
+						.orElse(subGraphNamespaceKey));
+			}
+			builder.addMetadata(nsAppliedKey(subGraphNamespaceKey), Boolean.TRUE);
+		}
+
+		RunnableConfig childConfig = builder.build();
+		stripParentResumeMetadata(childConfig, nodeId);
+		return childConfig;
+	}
+
+	/**
+	 * Restores child execution from checkpoint only when the parent is resuming
+	 * <em>and</em> the child namespace already has a checkpoint. Otherwise cold-starts.
+	 * When the child is resumed, forwards real {@link InterruptionMetadata} for HITL
+	 * hooks (never the {@code resume()} placeholder string).
+	 *
+	 * <p>
+	 * Parent resume intent is {@code resume_subgraph_*} <strong>or</strong>
+	 * {@code HUMAN_FEEDBACK} on the parent config. The latter is required for
+	 * {@code ReactAgent.asNode()} because {@code node_async} wrapping usually prevents
+	 * the parent runner from setting {@code resume_subgraph_*}.
+	 * </p>
+	 */
+	public static RunnableConfig resolveForCompiledChildResume(Map<String, Object> stateForChild,
+			CompiledGraph childGraph, RunnableConfig preparedChildConfig, RunnableConfig parentConfig, String nodeId)
+			throws Exception {
+		boolean parentResuming = hasParentResumeIntent(parentConfig, nodeId);
+		var childSaver = childGraph.compileConfig.checkpointSaver();
+		boolean childCheckpointExists = childSaver.isPresent()
+				&& childSaver.get().get(preparedChildConfig).isPresent();
+
+		RunnableConfig resolved = preparedChildConfig;
+		boolean childResumed = false;
+		if (parentResuming && childCheckpointExists) {
+			resolved = childGraph.updateState(preparedChildConfig, stateForChild);
+			childResumed = true;
+		}
+		return withInterruptionMetadataForHooks(parentConfig, resolved, childResumed);
+	}
+
+	/**
+	 * Forwards {@link InterruptionMetadata} for agent hooks only when the child
+	 * checkpoint was actually resumed; does not forward {@code resume()} placeholder.
+	 */
+	public static RunnableConfig withInterruptionMetadataForHooks(RunnableConfig parentConfig,
+			RunnableConfig childConfig, boolean childCheckpointResumed) {
+		if (!childCheckpointResumed) {
+			return childConfig;
+		}
+		Optional<Object> feedback = parentConfig.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY);
+		if (feedback.isEmpty() || !(feedback.get() instanceof InterruptionMetadata metadata)) {
+			return childConfig;
+		}
+		return RunnableConfig.builder(childConfig)
+			.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, metadata)
+			.build();
+	}
+
+	public static void stripParentResumeMetadata(RunnableConfig childConfig, String nodeId) {
+		childConfig.metadata().ifPresent(m -> {
+			m.remove(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY);
+			m.remove(resumeSubGraphId(nodeId));
+		});
+	}
+
+	static boolean hasParentResumeIntent(RunnableConfig parentConfig, String nodeId) {
+		if (parentConfig.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isPresent()) {
+			return true;
+		}
+		return parentConfig.metadata(resumeSubGraphId(nodeId), new TypeRef<Boolean>() {
+		}).orElse(false);
+	}
+
+	static boolean alreadyAppliedNamespace(RunnableConfig config, String namespaceKey) {
+		return config.metadata(nsAppliedKey(namespaceKey)).map(v -> Boolean.TRUE.equals(v)).orElse(false);
+	}
+
+	static String nsAppliedKey(String namespaceKey) {
+		return NS_APPLIED_METADATA_PREFIX + namespaceKey;
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeResumeCheckpointTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeResumeCheckpointTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.internal.node;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4639">#4639</a> regression for
+ * {@link SubCompiledGraphNodeAction} ({@link StateGraph#addNode(String, CompiledGraph)}).
+ */
+class SubCompiledGraphNodeResumeCheckpointTest {
+
+	@Nested
+	class ResumeCheckpointRegression {
+
+		private static final String AGENT_NAME = "qa_agent";
+
+		@Test
+		void parentInterruptBeforeSubCompiledNode_resumeWithParentThreadId_succeeds() throws Exception {
+			MemorySaver saver = MemorySaver.builder().build();
+			AtomicInteger childNodeRuns = new AtomicInteger();
+
+			CompiledGraph childGraph = buildChildGraph(saver, childNodeRuns);
+			CompiledGraph parentGraph = buildParentGraph(childGraph, saver);
+
+			String threadId = "conv-subcompiled-" + System.nanoTime();
+			RunnableConfig invokeConfig = RunnableConfig.builder().threadId(threadId).build();
+
+			AtomicReference<NodeOutput> last = new AtomicReference<>();
+			parentGraph.stream(Map.of("input", "x"), invokeConfig).doOnNext(last::set).blockLast();
+
+			assertInstanceOf(InterruptionMetadata.class, last.get(), "应在进入子图节点前中断");
+			assertEquals(0, childNodeRuns.get(), "首次中断前子图节点不应执行");
+
+			RunnableConfig resumeConfig = RunnableConfig.builder().threadId(threadId).resume().build();
+
+			assertFalse(throwsCheckpointFailure(parentGraph, resumeConfig),
+					"父 threadId resume 不应因子 namespace 无 checkpoint 失败");
+			assertTrue(childNodeRuns.get() >= 1, "resume 后应冷启动子图并执行子节点");
+		}
+
+		private static CompiledGraph buildChildGraph(MemorySaver saver, AtomicInteger childNodeRuns)
+				throws Exception {
+			KeyStrategyFactory keyStrategyFactory = () -> {
+				Map<String, KeyStrategy> strategies = new HashMap<>();
+				strategies.put("input", new ReplaceStrategy());
+				strategies.put("qa_result", new ReplaceStrategy());
+				return strategies;
+			};
+
+			return new StateGraph(keyStrategyFactory)
+					.addNode("child_work", node_async(state -> {
+						childNodeRuns.incrementAndGet();
+						return Map.of("qa_result", "ok");
+					}))
+					.addEdge(START, "child_work")
+					.addEdge("child_work", END)
+					.compile(CompileConfig.builder()
+							.saverConfig(SaverConfig.builder().register(saver).build())
+							.build());
+		}
+
+		private static CompiledGraph buildParentGraph(CompiledGraph childGraph, MemorySaver saver)
+				throws Exception {
+			KeyStrategyFactory keyStrategyFactory = () -> {
+				Map<String, KeyStrategy> strategies = new HashMap<>();
+				strategies.put("input", new ReplaceStrategy());
+				strategies.put("prep_marker", new ReplaceStrategy());
+				strategies.put(ResumableSubGraphAction.outputKeyToParent(AGENT_NAME), new ReplaceStrategy());
+				return strategies;
+			};
+
+			StateGraph workflow = new StateGraph(keyStrategyFactory)
+					.addNode("prep", node_async(state -> Map.of("prep_marker", "ok")))
+					.addNode(AGENT_NAME, childGraph)
+					.addEdge(START, "prep")
+					.addEdge("prep", AGENT_NAME)
+					.addEdge(AGENT_NAME, END);
+
+			return workflow.compile(CompileConfig.builder()
+					.saverConfig(SaverConfig.builder().register(saver).build())
+					.interruptBefore(AGENT_NAME)
+					.build());
+		}
+
+		private static boolean throwsCheckpointFailure(CompiledGraph graph, RunnableConfig resumeConfig) {
+			try {
+				graph.stream(null, resumeConfig).blockLast();
+				return false;
+			}
+			catch (Exception ex) {
+				Throwable root = ex;
+				while (root.getCause() != null && root.getCause() != root) {
+					root = root.getCause();
+				}
+				String message = root.getMessage();
+				return message != null
+						&& (message.contains("valid checkpoint") || message.contains("Missing Checkpoint"));
+			}
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeResumeCheckpointTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeResumeCheckpointTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.internal.node;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.GraphResponse;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.OverAllStateBuilder;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4639">#4639</a> regression for
+ * {@link SubCompiledGraphNodeAction} ({@link StateGraph#addNode(String, CompiledGraph)}).
+ */
+class SubCompiledGraphNodeResumeCheckpointTest {
+
+	private static final String AGENT_NAME = "qa_agent";
+
+	@Test
+	void parentInterruptBeforeSubCompiledNode_resumeWithParentThreadId_succeeds() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		AtomicInteger childNodeRuns = new AtomicInteger();
+
+		CompiledGraph childGraph = buildChildGraph(saver, childNodeRuns);
+		CompiledGraph parentGraph = buildParentGraph(childGraph, saver, true);
+
+		String threadId = "conv-subcompiled-" + System.nanoTime();
+		RunnableConfig invokeConfig = RunnableConfig.builder().threadId(threadId).build();
+
+		AtomicReference<NodeOutput> last = new AtomicReference<>();
+		parentGraph.stream(Map.of("input", "x"), invokeConfig).doOnNext(last::set).blockLast();
+
+		assertInstanceOf(InterruptionMetadata.class, last.get(), "应在进入子图节点前中断");
+		assertEquals(0, childNodeRuns.get(), "首次中断前子图节点不应执行");
+
+		RunnableConfig resumeConfig = RunnableConfig.builder().threadId(threadId).resume().build();
+		AtomicReference<NodeOutput> resumeLast = new AtomicReference<>();
+		parentGraph.stream(null, resumeConfig).doOnNext(resumeLast::set).blockLast();
+
+		assertTrue(childNodeRuns.get() >= 1, "resume 后应冷启动子图并执行子节点");
+		OverAllState state = resumeLast.get().state();
+		assertEquals("ok", state.value("prep_marker").orElse(null), "父终态应保留 prep 结果");
+		assertEquals("ok", state.value("qa_result").orElse(null), "父终态应包含子图输出");
+	}
+
+	@Test
+	void reusedThreadColdStart_withStaleChildCheckpoint_rerunsChildFromStart() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		AtomicInteger childNodeRuns = new AtomicInteger();
+
+		CompiledGraph childGraph = buildChildGraph(saver, childNodeRuns);
+		CompiledGraph parentGraph = buildParentGraph(childGraph, saver, false);
+
+		String threadId = "conv-reuse-" + System.nanoTime();
+		RunnableConfig config = RunnableConfig.builder().threadId(threadId).build();
+
+		parentGraph.stream(Map.of("input", "first"), config).blockLast();
+		assertEquals(1, childNodeRuns.get());
+
+		// Same threadId, no resume(): strategy A must not continue from child CP
+		parentGraph.stream(Map.of("input", "second"), config).blockLast();
+		assertEquals(2, childNodeRuns.get(), "冷启动应再次从 START 跑子节点，而非接着旧 CP");
+	}
+
+	@Test
+	void subCompiled_resumeWithChildCheckpoint_forwardsInterruptionMetadata() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		AtomicReference<Object> feedbackSeen = new AtomicReference<>();
+
+		KeyStrategyFactory childKeys = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			return strategies;
+		};
+		CompileConfig compileConfig = CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build())
+				.build();
+		CompiledGraph childGraph = new StateGraph(childKeys)
+				.addNode("child_work", AsyncNodeActionWithConfig.node_async((state, config) -> {
+					feedbackSeen.set(config.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).orElse(null));
+					return Map.of("qa_result", "ok");
+				}))
+				.addEdge(START, "child_work")
+				.addEdge("child_work", END)
+				.compile(compileConfig);
+
+		String threadId = "conv-hitl-" + System.nanoTime();
+		RunnableConfig prepared = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(
+				RunnableConfig.builder().threadId(threadId).build(), AGENT_NAME, compileConfig, compileConfig);
+		saver.put(prepared, Checkpoint.builder()
+				.id(UUID.randomUUID().toString())
+				.nodeId(START)
+				.nextNodeId("child_work")
+				.state(Map.of("qa_result", "paused"))
+				.build());
+
+		InterruptionMetadata feedback = InterruptionMetadata.builder(AGENT_NAME, OverAllStateBuilder.builder().build())
+				.build();
+		RunnableConfig parentConfig = RunnableConfig.builder()
+				.threadId(threadId)
+				.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, feedback)
+				.addMetadata(resumeSubGraphId(AGENT_NAME), true)
+				.build();
+
+		SubCompiledGraphNodeAction action = new SubCompiledGraphNodeAction(AGENT_NAME, compileConfig, childGraph);
+		OverAllState state = OverAllStateBuilder.builder()
+				.withData(Map.of("input", "x"))
+				.withKeyStrategies(childKeys.apply())
+				.build();
+		Map<String, Object> result = action.apply(state, parentConfig).join();
+		@SuppressWarnings("unchecked")
+		Flux<GraphResponse<NodeOutput>> flux = (Flux<GraphResponse<NodeOutput>>) result
+				.get(outputKeyToParent(AGENT_NAME));
+		flux.blockLast();
+
+		assertInstanceOf(InterruptionMetadata.class, feedbackSeen.get(), "子图应收到真实 HITL 反馈");
+	}
+
+	@Test
+	void subCompiled_interruptionMetadataWithoutChildCheckpoint_doesNotForward() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		AtomicReference<Object> feedbackSeen = new AtomicReference<>("unset");
+
+		KeyStrategyFactory childKeys = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			return strategies;
+		};
+		CompileConfig compileConfig = CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build())
+				.build();
+		CompiledGraph childGraph = new StateGraph(childKeys)
+				.addNode("child_work", AsyncNodeActionWithConfig.node_async((state, config) -> {
+					feedbackSeen.set(config.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).orElse(null));
+					return Map.of("qa_result", "ok");
+				}))
+				.addEdge(START, "child_work")
+				.addEdge("child_work", END)
+				.compile(compileConfig);
+
+		InterruptionMetadata feedback = InterruptionMetadata.builder(AGENT_NAME, OverAllStateBuilder.builder().build())
+				.build();
+		RunnableConfig parentConfig = RunnableConfig.builder()
+				.threadId("conv-cold-hitl-" + System.nanoTime())
+				.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, feedback)
+				.build();
+
+		SubCompiledGraphNodeAction action = new SubCompiledGraphNodeAction(AGENT_NAME, compileConfig, childGraph);
+		OverAllState state = OverAllStateBuilder.builder()
+				.withData(Map.of("input", "x"))
+				.withKeyStrategies(childKeys.apply())
+				.build();
+		Map<String, Object> result = action.apply(state, parentConfig).join();
+		@SuppressWarnings("unchecked")
+		Flux<GraphResponse<NodeOutput>> flux = (Flux<GraphResponse<NodeOutput>>) result
+				.get(outputKeyToParent(AGENT_NAME));
+		flux.blockLast();
+
+		assertNull(feedbackSeen.get(), "冷子图不应写回 InterruptionMetadata");
+	}
+
+	private static CompiledGraph buildChildGraph(MemorySaver saver, AtomicInteger childNodeRuns) throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			return strategies;
+		};
+
+		return new StateGraph(keyStrategyFactory)
+				.addNode("child_work", node_async(state -> {
+					childNodeRuns.incrementAndGet();
+					return Map.of("qa_result", "ok");
+				}))
+				.addEdge(START, "child_work")
+				.addEdge("child_work", END)
+				.compile(CompileConfig.builder()
+						.saverConfig(SaverConfig.builder().register(saver).build())
+						.build());
+	}
+
+	private static CompiledGraph buildParentGraph(CompiledGraph childGraph, MemorySaver saver, boolean interruptBefore)
+			throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("prep_marker", new ReplaceStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			strategies.put(ResumableSubGraphAction.outputKeyToParent(AGENT_NAME), new ReplaceStrategy());
+			return strategies;
+		};
+
+		StateGraph workflow = new StateGraph(keyStrategyFactory)
+				.addNode("prep", node_async(state -> Map.of("prep_marker", "ok")))
+				.addNode(AGENT_NAME, childGraph)
+				.addEdge(START, "prep")
+				.addEdge("prep", AGENT_NAME)
+				.addEdge(AGENT_NAME, END);
+
+		CompileConfig.Builder compileBuilder = CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build());
+		if (interruptBefore) {
+			compileBuilder.interruptBefore(AGENT_NAME);
+		}
+		return workflow.compile(compileBuilder.build());
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/SubGraphRunnableConfigBridgeTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/SubGraphRunnableConfigBridgeTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.internal.node;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.OverAllStateBuilder;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit coverage for {@link SubGraphRunnableConfigBridge} gate / namespace / HITL rules.
+ */
+class SubGraphRunnableConfigBridgeTest {
+
+	private static final String NODE_ID = "qa_agent";
+
+	@Test
+	void prepare_stripsResumeMarkersImmediately() {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		RunnableConfig parent = RunnableConfig.builder()
+				.threadId("t1")
+				.resume()
+				.addMetadata(resumeSubGraphId(NODE_ID), true)
+				.build();
+
+		RunnableConfig child = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID, compileConfig,
+				compileConfig);
+
+		assertTrue(child.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isEmpty());
+		assertTrue(child.metadata(resumeSubGraphId(NODE_ID)).isEmpty());
+		assertEquals("t1_" + subGraphId(NODE_ID), child.threadId().orElseThrow());
+	}
+
+	@Test
+	void prepare_preservesParentContextCopy() {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		RunnableConfig parent = RunnableConfig.builder().threadId("t1").build();
+		parent.context().put("request-id", "context-value");
+
+		RunnableConfig child = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID, compileConfig,
+				compileConfig);
+
+		assertEquals("context-value", child.context().get("request-id"));
+		child.context().put("child-only", "x");
+		assertFalse(parent.context().containsKey("child-only"), "child writes must not leak to parent context");
+	}
+
+	@Test
+	void prepare_forceNamespace_whenSaversDiffer() {
+		MemorySaver parentSaver = MemorySaver.builder().build();
+		MemorySaver childSaver = MemorySaver.builder().build();
+		CompileConfig parentCompile = compileConfig(parentSaver);
+		CompileConfig childCompile = compileConfig(childSaver);
+		RunnableConfig parent = RunnableConfig.builder().threadId("conv").build();
+
+		RunnableConfig withoutForce = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID,
+				subGraphId(NODE_ID), parentCompile, childCompile, false);
+		assertEquals("conv", withoutForce.threadId().orElseThrow());
+
+		RunnableConfig withForce = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID,
+				subGraphId(NODE_ID), parentCompile, childCompile, true);
+		assertEquals("conv_" + subGraphId(NODE_ID), withForce.threadId().orElseThrow());
+	}
+
+	@Test
+	void prepare_forceNamespace_parentWithoutSaver_childWithSaver_succeeds() {
+		CompileConfig parentWithoutSaver = compileConfigWithoutSaver();
+		CompileConfig childWithSaver = compileConfig(MemorySaver.builder().build());
+		RunnableConfig parent = RunnableConfig.builder().threadId("conv-no-parent-saver").resume().build();
+
+		RunnableConfig child = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID,
+				subGraphId(NODE_ID), parentWithoutSaver, childWithSaver, true);
+
+		assertEquals("conv-no-parent-saver_" + subGraphId(NODE_ID), child.threadId().orElseThrow());
+		assertTrue(child.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isEmpty());
+	}
+
+	@Test
+	void prepare_forceNamespace_neitherHasSaver_stillNamespaces() {
+		CompileConfig noSaver = compileConfigWithoutSaver();
+		RunnableConfig parent = RunnableConfig.builder().threadId("conv-none").build();
+
+		RunnableConfig child = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID,
+				subGraphId(NODE_ID), noSaver, noSaver, true);
+
+		assertEquals("conv-none_" + subGraphId(NODE_ID), child.threadId().orElseThrow());
+	}
+
+	@Test
+	void prepare_withoutForceNamespace_parentWithoutSaver_childWithSaver_throws() {
+		CompileConfig parentWithoutSaver = compileConfigWithoutSaver();
+		CompileConfig childWithSaver = compileConfig(MemorySaver.builder().build());
+		RunnableConfig parent = RunnableConfig.builder().threadId("conv").build();
+
+		IllegalStateException ex = assertThrows(IllegalStateException.class,
+				() -> SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID, subGraphId(NODE_ID),
+						parentWithoutSaver, childWithSaver, false));
+		assertTrue(ex.getMessage().contains("Missing CheckpointSaver"));
+	}
+
+	@Test
+	void prepare_callerThreadIdEndingWithSuffix_stillNamespaces() {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		String namespace = subGraphId(NODE_ID);
+		// Caller-controlled id that already ends with the suffix must still be namespaced
+		RunnableConfig parent = RunnableConfig.builder().threadId("x_" + namespace).build();
+
+		RunnableConfig child = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID, compileConfig,
+				compileConfig);
+
+		assertEquals("x_" + namespace + "_" + namespace, child.threadId().orElseThrow());
+	}
+
+	@Test
+	void prepare_sameNamespaceKey_isIdempotentViaProvenance() {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		RunnableConfig parent = RunnableConfig.builder().threadId("t1").build();
+
+		RunnableConfig once = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID, compileConfig,
+				compileConfig);
+		RunnableConfig twice = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(once, NODE_ID, compileConfig,
+				compileConfig);
+
+		assertEquals(once.threadId().orElseThrow(), twice.threadId().orElseThrow());
+	}
+
+	@Test
+	void prepare_nestedDifferentNamespaceKeys_append() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		RunnableConfig parent = RunnableConfig.builder().threadId("t1").build();
+
+		RunnableConfig outer = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, "outer",
+				subGraphId("outer"), compileConfig, compileConfig, true);
+		RunnableConfig inner = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(outer, "inner",
+				subGraphId("inner"), compileConfig, compileConfig, true);
+
+		assertEquals("t1_subgraph_outer_subgraph_inner", inner.threadId().orElseThrow());
+	}
+
+	@Test
+	void resolve_coldParent_withStaleChildCheckpoint_doesNotUpdateState() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		CompiledGraph childGraph = buildChildGraph(saver);
+
+		String parentThread = "conv-stale-" + System.nanoTime();
+		RunnableConfig parent = RunnableConfig.builder().threadId(parentThread).build();
+		RunnableConfig prepared = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID,
+				compileConfig, compileConfig);
+
+		saver.put(prepared, Checkpoint.builder()
+				.id(UUID.randomUUID().toString())
+				.nodeId("child_work")
+				.nextNodeId(END)
+				.state(Map.of("qa_result", "stale"))
+				.build());
+
+		RunnableConfig resolved = SubGraphRunnableConfigBridge.resolveForCompiledChildResume(Map.of("input", "x"),
+				childGraph, prepared, parent, NODE_ID);
+
+		assertTrue(resolved.checkPointId().isEmpty(), "cold parent must not resume stale child CP");
+		assertTrue(resolved.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isEmpty());
+	}
+
+	@Test
+	void resolve_parentResume_withChildCheckpoint_updatesAndForwardsInterruptionMetadata() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		CompiledGraph childGraph = buildChildGraph(saver);
+
+		String parentThread = "conv-hitl-" + System.nanoTime();
+		InterruptionMetadata feedback = InterruptionMetadata.builder(NODE_ID, OverAllStateBuilder.builder().build())
+				.build();
+		RunnableConfig parent = RunnableConfig.builder()
+				.threadId(parentThread)
+				.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, feedback)
+				.addMetadata(resumeSubGraphId(NODE_ID), true)
+				.build();
+		RunnableConfig prepared = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID,
+				compileConfig, compileConfig);
+
+		saver.put(prepared, Checkpoint.builder()
+				.id(UUID.randomUUID().toString())
+				.nodeId("child_work")
+				.nextNodeId(END)
+				.state(Map.of("qa_result", "paused"))
+				.build());
+
+		RunnableConfig resolved = SubGraphRunnableConfigBridge.resolveForCompiledChildResume(Map.of("input", "x"),
+				childGraph, prepared, parent, NODE_ID);
+
+		assertTrue(resolved.checkPointId().isPresent(), "parent resume + child CP should updateState");
+		assertInstanceOf(InterruptionMetadata.class,
+				resolved.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).orElseThrow());
+	}
+
+	@Test
+	void resolve_parentInterruptionMetadata_withoutChildCheckpoint_doesNotForwardFeedback() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompileConfig compileConfig = compileConfig(saver);
+		CompiledGraph childGraph = buildChildGraph(saver);
+
+		InterruptionMetadata feedback = InterruptionMetadata.builder(NODE_ID, OverAllStateBuilder.builder().build())
+				.build();
+		RunnableConfig parent = RunnableConfig.builder()
+				.threadId("conv-cold-hitl-" + System.nanoTime())
+				.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, feedback)
+				.build();
+		RunnableConfig prepared = SubGraphRunnableConfigBridge.prepareChildRunnableConfig(parent, NODE_ID,
+				compileConfig, compileConfig);
+
+		RunnableConfig resolved = SubGraphRunnableConfigBridge.resolveForCompiledChildResume(Map.of("input", "x"),
+				childGraph, prepared, parent, NODE_ID);
+
+		assertTrue(resolved.checkPointId().isEmpty());
+		assertTrue(resolved.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isEmpty(),
+				"cold child must not receive InterruptionMetadata");
+	}
+
+	@Test
+	void hasParentResumeIntent_acceptsHumanFeedbackOrResumeSubgraphFlag() {
+		assertFalse(SubGraphRunnableConfigBridge.hasParentResumeIntent(RunnableConfig.builder().build(), NODE_ID));
+		assertTrue(SubGraphRunnableConfigBridge.hasParentResumeIntent(
+				RunnableConfig.builder().resume().build(), NODE_ID));
+		assertTrue(SubGraphRunnableConfigBridge.hasParentResumeIntent(
+				RunnableConfig.builder().addMetadata(resumeSubGraphId(NODE_ID), true).build(), NODE_ID));
+	}
+
+	private static CompileConfig compileConfig(MemorySaver saver) {
+		return CompileConfig.builder().saverConfig(SaverConfig.builder().register(saver).build()).build();
+	}
+
+	/** Explicit empty SaverConfig — {@code CompileConfig.builder().build()} still defaults to MemorySaver. */
+	private static CompileConfig compileConfigWithoutSaver() {
+		return CompileConfig.builder().saverConfig(new SaverConfig()).build();
+	}
+
+	private static CompiledGraph buildChildGraph(MemorySaver saver) throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("input", new ReplaceStrategy());
+			strategies.put("qa_result", new ReplaceStrategy());
+			return strategies;
+		};
+		return new StateGraph(keyStrategyFactory)
+				.addNode("child_work", node_async(state -> Map.of("qa_result", "ok")))
+				.addEdge(START, "child_work")
+				.addEdge("child_work", END)
+				.compile(compileConfig(saver));
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
When a parent StateGraph embeds a ReactAgent via asNode() with a shared CheckpointSaver, interrupts before the agent node (e.g. `interruptBefore("qa_agent")`), and the user resumes with the parent threadId (the documented pattern), the run failed with:

Resume request without a valid checkpoint!(Refer to the test submission form for the reproduction steps.)
<img width="1404" height="202" alt="image" src="https://github.com/user-attachments/assets/41b66b9b-714a-4f3c-a4de-772a8842be61" />

The parent checkpoint lives on the parent thread namespace; the child agent uses `{parentThreadId}_subgraph_{nodeId}` and had never run, so no child checkpoint exists. The adapter still copied the parent `HUMAN_FEEDBACK` resume marker into the child RunnableConfig, so the child GraphRunner tried initializeFromResume on an empty child namespace.

Additionally, during the repair process, it was discovered that `StateGraph.addNode(id, compiledGraph)` (`SubCompiledGraphNodeAction`) and `A2aRemoteAgent.asNode()` (`A2aNodeActionWithConfig`) also have the same issue:
**Same class of bug also affects:**
| Entry | Typical failure before fix |
|-------|----------------------------|
| `ReactAgent.asNode()` (`AgentToSubCompiledGraphNodeAdapter`) | `Resume request without a valid checkpoint!` (`HUMAN_FEEDBACK` → child `initializeFromResume`) |
| `StateGraph.addNode(id, compiledGraph)` (`SubCompiledGraphNodeAction`) | `Missing Checkpoint!` (parent sets `resume_subgraph_*` → `updateState` without child CP) |
| `A2aRemoteAgent.asNode()` (`A2aNodeActionWithConfig`) | Same metadata leak on `RunnableConfig` / child threadId (HTTP path may not throw; inner graph does) |

### Root cause
1. Parent `resume()` adds `HUMAN_FEEDBACK` (and sometimes `resume_subgraph_*`) to `RunnableConfig`.
2. Child config was built via `RunnableConfig.builder(parentConfig)` and shared-saver `threadId` rewrite to `{parentId}_subgraph_{nodeId}`.
3. Child had **no** checkpoint in that namespace (parent interrupted **before** the subgraph ran).
4. Child `GraphRunner` still attempted resume (`initializeFromResume` or `updateState`) → failure.

This PR extracts SubGraphRunnableConfigBridge for shared parent→child RunnableConfig handling.  Fix ReactAgent. asNode, SubCompiledGraphNodeAction, and A2aNodeActionWithConfig when parent interruptBefore leaves no child CP.
Add regression tests and examples/fix repro harness for all three paths.

### Does this pull request fix one issue?
Yes. Fixes #4639


### Describe how you did it
Introduce **`SubGraphRunnableConfigBridge`** in `graph-core` to centralize parent→child config bridging:
- **`prepareChildRunnableConfig`**: copy business metadata; clear `checkPointId`; **strip** `HUMAN_FEEDBACK` and `resume_subgraph_*`; rewrite `threadId` when parent/child share the same saver (idempotent suffix).
- **`resolveForCompiledChildResume`**: call `updateState` **only** when a checkpoint already exists in the child namespace; otherwise cold-start.
- **`withInterruptionMetadataForHooks`**: forward real `InterruptionMetadata` for HITL hooks only (not `resume()` placeholder).
**Call sites:**
- `SubCompiledGraphNodeAction` (graph-core)
- `ReactAgent.AgentToSubCompiledGraphNodeAdapter` (agent-framework)
- `A2aNodeActionWithConfig` (+ pass child `CompileConfig` from `A2aRemoteAgentNode`)


### Describe how to verify it
```
export AI_DASHSCOPE_API_KEY=sk-xxxx
./mvnw install -pl spring-ai-alibaba-graph-core,spring-ai-alibaba-agent-framework -DskipTests -q
./mvnw -pl spring-ai-alibaba-graph-core \
  -Dtest=SubCompiledGraphNodeResumeCheckpointTest test
./mvnw -pl spring-ai-alibaba-agent-framework \
  -Dtest='ReactAgentTest$ResumeCheckpointRegression,A2aRemoteAgentResumeCheckpointTest' test
```
### Special notes for reviews

- **Scope:** Fixes [#4639](https://github.com/alibaba/spring-ai-alibaba/issues/4639) for **all three** parent→child subgraph entry points, not only `ReactAgent.asNode()`:
- `AgentToSubCompiledGraphNodeAdapter` (wrapped with `node_async` — parent usually does **not** set `resume_subgraph_*`)
- `SubCompiledGraphNodeAction` (bare `ResumableSubGraphAction` — parent **does** set `resume_subgraph_*`; pre-fix failure was often `Missing Checkpoint! ` rather than `valid checkpoint! `)
- `A2aNodeActionWithConfig` (HTTP path; metadata leak verified via **inner-graph probe** in tests)

- **New type `SubGraphRunnableConfigBridge`:** Not a domain entity — static helpers in `graph-core` `internal. node` to avoid duplicating strip / threadId / `updateState` logic.  **Please review this class first**;  the three call sites should stay thin.

- **Core rule :** `resolveForCompiledChildResume` calls `updateState` **only when** `saver. get(preparedChildConfig)` finds a child checkpoint.  Parent `resume_subgraph_*` alone must **not** trigger `updateState` if the child namespace has no CP (#4639 PRIMARY).

- **`HUMAN_FEEDBACK` handling:**
- Stripped in `prepareChildRunnableConfig` so the child does not `initializeFromResume` without a child CP.
- Re-added via `withInterruptionMetadataForHooks` **only** when the parent value is `InterruptionMetadata` (HITL), not the `resume()` string placeholder.

- **Business metadata:** Still copied via `RunnableConfig. builder(parentConfig)` (same as pre-fix `SubCompiledGraphNodeAction`);  only resume-specific keys are removed.

- **A2a specifics:** `A2aRemoteAgentNode` now passes `subGraph.compileConfig` into `A2aNodeActionWithConfig` so shared-saver detection uses the real child compile config.  `namespacedThreadId` is idempotent to avoid double `_subgraph_*` suffix when the inner graph hits `A2aNode` again.

- **Breaking-change risk:** Low.  Callers that incorrectly relied on parent `HUMAN_FEEDBACK` forcing child `initializeFromResume` without a child CP will now get a **cold-start** child run (intended).  Legitimate child-namespace resume (child already has CP, or CONTROL scenarios) unchanged.