### PR TITLE
fix(agent): skip redundant agentscope merge synthesis

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/main/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNode.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/main/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNode.java
@@ -89,6 +89,12 @@ public class AgentScopeRoutingMergeNode implements NodeAction {
 			}
 		}
 
+		if (formattedResults.size() == 1) {
+			String singleResult = extractSingleResult(formattedResults.get(0));
+			logger.debug("AgentScopeRoutingMergeNode: single routed result, returning it without re-synthesis");
+			return Map.of(mergedOutputKey, singleResult);
+		}
+
 		String query = extractOriginalQuery(state);
 		String finalAnswer = synthesize(query, formattedResults);
 		logger.debug("AgentScopeRoutingMergeNode: synthesized {} sources into merged result", formattedResults.size());
@@ -126,6 +132,14 @@ public class AgentScopeRoutingMergeNode implements NodeAction {
 		}
 		String text = response.getTextContent();
 		return text != null ? text : "";
+	}
+
+	private String extractSingleResult(String formattedResult) {
+		int split = formattedResult.indexOf("\n");
+		if (split < 0) {
+			return formattedResult;
+		}
+		return formattedResult.substring(split + 1).strip();
 	}
 
 	private static String extractText(Object output) {

--- a/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/test/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNodeTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-agentscope/src/test/java/com/alibaba/cloud/ai/agent/agentscope/flow/AgentScopeRoutingMergeNodeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.agent.agentscope.flow;
+
+import java.util.List;
+import java.util.Map;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.agent.BaseAgent;
+import io.agentscope.core.model.Model;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AgentScopeRoutingMergeNodeTest {
+
+	@Test
+	void returnsSingleRoutedResultWithoutResynthesis() throws Exception {
+		Model model = mock(Model.class);
+		BaseAgent subAgent = mock(BaseAgent.class);
+		when(subAgent.getOutputKey()).thenReturn("writer_output");
+		when(subAgent.name()).thenReturn("writer_agent");
+
+		OverAllState state = new OverAllState();
+		state.updateState(Map.of(
+				"messages", List.of(new AssistantMessage("original question")),
+				"writer_output", new AssistantMessage("final single answer")
+		));
+
+		AgentScopeRoutingMergeNode node = new AgentScopeRoutingMergeNode(model, List.of(subAgent));
+
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("final single answer", result.get("merged_result"));
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4699.

This makes `AgentScopeRoutingMergeNode` match the existing `RoutingMergeNode` behavior: when exactly one routed sub-agent result exists, it returns that result directly instead of making an unnecessary synthesis model call.

## Changes

- short-circuit the AgentScope merge node when only one routed result is present
- preserve the existing synthesis path for multi-result merges
- add a focused regression test for the single-result case

## Verification

- `./mvnw -pl spring-boot-starters/spring-ai-alibaba-starter-agentscope -Dtest=AgentScopeRoutingMergeNodeTest test`
- `git diff --check`
