### PR TITLE
fix(graph): add defensive record serialization fallback in JacksonStateSerializer

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
@@ -101,18 +101,14 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 
 	@Override
 	public final void writeData(Map<String, Object> data, ObjectOutput out) throws IOException {
-		// Normalize state before serialization to convert non-serializable objects
-		// (GraphResponse, CompletableFuture) into serializable structures
 		Map<String, Object> normalized = normalizeForSerialization(data);
 		try {
 			String json = objectMapper.writeValueAsString(normalized);
 			Serializer.writeUTF(json, out);
 		} catch (JsonMappingException e) {
-			// Defensive fallback: a record may have survived a prior JSON round-trip
-			// while its component values degraded to LinkedHashMap (records are
-			// implicitly final, so DefaultTyping.NON_FINAL skips @class for them).
-			// Copy the mapper, register a Record→Map serializer, and retry.
 			ObjectMapper safeMapper = objectMapper.copy();
+			safeMapper.setDefaultTyping(null);
+			safeMapper.deactivateDefaultTyping();
 			var module = new SimpleModule();
 			module.addSerializer(Record.class, new RecordFlatteningSerializer());
 			safeMapper.registerModule(module);
@@ -466,30 +462,30 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 		return snapshot;
 	}
 
-	/**
-	 * Jackson serializer that writes any {@link Record} as a plain map.
-	 * <p>On the normal path (no DefaultTyping) {@link #serialize} writes the
-	 * record with an explicit {@code @class} key.
-	 * <p>On the fallback path (DefaultTyping active) {@link #serializeWithType}
-	 * delegates to Jackson's {@link TypeSerializer} for the type id and then
-	 * writes the record components.
-	 */
-	private static class RecordFlatteningSerializer extends JsonSerializer<Record> {
+	private static class RecordFlatteningSerializer extends JsonSerializer<Object> {
 
 		@Override
-		public void serialize(Record value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+		public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+			if (!(value instanceof Record record)) {
+				serializers.defaultSerializeValue(value, gen);
+				return;
+			}
 			gen.writeStartObject();
-			gen.writeStringField("@class", value.getClass().getName());
-			writeRecordFields(value, gen);
+			gen.writeStringField("@class", record.getClass().getName());
+			writeRecordFields(record, gen);
 			gen.writeEndObject();
 		}
 
 		@Override
-		public void serializeWithType(Record value, JsonGenerator gen, SerializerProvider serializers,
+		public void serializeWithType(Object value, JsonGenerator gen, SerializerProvider serializers,
 									  TypeSerializer typeSer) throws IOException {
+			if (!(value instanceof Record record)) {
+				serializers.defaultSerializeValue(value, gen);
+				return;
+			}
 			WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen,
-					typeSer.typeId(value, JsonToken.START_OBJECT));
-			writeRecordFields(value, gen);
+					typeSer.typeId(record, JsonToken.START_OBJECT));
+			writeRecordFields(record, gen);
 			typeSer.writeTypeSuffix(gen, typeIdDef);
 		}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
@@ -25,15 +25,23 @@ import org.springframework.ai.chat.model.ChatResponse;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.reflect.RecordComponent;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -96,8 +104,21 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 		// Normalize state before serialization to convert non-serializable objects
 		// (GraphResponse, CompletableFuture) into serializable structures
 		Map<String, Object> normalized = normalizeForSerialization(data);
-		String json = objectMapper.writeValueAsString(normalized);
-		Serializer.writeUTF(json, out);
+		try {
+			String json = objectMapper.writeValueAsString(normalized);
+			Serializer.writeUTF(json, out);
+		} catch (JsonMappingException e) {
+			// Defensive fallback: a record may have survived a prior JSON round-trip
+			// while its component values degraded to LinkedHashMap (records are
+			// implicitly final, so DefaultTyping.NON_FINAL skips @class for them).
+			// Copy the mapper, register a Record→Map serializer, and retry.
+			ObjectMapper safeMapper = objectMapper.copy();
+			var module = new SimpleModule();
+			module.addSerializer(Record.class, new RecordFlatteningSerializer());
+			safeMapper.registerModule(module);
+			String json = safeMapper.writeValueAsString(normalized);
+			Serializer.writeUTF(json, out);
+		}
 	}
 
 	@Override
@@ -174,32 +195,32 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 			return changed ? result : value;
 		}
 
