### PR TITLE
docs: unify example startup commands with Maven Wrapper (mvnw)

### DIFF
--- a/examples/deepresearch/README.md
+++ b/examples/deepresearch/README.md
@@ -17,9 +17,9 @@ export JINA_API_KEY=your_jina_api_key  # Optional
 
 ### Run the Agent
 
-1. **Run with Maven**
+1. **Run with Maven Wrapper** (run from the repository root; Maven installation is optional when using `mvnw`)
 ```bash
-mvn spring-boot:run
+./mvnw -f examples/deepresearch spring-boot:run
 ```
 
 2. **Run in IDE**

--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/a2a/README.md
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/a2a/README.md
@@ -78,7 +78,7 @@ docker run --name nacos -d -p 8848:8848 -e MODE=standalone nacos/nacos-server:la
 ### 2) 启动应用
 
 ```bash
-mvn -q -pl examples/documentation -am spring-boot:run
+./mvnw -q -f examples/documentation spring-boot:run
 ```
 
 ### 3) 访问演示接口

--- a/examples/multiagent-patterns/workflow/README.md
+++ b/examples/multiagent-patterns/workflow/README.md
@@ -30,12 +30,14 @@ Flow: **Question → Agent (list_tables → get_schema → run_query) → Answer
 
 ## Run
 
+From the repository root (Maven installation is optional when using `mvnw`):
+
 ```bash
 # RAG agent
-mvn spring-boot:run -Dspring-boot.run.arguments="--workflow.rag.enabled=true --workflow.runner.enabled=true"
+./mvnw -f examples/multiagent-patterns/workflow spring-boot:run -Dspring-boot.run.arguments="--workflow.rag.enabled=true --workflow.runner.enabled=true"
 
 # SQL agent
-mvn spring-boot:run -Dspring-boot.run.arguments="--workflow.sql.enabled=true --workflow.runner.enabled=true"
+./mvnw -f examples/multiagent-patterns/workflow spring-boot:run -Dspring-boot.run.arguments="--workflow.sql.enabled=true --workflow.runner.enabled=true"
 ```
 
 Set `AI_DASHSCOPE_API_KEY` environment variable.

--- a/examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/ragagent/README.md
+++ b/examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/ragagent/README.md
@@ -22,6 +22,8 @@ workflow.runner.enabled: true  # optional demo on startup
 
 ## Run
 
+From the repository root (Maven installation is optional when using `mvnw`):
+
 ```bash
-mvn spring-boot:run -Dspring-boot.run.arguments="--workflow.rag.enabled=true --workflow.runner.enabled=true"
+./mvnw -f examples/multiagent-patterns/workflow spring-boot:run -Dspring-boot.run.arguments="--workflow.rag.enabled=true --workflow.runner.enabled=true"
 ```

--- a/examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/sqlagent/README.md
+++ b/examples/multiagent-patterns/workflow/src/main/java/com/alibaba/cloud/ai/examples/multiagents/workflow/sqlagent/README.md
@@ -26,6 +26,8 @@ Uses H2 in-memory with a Chinook-like schema. Schema is initialized from `schema
 
 ## Run
 
+From the repository root (Maven installation is optional when using `mvnw`):
+
 ```bash
-mvn spring-boot:run -Dspring-boot.run.arguments="--workflow.sql.enabled=true --workflow.runner.enabled=true"
+./mvnw -f examples/multiagent-patterns/workflow spring-boot:run -Dspring-boot.run.arguments="--workflow.sql.enabled=true --workflow.runner.enabled=true"
 ```


### PR DESCRIPTION
### Describe what this PR does / why we need it

Following up on #4403. The root `README.md` and `examples/chatbot/README.md` already use the Maven Wrapper, but several other example READMEs still use a bare `mvn` command without an explicit execution directory. This causes onboarding friction for contributors who don't have Maven installed (`mvn: command not found`) and ambiguity about where to run the command.

This PR standardizes the remaining example run commands to the Maven Wrapper, run from the repository root.

### Does this pull request fix one issue?

Fixes #4403

### Describe how you did it

Updated the run commands in the following example READMEs to use `./mvnw -f <module>` from the repository root, and added a short note that Maven installation is optional when using `mvnw`:

- `examples/deepresearch/README.md`
- `examples/documentation/.../advanced/a2a/README.md`
- `examples/multiagent-patterns/workflow/README.md`
- `examples/multiagent-patterns/workflow/.../ragagent/README.md`
- `examples/multiagent-patterns/workflow/.../sqlagent/README.md`

Note: the `examples` modules are standalone projects and are **not** part of the root reactor, so `-pl <module>` does not resolve them (`Could not find the selected project in the reactor`). The `./mvnw -f <module>` form invokes the wrapper from the root while targeting the example's own POM, which works reliably.

The other example READMEs that already document a root-level `./mvnw` command (e.g. `multiagent-patterns/skills`, `supervisor`, `routing/*`, which keep a bare `mvn` only as an explicit "or from this directory" alternative) were intentionally left unchanged.

### Describe how to verify it

From the repository root, the documented commands resolve correctly (verified with `validate`):

```bash
./mvnw -f examples/deepresearch validate
./mvnw -f examples/documentation validate
./mvnw -f examples/multiagent-patterns/workflow validate
```

All three complete successfully. The previous `-pl :multi-agent-workflow` / `-pl examples/...` forms fail with "Could not find the selected project in the reactor".

### Special notes for reviews

Docs-only change. Happy to extend the same convention to additional example READMEs if preferred.