### PR TITLE
fix(graph): reuse classpath skill jar filesystem

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -80,6 +81,7 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	private final Map<String, String> jarSkillContentCache = new HashMap<>();
 	// JAR FileSystem for classpath resources (only created if resource is in JAR)
 	private FileSystem jarFileSystem;
+	private boolean ownsJarFileSystem;
 
 	private ClasspathSkillRegistry(Builder builder) {
 		this.classpathPath = builder.classpathPath != null && !builder.classpathPath.isEmpty()
@@ -149,8 +151,8 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				else if ("jar".equals(uri.getScheme())) {
 					// Resource is in a JAR file (production mode)
 					// Create or reuse JAR FileSystem
-					if (jarFileSystem == null) {
-						jarFileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+					if (jarFileSystem == null || !jarFileSystem.isOpen()) {
+						jarFileSystem = getOrCreateJarFileSystem(uri);
 					}
 					// Get path within the JAR file system
 					// URI format: jar:file:/path/to.jar!/skills
@@ -201,6 +203,21 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		}
 
 		this.skills = loadedSkills;
+	}
+
+	FileSystem getOrCreateJarFileSystem(URI uri) throws IOException {
+		if (jarFileSystem != null && jarFileSystem.isOpen()) {
+			return jarFileSystem;
+		}
+		try {
+			jarFileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
+			ownsJarFileSystem = true;
+		}
+		catch (FileSystemAlreadyExistsException ex) {
+			jarFileSystem = FileSystems.getFileSystem(uri);
+			ownsJarFileSystem = false;
+		}
+		return jarFileSystem;
 	}
 
 	/**
@@ -466,15 +483,16 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	 * Should be called when the registry is no longer needed.
 	 */
 	public void close() {
-		if (jarFileSystem != null) {
+		if (ownsJarFileSystem && jarFileSystem != null) {
 			try {
 				jarFileSystem.close();
 			}
 			catch (IOException e) {
 				logger.warn("Failed to close JAR filesystem: {}", e.getMessage());
-			}
-			jarFileSystem = null;
 		}
+		jarFileSystem = null;
+		ownsJarFileSystem = false;
+	}
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryEnhancementsTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryEnhancementsTest.java
@@ -20,11 +20,17 @@ import com.alibaba.cloud.ai.graph.skills.SkillMetadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.net.URI;
+import java.nio.file.FileSystem;
 import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -50,6 +56,33 @@ class ClasspathSkillRegistryEnhancementsTest {
 		assertFalse(registry.contains("sample-skill"));
 		assertTrue(registry.search("sample").isEmpty());
 		assertThrows(IllegalStateException.class, () -> registry.readSkillContentByPath(skill.getSkillPath()));
+	}
+
+	@Test
+	void classpathRegistryReusesExistingJarFileSystem(@TempDir Path tempDir) throws Exception {
+		Path jarPath = tempDir.resolve("skills.jar");
+		try (JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jarPath))) {
+			jarOutputStream.putNextEntry(new JarEntry("skills/"));
+			jarOutputStream.closeEntry();
+		}
+		URI jarUri = URI.create("jar:" + jarPath.toUri());
+
+		ClasspathSkillRegistry firstRegistry = ClasspathSkillRegistry.builder()
+				.autoLoad(false)
+				.build();
+		ClasspathSkillRegistry secondRegistry = ClasspathSkillRegistry.builder()
+				.autoLoad(false)
+				.build();
+
+		FileSystem firstFileSystem = firstRegistry.getOrCreateJarFileSystem(jarUri);
+		FileSystem secondFileSystem = secondRegistry.getOrCreateJarFileSystem(jarUri);
+
+		assertSame(firstFileSystem, secondFileSystem);
+		secondRegistry.close();
+		assertTrue(firstFileSystem.isOpen());
+
+		firstRegistry.close();
+		assertFalse(firstFileSystem.isOpen());
 	}
 
 }


### PR DESCRIPTION
## Summary
- reuse an already-registered JAR FileSystem when loading classpath skills from the same jar URI
- track whether a registry owns the JAR FileSystem before closing it
- add a regression test for two registries opening the same classpath skill jar

Fixes #4547

## Validation
- `./mvnw.cmd -pl spring-ai-alibaba-graph-core "-Dtest=ClasspathSkillRegistryEnhancementsTest" test`