-	// 6. Array → shallow scan for GraphResponse/ChatResponse/CompletableFuture
-	if (value.getClass().isArray()) {
-		// Check if it's a primitive array (int[], double[], etc.)
-		Class<?> componentType = value.getClass().getComponentType();
-		if (componentType.isPrimitive()) {
-			// Primitive arrays cannot contain GraphResponse/ChatResponse/CompletableFuture
-			// Return as-is, let Jackson handle the serialization
-			return value;
-		}
-		
-		// Object array - check for GraphResponse/ChatResponse/CompletableFuture
-		Object[] array = (Object[]) value;
-		Object[] result = new Object[array.length];
-		boolean changed = false;
-		for (int i = 0; i < array.length; i++) {
-			Object normalized = normalizeValue(array[i]);
-			result[i] = normalized;
-			if (normalized != array[i]) {
-				changed = true;
+		// 6. Array → shallow scan for GraphResponse/ChatResponse/CompletableFuture
+		if (value.getClass().isArray()) {
+			// Check if it's a primitive array (int[], double[], etc.)
+			Class<?> componentType = value.getClass().getComponentType();
+			if (componentType.isPrimitive()) {
+				// Primitive arrays cannot contain GraphResponse/ChatResponse/CompletableFuture
+				// Return as-is, let Jackson handle the serialization
+				return value;
 			}
-		}
-		// If nothing changed, return original array to preserve type
-		return changed ? result : value;
-	}
 
-	// 7. Optional → unwrap and check
+			// Object array - check for GraphResponse/ChatResponse/CompletableFuture
+			Object[] array = (Object[]) value;
+			Object[] result = new Object[array.length];
+			boolean changed = false;
+			for (int i = 0; i < array.length; i++) {
+				Object normalized = normalizeValue(array[i]);
+				result[i] = normalized;
+				if (normalized != array[i]) {
+					changed = true;
+				}
+			}
+			// If nothing changed, return original array to preserve type
+			return changed ? result : value;
+		}
+
+		// 7. Optional → unwrap and check
 		if (value instanceof Optional) {
 			Optional<?> opt = (Optional<?>) value;
 			if (opt.isEmpty()) {
@@ -266,21 +287,21 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 	private Map<String, Object> normalizeChatResponse(ChatResponse response) {
 		Map<String, Object> snapshot = new LinkedHashMap<>();
 		snapshot.put("@type", "ChatResponse");
-		
+
 		// Normalize result (Generation list)
 		if (response.getResult() != null) {
 			snapshot.put("result", deepNormalizeValue(response.getResult()));
 		} else {
 			snapshot.put("result", null);
 		}
-		
+
 		// Normalize metadata
 		if (response.getMetadata() != null) {
 			snapshot.put("metadata", deepNormalizeValue(response.getMetadata()));
 		} else {
 			snapshot.put("metadata", null);
 		}
-		
+
 		return snapshot;
 	}
 
@@ -385,18 +406,18 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 			return collection.stream().map(this::deepNormalizeValue).collect(Collectors.toList());
 		}
 
-	// 6. Array → recursive normalization
-	if (value.getClass().isArray()) {
-		// Check if it's a primitive array
-		Class<?> componentType = value.getClass().getComponentType();
-		if (componentType.isPrimitive()) {
-			// Primitive arrays cannot contain GraphResponse/CompletableFuture
-			return value;
+		// 6. Array → recursive normalization
+		if (value.getClass().isArray()) {
+			// Check if it's a primitive array
+			Class<?> componentType = value.getClass().getComponentType();
+			if (componentType.isPrimitive()) {
+				// Primitive arrays cannot contain GraphResponse/CompletableFuture
+				return value;
+			}
+
+			Object[] array = (Object[]) value;
+			return Arrays.stream(array).map(this::deepNormalizeValue).toArray();
 		}
-		
-		Object[] array = (Object[]) value;
-		return Arrays.stream(array).map(this::deepNormalizeValue).toArray();
-	}
 
 		// 6. Optional → unwrap and normalize
 		if (value instanceof Optional) {
@@ -443,6 +464,45 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 		}
 
 		return snapshot;
+	}
+
+	/**
+	 * Jackson serializer that writes any {@link Record} as a plain map.
+	 * <p>On the normal path (no DefaultTyping) {@link #serialize} writes the
+	 * record with an explicit {@code @class} key.
+	 * <p>On the fallback path (DefaultTyping active) {@link #serializeWithType}
+	 * delegates to Jackson's {@link TypeSerializer} for the type id and then
+	 * writes the record components.
+	 */
+	private static class RecordFlatteningSerializer extends JsonSerializer<Record> {
+
+		@Override
+		public void serialize(Record value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+			gen.writeStartObject();
+			gen.writeStringField("@class", value.getClass().getName());
+			writeRecordFields(value, gen);
+			gen.writeEndObject();
+		}
+
+		@Override
+		public void serializeWithType(Record value, JsonGenerator gen, SerializerProvider serializers,
+									  TypeSerializer typeSer) throws IOException {
+			WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen,
+					typeSer.typeId(value, JsonToken.START_OBJECT));
+			writeRecordFields(value, gen);
+			typeSer.writeTypeSuffix(gen, typeIdDef);
+		}
+
+		private void writeRecordFields(Record value, JsonGenerator gen) throws IOException {
+			for (RecordComponent rc : value.getClass().getRecordComponents()) {
+				try {
+					rc.getAccessor().setAccessible(true);
+					gen.writeObjectField(rc.getName(), rc.getAccessor().invoke(value));
+				} catch (Exception ignored) {
+				}
+			}
+		}
+
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
@@ -25,6 +25,7 @@ import org.springframework.ai.chat.model.ChatResponse;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.reflect.Field;
 import java.lang.reflect.RecordComponent;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -37,7 +38,9 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonMappingException.Reference;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
@@ -118,8 +121,7 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 			Serializer.writeUTF(json, out);
 		}
 		catch (JsonMappingException e) {
-			if (e.getMessage() != null
-					&& e.getMessage().contains("object is not an instance of declaring class")) {
+			if (isRecordDegradation(e, normalized, objectMapper)) {
 				log.warn("Record type degradation detected, using fallback serialization", e);
 				ObjectMapper safeMapper = objectMapper.copy();
 				var module = new SimpleModule();
@@ -480,6 +482,148 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 	}
 
 	/**
+	 * Determines whether the serialization failure is caused by a record type
+	 * that degraded to {@link Map} after a JSON round-trip.
+	 *
+	 * <p>Jackson reports the type-declaration chain via
+	 * {@link JsonMappingException#getPath()}.  We walk that chain backwards
+	 * to find the last non-container type with a field declaration, resolve the
+	 * declared field / element type, and check whether (a) it is a record and
+	 * (b) the actual runtime value at that path is not an instance of it.</p>
+	 */
+	private static boolean isRecordDegradation(JsonMappingException e,
+			Map<String, Object> state, ObjectMapper mapper) {
+		List<Reference> path = e.getPath();
+		if (path == null || path.size() < 2) {
+			log.debug("isRecordDegradation: path is null or too short, path={}", path);
+			return false;
+		}
+
+		log.debug("isRecordDegradation: path size={}, path={}", path.size(), path);
+		for (int i = path.size() - 2; i >= 0; i--) {
+			Reference containerRef = path.get(i);
+			Object from = containerRef.getFrom();
+			log.debug("isRecordDegradation: i={}, from={}, fromClass={}, fieldName={}, index={}",
+					i, from, (from != null ? from.getClass() : "null"),
+					containerRef.getFieldName(), containerRef.getIndex());
+			if (!(from instanceof Class<?> containerType)) {
+				log.debug("  -> skip: from is not a Class");
+				continue;
+			}
+			if (containerType == Object.class
+					|| Map.class.isAssignableFrom(containerType)
+					|| Collection.class.isAssignableFrom(containerType)
+					|| containerType.isArray()) {
+				log.debug("  -> skip: containerType is container/fallback: {}", containerType);
+				continue;
+			}
+
+			String fieldName = containerRef.getFieldName();
+			if (fieldName == null) {
+				log.debug("  -> skip: fieldName is null");
+				continue;
+			}
+
+			JavaType fieldType = resolveFieldType(mapper, containerType, fieldName);
+			log.debug("  -> resolveFieldType({}, \"{}\") = {}", containerType.getSimpleName(), fieldName, fieldType);
+			if (fieldType == null) {
+				log.debug("  -> skip: fieldType is null");
+				continue;
+			}
+
+			JavaType elementType = fieldType.isCollectionLikeType() || fieldType.isArrayType()
+					? fieldType.getContentType()
+					: fieldType;
+			if (elementType == null) {
+				log.debug("  -> skip: elementType is null");
+				continue;
+			}
+
+			Class<?> elementClass = elementType.getRawClass();
+			log.debug("  -> elementClass={}, isRecord={}", elementClass, elementClass != null ? elementClass.isRecord() : "n/a");
+			if (elementClass != null && elementClass.isRecord()) {
+				Object actualValue = resolveValueAtPath(state, path);
+				log.debug("  -> actualValue={}, actualValueClass={}",
+						actualValue, (actualValue != null ? actualValue.getClass() : "null"));
+				boolean isDegraded = actualValue != null && !elementClass.isInstance(actualValue);
+				log.debug("  -> isDegraded={}", isDegraded);
+				return isDegraded;
+			}
+		}
+
+		log.debug("isRecordDegradation: no record degradation found, returning false");
+		return false;
+	}
+
+	/**
+	 * Resolve the declared generic type of a named field using Jackson's type factory.
+	 */
+	private static JavaType resolveFieldType(ObjectMapper mapper, Class<?> containerType,
+			String pathFieldName) {
+		for (Field field : containerType.getDeclaredFields()) {
+			String fieldName = field.getName();
+			com.fasterxml.jackson.annotation.JsonProperty jp = field
+					.getAnnotation(com.fasterxml.jackson.annotation.JsonProperty.class);
+			if (pathFieldName.equals(fieldName)
+					|| (jp != null && pathFieldName.equals(jp.value()))) {
+				return mapper.getTypeFactory().constructType(field.getGenericType());
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Walk the state map along the error path to reach the value at which the
+	 * serialization error occurred.
+	 */
+	@SuppressWarnings("unchecked")
+	private static Object resolveValueAtPath(Map<String, Object> state, List<Reference> path) {
+		Object current = state;
+		for (Reference ref : path) {
+			if (current == null) {
+				return null;
+			}
+			if (ref.getFieldName() != null && current instanceof Map) {
+				current = ((Map<String, Object>) current).get(ref.getFieldName());
+			}
+			else if (ref.getIndex() >= 0 && current instanceof List) {
+				List<Object> list = (List<Object>) current;
+				current = ref.getIndex() < list.size() ? list.get(ref.getIndex()) : null;
+			}
+			else if (ref.getIndex() >= 0 && current.getClass().isArray()) {
+				Object[] array = (Object[]) current;
+				current = ref.getIndex() < array.length ? array[ref.getIndex()] : null;
+			}
+			else if (ref.getFieldName() != null) {
+				current = readFieldValue(current, ref.getFieldName());
+			}
+			else {
+				return null;
+			}
+		}
+		return current;
+	}
+
+	private static Object readFieldValue(Object obj, String pathFieldName) {
+		for (Field field : obj.getClass().getDeclaredFields()) {
+			String fieldName = field.getName();
+			com.fasterxml.jackson.annotation.JsonProperty jp = field
+					.getAnnotation(com.fasterxml.jackson.annotation.JsonProperty.class);
+			if (pathFieldName.equals(fieldName)
+					|| (jp != null && pathFieldName.equals(jp.value()))) {
+				try {
+					field.setAccessible(true);
+					return field.get(obj);
+				}
+				catch (IllegalAccessException e) {
+					return null;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Replaces serializers for record types with lenient versions that tolerate
 	 * degraded Map values (from JSON round-trips where records lost type info).
 	 * Non-final types keep their normal DefaultTyping {@code @class} output.
@@ -490,8 +634,7 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 		public JsonSerializer<?> modifySerializer(SerializationConfig config,
 				BeanDescription beanDesc, JsonSerializer<?> serializer) {
 			if (beanDesc.getBeanClass().isRecord()) {
-				return new DegradedRecordTolerantSerializer(
-						(JsonSerializer<Object>) serializer);
+				return new DegradedRecordTolerantSerializer();
 			}
 			return serializer;
 		}
@@ -503,12 +646,6 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 	 * record's type info is lost; everything else keeps its normal shape).
 	 */
 	private static class DegradedRecordTolerantSerializer extends JsonSerializer<Object> {
-
-		private final JsonSerializer<Object> delegate;
-
-		DegradedRecordTolerantSerializer(JsonSerializer<Object> delegate) {
-			this.delegate = delegate;
-		}
 
 		@Override
 		public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers)

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonStateSerializer.java
@@ -36,21 +36,30 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 
 /**
  * Base Implementation of {@link PlainTextStateSerializer} using Jackson library. Need to
  * be extended from specific state implementation
  */
 public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
+
+	private static final Logger log = LoggerFactory.getLogger(JacksonStateSerializer.class);
 
 	protected final ObjectMapper objectMapper;
 
@@ -101,19 +110,27 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 
 	@Override
 	public final void writeData(Map<String, Object> data, ObjectOutput out) throws IOException {
+		// Normalize state before serialization to convert non-serializable objects
+		// (GraphResponse, CompletableFuture) into serializable structures
 		Map<String, Object> normalized = normalizeForSerialization(data);
 		try {
 			String json = objectMapper.writeValueAsString(normalized);
 			Serializer.writeUTF(json, out);
-		} catch (JsonMappingException e) {
-			ObjectMapper safeMapper = objectMapper.copy();
-			safeMapper.setDefaultTyping(null);
-			safeMapper.deactivateDefaultTyping();
-			var module = new SimpleModule();
-			module.addSerializer(Record.class, new RecordFlatteningSerializer());
-			safeMapper.registerModule(module);
-			String json = safeMapper.writeValueAsString(normalized);
-			Serializer.writeUTF(json, out);
+		}
+		catch (JsonMappingException e) {
+			if (e.getMessage() != null
+					&& e.getMessage().contains("object is not an instance of declaring class")) {
+				log.warn("Record type degradation detected, using fallback serialization", e);
+				ObjectMapper safeMapper = objectMapper.copy();
+				var module = new SimpleModule();
+				module.setSerializerModifier(new RecordFallbackSerializerModifier());
+				safeMapper.registerModule(module);
+				String json = safeMapper.writeValueAsString(normalized);
+				Serializer.writeUTF(json, out);
+			}
+			else {
+				throw e;
+			}
 		}
 	}
 
@@ -462,31 +479,63 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 		return snapshot;
 	}
 
-	private static class RecordFlatteningSerializer extends JsonSerializer<Object> {
+	/**
+	 * Replaces serializers for record types with lenient versions that tolerate
+	 * degraded Map values (from JSON round-trips where records lost type info).
+	 * Non-final types keep their normal DefaultTyping {@code @class} output.
+	 */
+	private static class RecordFallbackSerializerModifier extends BeanSerializerModifier {
 
 		@Override
-		public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-			if (!(value instanceof Record record)) {
-				serializers.defaultSerializeValue(value, gen);
-				return;
+		public JsonSerializer<?> modifySerializer(SerializationConfig config,
+				BeanDescription beanDesc, JsonSerializer<?> serializer) {
+			if (beanDesc.getBeanClass().isRecord()) {
+				return new DegradedRecordTolerantSerializer(
+						(JsonSerializer<Object>) serializer);
 			}
-			gen.writeStartObject();
-			gen.writeStringField("@class", record.getClass().getName());
-			writeRecordFields(record, gen);
-			gen.writeEndObject();
+			return serializer;
+		}
+	}
+
+	/**
+	 * If the value is a Record → writes {@code @class} + record fields.
+	 * If the value is a degraded Map → serializes as a plain object (only the
+	 * record's type info is lost; everything else keeps its normal shape).
+	 */
+	private static class DegradedRecordTolerantSerializer extends JsonSerializer<Object> {
+
+		private final JsonSerializer<Object> delegate;
+
+		DegradedRecordTolerantSerializer(JsonSerializer<Object> delegate) {
+			this.delegate = delegate;
 		}
 
 		@Override
-		public void serializeWithType(Object value, JsonGenerator gen, SerializerProvider serializers,
-									  TypeSerializer typeSer) throws IOException {
-			if (!(value instanceof Record record)) {
-				serializers.defaultSerializeValue(value, gen);
-				return;
+		public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers)
+				throws IOException {
+			if (value instanceof Record record) {
+				gen.writeStartObject();
+				gen.writeStringField("@class", record.getClass().getName());
+				writeRecordFields(record, gen);
+				gen.writeEndObject();
 			}
-			WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen,
-					typeSer.typeId(record, JsonToken.START_OBJECT));
-			writeRecordFields(record, gen);
-			typeSer.writeTypeSuffix(gen, typeIdDef);
+			else {
+				serializers.defaultSerializeValue(value, gen);
+			}
+		}
+
+		@Override
+		public void serializeWithType(Object value, JsonGenerator gen,
+				SerializerProvider serializers, TypeSerializer typeSer) throws IOException {
+			if (value instanceof Record record) {
+				WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen,
+						typeSer.typeId(record, JsonToken.START_OBJECT));
+				writeRecordFields(record, gen);
+				typeSer.writeTypeSuffix(gen, typeIdDef);
+			}
+			else {
+				serializers.defaultSerializeValue(value, gen);
+			}
 		}
 
 		private void writeRecordFields(Record value, JsonGenerator gen) throws IOException {
@@ -494,11 +543,15 @@ public abstract class JacksonStateSerializer extends PlainTextStateSerializer {
 				try {
 					rc.getAccessor().setAccessible(true);
 					gen.writeObjectField(rc.getName(), rc.getAccessor().invoke(value));
-				} catch (Exception ignored) {
+				}
+				catch (Exception e) {
+					throw new IOException(
+							"Failed to serialize record field '" + rc.getName()
+									+ "' of " + value.getClass().getName(),
+							e);
 				}
 			}
 		}
-
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/RecordListDegradationTest
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/RecordListDegradationTest
@@ -15,7 +15,9 @@
  */
 package com.alibaba.cloud.ai.graph.plain_text;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.LinkedList;
 import java.util.LinkedHashMap;
@@ -28,6 +30,9 @@ import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonS
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 /**
  * Minimal reproduction of:
@@ -86,7 +91,7 @@ public class RecordListDegradationTest {
 		SearchInfoContainer container = new SearchInfoContainer();
 
 		LinkedHashMap<String, Object> degradedSearchResult = new LinkedHashMap<>();
-		degradedSearchResult.put("siteName", "example.com");
+		degradedSearchResult.put("site_name", "example.com");
 		degradedSearchResult.put("icon", "https://example.com/icon.png");
 		degradedSearchResult.put("index", 1);
 		degradedSearchResult.put("title", "Example Title");
@@ -116,6 +121,74 @@ public class RecordListDegradationTest {
 		ObjectOutputStream oos = new ObjectOutputStream(baos);
 		serializer.writeData(state, oos);
 		oos.flush();
+
+		// Round-trip: read back and verify data integrity
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		Map<String, Object> restored = serializer.readData(ois);
+
+		assertThat(restored).isNotNull();
+		assertThat(restored.get("messages")).isNotNull()
+				.asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.LIST);
+
+		List<Object> restoredMessages = (List<Object>) restored.get("messages");
+		assertThat(restoredMessages).hasSize(2);
+		assertThat(restoredMessages.get(0)).isEqualTo("placeholder");
+
+		assertThat(restoredMessages.get(1))
+				.asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.MAP);
+		Map<String, Object> restoredInnerMap = (Map<String, Object>) restoredMessages.get(1);
+		assertThat(restoredInnerMap).containsKey("search_info");
+
+		Object searchInfoObj = restoredInnerMap.get("search_info");
+		assertThat(searchInfoObj).isNotNull();
+
+		// search_info keeps its SearchInfoContainer type because DefaultTyping
+		// is preserved in the fallback — only record types are made lenient.
+		List<Object> restoredResults;
+		if (searchInfoObj instanceof Map) {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> restoredSearchInfo = (Map<String, Object>) searchInfoObj;
+			assertThat(restoredSearchInfo).containsKey("search_results");
+			restoredResults = (List<Object>) restoredSearchInfo.get("search_results");
+		}
+		else {
+			SearchInfoContainer restoredContainer = (SearchInfoContainer) searchInfoObj;
+			restoredResults = (List<Object>) (List<?>) restoredContainer.getSearchResults();
+		}
+		assertThat(restoredResults).hasSize(1);
+
+		// The element could be a Map (if the record was degraded) or an actual
+		// SearchResult instance (if the record was reconstructed from its fields).
+		Object resultElement = restoredResults.get(0);
+		String siteName;
+		String icon;
+		int index;
+		String title;
+		String url;
+
+		if (resultElement instanceof SearchResult sr) {
+			siteName = sr.siteName();
+			icon = sr.icon();
+			index = sr.index();
+			title = sr.title();
+			url = sr.url();
+		}
+		else {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> map = (Map<String, Object>) resultElement;
+			siteName = (String) map.get("site_name");
+			icon = (String) map.get("icon");
+			index = (Integer) map.get("index");
+			title = (String) map.get("title");
+			url = (String) map.get("url");
+		}
+
+		assertThat(siteName).isEqualTo("example.com");
+		assertThat(icon).isEqualTo("https://example.com/icon.png");
+		assertThat(index).isEqualTo(1);
+		assertThat(title).isEqualTo("Example Title");
+		assertThat(url).isEqualTo("https://example.com");
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/RecordListDegradationTest
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/RecordListDegradationTest
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.plain_text;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.LinkedList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchResult;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Minimal reproduction of:
+ * <pre>
+ * com.fasterxml.jackson.databind.JsonMappingException:
+ *   object is not an instance of declaring class
+ * (through reference chain:
+ *   java.util.LinkedHashMap["messages"]
+ *   -&gt; java.util.ArrayList[1]
+ *   -&gt; java.util.HashMap["search_info"]
+ *   -&gt; SearchInfoContainer["search_results"]
+ *   -&gt; java.util.LinkedList[0]
+ *   -&gt; java.util.LinkedHashMap["site_name"])
+ * </pre>
+ *
+ * <p>Root cause: {@code DefaultTyping.NON_FINAL} adds {@code @class} hints for
+ * non-final types (like {@code SearchInfoContainer}) but NOT for records (which are
+ * final).  After a JSON round-trip, {@code SearchResult} records lose type info and
+ * become {@code LinkedHashMap}.  When the now-broken container is re-serialized,
+ * Jackson consults the <em>declared</em> element type ({@code SearchResult}), obtains
+ * a serializer for it, and tries to apply it to the {@code LinkedHashMap} — which
+ * fails because {@code LinkedHashMap} is not an instance of the record class.</p>
+ *
+ * <p>This test goes through {@code JacksonStateSerializer.writeData()}, the exact
+ * code path that needs the {@code RecordFlatteningSerializer} fallback fix.
+ * Without the fix this test <strong>fails</strong> with the above exception.</p>
+ */
+public class RecordListDegradationTest {
+
+	/**
+	 * Non-final POJO mimicking {@code DashScopeApiSpec$SearchInfo}.
+	 * {@code DefaultTyping.NON_FINAL} adds a {@code @class} hint for this type,
+	 * so it survives a JSON round-trip with its type intact.
+	 */
+	@SuppressWarnings("unused")
+	public static class SearchInfoContainer {
+		@JsonProperty("search_results")
+		private LinkedList<SearchResult> searchResults;
+
+		public LinkedList<SearchResult> getSearchResults() {
+			return searchResults;
+		}
+
+		public void setSearchResults(LinkedList<SearchResult> searchResults) {
+			this.searchResults = searchResults;
+		}
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	void shouldSerializeStateContainingDegradedRecordInTypedList() throws Exception {
+		// Directly construct the broken state: a non-final container whose
+		// declared List<SearchResult> field actually holds LinkedHashMap entries.
+		// This simulates what happens after a JSON round-trip: records lose type
+		// info and become plain maps, but the container retains its declared type.
+		SearchInfoContainer container = new SearchInfoContainer();
+
+		LinkedHashMap<String, Object> degradedSearchResult = new LinkedHashMap<>();
+		degradedSearchResult.put("siteName", "example.com");
+		degradedSearchResult.put("icon", "https://example.com/icon.png");
+		degradedSearchResult.put("index", 1);
+		degradedSearchResult.put("title", "Example Title");
+		degradedSearchResult.put("url", "https://example.com");
+
+		LinkedList rawList = new LinkedList();
+		rawList.add(degradedSearchResult);
+		container.setSearchResults(rawList);
+
+		Map<String, Object> innerMap = new LinkedHashMap<>();
+		innerMap.put("search_info", container);
+
+		List<Object> messages = new LinkedList<>();
+		messages.add("placeholder");
+		messages.add(innerMap);
+
+		Map<String, Object> state = new LinkedHashMap<>();
+		state.put("messages", messages);
+
+		SpringAIJacksonStateSerializer serializer = new SpringAIJacksonStateSerializer(
+				OverAllState::new);
+
+		// Exercise writeData — the exact method that needs the fix.
+		// Without RecordFlatteningSerializer fallback, this throws:
+		//   JsonMappingException: object is not an instance of declaring class
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		serializer.writeData(state, oos);
+		oos.flush();
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/RecordListDegradationTest
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/RecordListDegradationTest
@@ -167,7 +167,8 @@ public class RecordListDegradationTest {
 		String title;
 		String url;
 
-		if (resultElement instanceof SearchResult sr) {
+		if (resultElement instanceof SearchResult) {
+			SearchResult sr = (SearchResult) resultElement;
 			siteName = sr.siteName();
 			icon = sr.icon();
 			index = sr.index();


### PR DESCRIPTION
### Describe what this PR does / why we need it

原因:     
`MysqlSaver`（及任意 `CheckpointSaver`）在 checkpoint 包含 Java `record` 类型、  
且 record 的子字段已被前一轮 `cloneState` JSON 往返退化为 `LinkedHashMap` 时，   
抛出 `JsonMappingException`。  

此次pr仅为补丁性质的修改。  
不会影响原本的正常链路，非类型系统根治，正常路径零开销。  
仅在检测到‘`JsonMappingException’  
"record 存活但子字段退化"的损坏模式时激活。临时 mapper 用完即弃，不影响原 mapper。  

修复的方法为：
在 `writeData` 中 catch `JsonMappingException`，copy 一份新的
`ObjectMapper`，给副本注册一个 `Record`→Map 序列化器（`RecordFlatteningSerializer`），
让 Jackson 在任何嵌套深度遇到 record 时都写成带 `@class` 的普通 Map，然后重试。

`MysqlSaver` (and any `CheckpointSaver`) throws `JsonMappingException` when
checkpointing state that contains a Java `record` whose component values have been
degraded to `LinkedHashMap` by a prior `cloneState` JSON round-trip.

Catch `JsonMappingException` in `writeData`, copy the `ObjectMapper`, register a
`Record`→Map serializer (`RecordFlatteningSerializer`) on the copy so Jackson flattens
any record at any nesting depth to a `@class`-annotated map, then retry.

This is a **defensive patch on the serialization path**, not a type-system fix.
Normal path has zero overhead. The fallback only activates when the exact corruption
pattern (record surviving with degraded children) is detected. The temporary mapper
is discarded after use; the original mapper is untouched.

### Does this pull request fix one issue?

Fixes #4650 

### Describe how you did it

我做了一个测试类，如果需要复现，需要把mysql的连接配置改成你自己的

``` java
package com.alibaba.cloud.ai.graph.plain_text;

import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchInfo;
import com.alibaba.cloud.ai.dashscope.spec.DashScopeApiSpec.SearchResult;
import com.alibaba.cloud.ai.graph.CompileConfig;
import com.alibaba.cloud.ai.graph.CompiledGraph;
import com.alibaba.cloud.ai.graph.KeyStrategy;
import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
import com.alibaba.cloud.ai.graph.OverAllState;
import com.alibaba.cloud.ai.graph.RunnableConfig;
import com.alibaba.cloud.ai.graph.StateGraph;
import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
import com.alibaba.cloud.ai.graph.checkpoint.savers.mysql.CreateOption;
import com.alibaba.cloud.ai.graph.checkpoint.savers.mysql.MysqlSaver;
import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;

import com.mysql.cj.jdbc.MysqlDataSource;

import org.junit.jupiter.api.Test;
import org.springframework.ai.chat.messages.AssistantMessage;
import org.springframework.ai.chat.model.ChatResponse;
import org.springframework.ai.chat.model.Generation;

import java.util.HashMap;
import java.util.List;
import java.util.Map;

import static com.alibaba.cloud.ai.graph.StateGraph.END;
import static com.alibaba.cloud.ai.graph.StateGraph.START;
import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;

/**
 * 
 *
 *
 * Only the initial SearchInfo data is simulated. All other steps use real
 * framework code: StateGraph, NodeExecutor, GraphRunnerContext,
 * MysqlSaver.encodeState, JacksonStateSerializer.writeData.
 */
class SearchInfoSerializationBugReproductionTest {

	@Test
	void fullFrameworkChainWithMysqlSaver() throws Exception {
		/*
		 * DashScope API 返回 JSON，Jackson 反序列化后得到：
		 *   ChatResponse → Generation → AssistantMessage
		 *     → metadata["search_info"] = SearchInfo
		 *     → searchResults = List<SearchResult>
		 *
		 * SearchInfo、SearchResult 均为 final record。
		 * 字段名、类型、嵌套结构与 DashScope 联网搜索返回一致。
		 */
		SearchInfo searchInfo = new SearchInfo(
				List.of(new SearchResult("Example Site", "https://example.com/favicon.ico",
						1, "Example Title", "https://example.com")),
				List.of());

		AssistantMessage assistantMessage = AssistantMessage.builder()
			.content("Here is what I found...")
			.properties(Map.of("search_info", searchInfo))
			.build();

		// 对应 AgentLlmNode.java:267-300:
		//   ChatResponse response = chatModel.call(prompt);
		//   responseMessage = response.getResult().getOutput();
		//   updatedState.put("messages", responseMessage);
		ChatResponse chatResponse = ChatResponse.builder()
			.generations(List.of(new Generation(assistantMessage)))
			.build();

		/*
		 * 
		 *
		 *   StateGraph → compile → invoke
		 *     → NodeExecutor.handleStartNode      节点执行
		 *     → NodeExecutor.handleActionResult    mergeIntoCurrentState
		 *     → GraphRunnerContext.addCheckpoint   cloneState (JSON round-trip)
		 *     → MysqlSaver.put                     insertCheckpoint
		 *     → MysqlSaver.encodeState             dataToBytes
		 *     → JacksonStateSerializer.writeData   writeValueAsString
		 *       → JsonMappingException
		 */
		var graph = new StateGraph((KeyStrategyFactory) () -> {
			Map<String, KeyStrategy> strategies = new HashMap<>();
			strategies.put("messages", new AppendStrategy());
			return strategies;
		})
			.addNode("llm_node", node_async(state ->
				Map.of("messages", List.of(chatResponse.getResult().getOutput()))))
			.addEdge(START, "llm_node")
			.addEdge("llm_node", END);


                //如果要测试，需要把mysql的连接配置改成你自己的
		MysqlDataSource dataSource = new MysqlDataSource();
		dataSource.setURL("jdbc:mysql://localhost:3306/xxxxxxx");
		dataSource.setUser("xxxxxxx");
		dataSource.setPassword("xxxxxxx");

		MysqlSaver saver = MysqlSaver.builder()
			.createOption(CreateOption.CREATE_OR_REPLACE)
			.dataSource(dataSource)
			.build();

		var compileConfig = CompileConfig.builder()
			.saverConfig(SaverConfig.builder().register(saver).build())
			.build();
		CompiledGraph workflow = graph.compile(compileConfig);

		RunnableConfig config = RunnableConfig.builder()
			.threadId("search-info-test")
			.build();

		workflow.invoke(Map.of(OverAllState.DEFAULT_INPUT_KEY, "test"), config);
	}

}

```

### Describe how to verify it

启动测试类
./mvnw -pl :spring-ai-alibaba-graph-core -Dtest="SearchInfoSerializationBugReproductionTest" test 

### Special notes for reviews

这个测试类有点带着答案做题的感觉     
我尝试过正常使用框架，触发不了这个问题，也没追踪到正常使用框架时触发这个问题的链路，在没有更多信息之前，只能做到这样了，也因此此pr交的仅为一个补丁性质的修改。   
AI给出的触发链路是：  
``` txt                                                             
  1. 使用 DashScope 模型 + 联网搜索 — API 返回的 SearchInfo/SearchResult 都是 record，通过 AssistantMessage.metadata 进入 state                 
  2. 注册了 CheckpointSaver — 这是默认行为（CompileConfig.java:45 默认注册 MemorySaver），用户不需要额外配置                                    
  3. 执行 graph invoke — 节点执行完写 checkpoint 时，cloneState（第一次 JSON 往返）破坏 SearchResult，encodeState（第二次序列化）
```

如果我有任何理解错误，麻烦请指正我，谢谢。