### PR TITLE
fix(graph): reject FileSystemStore path traversal segments

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStore.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStore.java
@@ -241,11 +241,27 @@ public class FileSystemStore extends BaseStore {
 	 * @return item path
 	 */
 	private Path createItemPath(List<String> namespace, String key) {
-		Path path = rootPath;
+		Path path = rootPath.toAbsolutePath().normalize();
 		for (String ns : namespace) {
+			validatePathSegment(ns, "namespace");
 			path = path.resolve(ns);
 		}
-		return path.resolve(key + ".json");
+		validatePathSegment(key, "key");
+		Path itemPath = path.resolve(key + ".json").normalize();
+		if (!itemPath.startsWith(rootPath.toAbsolutePath().normalize())) {
+			throw new IllegalArgumentException("resolved path escapes root directory");
+		}
+		return itemPath;
+	}
+
+	private void validatePathSegment(String segment, String fieldName) {
+		if (segment == null || segment.trim().isEmpty()) {
+			throw new IllegalArgumentException(fieldName + " cannot be null or empty");
+		}
+		Path candidate = Paths.get(segment);
+		if (candidate.isAbsolute() || candidate.getNameCount() != 1 || "..".equals(segment) || ".".equals(segment)) {
+			throw new IllegalArgumentException(fieldName + " contains unsafe path segment: " + segment);
+		}
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStoreTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/store/stores/FileSystemStoreTest.java
@@ -164,6 +164,21 @@ class FileSystemStoreTest {
 	}
 
 	@Test
+	void testRejectsNamespaceTraversalSegments() {
+		RuntimeException ex = assertThrows(RuntimeException.class, () -> store.putItem(
+				StoreItem.of(List.of(".."), "escaped", Map.of("x", "y"))));
+		assertThat(ex).hasCauseInstanceOf(IllegalArgumentException.class);
+		assertThat(ex.getCause()).hasMessageContaining("unsafe path segment");
+	}
+
+	@Test
+	void testRejectsKeyTraversalSegments() {
+		RuntimeException ex = assertThrows(RuntimeException.class, () -> store.getItem(List.of("safe"), "../escaped"));
+		assertThat(ex).hasCauseInstanceOf(IllegalArgumentException.class);
+		assertThat(ex.getCause()).hasMessageContaining("unsafe path segment");
+	}
+
+	@Test
 	void testDirectoryCreation() {
 		// Given
 		List<String> deepNamespace = List.of("level1", "level2", "level3", "level4");


### PR DESCRIPTION
## Summary
- reject unsafe namespace and key path segments in `FileSystemStore`
- normalize resolved item paths and ensure they stay under the configured root directory
- add focused regression tests for namespace/key traversal attempts

## Testing
- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=FileSystemStoreTest test`
- `git diff --check`

Closes #4674
