### PR TITLE
fix: remove dangling ToolExample reference that breaks admin-server-runtime compilation

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/plugin/Tool.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/plugin/Tool.java
@@ -121,11 +121,6 @@ public class Tool {
 		@JsonProperty("output_params")
 		private List<ApiParameter> outputParams;
 
-		/**
-		 * Usage examples
-		 */
-		private List<ToolExample> examples;
-
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

The `spring-ai-alibaba-admin-server-runtime` module currently fails to compile on `main`:

```
Tool.java:[127] cannot find symbol: class ToolExample
```

`Tool.ToolConfig` declares `private List<ToolExample> examples;`, but no `ToolExample` type exists anywhere in the repository.

Root cause: the only `ToolExample.java` was a misplaced file that actually contained the `ToolsExample` tutorial class (package `com.alibaba.cloud.ai.examples.documentation.framework.tutorials`). It was correctly removed in #4721, but the dangling `examples` field it left behind was not. The field is unused — nothing calls `Tool.ToolConfig#getExamples()/setExamples()` (the `setExamples(getExamples())` call in `OpenApiUtils` operates on a different `ToolCallSchema` type).

This PR removes the dead field to restore compilation.

> Note: this break isn't caught by CI because `spring-ai-alibaba-admin` is not part of the root Maven reactor that `make test` / `make build` build. Wiring the admin module into CI would prevent regressions like this — happy to open a follow-up issue if useful.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Removed the unused `List<ToolExample> examples` field (and its Javadoc) from `Tool.ToolConfig`. No other references to `ToolExample` exist in the codebase.

### Describe how to verify it

Before this change:

```
./mvnw -f spring-ai-alibaba-admin/pom.xml -pl spring-ai-alibaba-admin-server-runtime compile
# => BUILD FAILURE: cannot find symbol: class ToolExample
```

After this change the module compiles. I also built `spring-ai-alibaba-admin-server-core` (which depends on runtime) and its tests are green.

### Special notes for reviews

If the `examples` field is actually intended functionality rather than dead code, the alternative fix would be to (re)introduce a proper `ToolExample` POJO instead of removing the field — happy to switch to that if you prefer.
