### PR TITLE
fix: let tool exceptions propagate to interceptor chain instead of swallowing them

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -573,8 +573,17 @@ public class AgentToolNode implements NodeActionWithConfig {
 		// Chain interceptors if any
 		ToolCallHandler chainedHandler = InterceptorChain.chainToolInterceptors(toolInterceptors, baseHandler);
 
-		// Execute the chained handler
-		return chainedHandler.call(request);
+		// Execute the chained handler with a fallback catch to ensure the graph
+		// never crashes from tool exceptions. This is the single place where
+		// unhandled exceptions are converted to ToolCallResponse.error(...) so
+		// that upstream interceptors have a chance to handle them first.
+		try {
+			return chainedHandler.call(request);
+		}
+		catch (Exception e) {
+			logger.error("Tool {} execution failed after interceptor chain: {}", request.getToolName(), e.getMessage(), e);
+			return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), extractErrorMessage(e));
+		}
 	}
 
 	/**
@@ -732,38 +741,34 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 			return ToolCallResponse.of(request.getToolCallId(), request.getToolName(), result);
 		}
+		catch (ToolExecutionException e) {
+			logger.error("Async tool {} execution failed, handling with processor: {}", request.getToolName(),
+					toolExecutionExceptionProcessor.getClass().getName(), e);
+			String result = toolExecutionExceptionProcessor.process(e);
+			return ToolCallResponse.of(request.getToolCallId(), request.getToolName(), result);
+		}
 		catch (CompletionException e) {
 			Throwable cause = e.getCause() != null ? e.getCause() : e;
 
-			// Clear state updates on timeout to prevent stale data from being merged
+			// Cancel the cancellation token on timeout so the async tool can stop
+			// gracefully, and clear stale state updates. This is async-specific
+			// infrastructure handling, not exception swallowing.
 			if (cause instanceof TimeoutException) {
-				// Cancel the token to notify the tool to stop gracefully
 				if (cancellationToken != null) {
 					cancellationToken.cancel();
 				}
 				extraStateFromToolCall.clear();
 				logger.warn("Async tool {} timed out, discarding any state updates", request.getToolName());
-				return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), extractErrorMessage(cause));
 			}
-			else if (cause instanceof ToolExecutionException toolExecutionException) {
-				logger.error("Async tool {} execution failed, handling with processor: {}", request.getToolName(),
-						toolExecutionExceptionProcessor.getClass().getName(), toolExecutionException);
-				String result = toolExecutionExceptionProcessor.process(toolExecutionException);
-				return ToolCallResponse.of(request.getToolCallId(), request.getToolName(), result);
-			}
-			else {
-				logger.error("Async tool {} execution failed: {}", request.getToolName(), cause.getMessage(), cause);
-				return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), extractErrorMessage(cause));
-			}
+
+			// Rethrow so upstream interceptors can handle (retry, error-classify, etc.)
+			throw e;
 		}
-		catch (CancellationException e) {
-			logger.warn("Async tool {} execution was cancelled", request.getToolName(), e);
-			return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), extractErrorMessage(e));
-		}
-		catch (Exception e) {
-			logger.error("Async tool {} execution failed: {}", request.getToolName(), e.getMessage(), e);
-			return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), extractErrorMessage(e));
-		}
+		// NOTE: CancellationException and generic Exception are no longer caught
+		// here. Previously this method swallowed all exceptions by returning
+		// ToolCallResponse.error(...), which prevented upstream interceptors from
+		// seeing them. Now exceptions propagate to the interceptor chain, and the
+		// final fallback is in executeToolCallWithInterceptors.
 	}
 
 	/**
@@ -793,10 +798,14 @@ public class AgentToolNode implements NodeActionWithConfig {
 			String result = toolExecutionExceptionProcessor.process(e);
 			return ToolCallResponse.of(request.getToolCallId(), request.getToolName(), result);
 		}
-		catch (Exception e) {
-			logger.error("Tool {} execution failed: {}", request.getToolName(), e.getMessage(), e);
-			return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), e);
-		}
+		// NOTE: generic Exception is no longer caught here. Previously this method
+		// swallowed all exceptions by returning ToolCallResponse.error(...), which
+		// prevented upstream interceptors (e.g., ToolRetryInterceptor,
+		// ToolErrorInterceptor) from seeing the exception. Interceptors that rely
+		// on catch(Exception) to implement retry or error-classification were
+		// effectively dead code. Now exceptions propagate to the interceptor chain
+		// so they can be handled, and the final fallback is in
+		// executeToolCallWithInterceptors.
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `AgentToolNode.executeSyncTool` 和 `executeAsyncTool` 在 `catch(Exception)` 时将异常转为 `ToolCallResponse.error(...)` 正常返回，导致上游拦截器链永远看不到异常
- 这使得框架自身提供的 `ToolRetryInterceptor`、`ToolErrorInterceptor` 等基于 `catch(Exception)` 实现的拦截器变成死代码
- 本 PR 让异常从 `executeSyncTool` / `executeAsyncTool` 向上冒泡到拦截器链，在 `executeToolCallWithInterceptors` 的最外层做兜底转换

## Problem

调用链如下：

```
executeToolCallWithInterceptors
  → InterceptorChain.chainToolInterceptors(interceptors, baseHandler)
    → chainedHandler.call(request)
      → interceptor[0].interceptToolCall(...)   // 外层
        → ...
          → interceptor[N].interceptToolCall(...)  // 内层
            → baseHandler.call(request)
              → executeToolByType(...)
                → executeSyncTool(...) / executeAsyncTool(...)
                  → callback.call(...)  ← 异常在这里被 catch 并吞掉
```

`executeSyncTool` 的 `catch(Exception e)` 返回 `ToolCallResponse.error(...)`，这是一个**正常返回值**，不是异常。因此拦截器的 `catch(Exception)` 块永远不会触发。

## Changes

### `executeSyncTool`
- 删除 `catch(Exception)` 块，异常向上冒泡
- 保留 `catch(ToolExecutionException)` 以兼容 `toolExecutionExceptionProcessor`

### `executeAsyncTool`
- `catch(CompletionException)`：保留 async 特有的基础设施处理（超时时取消 `CancellationToken`、清理 stale state），然后 **rethrow**
- 删除 `catch(CancellationException)` 和 `catch(Exception)` 块

### `executeToolCallWithInterceptors`
- 在 `chainedHandler.call(request)` 外层新增 `try-catch(Exception)` 兜底
- 这是唯一将未处理异常转为 `ToolCallResponse.error(...)` 的地方
- 保证 graph 主循环不会因工具异常崩溃，同时让拦截器有机会先处理

## Impact

- **向前兼容**：没有注册拦截器时，异常从 `baseHandler` 冒泡到 `executeToolCallWithInterceptors` 的兜底 catch，行为与之前一致
- **拦截器生效**：`ToolRetryInterceptor` 的 `catch(Exception) { lastException = e; ... }` 终于能工作
- **Error 分类生效**：`ToolErrorInterceptor` 的 `catch(Exception)` 终于能捕获异常并分类
- **自定义拦截器**：所有基于异常机制的拦截器不再受限

## Test Plan

- [ ] 现有单元测试全部通过
- [ ] 新增测试：sync tool 抛异常时，注册的 ToolRetryInterceptor 能触发重试
- [ ] 新增测试：sync tool 抛异常时，注册的 ToolErrorInterceptor 能捕获并分类
- [ ] 新增测试：无拦截器时，异常仍被兜底 catch 转为 error response
- [ ] 验证 async tool 的超时 CancellationToken 取消逻辑仍然正常工作