### PR TITLE
fix(graph): allow MySQL saver repeated thread releases

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/mysql/MysqlSaver.java
@@ -55,10 +55,13 @@ import static java.util.Objects.requireNonNull;
  *     CREATE TABLE GRAPH_THREAD (
  *          thread_id VARCHAR(36) PRIMARY KEY,
  *          thread_name VARCHAR(255),
- *          is_released BOOLEAN DEFAULT FALSE NOT NULL
+ *          is_released BOOLEAN DEFAULT FALSE NOT NULL,
+ *          active_thread_name VARCHAR(255) GENERATED ALWAYS AS (
+ *              CASE WHEN is_released = FALSE THEN thread_name ELSE NULL END
+ *          ) STORED
  *     )
- *     CREATE UNIQUE INDEX IDX_GRAPH_THREAD_NAME_RELEASED
- *          ON GRAPH_THREAD(thread_name, is_released)
+ *     CREATE UNIQUE INDEX IDX_GRAPH_THREAD_ACTIVE_NAME
+ *          ON GRAPH_THREAD(active_thread_name)
  *
  *     CREATE TABLE GRAPH_CHECKPOINT (
  *          checkpoint_seq BIGINT NOT NULL AUTO_INCREMENT UNIQUE,
@@ -106,12 +109,15 @@ public class MysqlSaver extends AbstractJdbcCheckpointSaver {
 			CREATE TABLE IF NOT EXISTS GRAPH_THREAD (
 			   thread_id VARCHAR(36) PRIMARY KEY,
 			   thread_name VARCHAR(255),
-			   is_released BOOLEAN DEFAULT FALSE NOT NULL
+			   is_released BOOLEAN DEFAULT FALSE NOT NULL,
+			   active_thread_name VARCHAR(255) GENERATED ALWAYS AS (
+			       CASE WHEN is_released = FALSE THEN thread_name ELSE NULL END
+			   ) STORED
 			)""";
 
 	private static final String INDEX_THREAD_TABLE = """
-			CREATE UNIQUE INDEX IDX_GRAPH_THREAD_NAME_RELEASED
-			  ON GRAPH_THREAD(thread_name, is_released)
+			CREATE UNIQUE INDEX IDX_GRAPH_THREAD_ACTIVE_NAME
+			  ON GRAPH_THREAD(active_thread_name)
 			""";
 
 	private static final String CREATE_CHECKPOINT_TABLE = """
@@ -132,6 +138,7 @@ public class MysqlSaver extends AbstractJdbcCheckpointSaver {
 
 	private static final String DROP_CHECKPOINT_TABLE = "DROP TABLE IF EXISTS GRAPH_CHECKPOINT";
 	private static final String DROP_THREAD_TABLE = "DROP TABLE IF EXISTS GRAPH_THREAD";
+	private static final String DROP_LEGACY_THREAD_INDEX = "DROP INDEX IDX_GRAPH_THREAD_NAME_RELEASED ON GRAPH_THREAD";
 
 	private static final String INDEX_CHECKPOINT_THREAD_SEQUENCE = """
 			CREATE INDEX IDX_GRAPH_CHECKPOINT_THREAD_SEQUENCE
@@ -145,6 +152,17 @@ public class MysqlSaver extends AbstractJdbcCheckpointSaver {
 
 	private static final String HAS_CHECKPOINT_SEQUENCE_COLUMN = """
 			SHOW COLUMNS FROM GRAPH_CHECKPOINT LIKE 'checkpoint_seq'
+			""";
+
+	private static final String ADD_ACTIVE_THREAD_NAME_COLUMN = """
+			ALTER TABLE GRAPH_THREAD
+			ADD COLUMN active_thread_name VARCHAR(255) GENERATED ALWAYS AS (
+			    CASE WHEN is_released = FALSE THEN thread_name ELSE NULL END
+			) STORED
+			""";
+
+	private static final String HAS_ACTIVE_THREAD_NAME_COLUMN = """
+			SHOW COLUMNS FROM GRAPH_THREAD LIKE 'active_thread_name'
 			""";
 
 	// DML statements
@@ -325,8 +343,9 @@ public class MysqlSaver extends AbstractJdbcCheckpointSaver {
 					createOption == CreateOption.CREATE_IF_NOT_EXISTS) {
 				statement.execute(CREATE_THREAD_TABLE);
 				statement.execute(CREATE_CHECKPOINT_TABLE);
+				ensureActiveThreadNameColumn(connection);
 				ensureCheckpointSequenceColumn(connection);
-				createIndexIfAbsent(statement, INDEX_THREAD_TABLE);
+				replaceThreadIndex(statement);
 				createIndexIfAbsent(statement, INDEX_CHECKPOINT_THREAD_SEQUENCE);
 			}
 		}
@@ -344,6 +363,32 @@ public class MysqlSaver extends AbstractJdbcCheckpointSaver {
 			if (e.getErrorCode() != 1061) {
 				throw e;
 			}
+		}
+	}
+
+	private void replaceThreadIndex(Statement statement) throws SQLException {
+		try {
+			statement.execute(DROP_LEGACY_THREAD_INDEX);
+		}
+		catch (SQLException e) {
+			// Ignore "Can't DROP ...; check that column/key exists" error (error code 1091)
+			if (e.getErrorCode() != 1091) {
+				throw e;
+			}
+		}
+		createIndexIfAbsent(statement, INDEX_THREAD_TABLE);
+	}
+
+	private void ensureActiveThreadNameColumn(Connection connection) throws SQLException {
+		try (Statement statement = connection.createStatement();
+			 ResultSet resultSet = statement.executeQuery(HAS_ACTIVE_THREAD_NAME_COLUMN)) {
+			if (resultSet.next()) {
+				return;
+			}
+		}
+
+		try (Statement statement = connection.createStatement()) {
+			statement.execute(ADD_ACTIVE_THREAD_NAME_COLUMN);
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
@@ -195,6 +195,32 @@ public class MysqlSaverTest {
     }
 
     @Test
+    public void testMysqlSaverCanReleaseSameThreadNameMoreThanOnce() throws Exception {
+        var saver = MysqlSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(DATA_SOURCE)
+                .build();
+
+        String threadId = "mysql-repeat-release-thread";
+        var firstCheckpoint = checkpoint("first");
+        var secondCheckpoint = checkpoint("second");
+
+        saver.put(config(threadId), firstCheckpoint);
+        var firstRelease = saver.release(config(threadId));
+        assertEquals(threadId, firstRelease.threadId());
+        assertEquals(1, firstRelease.checkpoints().size());
+        assertTrue(saver.get(config(threadId)).isEmpty());
+
+        saver.put(config(threadId), secondCheckpoint);
+        assertEquals(secondCheckpoint.getId(), saver.get(config(threadId)).orElseThrow().getId());
+
+        var secondRelease = saver.release(config(threadId));
+        assertEquals(threadId, secondRelease.threadId());
+        assertEquals(1, secondRelease.checkpoints().size());
+        assertTrue(saver.get(config(threadId)).isEmpty());
+    }
+
+    @Test
     public void testCheckpointWithReleasedThread() throws Exception {
 
         var saver = MysqlSaver.builder()


### PR DESCRIPTION
## Describe what this PR does / why we need it

跟进 #4635。

前面几个 PR 已经分别处理了 MysqlSaver、PostgresSaver、OracleSaver 和 FileSystemSaver 的 checkpoint history 内存持有问题，并在 #4635 里把 MySQL、PostgreSQL、Oracle 三个 JDBC saver 的公共流程收敛到了 `AbstractJdbcCheckpointSaver`。

这个 PR 修复 MySQL Saver 在 release 同名 thread 时的唯一索引语义问题。原来的 `UNIQUE(thread_name, is_released)` 会导致同一个 thread name 第二次 release 时撞到已有的 released 记录；实际语义应该是只限制 active thread 唯一，released history 可以保留多条。

## Does this pull request fix one issue?

Related to #4635

## Describe how you did it

* 将 MySQL `GRAPH_THREAD` 的 active 唯一约束改为 generated column：`active_thread_name`。
* `active_thread_name` 只在 `is_released = FALSE` 时等于 `thread_name`，released 记录则为 `NULL`。
* 唯一索引改为 `UNIQUE(active_thread_name)`，从而只限制同名 active thread 唯一。
* 在 `CREATE_IF_NOT_EXISTS` 路径下补充旧表迁移：新增 `active_thread_name` 列，删除旧的 `IDX_GRAPH_THREAD_NAME_RELEASED`，再创建新的 `IDX_GRAPH_THREAD_ACTIVE_NAME`。
* 新增 MySQL Testcontainers 覆盖：同一个 thread name 可以连续执行两轮 `put -> release -> put -> release`。

## Describe how to verify it

* `JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.17-tem PATH=$HOME/.sdkman/candidates/java/17.0.17-tem/bin:$PATH CI=true ./mvnw -pl spring-ai-alibaba-graph-core -Dtest=MysqlSaverTest test`

验证结果：`Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`。

## Special notes for reviews

这次不改变 checkpoint 数据格式，也不改变 `AbstractJdbcCheckpointSaver` 的公共流程，只修正 MySQL 方言下 active thread 唯一约束的表达方式。

PostgreSQL 使用 partial unique index 表达“只约束 unreleased thread”。MySQL 没有同等 partial unique index，这里用 generated column + unique index 模拟相同语义。

如果这个 MySQL schema 迁移方式不符合项目预期，欢迎指出，我会及时调整。