### PR TITLE
fix(agent): register supervisor coder tool callback

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/examples/MultiAgentSupervisorExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/examples/MultiAgentSupervisorExample.java
@@ -441,7 +441,7 @@ public class MultiAgentSupervisorExample {
 					.build();
 
 			this.chatClient = ChatClient.builder(model)
-					.defaultTools(coderTool)
+					.defaultToolCallbacks(coderTool)
 					.build();
 		}
 


### PR DESCRIPTION
## Summary
- Register the CoderNode function tool as a ToolCallback in MultiAgentSupervisorExample.
- Keep the existing executeCode callback and only adjust the ChatClient tool registration path.

Closes #4668

## Validation
- `mvn -f examples/documentation/pom.xml -DskipTests compile`
- `git diff --check`
