### PR TITLE
fix(agent): clarify skill loading instructions

### DIFF
--- a/examples/multiagent-patterns/skills/README.md
+++ b/examples/multiagent-patterns/skills/README.md
@@ -12,6 +12,7 @@ This example implements the **skills** (progressive disclosure) pattern with Spr
 - **Progressive disclosure**  
   - The model sees only skill **descriptions** in the prompt (e.g. “sales_analytics: Database schema and business logic for sales data…”).  
   - When the user asks for something that requires schema or examples, the agent calls **read_skill(skill_name)** to load the full SKILL.md content (tables, business logic, example queries).  
+  - Skill names are registry identifiers, not tool names. The model should not call a skill name directly as a tool; it should call **read_skill** with the skill name first.
   - This keeps the initial context small and avoids loading all skill text upfront.
 
 - **Skills in this example**  
@@ -23,7 +24,7 @@ This example implements the **skills** (progressive disclosure) pattern with Spr
    Uses **ClasspathSkillRegistry.builder().classpathPath("skills").build()** so skills are loaded from `src/main/resources/skills/` (and the same path inside the packaged JAR). No custom in-memory skill list.
 
 2. **SkillsAgentHook**  
-   **SkillsAgentHook.builder().skillRegistry(registry).build()** provides the `read_skill` tool and the interceptor that injects skill descriptions into the system message. No custom LoadSkillTool or SkillInterceptor.
+   **SkillsAgentHook.builder().skillRegistry(registry).build()** provides the `read_skill` tool and the interceptor that injects skill descriptions into the system message. No custom LoadSkillTool or SkillInterceptor. Skills do not automatically become ToolCallbacks; use `groupedTools` when tools should become available after a skill is read.
 
 3. **Agent configuration**  
    ReactAgent is built with **.hooks(List.of(skillsAgentHook))**; no need to add tools or interceptors explicitly—the hook contributes both.

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/SkillsToolingTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/SkillsToolingTest.java
@@ -98,9 +98,10 @@ class SkillsToolingTest {
 	@Test
 	void skillsAgentHookExposesRegistryTools() {
 		SkillsAgentHook hook = SkillsAgentHook.builder().skillRegistry(registry).build();
+		List<String> toolNames = hook.getTools().stream().map(tool -> tool.getToolDefinition().name()).toList();
 
-		assertEquals(List.of("read_skill", "search_skills", "disable_skill"),
-				hook.getTools().stream().map(tool -> tool.getToolDefinition().name()).toList());
+		assertEquals(List.of("read_skill", "search_skills", "disable_skill"), toolNames);
+		assertFalse(toolNames.contains("allowed-tools-test"));
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -465,6 +465,7 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				+ "\n"
 				+ "**Skill Path Format:**\n"
 				+ "Each skill has a unique id shown in the skill list above. "
+				+ "Skill ids identify registry entries and are not direct tool names. "
 				+ "Use the exact id shown when calling `read_skill` to read the SKILL.md file.\n";
 	}
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/filesystem/FileSystemSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/filesystem/FileSystemSkillRegistry.java
@@ -99,6 +99,7 @@ public class FileSystemSkillRegistry extends AbstractSkillRegistry {
 			
 			**Important:**
 			
+			  - **For skill names**: Skill names are registry identifiers, not tool names. Do not call a skill name directly as a tool; call `read_skill` with the skill name or path to load the skill first.
 			  - **For SKILL.md files (skill instructions)**: Always use `read_skill` to read skill instructions. Do not attempt to access SKILL.md files through other methods.
 			  - **For other supporting files that skill uses (scripts, references, etc.)**: You may use other appropriate tools to read or access these files as needed, always use absolute paths from the skill list.
 			
@@ -275,6 +276,7 @@ public class FileSystemSkillRegistry extends AbstractSkillRegistry {
 
 		instructions.append("**Skill Path Format:**\n");
 		instructions.append("Each skill has a unique path shown in the skill list above. ");
+		instructions.append("Skill names and paths identify registry entries and are not direct tool names. ");
 		instructions.append("Use the exact path shown when calling `read_skill` to read the SKILL.md file.\n");
 
 		return instructions.toString();

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryEnhancementsTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryEnhancementsTest.java
@@ -50,6 +50,8 @@ class ClasspathSkillRegistryEnhancementsTest {
 		assertEquals(List.of("sample-skill"),
 				registry.search("classpath registry enhancement").stream().map(SkillMetadata::getName).toList());
 		assertTrue(registry.readSkillContentByPath(skill.getSkillPath()).contains("# Sample Skill"));
+		assertTrue(registry.getSkillLoadInstructions().contains("not direct tool names"));
+		assertTrue(registry.getSkillLoadInstructions().contains("calling `read_skill`"));
 
 		assertTrue(registry.disable("sample-skill"));
 		assertTrue(registry.isDisabled("sample-skill"));

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/filesystem/FileSystemSkillRegistryEnhancementsTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/filesystem/FileSystemSkillRegistryEnhancementsTest.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.graph.skills.registry.filesystem;
 
 import com.alibaba.cloud.ai.graph.skills.SkillMetadata;
+import com.alibaba.cloud.ai.graph.skills.SkillPromptConstants;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,6 +72,23 @@ class FileSystemSkillRegistryEnhancementsTest {
 		assertEquals(List.of("copy-helper"), registry.search("editing").stream().map(SkillMetadata::getName).toList());
 		assertEquals(List.of("allowed-tools-skill"),
 				registry.search(allowedToolsSkillDir.getFileName().toString()).stream().map(SkillMetadata::getName).toList());
+	}
+
+	@Test
+	void defaultPromptClarifiesSkillsAreLoadedThroughReadSkill() throws Exception {
+		FileSystemSkillRegistry registry = FileSystemSkillRegistry.builder()
+				.projectSkillsDirectory(skillsDir.toString())
+				.build();
+
+		String loadInstructions = registry.getSkillLoadInstructions();
+		String prompt = SkillPromptConstants.buildSkillsPrompt(
+				registry.listAll(), registry, registry.getSystemPromptTemplate());
+
+		assertTrue(loadInstructions.contains("not direct tool names"));
+		assertTrue(loadInstructions.contains("calling `read_skill`"));
+		assertTrue(prompt.contains("Skill names are registry identifiers, not tool names"));
+		assertTrue(prompt.contains("Do not call a skill name directly as a tool"));
+		assertTrue(prompt.contains("call `read_skill` with the skill name or path"));
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

Skills are loaded through the framework-provided `read_skill` tool, while skill names are registry identifiers. The current prompt already tells the model to use `read_skill`, but it does not explicitly say that a skill name itself is not a tool name.

This can make skill usage harder to diagnose when a model tries to call a skill name directly instead of loading it through `read_skill`.

This PR clarifies the default skill loading instructions and the skills example documentation while preserving the existing progressive disclosure behavior.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Clarify the default filesystem skill prompt so skill names are described as registry identifiers, not tool names.
- Clarify filesystem and classpath skill loading instructions to guide calls through `read_skill`.
- Document that skills do not automatically become ToolCallbacks and that `groupedTools` should be used when tools need to become available after a skill is read.
- Add tests covering the prompt wording, classpath instructions, and the tools exposed by `SkillsAgentHook`.

### Describe how to verify it

- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=FileSystemSkillRegistryEnhancementsTest,ClasspathSkillRegistryEnhancementsTest test`
- `./mvnw -pl spring-ai-alibaba-agent-framework -am -Dtest=SkillsToolingTest -DfailIfNoTests=false -DfailIfNoSpecifiedTests=false test`
- `./mvnw -pl spring-ai-alibaba-graph-core,spring-ai-alibaba-agent-framework -am test`
- `git diff --check`

### Special notes for reviews

This change only clarifies the default instructions and documentation. It does not change the set of tools exposed by `SkillsAgentHook` or the existing `groupedTools` activation behavior.
