### PR TITLE
fix(graph): preserve typed list elements in state serialization

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/GenericListDeserializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/GenericListDeserializer.java
@@ -20,20 +20,51 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
-class GenericListDeserializer extends StdDeserializer<List<Object>> {
+class GenericListDeserializer extends StdDeserializer<List<Object>> implements ContextualDeserializer {
 
 	final TypeMapper typeMapper;
 
+	private final JavaType elementType;
+
 	public GenericListDeserializer(TypeMapper typeMapper) {
+		this(typeMapper, null);
+	}
+
+	private GenericListDeserializer(TypeMapper typeMapper, JavaType elementType) {
 		super(List.class);
 		this.typeMapper = Objects.requireNonNull(typeMapper, "typeMapper cannot be null");
+		this.elementType = elementType;
+	}
+
+	@Override
+	public JsonDeserializer<?> createContextual(DeserializationContext ctx, BeanProperty property)
+			throws JsonMappingException {
+		JavaType contextualType = ctx.getContextualType();
+		if (contextualType == null && property != null) {
+			contextualType = property.getType();
+		}
+
+		JavaType contextualElementType = null;
+		if (contextualType != null && contextualType.isCollectionLikeType() && contextualType.containedTypeCount() > 0) {
+			contextualElementType = contextualType.containedType(0);
+		}
+		if (contextualElementType == null || contextualElementType.hasRawClass(Object.class)) {
+			return this;
+		}
+		return new GenericListDeserializer(typeMapper, contextualElementType);
 	}
 
 	@Override
@@ -48,13 +79,41 @@ class GenericListDeserializer extends StdDeserializer<List<Object>> {
 
 		final ArrayNode node = (ArrayNode) jsonNode;
 		final List<Object> result = new LinkedList<>();
+		final ObjectMapper typedMapper = hasTypedElement() ? mapperWithoutDefaultTyping(mapper) : null;
 
 		for (JsonNode valueNode : node) {
-
-			result.add(JacksonDeserializer.valueFromNode(valueNode, mapper, typeMapper));
+			result.add(deserializeElement(valueNode, mapper, typedMapper));
 		}
 
 		return result;
+	}
+
+	private Object deserializeElement(JsonNode valueNode, ObjectMapper mapper, ObjectMapper typedMapper)
+			throws IOException {
+		if (!hasTypedElement() || valueNode == null || valueNode.isNull()) {
+			return JacksonDeserializer.valueFromNode(valueNode, mapper, typeMapper);
+		}
+		if (valueNode.isObject()
+				&& (valueNode.has("@class") || valueNode.has("@type") || valueNode.has("@typeHint"))) {
+			return JacksonDeserializer.valueFromNode(valueNode, mapper, typeMapper);
+		}
+		try {
+			return typedMapper.readValue(typedMapper.treeAsTokens(valueNode), elementType);
+		}
+		catch (JsonProcessingException ex) {
+			return JacksonDeserializer.valueFromNode(valueNode, mapper, typeMapper);
+		}
+	}
+
+	private boolean hasTypedElement() {
+		return elementType != null && !elementType.hasRawClass(Object.class);
+	}
+
+	private ObjectMapper mapperWithoutDefaultTyping(ObjectMapper mapper) {
+		ObjectMapper typedMapper = mapper.copy();
+		typedMapper.setDefaultTyping(null);
+		typedMapper.deactivateDefaultTyping();
+		return typedMapper;
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/SpringAIJacksonStateSerializerTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/SpringAIJacksonStateSerializerTest.java
@@ -261,6 +261,26 @@ class SpringAIJacksonStateSerializerTest {
 	}
 
 	@Test
+	void shouldPreserveTypedListElementsInStateValue() throws Exception {
+		Plan original = new Plan(List.of(new PlanStep("search"), new PlanStep("write")));
+
+		Plan deserialized = serializeAndDeserialize(original);
+
+		assertNotNull(deserialized);
+		assertEquals(2, deserialized.steps().size());
+		assertTrue(deserialized.steps().get(0) instanceof PlanStep);
+		assertEquals("search", deserialized.steps().get(0).title());
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("plan", deserialized);
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		serializer.writeData(data, oos);
+		oos.flush();
+	}
+
+	@Test
 	void testComplexMetadataSerialization() throws Exception {
 		// 测试复杂元数据的序列化
 		Map<String, Object> metadata = new HashMap<>();
@@ -410,6 +430,42 @@ class SpringAIJacksonStateSerializerTest {
 			index += substring.length();
 		}
 		return count;
+	}
+
+	public static class Plan {
+
+		private List<PlanStep> steps;
+
+		@SuppressWarnings("unused")
+		public Plan() {
+		}
+
+		public Plan(List<PlanStep> steps) {
+			this.steps = steps;
+		}
+
+		public List<PlanStep> steps() {
+			return steps;
+		}
+
+	}
+
+	public static final class PlanStep {
+
+		private String title;
+
+		@SuppressWarnings("unused")
+		public PlanStep() {
+		}
+
+		public PlanStep(String title) {
+			this.title = title;
+		}
+
+		public String title() {
+			return title;
+		}
+
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

Graph checkpoint state can contain user-defined objects whose fields are typed lists, for example a plan object with `List<Step>`. `GenericListDeserializer` currently ignores the contextual element type when Jackson deserializes those fields, so list elements without explicit type markers are restored as `LinkedHashMap`.

This can make restored checkpoint state fail on the next serialization pass, because the owning object still expects typed list elements.

This PR makes list state deserialization use the declared element type when Jackson provides one, while keeping the existing generic fallback for raw/object lists and explicitly typed values.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Make `GenericListDeserializer` contextual so it can read the declared collection element type.
- Deserialize list elements with the contextual type when the JSON value has no explicit `@class`, `@type`, or `@typeHint`.
- Keep the current generic `valueFromNode` path for raw lists, `Object` lists, null values, and explicitly typed values.
- Add serializer coverage for a state value that contains a typed `List<PlanStep>` and is serialized again after checkpoint restore.

### Describe how to verify it

- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=SpringAIJacksonStateSerializerTest#shouldPreserveTypedListElementsInStateValue test`
- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=SpringAIJacksonStateSerializerTest test`
- `./mvnw -pl spring-ai-alibaba-graph-core test`
- `git diff --check`

### Special notes for reviews

The change only uses contextual element types when Jackson exposes a concrete list element type and the element itself has no explicit type marker. Existing polymorphic state entries with `@class`, `@type`, or `@typeHint` continue to use the current generic state deserialization path.
