### PR TITLE
fix(graph): stabilize conditional parallel target reporting

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -362,7 +363,7 @@ public class CompiledGraph {
 		return parallelNodeEdges.stream()
 				.map(ee -> ee.target().id())
 				.filter(Objects::nonNull)
-				.collect(Collectors.toSet());
+				.collect(Collectors.toCollection(TreeSet::new));
 	}
 
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/StateGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/StateGraph.java
@@ -294,6 +294,8 @@ public class StateGraph {
 	/**
 	 * Adds node that behave as parallel conditional edges.
 	 * This method allows routing to multiple nodes in parallel based on the multi-command action.
+	 * All nodes referenced by the mappings must have outgoing edges to the same
+	 * immediate convergence node.
 	 * @param id the identifier of the node
 	 * @param action multi-command action to determine multiple target nodes for parallel execution
 	 * @param mappings the mappings of conditions to target nodes
@@ -471,6 +473,8 @@ public class StateGraph {
 	 * Adds conditional edges to the graph that can route to multiple nodes in parallel.
 	 * This method is used when the condition action can return multiple target nodes
 	 * that should be executed in parallel.
+	 * All mapped target nodes must have outgoing edges to the same immediate
+	 * convergence node.
 	 *
 	 * @param sourceId the identifier of the source node
 	 * @param condition the multi-command action used to determine multiple target nodes

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
@@ -1794,8 +1794,11 @@ public class StateGraphTest {
 				.addEdge("E", END);
 
 		GraphStateException exception = assertThrows(GraphStateException.class, () -> workflow.compile());
-		assertTrue(exception.getMessage().contains("parallel node [conditional_node] must have only one target"),
-				"Expected compile error for divergent immediate successors, but got: " + exception.getMessage());
+		String message = exception.getMessage();
+		assertTrue(message.contains("parallel node [conditional_node] must have only one target"),
+				"Expected compile error for divergent immediate successors, but got: " + message);
+		assertTrue(message.indexOf("C1") < message.indexOf("D"),
+				"Expected divergent targets to be reported in sorted order, but got: " + message);
 	}
 
 	/**


### PR DESCRIPTION
### What changed

Fixes #4411.

- Sort conditional parallel branch targets before reporting them
- Make generated graph output deterministic
- Add test coverage for stable conditional target ordering

### Tests

- git diff --check
- Not run: Maven tests require JAVA_HOME in the local environment