### PR TITLE
fix(graph): remove dead code branch in TemplateTransformNode placeholder fallback

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/TemplateTransformNode.java
@@ -102,11 +102,7 @@ public class TemplateTransformNode implements NodeAction {
 				logger.debug("Variable '{}' exists but is null: {}", key, replacement);
 			}
 			else {
-				if (defaultValue != null) {
-					replacement = "{{" + key + " ?: " + defaultValue.trim() + "}}";
-				} else {
-					replacement = "{{" + key + "}}";
-				}
+				replacement = "{{" + key + "}}";
 				logger.debug("Variable '{}' not found, keeping placeholder: {}", key, replacement);
 			}
 			replacement = replacement.replace("\\", "\\\\").replace("$", "\\$");


### PR DESCRIPTION
## Summary

Fixes #4652

The `else` block inside `TemplateTransformNode.apply()` contained an inner `if (defaultValue != null)` check that could never evaluate to `true`.

**Why it's dead code:**

The `else` block (line 104) is only reached when all three prior conditions are false:
1. `val != null` → false (no value in state)
2. `else if (defaultValue != null)` → **false** (no default value in template)
3. `else if (state.data().containsKey(key))` → false (key not in state at all)

Since condition 2 must be false to reach the `else` block, `defaultValue` is always `null` inside it. The inner `if (defaultValue != null)` branch that reconstructed `{{key ?: default}}` was therefore unreachable.

**Fix:**

Remove the dead inner `if/else` and keep only the correct fallback:

```java
// Before
else {
    if (defaultValue != null) {
        replacement = "{{" + key + " ?: " + defaultValue.trim() + "}}";
    } else {
        replacement = "{{" + key + "}}";
    }
    logger.debug("Variable '{}' not found, keeping placeholder: {}", key, replacement);
}

// After
else {
    replacement = "{{" + key + "}}";
    logger.debug("Variable '{}' not found, keeping placeholder: {}", key, replacement);
}
```

No behavior change — the `else` branch already always executed `replacement = "{{" + key + "}}"` in practice.

## Test plan

- [ ] Existing `TemplateTransformNode` tests pass
- [ ] Template with unknown variable `{{missing_key}}` still keeps the placeholder unchanged
- [ ] Template with known variable `{{name ?: default}}` still resolves to `default` when `name` is absent from state (handled by the `else if (defaultValue != null)` branch, unchanged)