### PR TITLE
fix(agent): use configured counter for context editing

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/contextediting/ContextEditingInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/contextediting/ContextEditingInterceptor.java
@@ -204,7 +204,7 @@ public class ContextEditingInterceptor extends ModelInterceptor {
 					continue;
 				}
 
-				int tokens = TokenCounter.approximateMsgCounter().countTokens(List.of(toolMsg));
+				int tokens = tokenCounter.countTokens(List.of(toolMsg));
 				candidates.add(new ClearableToolMessage(i, tokens));
 			}
 			else if (msg instanceof AssistantMessage assistantMsg) {
@@ -240,7 +240,7 @@ public class ContextEditingInterceptor extends ModelInterceptor {
 					continue;
 				}
 
-				int tokens = TokenCounter.approximateMsgCounter().countTokens(List.of(assistantMsg));
+				int tokens = tokenCounter.countTokens(List.of(assistantMsg));
 				candidates.add(new ClearableToolMessage(i, tokens));
 			}
 		}
@@ -326,4 +326,3 @@ public class ContextEditingInterceptor extends ModelInterceptor {
 		}
 	}
 }
-

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ContextEditingTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ContextEditingTest.java
@@ -17,6 +17,8 @@ package com.alibaba.cloud.ai.graph.agent.interceptors;
 
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import com.alibaba.cloud.ai.graph.agent.interceptor.contextediting.ContextEditingInterceptor;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 
@@ -35,7 +37,9 @@ import org.springframework.ai.chat.prompt.Prompt;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -86,6 +90,58 @@ class ContextEditingTest {
 
 		assertTrue(result.isPresent(), "Agent result should be present");
 //		assertCompactionOccurred(result.get());
+	}
+
+	@Test
+	void testContextEditingUsesConfiguredTokenCounterForCandidateBudget() {
+		ContextEditingInterceptor contextEditingInterceptor = ContextEditingInterceptor.builder()
+				.trigger(50)
+				.keep(0)
+				.clearAtLeast(100)
+				.tokenCounter(messages -> messages.stream()
+						.mapToInt(message -> message instanceof ToolResponseMessage ? 100 : 0)
+						.sum())
+				.build();
+		List<Message> messages = List.of(
+				new UserMessage("Use the tool responses."),
+				toolResponse("call-1", "search", "a"),
+				toolResponse("call-2", "search", "b"),
+				toolResponse("call-3", "search", "c"));
+
+		AtomicReference<ModelRequest> capturedRequest = new AtomicReference<>();
+		contextEditingInterceptor.interceptModel(ModelRequest.builder().messages(messages).build(), request -> {
+			capturedRequest.set(request);
+			return ModelResponse.of(new AssistantMessage("Task completed."));
+		});
+
+		assertTrue(capturedRequest.get() != null, "Updated request should be passed to handler");
+		assertEquals(1, countClearedToolResponses(capturedRequest.get().getMessages()));
+	}
+
+	@Test
+	void testContextEditingUsesConfiguredTokenCounterForToolCallBudget() {
+		ContextEditingInterceptor contextEditingInterceptor = ContextEditingInterceptor.builder()
+				.trigger(50)
+				.keep(0)
+				.clearAtLeast(100)
+				.tokenCounter(messages -> messages.stream()
+						.mapToInt(message -> message instanceof AssistantMessage ? 100 : 0)
+						.sum())
+				.build();
+		List<Message> messages = List.of(
+				new UserMessage("Use the tool calls."),
+				assistantToolCall("call-1", "search", "a"),
+				assistantToolCall("call-2", "search", "b"),
+				assistantToolCall("call-3", "search", "c"));
+
+		AtomicReference<ModelRequest> capturedRequest = new AtomicReference<>();
+		contextEditingInterceptor.interceptModel(ModelRequest.builder().messages(messages).build(), request -> {
+			capturedRequest.set(request);
+			return ModelResponse.of(new AssistantMessage("Task completed."));
+		});
+
+		assertTrue(capturedRequest.get() != null, "Updated request should be passed to handler");
+		assertEquals(1, countClearedToolCalls(capturedRequest.get().getMessages()));
 	}
 
 	/**
@@ -139,6 +195,47 @@ class ContextEditingTest {
 				.build());
 
 		return messages;
+	}
+
+	private ToolResponseMessage toolResponse(String id, String name, String data) {
+		return ToolResponseMessage.builder()
+				.responses(List.of(new ToolResponseMessage.ToolResponse(id, name, data)))
+				.build();
+	}
+
+	private AssistantMessage assistantToolCall(String id, String name, String arguments) {
+		return AssistantMessage.builder()
+				.content("")
+				.toolCalls(List.of(new AssistantMessage.ToolCall(id, "function", name, arguments)))
+				.build();
+	}
+
+	private int countClearedToolResponses(List<Message> messages) {
+		int cleared = 0;
+		for (Message msg : messages) {
+			if (msg instanceof ToolResponseMessage trm) {
+				for (ToolResponseMessage.ToolResponse response : trm.getResponses()) {
+					if (PLACEHOLDER.equals(response.responseData())) {
+						cleared++;
+					}
+				}
+			}
+		}
+		return cleared;
+	}
+
+	private int countClearedToolCalls(List<Message> messages) {
+		int cleared = 0;
+		for (Message msg : messages) {
+			if (msg instanceof AssistantMessage assistantMessage) {
+				for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
+					if (PLACEHOLDER.equals(toolCall.arguments())) {
+						cleared++;
+					}
+				}
+			}
+		}
+		return cleared;
 	}
 
 	private void assertCompactionOccurred(OverAllState state) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

`ContextEditingInterceptor` accepts a custom `TokenCounter`, but candidate scoring inside context editing still used the default approximate counter. This made the trigger check and the clear-at-least budget use different estimates when users configured an application-specific counter.

This PR makes context editing use the configured counter consistently.

### Does this pull request fix one issue?

NONE

### Describe how you did it

* Use the interceptor's configured `tokenCounter` for clearable tool response and tool-call candidate estimates.
* Keep the existing approximate counter as the default when no custom counter is configured.
* Add coverage for both tool response and tool-call candidate budgets.

### Describe how to verify it

* `./mvnw -pl spring-ai-alibaba-agent-framework -am -Dtest=ContextEditingTest test`
* `git diff --check`

### Special notes for reviews

This does not change the default counter. It only makes `tokenCounter(...)` apply consistently to both the trigger check and the candidate-clearing budget.