### PR TITLE
fix(graph): make JDBC latest checkpoint cache opt-in

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/config/SaverConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/config/SaverConfig.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.graph.checkpoint.config;
 
 import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.common.LatestCheckpointCacheConfigurable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,12 +25,21 @@ public class SaverConfig {
 
 	private final List<BaseCheckpointSaver> savers = new ArrayList<>();
 
+	private boolean latestCheckpointCacheEnabled = false;
+
 	public static Builder builder() {
 		return new Builder();
 	}
 
 	public SaverConfig register(BaseCheckpointSaver saver) {
 		savers.add(saver);
+		applyLatestCheckpointCacheConfig(saver);
+		return this;
+	}
+
+	public SaverConfig latestCheckpointCacheEnabled(boolean enabled) {
+		this.latestCheckpointCacheEnabled = enabled;
+		applyLatestCheckpointCacheConfig();
 		return this;
 	}
 
@@ -47,6 +57,20 @@ public class SaverConfig {
 		return savers;
 	}
 
+	public boolean latestCheckpointCacheEnabled() {
+		return latestCheckpointCacheEnabled;
+	}
+
+	private void applyLatestCheckpointCacheConfig() {
+		savers.forEach(this::applyLatestCheckpointCacheConfig);
+	}
+
+	private void applyLatestCheckpointCacheConfig(BaseCheckpointSaver saver) {
+		if (saver instanceof LatestCheckpointCacheConfigurable configurable) {
+			configurable.latestCheckpointCacheEnabled(latestCheckpointCacheEnabled);
+		}
+	}
+
 	public static class Builder {
 
 		private final SaverConfig config;
@@ -57,6 +81,11 @@ public class SaverConfig {
 
 		public Builder register(BaseCheckpointSaver saver) {
 			this.config.register(saver);
+			return this;
+		}
+
+		public Builder latestCheckpointCacheEnabled(boolean enabled) {
+			this.config.latestCheckpointCacheEnabled(enabled);
 			return this;
 		}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCache.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCache.java
@@ -82,6 +82,15 @@ public final class LatestCheckpointCache {
 	}
 
 	/**
+	 * Clears all cached latest checkpoints.
+	 */
+	public synchronized void clear() {
+		if (maxCachedThreads > 0) {
+			checkpoints.clear();
+		}
+	}
+
+	/**
 	 * Creates either an empty disabled cache or an access-ordered LRU map.
 	 *
 	 * @param maxCachedThreads maximum number of thread entries to keep

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCacheConfigurable.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/common/LatestCheckpointCacheConfigurable.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers.common;
+
+/**
+ * Contract for savers that expose a local latest-checkpoint cache switch.
+ */
+public interface LatestCheckpointCacheConfigurable {
+
+	/**
+	 * Enables or disables the local JVM latest-checkpoint cache.
+	 * @param enabled true to use the local cache, false to always read latest from
+	 * backing storage
+	 */
+	void latestCheckpointCacheEnabled(boolean enabled);
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaver.java
@@ -18,7 +18,9 @@ package com.alibaba.cloud.ai.graph.checkpoint.savers.jdbc;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.common.LatestCheckpointCache;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.common.LatestCheckpointCacheConfigurable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -33,14 +35,17 @@ import java.util.concurrent.locks.ReentrantLock;
  * This class owns the common saver lifecycle and latest-checkpoint cache behavior.
  * Subclasses keep database-specific SQL, transaction details and row mapping logic.
  */
-public abstract class AbstractJdbcCheckpointSaver implements BaseCheckpointSaver {
+public abstract class AbstractJdbcCheckpointSaver implements BaseCheckpointSaver, LatestCheckpointCacheConfigurable {
 
 	private final LatestCheckpointCache latestCheckpointCache;
 
 	private final ReentrantLock lock = new ReentrantLock();
 
+	private boolean latestCheckpointCacheEnabled = false;
+
 	/**
-	 * Creates a JDBC saver base with a bounded latest-checkpoint cache.
+	 * Creates a JDBC saver base with a bounded latest-checkpoint cache. The local
+	 * cache is disabled by default and can be enabled from {@link SaverConfig}.
 	 *
 	 * @param maxCachedThreads maximum number of thread latest-checkpoint entries to
 	 * cache, or 0 to disable the cache
@@ -62,7 +67,7 @@ public abstract class AbstractJdbcCheckpointSaver implements BaseCheckpointSaver
 		try {
 			String threadId = threadId(config);
 			LinkedList<Checkpoint> checkpoints = selectCheckpoints(threadId);
-			if (!checkpoints.isEmpty()) {
+			if (latestCheckpointCacheEnabled && !checkpoints.isEmpty()) {
 				latestCheckpointCache.put(threadId, checkpoints.peek());
 			}
 			return Collections.unmodifiableCollection(checkpoints);
@@ -92,13 +97,17 @@ public abstract class AbstractJdbcCheckpointSaver implements BaseCheckpointSaver
 				return selectCheckpointById(threadId, config.checkPointId().get());
 			}
 
-			Optional<Checkpoint> cached = latestCheckpointCache.get(threadId);
-			if (cached.isPresent()) {
-				return cached;
+			if (latestCheckpointCacheEnabled) {
+				Optional<Checkpoint> cached = latestCheckpointCache.get(threadId);
+				if (cached.isPresent()) {
+					return cached;
+				}
 			}
 
 			Optional<Checkpoint> latest = selectLatestCheckpoint(threadId);
-			latest.ifPresent(checkpoint -> latestCheckpointCache.put(threadId, checkpoint));
+			if (latestCheckpointCacheEnabled) {
+				latest.ifPresent(checkpoint -> latestCheckpointCache.put(threadId, checkpoint));
+			}
 			return latest;
 		}
 		catch (Exception ex) {
@@ -129,15 +138,19 @@ public abstract class AbstractJdbcCheckpointSaver implements BaseCheckpointSaver
 				String checkpointId = config.checkPointId().get();
 				updateCheckpoint(threadId, checkpointId, checkpoint);
 				deleteRetainedCheckpoints(threadId, config);
-				latestCheckpointCache.get(threadId)
-						.filter(latest -> latest.getId().equals(checkpointId))
-						.ifPresent(latest -> latestCheckpointCache.put(threadId, checkpoint));
+				if (latestCheckpointCacheEnabled) {
+					latestCheckpointCache.get(threadId)
+							.filter(latest -> latest.getId().equals(checkpointId))
+							.ifPresent(latest -> latestCheckpointCache.put(threadId, checkpoint));
+				}
 				return config;
 			}
 
 			insertCheckpoint(threadId, checkpoint);
 			deleteRetainedCheckpoints(threadId, config);
-			latestCheckpointCache.put(threadId, checkpoint);
+			if (latestCheckpointCacheEnabled) {
+				latestCheckpointCache.put(threadId, checkpoint);
+			}
 			return RunnableConfig.builder(config)
 					.checkPointId(checkpoint.getId())
 					.build();
@@ -164,6 +177,20 @@ public abstract class AbstractJdbcCheckpointSaver implements BaseCheckpointSaver
 			releaseThread(threadId);
 			latestCheckpointCache.remove(threadId);
 			return new Tag(threadId, checkpoints);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public final void latestCheckpointCacheEnabled(boolean enabled) {
+		lock.lock();
+		try {
+			this.latestCheckpointCacheEnabled = enabled;
+			if (!enabled) {
+				latestCheckpointCache.clear();
+			}
 		}
 		finally {
 			lock.unlock();

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/LatestCheckpointCacheTestSupport.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/LatestCheckpointCacheTestSupport.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.checkpoint.savers;
+
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+
+public final class LatestCheckpointCacheTestSupport {
+
+	private LatestCheckpointCacheTestSupport() {
+	}
+
+	public static <T extends BaseCheckpointSaver> T enableLatestCheckpointCache(T saver) {
+		SaverConfig.builder()
+				.latestCheckpointCacheEnabled(true)
+				.register(saver)
+				.build();
+		return saver;
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/MysqlSaverTest.java
@@ -51,6 +51,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static com.alibaba.cloud.ai.graph.checkpoint.savers.LatestCheckpointCacheTestSupport.enableLatestCheckpointCache;
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
 import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
@@ -317,11 +318,11 @@ public class MysqlSaverTest {
     @Test
     public void testLatestCheckpointCacheIsBoundedByThreadCount() throws Exception {
         var countingDataSource = new CountingDataSource(DATA_SOURCE);
-        var saver = MysqlSaver.builder()
+        var saver = enableLatestCheckpointCache(MysqlSaver.builder()
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .dataSource(countingDataSource)
                 .maxCachedThreads(2)
-                .build();
+                .build());
 
         var firstCheckpoint = checkpoint("first");
         var firstConfig = config("mysql-cache-thread-1");
@@ -339,11 +340,11 @@ public class MysqlSaverTest {
     @Test
     public void testMysqlSaverKeepsOnlyLatestCheckpointInMemory() throws Exception {
         var countingDataSource = new CountingDataSource(DATA_SOURCE);
-        var saver = MysqlSaver.builder()
+        var saver = enableLatestCheckpointCache(MysqlSaver.builder()
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .dataSource(countingDataSource)
                 .maxCachedThreads(16)
-                .build();
+                .build());
 
         String threadId = "mysql-cache-single-thread";
         var firstCheckpoint = checkpoint("first");

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/OracleSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/OracleSaverTest.java
@@ -52,6 +52,7 @@ import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.oracle.OracleContainer;
 
+import static com.alibaba.cloud.ai.graph.checkpoint.savers.LatestCheckpointCacheTestSupport.enableLatestCheckpointCache;
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
 import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
@@ -275,11 +276,11 @@ public class OracleSaverTest {
     @Test
     public void testLatestCheckpointCacheIsBoundedByThreadCount() throws Exception {
         var countingDataSource = new CountingDataSource(DATA_SOURCE);
-        var saver = OracleSaver.builder()
+        var saver = enableLatestCheckpointCache(OracleSaver.builder()
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .dataSource(countingDataSource)
                 .maxCachedThreads(2)
-                .build();
+                .build());
 
         var firstCheckpoint = checkpoint("first");
         var firstConfig = config("oracle-cache-thread-1");
@@ -297,11 +298,11 @@ public class OracleSaverTest {
     @Test
     public void testOracleSaverKeepsOnlyLatestCheckpointInMemory() throws Exception {
         var countingDataSource = new CountingDataSource(DATA_SOURCE);
-        var saver = OracleSaver.builder()
+        var saver = enableLatestCheckpointCache(OracleSaver.builder()
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .dataSource(countingDataSource)
                 .maxCachedThreads(16)
-                .build();
+                .build());
 
         String threadId = "oracle-cache-single-thread";
         var firstCheckpoint = checkpoint("first");
@@ -331,11 +332,11 @@ public class OracleSaverTest {
     @Test
     public void testOracleSaverRefreshesLatestCacheWhenLatestCheckpointIsUpdated() throws Exception {
         var countingDataSource = new CountingDataSource(DATA_SOURCE);
-        var saver = OracleSaver.builder()
+        var saver = enableLatestCheckpointCache(OracleSaver.builder()
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .dataSource(countingDataSource)
                 .maxCachedThreads(16)
-                .build();
+                .build());
 
         String threadId = "oracle-cache-update-latest-thread";
         var originalCheckpoint = checkpoint("original");
@@ -354,11 +355,11 @@ public class OracleSaverTest {
     @Test
     public void testOracleSaverClearsLatestCacheWhenThreadIsReleased() throws Exception {
         var countingDataSource = new CountingDataSource(DATA_SOURCE);
-        var saver = OracleSaver.builder()
+        var saver = enableLatestCheckpointCache(OracleSaver.builder()
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .dataSource(countingDataSource)
                 .maxCachedThreads(16)
-                .build();
+                .build());
 
         String threadId = "oracle-cache-release-thread";
         saver.put(config(threadId), checkpoint("released"));

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/PostgresSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/PostgresSaverTest.java
@@ -50,6 +50,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static com.alibaba.cloud.ai.graph.checkpoint.savers.LatestCheckpointCacheTestSupport.enableLatestCheckpointCache;
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
@@ -270,12 +271,12 @@ public class PostgresSaverTest {
     @Test
     public void testLatestCheckpointCacheIsBoundedByThreadCount() throws Exception {
         var countingDataSource = new CountingDataSource(dataSource());
-        var saver = PostgresSaver.builder()
+        var saver = enableLatestCheckpointCache(PostgresSaver.builder()
                 .datasource(countingDataSource)
                 .stateSerializer(serializer)
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .maxCachedThreads(2)
-                .build();
+                .build());
 
         var firstCheckpoint = checkpoint("first");
         var firstConfig = config("postgres-cache-thread-1");
@@ -293,12 +294,12 @@ public class PostgresSaverTest {
     @Test
     public void testPostgresSaverKeepsOnlyLatestCheckpointInMemory() throws Exception {
         var countingDataSource = new CountingDataSource(dataSource());
-        var saver = PostgresSaver.builder()
+        var saver = enableLatestCheckpointCache(PostgresSaver.builder()
                 .datasource(countingDataSource)
                 .stateSerializer(serializer)
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .maxCachedThreads(16)
-                .build();
+                .build());
 
         String threadId = "postgres-cache-single-thread";
         var firstCheckpoint = checkpoint("first");
@@ -328,12 +329,12 @@ public class PostgresSaverTest {
     @Test
     public void testPostgresSaverRefreshesLatestCacheWhenLatestCheckpointIsUpdated() throws Exception {
         var countingDataSource = new CountingDataSource(dataSource());
-        var saver = PostgresSaver.builder()
+        var saver = enableLatestCheckpointCache(PostgresSaver.builder()
                 .datasource(countingDataSource)
                 .stateSerializer(serializer)
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .maxCachedThreads(16)
-                .build();
+                .build());
 
         String threadId = "postgres-cache-update-latest-thread";
         var originalCheckpoint = checkpoint("original");
@@ -352,12 +353,12 @@ public class PostgresSaverTest {
     @Test
     public void testPostgresSaverClearsLatestCacheWhenThreadIsReleased() throws Exception {
         var countingDataSource = new CountingDataSource(dataSource());
-        var saver = PostgresSaver.builder()
+        var saver = enableLatestCheckpointCache(PostgresSaver.builder()
                 .datasource(countingDataSource)
                 .stateSerializer(serializer)
                 .createOption(CreateOption.CREATE_OR_REPLACE)
                 .maxCachedThreads(16)
-                .build();
+                .build());
 
         String threadId = "postgres-cache-release-thread";
         saver.put(config(threadId), checkpoint("released"));

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/jdbc/AbstractJdbcCheckpointSaverTest.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph.checkpoint.savers.jdbc;
 
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,6 +30,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import static com.alibaba.cloud.ai.graph.checkpoint.savers.LatestCheckpointCacheTestSupport.enableLatestCheckpointCache;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,7 +39,7 @@ class AbstractJdbcCheckpointSaverTest {
 
 	@Test
 	void shouldCacheLatestCheckpointAndReloadEvictedThread() throws Exception {
-		var saver = new FakeJdbcCheckpointSaver(2);
+		var saver = enableLatestCheckpointCache(new FakeJdbcCheckpointSaver(2));
 		var firstCheckpoint = checkpoint("first");
 		var firstConfig = config("thread-1");
 
@@ -53,8 +55,21 @@ class AbstractJdbcCheckpointSaverTest {
 	}
 
 	@Test
-	void shouldBypassLatestCacheWhenCheckpointIdIsProvided() throws Exception {
+	void shouldReadLatestCheckpointFromStorageByDefault() throws Exception {
 		var saver = new FakeJdbcCheckpointSaver(16);
+		String threadId = "thread-default-no-cache";
+		var checkpoint = checkpoint("latest");
+		saver.put(config(threadId), checkpoint);
+
+		saver.get(config(threadId));
+		saver.get(config(threadId));
+
+		assertEquals(2, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldBypassLatestCacheWhenCheckpointIdIsProvided() throws Exception {
+		var saver = enableLatestCheckpointCache(new FakeJdbcCheckpointSaver(16));
 		String threadId = "thread-by-id";
 		var firstCheckpoint = checkpoint("first");
 		var secondCheckpoint = checkpoint("second");
@@ -72,7 +87,7 @@ class AbstractJdbcCheckpointSaverTest {
 
 	@Test
 	void shouldRefreshLatestCacheWhenLatestCheckpointIsUpdated() throws Exception {
-		var saver = new FakeJdbcCheckpointSaver(16);
+		var saver = enableLatestCheckpointCache(new FakeJdbcCheckpointSaver(16));
 		String threadId = "thread-update";
 		var originalCheckpoint = checkpoint("original");
 		var updatedCheckpoint = checkpoint("updated");
@@ -88,7 +103,7 @@ class AbstractJdbcCheckpointSaverTest {
 
 	@Test
 	void shouldClearLatestCacheWhenThreadIsReleased() throws Exception {
-		var saver = new FakeJdbcCheckpointSaver(16);
+		var saver = enableLatestCheckpointCache(new FakeJdbcCheckpointSaver(16));
 		String threadId = "thread-release";
 		saver.put(config(threadId), checkpoint("released"));
 
@@ -103,8 +118,43 @@ class AbstractJdbcCheckpointSaverTest {
 
 	@Test
 	void shouldDisableLatestCacheWhenMaxCachedThreadsIsZero() throws Exception {
-		var saver = new FakeJdbcCheckpointSaver(0);
+		var saver = enableLatestCheckpointCache(new FakeJdbcCheckpointSaver(0));
 		String threadId = "thread-no-cache";
+		var checkpoint = checkpoint("latest");
+		saver.put(config(threadId), checkpoint);
+
+		saver.get(config(threadId));
+		saver.get(config(threadId));
+
+		assertEquals(2, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldDisableLatestCacheFromSaverConfig() throws Exception {
+		var saver = enableLatestCheckpointCache(new FakeJdbcCheckpointSaver(16));
+		String threadId = "thread-config-no-cache";
+		var checkpoint = checkpoint("latest");
+		saver.put(config(threadId), checkpoint);
+
+		SaverConfig.builder()
+				.register(saver)
+				.latestCheckpointCacheEnabled(false)
+				.build();
+
+		saver.get(config(threadId));
+		saver.get(config(threadId));
+
+		assertEquals(2, saver.latestCheckpointSelects);
+	}
+
+	@Test
+	void shouldApplySaverConfigLatestCacheSettingToLaterRegistrations() throws Exception {
+		var saver = new FakeJdbcCheckpointSaver(16);
+		SaverConfig.builder()
+				.latestCheckpointCacheEnabled(false)
+				.register(saver)
+				.build();
+		String threadId = "thread-config-later-register";
 		var checkpoint = checkpoint("latest");
 		saver.put(config(threadId), checkpoint);
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

跟进 #4644 里的 review 讨论。

这里的多节点 latest checkpoint 一致性风险不是 checkpoint retention 新引入的问题。回溯历史，在 `latestCheckpointCache` 之前，JDBC/FileSystem saver 也会通过 `MemorySaver` 路径在本地缓存全量 checkpoint history；本地 history 不为空时，并不会每次都从 DB/file 重新加载。因此多节点下本地 cache 从一开始就不能作为一致性来源。

这个 PR 收窄 JDBC saver 的边界：默认只信 backing storage 这个真相源；JVM 侧 latest checkpoint cache 只作为单节点性能优化，需要显式开启。

### Does this pull request fix one issue?

Related to #4644

### Describe how you did it

* 在 `SaverConfig` 增加 `latestCheckpointCacheEnabled`，默认 `false`。
* 新增 `LatestCheckpointCacheConfigurable`，让 `SaverConfig` 只对支持该能力的 saver 下发开关。
* 调整 `AbstractJdbcCheckpointSaver`：默认 latest checkpoint 读取直接回源。
* 显式开启 cache 时，保留原有 bounded latest-checkpoint cache 行为。
* 关闭 cache 时清理 JVM 内已有 latest cache。
* 更新 JDBC saver 相关测试，让 cache 优化场景显式 opt-in。

### Describe how to verify it

```bash
JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.17-tem \
PATH=$HOME/.sdkman/candidates/java/17.0.17-tem/bin:$PATH \
./mvnw -pl spring-ai-alibaba-graph-core \
  -Dtest=AbstractJdbcCheckpointSaverTest,MysqlSaverTest,PostgresSaverTest,OracleSaverTest test
```

验证结果：

`Tests run: 34, Failures: 0, Errors: 0, Skipped: 24`。

其中 `MysqlSaverTest`、`PostgresSaverTest`、`OracleSaverTest` 在本机因为 CI 条件被跳过；`AbstractJdbcCheckpointSaverTest` 本机实际执行 10 个用例，全部通过。

另外执行：

```bash
git diff --check HEAD~1..HEAD
```

结果通过。

### Special notes for reviews

这个 PR 不尝试新增分布式协调语义，也不把 #4644 的 retention 改动扩大成多节点一致性修复。

这里修的是之前就存在的本地 cache 部署边界：多节点场景 latest checkpoint 应该信 backing storage；单 JVM 场景如果需要性能优化，可以通过 `SaverConfig.latestCheckpointCacheEnabled(true)` 显式开启 bounded latest cache。

本 PR 不改变 MySQL、PostgreSQL、Oracle 的表结构、checkpoint 持久化格式、retention 行为，也不修改 Redis/Mongo/FileSystem saver 行为。
