### PR TITLE
fix(graph): merge object fields in MergeStrategy

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/MergeStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/MergeStrategy.java
@@ -17,12 +17,17 @@ package com.alibaba.cloud.ai.graph.state.strategy;
 
 import com.alibaba.cloud.ai.graph.KeyStrategy;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * Strategy that merges two values, typically used for merging maps or objects
+ * Strategy that merges two values, typically used for merging maps or mutable objects
  */
 public class MergeStrategy implements KeyStrategy {
 
@@ -57,7 +62,99 @@ public class MergeStrategy implements KeyStrategy {
 			);
 		}
 
+		if (shouldMergeObjectFields(oldValue.getClass())) {
+			return mergeObjectFields(oldValue, newValue).orElse(newValue);
+		}
+
 		return newValue;
+	}
+
+	private Optional<Object> mergeObjectFields(Object oldValue, Object newValue) {
+		try {
+			Object mergedValue = createInstance(oldValue.getClass());
+			for (Field field : mergeableFields(oldValue.getClass())) {
+				field.setAccessible(true);
+				Object oldFieldValue = field.get(oldValue);
+				Object newFieldValue = field.get(newValue);
+				field.set(mergedValue, mergeFieldValue(oldFieldValue, newFieldValue));
+			}
+			return Optional.of(mergedValue);
+		}
+		catch (ReflectiveOperationException | RuntimeException ex) {
+			return Optional.empty();
+		}
+	}
+
+	private Object mergeFieldValue(Object oldValue, Object newValue) {
+		if (newValue == null) {
+			return oldValue;
+		}
+
+		if (oldValue == null) {
+			return newValue;
+		}
+
+		if (oldValue instanceof Map && newValue instanceof Map) {
+			Map<Object, Object> mergedMap = new HashMap<>((Map<?, ?>) oldValue);
+			mergedMap.putAll((Map<?, ?>) newValue);
+			return mergedMap;
+		}
+
+		if (oldValue.getClass() == newValue.getClass() && shouldMergeObjectFields(oldValue.getClass())) {
+			return mergeObjectFields(oldValue, newValue).orElse(newValue);
+		}
+
+		return newValue;
+	}
+
+	private Object createInstance(Class<?> valueType) throws ReflectiveOperationException {
+		Constructor<?> constructor = valueType.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		return constructor.newInstance();
+	}
+
+	private static boolean shouldMergeObjectFields(Class<?> valueType) {
+		if (valueType.isPrimitive() || valueType.isEnum() || valueType.isArray()) {
+			return false;
+		}
+
+		if (Map.class.isAssignableFrom(valueType) || Iterable.class.isAssignableFrom(valueType)) {
+			return false;
+		}
+
+		Package valuePackage = valueType.getPackage();
+		if (valuePackage != null) {
+			String packageName = valuePackage.getName();
+			if (packageName.startsWith("java.") || packageName.startsWith("javax.")
+					|| packageName.startsWith("jakarta.")) {
+				return false;
+			}
+		}
+
+		try {
+			valueType.getDeclaredConstructor();
+		}
+		catch (NoSuchMethodException ex) {
+			return false;
+		}
+
+		List<Field> fields = mergeableFields(valueType);
+		return !fields.isEmpty() && fields.stream().noneMatch(field -> Modifier.isFinal(field.getModifiers()));
+	}
+
+	private static List<Field> mergeableFields(Class<?> valueType) {
+		List<Field> fields = new ArrayList<>();
+		Class<?> currentType = valueType;
+		while (currentType != null && currentType != Object.class) {
+			for (Field field : currentType.getDeclaredFields()) {
+				int modifiers = field.getModifiers();
+				if (!field.isSynthetic() && !Modifier.isStatic(modifiers)) {
+					fields.add(field);
+				}
+			}
+			currentType = currentType.getSuperclass();
+		}
+		return fields;
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/strategy/MergeStrategyTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/strategy/MergeStrategyTest.java
@@ -78,4 +78,130 @@ class MergeStrategyTest {
         assertEquals("New", strategy.apply(null, "New"));
         assertNull(strategy.apply(null, null));
     }
+
+    @Test
+    void testMergeObjectFields() {
+        PlanState oldPlan = new PlanState("Original title", "Initial thought", null);
+        PlanState newPlan = new PlanState(null, "Updated thought", "Completed");
+
+        PlanState result = (PlanState) strategy.apply(oldPlan, newPlan);
+
+        assertNotSame(oldPlan, result);
+        assertNotSame(newPlan, result);
+        assertEquals("Original title", result.title);
+        assertEquals("Updated thought", result.thought);
+        assertEquals("Completed", result.status);
+    }
+
+    @Test
+    void testMergeNestedObjectFields() {
+        PlanState oldPlan = new PlanState("Original title", "Initial thought", "Running");
+        oldPlan.metrics = new PlanMetrics(4, null);
+        PlanState newPlan = new PlanState(null, "Updated thought", null);
+        newPlan.metrics = new PlanMetrics(null, 2);
+
+        PlanState result = (PlanState) strategy.apply(oldPlan, newPlan);
+
+        assertEquals("Original title", result.title);
+        assertEquals("Updated thought", result.thought);
+        assertEquals("Running", result.status);
+        assertEquals(4, result.metrics.totalSteps);
+        assertEquals(2, result.metrics.completedSteps);
+    }
+
+    @Test
+    void testMergeObjectMapFields() {
+        PlanState oldPlan = new PlanState("Original title", null, null);
+        oldPlan.metadata.put("source", "planner");
+        PlanState newPlan = new PlanState(null, null, "Completed");
+        newPlan.metadata.put("owner", "worker");
+
+        PlanState result = (PlanState) strategy.apply(oldPlan, newPlan);
+
+        assertEquals("Original title", result.title);
+        assertEquals("Completed", result.status);
+        assertEquals("planner", result.metadata.get("source"));
+        assertEquals("worker", result.metadata.get("owner"));
+    }
+
+    @Test
+    void testKeepReplacementForObjectsWithoutNoArgsConstructor() {
+        ImmutablePlanState oldPlan = new ImmutablePlanState("Original title");
+        ImmutablePlanState newPlan = new ImmutablePlanState("Updated title");
+
+        Object result = strategy.apply(oldPlan, newPlan);
+
+        assertSame(newPlan, result);
+    }
+
+    @Test
+    void testKeepReplacementForObjectsWithoutFields() {
+        EmptyState oldState = new EmptyState();
+        EmptyState newState = new EmptyState();
+
+        Object result = strategy.apply(oldState, newState);
+
+        assertSame(newState, result);
+    }
+
+    @Test
+    void testIncompatibleTypes() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> strategy.apply(new PlanState("Original title", null, null), new PlanMetrics(1, 0)));
+
+        assertTrue(exception.getMessage().contains("Cannot merge incompatible types"));
+    }
+
+    private static class PlanState {
+
+        private String title;
+
+        private String thought;
+
+        private String status;
+
+        private PlanMetrics metrics;
+
+        private Map<String, String> metadata = new HashMap<>();
+
+        PlanState() {
+        }
+
+        PlanState(String title, String thought, String status) {
+            this.title = title;
+            this.thought = thought;
+            this.status = status;
+        }
+
+    }
+
+    private static class PlanMetrics {
+
+        private Integer totalSteps;
+
+        private Integer completedSteps;
+
+        PlanMetrics() {
+        }
+
+        PlanMetrics(Integer totalSteps, Integer completedSteps) {
+            this.totalSteps = totalSteps;
+            this.completedSteps = completedSteps;
+        }
+
+    }
+
+    private static class ImmutablePlanState {
+
+        private final String title;
+
+        ImmutablePlanState(String title) {
+            this.title = title;
+        }
+
+    }
+
+    private static class EmptyState {
+
+    }
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

