### PR TITLE
fix(graph): prevent filesystem store path traversal

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStore.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStore.java
@@ -57,7 +57,7 @@ public class FileSystemStore extends BaseStore {
 	 * @param rootPath the root path for storage
 	 */
 	public FileSystemStore(Path rootPath) {
-		this.rootPath = rootPath;
+		this.rootPath = rootPath.toAbsolutePath().normalize();
 		this.objectMapper = new ObjectMapper();
 		this.objectMapper.findAndRegisterModules();
 		initializeRootDirectory();
@@ -74,6 +74,9 @@ public class FileSystemStore extends BaseStore {
 
 			String itemJson = objectMapper.writeValueAsString(item);
 			Files.write(itemPath, itemJson.getBytes());
+		}
+		catch (IllegalArgumentException e) {
+			throw e;
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Failed to store item to file system", e);
@@ -98,6 +101,9 @@ public class FileSystemStore extends BaseStore {
 			StoreItem item = objectMapper.readValue(itemJson, StoreItem.class);
 			return Optional.of(item);
 		}
+		catch (IllegalArgumentException e) {
+			throw e;
+		}
 		catch (Exception e) {
 			throw new RuntimeException("Failed to retrieve item from file system", e);
 		}
@@ -120,6 +126,9 @@ public class FileSystemStore extends BaseStore {
 				return true;
 			}
 			return false;
+		}
+		catch (IllegalArgumentException e) {
+			throw e;
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Failed to delete item from file system", e);
@@ -245,7 +254,11 @@ public class FileSystemStore extends BaseStore {
 		for (String ns : namespace) {
 			path = path.resolve(ns);
 		}
-		return path.resolve(key + ".json");
+		Path itemPath = path.resolve(key + ".json").toAbsolutePath().normalize();
+		if (!itemPath.startsWith(rootPath)) {
+			throw new IllegalArgumentException("store item path must stay under root directory");
+		}
+		return itemPath;
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStoreTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStoreTest.java
@@ -145,6 +145,34 @@ class FileSystemStoreTest {
 	}
 
 	@Test
+	void testRejectsPathTraversalInNamespace() {
+		Path escapedFile = tempDir.resolveSibling("escaped.json");
+
+		assertThrows(IllegalArgumentException.class,
+				() -> store.putItem(StoreItem.of(List.of(".."), "escaped", Map.of("data", "test_value"))));
+
+		assertThat(Files.exists(escapedFile)).isFalse();
+	}
+
+	@Test
+	void testRejectsPathTraversalInKey() {
+		Path escapedFile = tempDir.resolveSibling("escaped.json");
+
+		assertThrows(IllegalArgumentException.class,
+				() -> store.putItem(StoreItem.of(List.of("safe"), "../../escaped", Map.of("data", "test_value"))));
+
+		assertThat(Files.exists(escapedFile)).isFalse();
+	}
+
+	@Test
+	void testRejectsPathTraversalForReadAndDelete() {
+		assertThrows(IllegalArgumentException.class, () -> store.getItem(List.of(".."), "escaped"));
+		assertThrows(IllegalArgumentException.class, () -> store.getItem(List.of("safe"), "../../escaped"));
+		assertThrows(IllegalArgumentException.class, () -> store.deleteItem(List.of(".."), "escaped"));
+		assertThrows(IllegalArgumentException.class, () -> store.deleteItem(List.of("safe"), "../../escaped"));
+	}
+
+	@Test
 	void testSizeAndClear() {
 		// Given
 		assertThat(store.isEmpty()).isTrue();


### PR DESCRIPTION
## Describe what this PR does / why we need it

This PR fixes a path traversal issue in `FileSystemStore`.

Previously, `FileSystemStore` built item file paths directly from `namespace` and `key`. Crafted values such as `namespace = List.of("..")` or traversal segments in `key` could cause the resolved item path to escape the configured `rootDirectory`.

This PR ensures that item paths are validated before file operations so that `putItem`, `getItem`, and `deleteItem` cannot access files outside the configured store root.

## Does this pull request fix one issue?

Fixes #4674

## Describe how you did it

- Normalize the store root path.
- Normalize the resolved item path before using it.
- Validate that the final item path stays under the configured `rootDirectory`.
- Reject unsafe paths that would escape the store root.
- Add regression tests for path traversal through `namespace` and `key`.

## Describe how to verify it

Run the related tests:

```bash
./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=FileSystemStoreTest,StoreIntegrationTest,GraphStoreIntegrationTest test