### PR TITLE
fix(a2a): use correct logger class references in A2aRemoteAgent and RemoteAgentCardProvider

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aRemoteAgent.java
@@ -28,11 +28,13 @@ import io.a2a.spec.AgentCard;
 
 import java.util.HashMap;
 import java.util.Objects;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class A2aRemoteAgent extends BaseAgent {
-	Logger logger = Logger.getLogger(A2aRemoteAgent.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(A2aRemoteAgent.class);
 
 	private final AgentCardWrapper agentCard;
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/RemoteAgentCardProvider.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/RemoteAgentCardProvider.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 
 public class RemoteAgentCardProvider implements AgentCardProvider {
 
-	private static final Logger logger = LoggerFactory.getLogger(AgentCard.class);
+	private static final Logger logger = LoggerFactory.getLogger(RemoteAgentCardProvider.class);
 
 	private final String url;
 


### PR DESCRIPTION
## Summary

Two logging bugs in the `a2a` module caused log output to be misattributed, making debugging difficult:

### Bug 1 — Wrong logger class in `RemoteAgentCardProvider`

```java
// Before (wrong)
private static final Logger logger = LoggerFactory.getLogger(AgentCard.class);

// After (correct)
private static final Logger logger = LoggerFactory.getLogger(RemoteAgentCardProvider.class);
```

All log messages from `RemoteAgentCardProvider` (e.g., the `logger.info` at line 61 and `logger.error` at line 66) were appearing under the `io.a2a.spec.AgentCard` logger namespace. This makes it impossible to filter logs by the actual class name and confuses tracing.

### Bug 2 — `java.util.logging.Logger` in `A2aRemoteAgent`

```java
// Before (wrong — uses JUL, not SLF4J)
import java.util.logging.Logger;
Logger logger = Logger.getLogger(A2aRemoteAgent.class.getName());

// After (correct — consistent with the rest of the codebase)
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;
private static final Logger logger = LoggerFactory.getLogger(A2aRemoteAgent.class);
```

`A2aRemoteAgent` was the only non-test class in the `agent-framework` module using `java.util.logging` instead of SLF4J, which is inconsistent with the project's coding standard (CLAUDE.md: "use SLF4J logging").

## Test plan

- [ ] Existing tests pass
- [ ] Log output from `RemoteAgentCardProvider` now appears under `com.alibaba.cloud.ai.graph.agent.a2a.RemoteAgentCardProvider` in the log namespace