### PR TITLE
fix(admin): harden legacy Playground/Evaluator frontend against crashes

### DIFF
--- a/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/evaluation/evaluator/evaluator-detail/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/evaluation/evaluator/evaluator-detail/index.tsx
@@ -35,6 +35,8 @@ import {
   CheckCircleOutlined
 } from '@ant-design/icons';
 import { handleApiError, notifySuccess, notifyError } from '../../../../utils/notification';
+import { safeJSONParse } from '../../../../utils/util';
+import { getLegacyPath } from '../../../../utils/path';
 import API from '../../../../services';
 import './index.css';
 import usePagination from '../../../../hooks/usePagination';
@@ -163,7 +165,7 @@ function EvaluatorDetail() {
       const evaluatorData = evaluatorResponse.data;
       setEvaluator(evaluatorData);
       try {
-        const isFromEvaluationDebug = stateFromDebug?.prePathname === '/evaluation-debug';
+        const isFromEvaluationDebug = stateFromDebug?.prePathname === getLegacyPath('/evaluation/debug');
         const modelConfig = isFromEvaluationDebug ? (stateFromDebug?.modelConfig || {}) : JSON.parse(evaluatorData.modelConfig || "{}");
         const { modelId, ...conf } = modelConfig;
         const defaultModelParams = !isFromEvaluationDebug && models[0]?.defaultParameters || {};
@@ -375,7 +377,7 @@ function EvaluatorDetail() {
     };
 
     // 跳转到调试页面，携带修改后的配置
-    navigate('/evaluation-debug', { state: debugConfig });
+    navigate(getLegacyPath('/evaluation/debug'), { state: debugConfig });
   };
 
   // 计算下一个版本号
@@ -1382,7 +1384,7 @@ function EvaluatorDetail() {
                       <div>
                         <Text strong className="block mb-2">模型配置</Text>
                         <div className="bg-gray-50 p-3 rounded border text-xs font-mono">
-                          {JSON.stringify(JSON.parse(selectedTemplateDetail.modelConfig), null, 2)}
+                          {JSON.stringify(safeJSONParse(selectedTemplateDetail.modelConfig, () => ({})), null, 2)}
                         </div>
                       </div>
                     )}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/evaluation/evaluator/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/evaluation/evaluator/index.tsx
@@ -179,7 +179,13 @@ const EvaluationEvaluator: React.FC = () => {
       key: 'modelConfig',
       render: (modelConfig: string) => {
         // 优先使用 modelName，如果为空或为 '-' 则从 modelConfig 中提取
-        const modelConfigJson = JSON.parse(modelConfig);
+        if (!modelConfig) return "-";
+        let modelConfigJson: any;
+        try {
+          modelConfigJson = JSON.parse(modelConfig);
+        } catch {
+          return "-";
+        }
         const name = modelNameMap[modelConfigJson?.modelId];
         return name ? (
           <Tag color="geekblue">{name}</Tag>

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/playground/playground.jsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/playground/playground.jsx
@@ -570,6 +570,12 @@ const PlaygroundPage = () => {
       enableFn
     } = promptInstance;
 
+    // Resolve the currently-selected prompt from the loaded prompts list so we
+    // can read its key/version. Previously this referenced an undefined
+    // `currentPrompt`, which threw `ReferenceError: currentPrompt is not defined`
+    // the moment the user clicked Send.
+    const currentPrompt = prompts.find(p => p.promptKey === promptInstance.selectedPromptId);
+
     const config = {
       promptId,
       content,
@@ -578,7 +584,7 @@ const PlaygroundPage = () => {
       modelParams,
       sessionId,
       promptKey: currentPrompt?.promptKey || 'playground',
-      version: currentPrompt?.latestVersion || '1.0',
+      version: currentPrompt?.currentVersion?.version || '1.0',
       mockTools: enableFn === false ? [] : mockTools,
     };
 
@@ -615,7 +621,7 @@ const PlaygroundPage = () => {
     setPromptInstances(prev => prev.map(prompt => {
       if (prompt.id === promptId) {
         const userMessage = {
-          id: Date.now() + prompt.id,
+          id: `user-${Date.now()}-${prompt.id}`,
           type: 'user',
           content: inputText,
           timestamp: formatTime(Date.now())

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/utils/streamingPrompt.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/utils/streamingPrompt.ts
@@ -93,7 +93,7 @@ export const executeStreamingPrompt = async (
     };
 
     let currentMessage = {
-      id: Date.now(),
+      id: `ai-${Date.now()}`,
       promptId,
       type: 'assistant', // 修正类型匹配，与UI中的判断一致
       content: '',


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes five independent crash bugs in the legacy Playground and Evaluator pages (all introduced in #3867), each breaking a core build/eval flow:

1. **Playground — Send crash:** clicking **Send** threw `ReferenceError: currentPrompt is not defined`. `runSinglePrompt` referenced `currentPrompt` without ever declaring it.
2. **Playground — first-turn mis-render:** on the first turn the user's own message text was rendered inside the assistant bubble (React key collision): the user-message id was `Date.now() + prompt.id` and the assistant (streaming) id was `Date.now()`, which collide on the first turn.
3. **Evaluator — list crash:** the Evaluator list threw `SyntaxError: "undefined" is not valid JSON` whenever any evaluator's `modelConfig` was unset/invalid.
4. **Evaluator — template-detail crash:** the template `modelConfig` display crashed on invalid JSON (guarded only by `modelConfig &&`, which doesn't stop the literal string `"undefined"`).
5. **Evaluator — detail "调试" white screen:** clicking 调试 navigated to `/evaluation-debug`, which is not a registered umi route (only `/admin/evaluation/debug` is registered in `.umirc.ts`) → blank page.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- **Bug 1** (`pages/playground/playground.jsx`): resolve `currentPrompt` from the loaded `prompts` state with the same lookup pattern used elsewhere in the file, and read the version from `currentVersion.version`.
- **Bug 2** (`playground.jsx` + `utils/streamingPrompt.ts`): prefix each chat-message id by type (`user-${Date.now()}-${id}` / `ai-${Date.now()}`) so user/assistant keys can never collide.
- **Bug 3** (`pages/evaluation/evaluator/index.tsx`): guard the modelConfig column's `JSON.parse` with a null check + try/catch.
- **Bug 4** (`pages/evaluation/evaluator/evaluator-detail/index.tsx`): replace the raw `JSON.parse` of the template modelConfig with the existing `safeJSONParse` helper.
- **Bug 5** (`evaluator-detail/index.tsx`): navigate to `getLegacyPath('/evaluation/debug')` — the registered `/admin/evaluation/debug` route the evaluator list already uses — and sync the `isFromEvaluationDebug` round-trip check.

### Describe how to verify it

1. Start the admin backend + frontend (`npm run dev`).
2. **Playground:** configure a prompt → Send → no `ReferenceError`; the first turn's assistant bubble shows only the model reply (not the user's question).
3. **Evaluator list:** open the list even when an evaluator has no `modelConfig` → no `SyntaxError`.
4. **Evaluator detail:** open an evaluator, configure a model, click **调试** → the debug page renders (no white screen); open a template detail → no crash.

### Special notes for reviews

- Four files changed, all under `frontend/packages/main/src/legacy/`. No new dependencies — Bugs 3/4 reuse the existing `safeJSONParse` helper; Bug 5 reuses the existing `getLegacyPath` helper.
- All five reproduce on current `main`; introduced in #3867.
