### PR TITLE
fix(graph): Deep copy Spring AI messages

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
@@ -15,7 +15,9 @@
  */
 package com.alibaba.cloud.ai.graph.utils;
 
+import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,15 @@ public class SerializationUtils {
 	private static final Logger log = LoggerFactory.getLogger(SerializationUtils.class);
 
 	// Jackson ObjectMapper for serialization
-	private static final ObjectMapper objectMapper = new ObjectMapper();
+	private static final ObjectMapper objectMapper = createObjectMapper();
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		SimpleModule module = new SimpleModule();
+		SpringAIJacksonStateSerializer.registerMessageHandlers(module);
+		mapper.registerModule(module);
+		return mapper;
+	}
 
 	private SerializationUtils() {
 		// Utility class - prevent instantiation

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SerializationUtilsCustomMapTypeTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SerializationUtilsCustomMapTypeTest.java
@@ -17,9 +17,11 @@ package com.alibaba.cloud.ai.graph;
 
 import com.alibaba.cloud.ai.graph.utils.SerializationUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.UserMessage;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -116,6 +118,29 @@ public class SerializationUtilsCustomMapTypeTest {
 		MockJSONObject copiedInner = (MockJSONObject) nestedData;
 		assertEquals("value", copiedInner.get("inner"));
 		assertEquals("outer", copiedOuter.get("name"));
+	}
+
+	@Test
+	public void testDeepCopyPreservesUserMessageType() {
+		UserMessage userMessage = UserMessage.builder()
+			.text("Hello from user")
+			.metadata(Map.of("user_id", "123"))
+			.build();
+
+		Map<String, Object> original = new HashMap<>();
+		original.put("messages", List.of(userMessage));
+
+		Map<String, Object> copied = SerializationUtils.deepCopyMap(original);
+
+		Object copiedMessages = copied.get("messages");
+		assertInstanceOf(List.class, copiedMessages);
+		Object copiedMessage = ((List<?>) copiedMessages).get(0);
+		assertInstanceOf(UserMessage.class, copiedMessage);
+		assertNotSame(userMessage, copiedMessage, "UserMessage should be deep copied instead of reused");
+
+		UserMessage copiedUserMessage = (UserMessage) copiedMessage;
+		assertEquals(userMessage.getText(), copiedUserMessage.getText());
+		assertEquals(userMessage.getMetadata(), copiedUserMessage.getMetadata());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes #4349.

`SerializationUtils.deepCopyMap` uses its internal `ObjectMapper` when copying complex values. That mapper did not register the existing Spring AI message serializers, so `UserMessage` values inside state data could not be deserialized and the copy path fell back to reusing the original object.

This registers the same Spring AI message handlers already used by `SpringAIJacksonStateSerializer` for the deep-copy mapper, so message values in state are copied with the project-supported serialization rules.

## Validation

- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=SerializationUtilsCustomMapTypeTest#testDeepCopyPreservesUserMessageType test`
- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=SerializationUtilsCustomMapTypeTest test`
- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=SpringAIJacksonStateSerializerTest test`
- `git diff --check`
