### PR TITLE
fix(agent): degrade gracefully on missing skill tools

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -544,7 +544,13 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 			if (toolCallback == null) {
 				logger.warn(POSSIBLE_LLM_TOOL_NAME_CHANGE_WARNING, req.getToolName());
-				throw new IllegalStateException("No ToolCallback found for tool name: " + req.getToolName());
+				return ToolCallResponse.builder()
+					.content("Tool not available: " + req.getToolName())
+					.toolName(req.getToolName())
+					.toolCallId(req.getToolCallId())
+					.status("error")
+					.metadata(Map.of("error", true, "unresolvedToolName", req.getToolName()))
+					.build();
 			}
 
 			if (enableActingLog) {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeIntegrationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeIntegrationTest.java
@@ -287,9 +287,32 @@ class AgentToolNodeIntegrationTest {
 
 	}
 
+
 	@Nested
 	@DisplayName("Sequential Execution Tests")
 	class SequentialExecutionTests {
+
+
+		@Test
+		@DisplayName("should degrade gracefully when tool callback cannot be resolved")
+		void apply_shouldReturnUnavailableToolResponse_whenToolCallbackMissing() throws Exception {
+			AgentToolNode node = baseBuilder.toolCallbacks(List.of()).build();
+
+			AssistantMessage assistantMessage = createAssistantMessageWithToolCalls(
+					createToolCall("call-1", "fuyao-web-search", "{}"));
+
+			OverAllState state = createStateWithMessages(assistantMessage);
+			RunnableConfig config = RunnableConfig.builder().build();
+
+			Map<String, Object> result = node.apply(state, config);
+
+			ToolResponseMessage responseMessage = (ToolResponseMessage) result.get("messages");
+			assertEquals(1, responseMessage.getResponses().size());
+			ToolResponseMessage.ToolResponse response = responseMessage.getResponses().get(0);
+			assertEquals("call-1", response.id());
+			assertEquals("fuyao-web-search", response.name());
+			assertEquals("Tool not available: fuyao-web-search", response.responseData());
+		}
 
 		@Test
 		@DisplayName("should maintain tool response order in sequential mode")
@@ -619,9 +642,8 @@ class AgentToolNodeIntegrationTest {
 		}
 
 		@Test
-		@DisplayName("should throw exception when tool not found anywhere")
-		void resolve_shouldThrow_whenToolNotFound() {
-			// Given
+		@DisplayName("should return unavailable response when tool not found anywhere")
+		void resolve_shouldReturnUnavailableResponse_whenToolNotFound() throws Exception {
 			AgentToolNode node = baseBuilder.toolCallbacks(List.of()).toolCallbackResolver(null).build();
 
 			AssistantMessage assistantMessage = createAssistantMessageWithToolCalls(
@@ -630,8 +652,14 @@ class AgentToolNodeIntegrationTest {
 			OverAllState state = createStateWithMessages(assistantMessage);
 			RunnableConfig config = RunnableConfig.builder().build();
 
-			// When/Then
-			assertThrows(IllegalStateException.class, () -> node.apply(state, config));
+			Map<String, Object> result = node.apply(state, config);
+
+			ToolResponseMessage responseMessage = (ToolResponseMessage) result.get("messages");
+			assertEquals(1, responseMessage.getResponses().size());
+			ToolResponseMessage.ToolResponse response = responseMessage.getResponses().get(0);
+			assertEquals("call-1", response.id());
+			assertEquals("nonExistentTool", response.name());
+			assertEquals("Tool not available: nonExistentTool", response.responseData());
 		}
 
 	}
@@ -748,6 +776,28 @@ class AgentToolNodeIntegrationTest {
 			assertNotNull(capturedToken.get(), "Token should be passed");
 			// Should NOT be NONE token
 			assertFalse(capturedToken.get() == CancellationToken.NONE, "Should receive real token, not NONE");
+		}
+
+
+		@Test
+		@DisplayName("should degrade gracefully when tool callback cannot be resolved")
+		void apply_shouldReturnUnavailableToolResponse_whenToolCallbackMissing() throws Exception {
+			AgentToolNode node = baseBuilder.toolCallbacks(List.of()).build();
+
+			AssistantMessage assistantMessage = createAssistantMessageWithToolCalls(
+					createToolCall("call-1", "fuyao-web-search", "{}"));
+
+			OverAllState state = createStateWithMessages(assistantMessage);
+			RunnableConfig config = RunnableConfig.builder().build();
+
+			Map<String, Object> result = node.apply(state, config);
+
+			ToolResponseMessage responseMessage = (ToolResponseMessage) result.get("messages");
+			assertEquals(1, responseMessage.getResponses().size());
+			ToolResponseMessage.ToolResponse response = responseMessage.getResponses().get(0);
+			assertEquals("call-1", response.id());
+			assertEquals("fuyao-web-search", response.name());
+			assertEquals("Tool not available: fuyao-web-search", response.responseData());
 		}
 
 	}


### PR DESCRIPTION
# Summary
- handle unresolved skill-declared tool calls without aborting agent execution
- return an unavailable tool response when a tool name cannot be resolved instead of throwing `No ToolCallback found`
- add `AgentToolNode` regression coverage for resolver misses and missing dynamic skill tools

# Testing
- `./mvnw -pl spring-ai-alibaba-agent-framework -am -Dcheckstyle.skip=true -Dspotless.skip=true -Dspring-javaformat.skip=true -Dtest=AgentToolNodeIntegrationTest test`
- `git diff --check`

# Breaking Changes
- [x] None
