### PR TITLE
fix: correct ConversationChatMemory eviction logic

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemory.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemory.java
@@ -64,12 +64,13 @@ public class ConversationChatMemory implements ChatMemory {
 			historyMessages = new ArrayDeque<>();
 		}
 
+		int messageLimit = Math.max(0, maxMessages);
 		for (Message message : messages) {
 			historyMessages.offer(message);
+		}
 
-			while (historyMessages.size() > maxMessages) {
-				historyMessages.poll();
-			}
+		while (historyMessages.size() > messageLimit) {
+			historyMessages.poll();
 		}
 
 		redisManager.put(key, historyMessages);

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemory.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemory.java
@@ -65,11 +65,11 @@ public class ConversationChatMemory implements ChatMemory {
 		}
 
 		for (Message message : messages) {
-			if (messages.size() >= maxMessages) {
+			historyMessages.offer(message);
+
+			while (historyMessages.size() > maxMessages) {
 				historyMessages.poll();
 			}
-
-			historyMessages.offer(message);
 		}
 
 		redisManager.put(key, historyMessages);

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/test/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemoryTest.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/test/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemoryTest.java
@@ -18,6 +18,7 @@ package com.alibaba.cloud.ai.studio.core.agent.memory;
 import com.alibaba.cloud.ai.studio.core.base.manager.RedisManager;
 import com.alibaba.cloud.ai.studio.core.config.CommonConfig;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 
@@ -26,9 +27,7 @@ import java.util.Deque;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -50,9 +49,10 @@ class ConversationChatMemoryTest {
 
 		chatMemory.add(conversationId, List.of(new UserMessage("message-5")));
 
-		assertThat(historyMessages).extracting(Message::getText)
+		ArgumentCaptor<Deque<Message>> savedMessages = messageDequeCaptor();
+		verify(redisManager).put(eq(key), savedMessages.capture());
+		assertThat(savedMessages.getValue()).extracting(Message::getText)
 			.containsExactly("message-3", "message-4", "message-5");
-		verify(redisManager).put(eq(key), same(historyMessages));
 	}
 
 	@Test
@@ -69,11 +69,35 @@ class ConversationChatMemoryTest {
 		chatMemory.add(conversationId, List.of(new UserMessage("message-1"), new UserMessage("message-2"),
 				new UserMessage("message-3"), new UserMessage("message-4"), new UserMessage("message-5")));
 
-		verify(redisManager).put(eq(key), argThat((Deque<Message> savedMessages) -> {
-			assertThat(savedMessages).extracting(Message::getText)
-				.containsExactly("message-3", "message-4", "message-5");
-			return true;
-		}));
+		ArgumentCaptor<Deque<Message>> savedMessages = messageDequeCaptor();
+		verify(redisManager).put(eq(key), savedMessages.capture());
+		assertThat(savedMessages.getValue()).extracting(Message::getText)
+			.containsExactly("message-3", "message-4", "message-5");
+	}
+
+	@Test
+	void shouldTreatNegativeMessageLimitAsZero() {
+		RedisManager redisManager = mock(RedisManager.class);
+		CommonConfig commonConfig = new CommonConfig();
+		commonConfig.setMaxConversationRoundInCache(-1);
+		ConversationChatMemory chatMemory = new ConversationChatMemory(redisManager, commonConfig);
+		String conversationId = "conversation-id";
+		String key = String.format(ConversationChatMemory.CONVERSATION_CHAT_MEMORY_PREFIX, conversationId);
+		Deque<Message> historyMessages = new ArrayDeque<>(
+				List.of(new UserMessage("message-1"), new UserMessage("message-2")));
+
+		when(redisManager.get(key)).thenReturn(historyMessages);
+
+		chatMemory.add(conversationId, List.of(new UserMessage("message-3")));
+
+		ArgumentCaptor<Deque<Message>> savedMessages = messageDequeCaptor();
+		verify(redisManager).put(eq(key), savedMessages.capture());
+		assertThat(savedMessages.getValue()).isEmpty();
+	}
+
+	@SuppressWarnings("unchecked")
+	private ArgumentCaptor<Deque<Message>> messageDequeCaptor() {
+		return ArgumentCaptor.forClass(Deque.class);
 	}
 
 }

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/test/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemoryTest.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/test/java/com/alibaba/cloud/ai/studio/core/agent/memory/ConversationChatMemoryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.studio.core.agent.memory;
+
+import com.alibaba.cloud.ai.studio.core.base.manager.RedisManager;
+import com.alibaba.cloud.ai.studio.core.config.CommonConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ConversationChatMemoryTest {
+
+	@Test
+	void shouldEvictOldMessagesBasedOnStoredHistorySize() {
+		RedisManager redisManager = mock(RedisManager.class);
+		CommonConfig commonConfig = new CommonConfig();
+		commonConfig.setMaxConversationRoundInCache(3);
+		ConversationChatMemory chatMemory = new ConversationChatMemory(redisManager, commonConfig);
+		String conversationId = "conversation-id";
+		String key = String.format(ConversationChatMemory.CONVERSATION_CHAT_MEMORY_PREFIX, conversationId);
+		Deque<Message> historyMessages = new ArrayDeque<>(List.of(new UserMessage("message-1"),
+				new UserMessage("message-2"), new UserMessage("message-3"), new UserMessage("message-4")));
+
+		when(redisManager.get(key)).thenReturn(historyMessages);
+
+		chatMemory.add(conversationId, List.of(new UserMessage("message-5")));
+
+		assertThat(historyMessages).extracting(Message::getText)
+			.containsExactly("message-3", "message-4", "message-5");
+		verify(redisManager).put(eq(key), same(historyMessages));
+	}
+
+	@Test
+	void shouldKeepLatestMessagesWhenIncomingBatchExceedsLimit() {
+		RedisManager redisManager = mock(RedisManager.class);
+		CommonConfig commonConfig = new CommonConfig();
+		commonConfig.setMaxConversationRoundInCache(3);
+		ConversationChatMemory chatMemory = new ConversationChatMemory(redisManager, commonConfig);
+		String conversationId = "conversation-id";
+		String key = String.format(ConversationChatMemory.CONVERSATION_CHAT_MEMORY_PREFIX, conversationId);
+
+		when(redisManager.get(key)).thenReturn(null);
+
+		chatMemory.add(conversationId, List.of(new UserMessage("message-1"), new UserMessage("message-2"),
+				new UserMessage("message-3"), new UserMessage("message-4"), new UserMessage("message-5")));
+
+		verify(redisManager).put(eq(key), argThat((Deque<Message> savedMessages) -> {
+			assertThat(savedMessages).extracting(Message::getText)
+				.containsExactly("message-3", "message-4", "message-5");
+			return true;
+		}));
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR fixes `ConversationChatMemory` eviction logic.

Previously, `ConversationChatMemory#add` checked the incoming batch size with `messages.size()` to decide whether old messages should be evicted. However, `messages.size()` only represents the number of messages in the current `add()` call, not the accumulated conversation history loaded from Redis.

As a result, when messages are appended one by one, cached conversation history can grow beyond the configured limit and old messages are not evicted as expected.


### Does this pull request fix one issue?
Fixes #4687
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Changed the eviction logic to append each new message first, then trim old messages while the stored history size exceeds `maxMessages`.

Also added unit tests for:

- sequential/small-batch append where stored history already exceeds the limit
- large incoming batch append where only the latest messages should be kept


### Describe how to verify it
Run:
```bash
cd spring-ai-alibaba-admin
../mvnw -pl spring-ai-alibaba-admin-server-core -am -Dtest=ConversationChatMemoryTest test
```
Note: I tried this command locally, but the current `spring-ai-alibaba-admin-server-runtime` module fails to compile before reaching this test due to existing unrelated errors in `ToolExample.java` and runtime module dependencies.
### Special notes for reviews
The fix keeps the existing `maxMessages` behavior and does not change the meaning of `maxConversationRoundInCache`. It only corrects the eviction condition so it is based on stored history size instead of incoming batch size.