### PR TITLE
fix: replace defaultTools() with defaultToolCallbacks() in MultiAgentSupervisorExample (#4668)

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/examples/MultiAgentSupervisorExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/examples/MultiAgentSupervisorExample.java
@@ -389,7 +389,7 @@ public class MultiAgentSupervisorExample {
 					.build();
 
 			this.chatClient = ChatClient.builder(model)
-					.defaultTools(searchTool)
+					.defaultToolCallbacks(searchTool)
 					.build();
 		}
 
@@ -441,7 +441,7 @@ public class MultiAgentSupervisorExample {
 					.build();
 
 			this.chatClient = ChatClient.builder(model)
-					.defaultTools(coderTool)
+					.defaultToolCallbacks(coderTool)
 					.build();
 		}
 


### PR DESCRIPTION
## Summary

Fixes #4668: `defaultTools()` → `defaultToolCallbacks()` in MultiAgentSupervisorExample.

## Root Cause

`ChatClient.Builder.defaultTools(ToolCallback...)` is overloaded with `defaultTools(Object...)`. Due to Java method resolution rules, calling `defaultTools(searchTool)` and `defaultTools(coderTool)` where both are `FunctionToolCallback` instances can be resolved to `defaultTools(Object...)` (varargs), which uses `@Tool` annotation scanning internally — and `FunctionToolCallback` has no `@Tool` annotations, so the tool silently never registers.

This is a known issue in Spring AI (see [spring-projects/spring-ai#2495](https://github.com/spring-projects/spring-ai/issues/2495)). The official recommendation is to use `defaultToolCallbacks()` which directly registers `ToolCallback` instances without ambiguity.

## Changes

- `ResearcherNode` (line 392): `.defaultTools(searchTool)` → `.defaultToolCallbacks(searchTool)`
- `CoderNode` (line 444): `.defaultTools(coderTool)` → `.defaultToolCallbacks(coderTool)`

## Verification

- [x] Code compiles (no API changes needed — `defaultToolCallbacks(ToolCallback...)` accepts the same `ToolCallback` instances)
- [x] Both `searchTool` and `coderTool` are `ToolCallback` type — compatible with the new API

Closes #4668