### PR TITLE
fix(graph): resolve GraphResponse futures synchronously in streamFromInitialNode to preserve streaming output order

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -46,7 +46,6 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
 import static java.lang.String.format;
@@ -582,20 +581,27 @@ public class CompiledGraph {
 		Objects.requireNonNull(config, "config cannot be null");
 		try {
 			GraphRunner runner = new GraphRunner(this, config);
-			return runner.run(overAllState).flatMap(data -> {
-				if (data.isDone()) {
-					if (data.resultValue().isPresent() && data.resultValue().get() instanceof NodeOutput) {
-						return Flux.just((NodeOutput) data.resultValue().get());
-					} else {
+			return runner.run(overAllState)
+				.<Flux<NodeOutput>>map(data -> {
+					if (data.isDone()) {
+						if (data.resultValue().isPresent()
+								&& data.resultValue().get() instanceof NodeOutput no) {
+							return Flux.just(no);
+						}
 						return Flux.empty();
 					}
-				}
-				if (data.isError()) {
-					return Mono.fromFuture(data.getOutput()).onErrorMap(throwable -> throwable).flux();
-				}
-
-				return Mono.fromFuture(data.getOutput()).flux();
-			});
+					if (data.isError()) {
+						try {
+							data.getOutput().join();
+							return Flux.<NodeOutput>empty();
+						}
+						catch (java.util.concurrent.CompletionException e) {
+							return Flux.error(e.getCause());
+						}
+					}
+					return Flux.just(data.getOutput().join());
+				})
+				.flatMap(flux -> flux);
 		} catch (Exception e) {
 			return Flux.error(e);
 		}


### PR DESCRIPTION
#Describe what this PR does / why we need it
                              
  Fixes streaming output ordering in ReactAgent.streamMessages(). The root cause is that
  CompiledGraph.streamFromInitialNode uses Mono.fromFuture to asynchronously unwrap already-completed
  CompletableFuture objects. Combined with flatMap, inner publishers complete on different threads and results
  are emitted in completion order rather than upstream emission order, causing text chunks to interleave. The
  fix resolves futures synchronously in a map stage via join(), wrapping results in Flux.just() / Flux.error() /
   Flux.empty(), while flatMap no longer handles async unwrapping. Mono.fromFuture is designed for in-flight
  futures, but here every future is already resolved via completedFuture() at construction time —
  Mono.fromFuture is unnecessary overhead at this boundary.
  If I have any misunderstandings, please feel free to correct me.
                                                                                  
  修复了 ReactAgent.streamMessages() 流式输出顺序错乱的问题。根因是 CompiledGraph.streamFromInitialNode
  对已完成的 CompletableFuture 使用了 Mono.fromFuture 异步解包，与 flatMap 配合时内部 publisher
  在不同线程上完成，flatMap 按完成顺序而非上游发射顺序输出，造成文本块乱序。
  修复方案是在 map 阶段通过 join() 同步读取已完成的值并包装为 Flux.just() / Flux.error() / Flux.empty()，flatMap
  不再承担异步解包职责。
  Mono.fromFuture 用于等待未完成的 Future，而此处的 Future 在创建时已通过completedFuture() 完成，Mono.fromFuture 是  多余的包装。

 如果我有任何理解上的错误，麻烦请指正我

 # Does this pull request fix one issue?

  Fixes #4630

 # Describe how you did it
  Moved future resolution from the flatMap lambda in CompiledGraph.streamFromInitialNode into a preceding map
  stage: isDone() with NodeOutput returns Flux.just(no), isDone() without NodeOutput returns Flux.empty(),
  isError() catches CompletionException and returns Flux.error(cause), normal data calls join() and returns
  Flux.just(value). Added StreamOutputOrderingTest covering bug reproduction, concurrent stress, and mixed
  signal handling.

  将 CompiledGraph.streamFromInitialNode 中 flatMap 内的 Future 解包逻辑前移至 map 阶段：isDone() 且携带
  NodeOutput 返回 Flux.just(no)，isDone() 无 NodeOutput 返回 Flux.empty()，isError() 捕获 CompletionException
  返回 Flux.error(cause)，正常数据 join() 后返回 Flux.just(value)。

  #Describe how to verify it

 ./mvnw -pl spring-ai-alibaba-graph-core test  

  #Special notes for reviews

  Mono.fromFuture was used only at these two call sites in the file; no other logic is affected.flatMap itself is unchanged; its concurrency is preserved.

  Mono.fromFuture 在该文件中仅此两处使用，替换后不影响其他逻辑。flatMap 本身未变更，并发度保持不变。
