### PR TITLE
fix(admin): guard null topK/threshold in KnowledgeBaseDocumentRetriever

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/rag/retriever/KnowledgeBaseDocumentRetriever.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/rag/retriever/KnowledgeBaseDocumentRetriever.java
@@ -96,10 +96,13 @@ public class KnowledgeBaseDocumentRetriever implements DocumentRetriever {
 				documents.addAll(future.get(SEARCH_TIMEOUT, TimeUnit.SECONDS));
 			}
 
+			Integer topK = searchOptions.getTopK();
+			Float similarityThreshold = searchOptions.getSimilarityThreshold();
 			List<Document> results = documents.stream()
 				.sorted(Comparator.comparing(Document::getScore, Comparator.nullsLast(Comparator.reverseOrder())))
-				.filter(x -> x.getScore() != null && x.getScore() > searchOptions.getSimilarityThreshold())
-				.limit(searchOptions.getTopK())
+				.filter(x -> x.getScore() != null
+						&& (similarityThreshold == null || x.getScore() > similarityThreshold))
+				.limit(topK != null ? topK.longValue() : Long.MAX_VALUE)
 				.toList();
 
 			LogUtils.monitor("DocumentRetriever", "retrieve", start, SUCCESS, query.text(), results.size());


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes the NPE reported in #4734: chatting with an Agent app that has a knowledge base throws `NullPointerException: ...FileSearchOptions.getTopK() is null` on the first turn whenever the agent-level `topK` / `similarityThreshold` are not explicitly set (the default), making RAG-backed chat unusable.

### Does this pull request fix one issue?

Fixes #4734

### Describe how you did it

In `KnowledgeBaseDocumentRetriever`, the public `retrieve(Query)` auto-unboxes `searchOptions.getSimilarityThreshold()` (in the `.filter`) and `searchOptions.getTopK()` (in the `.limit`), so either being `null` throws. The private `retrieve(KnowledgeBase, Query)` in the same class already null-checks both; this PR mirrors that null-safety in the public method:

- `null` `topK` → no post-merge cap (`Long.MAX_VALUE`);
- `null` `similarityThreshold` → skip the threshold filter (per-KB retrieval already applied its own).

### Describe how to verify it

1. Build & start the admin backend + frontend.
2. Create an Agent app, attach a knowledge base (RAG enabled), leave the file-search `topK` unset (default).
3. Open the app's chat, send any message → no NPE; chat returns results.

### Special notes for reviews

- Single-file, ~5-line change; mirrors the null-safety already present in the private `retrieve(KnowledgeBase, Query)` of the same class.
- Optional companion (NOT included — maintainer call): `FileSearchOptions.topK` / `similarityThreshold` document defaults of `3` / `0.2` but have no `@Builder.Default`, so they're `null` when unset. Adding `@Builder.Default` would enforce those defaults everywhere; left out here to keep this PR focused on the NPE and because it changes the meaning of "unset" (null = uncapped vs. fixed default). Happy to follow up if you prefer that direction.
