### PR TITLE
fix(graph): preserve context for compiled subgraphs

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -69,7 +69,6 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 		}).orElse(false);
 
 		RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config).checkPointId(null).nextNode(null).build();
-		subGraphRunnableConfig.clearContext();
 
 		var parentSaver = parentCompileConfig.checkpointSaver();
 		var subGraphSaver = subGraph.compileConfig.checkpointSaver();
@@ -89,7 +88,6 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 					.nextNode(null)
 					.checkPointId(null)
 					.build();
-				subGraphRunnableConfig.clearContext();
 			}
 		}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -68,6 +68,8 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 		final boolean resumeSubgraph = config.metadata(resumeSubGraphId(nodeId), new TypeRef<Boolean>() {
 		}).orElse(false);
 
+		// Build from the parent config so the subgraph receives run-scoped context,
+		// while RunnableConfig.Builder keeps the child context isolated.
 		RunnableConfig subGraphRunnableConfig = RunnableConfig.builder(config).checkPointId(null).nextNode(null).build();
 
 		var parentSaver = parentCompileConfig.checkpointSaver();

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CompiledSubGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CompiledSubGraphTest.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.graph;
 
 import com.alibaba.cloud.ai.graph.action.AsyncNodeAction;
+import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
@@ -101,6 +102,32 @@ public class CompiledSubGraphTest {
 			.addEdge("NODE3.3", "NODE3.4")
 			.addEdge("NODE3.4", END)
 			.compile(compileConfig);
+	}
+
+	@Test
+	public void testCompiledSubgraphReceivesParentContext() throws Exception {
+		var subGraph = new StateGraph(getStrategyFactory())
+			.addNode("child", AsyncNodeActionWithConfig.node_async((state, config) -> Map.of("messages",
+					"child:" + config.context().get("request-id"))))
+			.addEdge(START, "child")
+			.addEdge("child", END)
+			.compile();
+
+		var parentGraph = new StateGraph(getStrategyFactory())
+			.addNode("parent", AsyncNodeActionWithConfig.node_async((state, config) -> {
+				config.context().put("request-id", "context-value");
+				return Map.of("messages", "parent");
+			}))
+			.addNode("subgraph", subGraph)
+			.addEdge(START, "parent")
+			.addEdge("parent", "subgraph")
+			.addEdge("subgraph", END)
+			.compile();
+
+		var output = parentGraph.invoke(Map.of(), RunnableConfig.builder().build()).orElseThrow();
+
+		assertIterableEquals(List.of("parent", "child:context-value"),
+				output.value("messages", List.class).orElseThrow());
 	}
 
 	@Test

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CompiledSubGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CompiledSubGraphTest.java
@@ -107,8 +107,10 @@ public class CompiledSubGraphTest {
 	@Test
 	public void testCompiledSubgraphReceivesParentContext() throws Exception {
 		var subGraph = new StateGraph(getStrategyFactory())
-			.addNode("child", AsyncNodeActionWithConfig.node_async((state, config) -> Map.of("messages",
-					"child:" + config.context().get("request-id"))))
+			.addNode("child", AsyncNodeActionWithConfig.node_async((state, config) -> {
+				config.context().put("child-only", "should-not-leak");
+				return Map.of("messages", "child:" + config.context().get("request-id"));
+			}))
 			.addEdge(START, "child")
 			.addEdge("child", END)
 			.compile();
@@ -119,14 +121,17 @@ public class CompiledSubGraphTest {
 				return Map.of("messages", "parent");
 			}))
 			.addNode("subgraph", subGraph)
+			.addNode("after", AsyncNodeActionWithConfig.node_async((state, config) -> Map.of("messages",
+					"after:" + config.context().containsKey("child-only"))))
 			.addEdge(START, "parent")
 			.addEdge("parent", "subgraph")
-			.addEdge("subgraph", END)
+			.addEdge("subgraph", "after")
+			.addEdge("after", END)
 			.compile();
 
 		var output = parentGraph.invoke(Map.of(), RunnableConfig.builder().build()).orElseThrow();
 
-		assertIterableEquals(List.of("parent", "child:context-value"),
+		assertIterableEquals(List.of("parent", "child:context-value", "after:false"),
 				output.value("messages", List.class).orElseThrow());
 	}
 


### PR DESCRIPTION
## Summary
- preserve parent `RunnableConfig.context()` when executing compiled subgraphs
- keep subgraph checkpoint/next-node isolation while allowing run-scoped context to be read inside the subgraph
- add a regression test for parent context flowing into a compiled subgraph node

Fixes #4191

## Validation
- `./mvnw.cmd -pl spring-ai-alibaba-graph-core "-Dtest=CompiledSubGraphTest" test`