`MergeStrategy` is documented as a strategy for merging maps or mutable objects. It currently merges `Map` values, but when two same-class object values are provided, it only checks that their classes match and then returns the new value.

For graph state updates, this can drop fields that were already produced by an earlier branch when a later branch only updates a different field on the same state object.

This PR makes `MergeStrategy` merge fields for mutable object state values while keeping the existing replacement behavior for simple values and unsupported object shapes.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Keep the existing behavior for null values, simple values, incompatible types, and `Map` merges.
- Add field-level merging for non-JDK mutable objects that have a no-args constructor and no final instance fields.
- Preserve the old field value when the new field value is `null`, and use the new field value when it is present.
- Merge nested mutable objects and map fields through the same merge rules.
- Fall back to the existing replacement behavior for immutable objects, objects without fields, and objects that cannot be safely constructed reflectively.
- Add unit coverage for object field merging, nested object fields, map fields inside objects, incompatible types, and replacement fallbacks.

### Describe how to verify it

- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=MergeStrategyTest test`
- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=StateGraphParallelTest#testParallelNodeAggregationStrategyWithStreamingNodes test`
- `./mvnw -pl spring-ai-alibaba-graph-core test`
- `git diff --check`

### Special notes for reviews

The object merge path is intentionally conservative. JDK types, maps, iterable values, arrays, enums, objects without a no-args constructor, objects without mergeable fields, and objects with final instance fields keep the existing replacement behavior. Collection-specific merging still belongs to `AppendStrategy` or a custom `KeyStrategy`.
