### PR TITLE
fix: avoid re-synthesizing single AgentScope routing result

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/main/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNode.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/main/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNode.java
@@ -73,6 +73,7 @@ public class AgentScopeRoutingMergeNode implements NodeAction {
 		logger.debug("AgentScopeRoutingMergeNode: merging results from {} sub-agents", subAgents.size());
 
 		List<String> formattedResults = new ArrayList<>();
+		String lastResult = null;
 		for (BaseAgent subAgent : subAgents) {
 			String outputKey = subAgent.getOutputKey();
 			if (outputKey == null) {
@@ -84,9 +85,15 @@ public class AgentScopeRoutingMergeNode implements NodeAction {
 				if (text != null && !text.isBlank()) {
 					String source = capitalize(subAgent.name());
 					formattedResults.add("**From " + source + ":**\n" + text);
+					lastResult = text;
 					logger.debug("Collected result from {} (key: {})", subAgent.name(), outputKey);
 				}
 			}
+		}
+
+		if (formattedResults.size() == 1) {
+			logger.debug("AgentScopeRoutingMergeNode: single routed result, returning it without re-synthesis");
+			return Map.of(mergedOutputKey, lastResult);
 		}
 
 		String query = extractOriginalQuery(state);

--- a/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/test/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNodeTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/test/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNodeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.agent.agentscope.flow;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.agent.BaseAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.node.RoutingMergeNode;
+import io.agentscope.core.model.Model;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class AgentScopeRoutingMergeNodeTest {
+
+	@Test
+	void singleRoutedResultIsPassedThroughWithoutSynthesis() throws Exception {
+		Model model = mock(Model.class);
+		BaseAgent poemAgent = mockAgent("poem_writer_agent", "poem_article");
+		BaseAgent proseAgent = mockAgent("prose_writer_agent", "prose_article");
+
+		OverAllState state = new OverAllState(Map.of(
+				"poem_article", new AssistantMessage("A short modern poem about spring."),
+				"messages", List.<Message>of(new UserMessage("Write a poem about spring"))));
+
+		AgentScopeRoutingMergeNode node = new AgentScopeRoutingMergeNode(model, List.of(poemAgent, proseAgent));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("A short modern poem about spring.", result.get(RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY),
+				"Single routed result must be returned verbatim, not re-synthesized");
+		verifyNoInteractions(model);
+	}
+
+	private static BaseAgent mockAgent(String name, String outputKey) {
+		BaseAgent agent = mock(BaseAgent.class);
+		when(agent.name()).thenReturn(name);
+		when(agent.getOutputKey()).thenReturn(outputKey);
+		return agent;
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes `AgentScopeRoutingMergeNode` to return a single routed sub-agent result directly instead of sending it through another synthesis model call.

The regular `RoutingMergeNode` already has this behavior, but the AgentScope implementation still always called `synthesize()`. This could cause an unnecessary extra model call, higher latency/token cost, and possible rewriting of the original sub-agent answer.

### Does this pull request fix one issue?

Fixes #4699

### Describe how you did it

- Track the last collected sub-agent result while iterating over routed outputs.
- Return the result directly when exactly one routed result is present.
- Keep the existing synthesis behavior for multiple routed results.
- Added a regression test to verify that single routed results are passed through without interacting with the AgentScope model.

### Describe how to verify it

Run:

```bash
./mvnw -pl spring-boot-starters/spring-ai-alibaba-starter-agentscope -Dtest=AgentScopeRoutingMergeNodeTest test
```

### Special notes for reviews
This mirrors the existing single-result behavior in `RoutingMergeNode` and keeps synthesis only for genuine multi-result merge scenarios.