### PR TITLE
fix(admin): resilient copy in ObservationMetadataChatOptions

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DashScopeObservationMetadataChatOptions.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DashScopeObservationMetadataChatOptions.java
@@ -2,7 +2,7 @@ package com.alibaba.cloud.ai.studio.admin.service.client;
 
 import com.alibaba.cloud.ai.dashscope.chat.DashScopeChatOptions;
 import com.alibaba.cloud.ai.observation.model.ObservationMetadataAwareOptions;
-import org.springframework.beans.BeanUtils;
+import com.alibaba.cloud.ai.studio.admin.utils.ObservationOptionsCopyUtils;
 
 import java.util.Map;
 
@@ -12,7 +12,7 @@ public class DashScopeObservationMetadataChatOptions extends DashScopeChatOption
     
     public static DashScopeObservationMetadataChatOptions fromDashScopeOptions(DashScopeChatOptions fromOptions) {
         DashScopeObservationMetadataChatOptions options = new DashScopeObservationMetadataChatOptions();
-        BeanUtils.copyProperties(fromOptions, options);
+        ObservationOptionsCopyUtils.copySafely(fromOptions, options);
         return options;
     }
     

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DeepSeekObservationMetadataChatOptions.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/DeepSeekObservationMetadataChatOptions.java
@@ -1,8 +1,8 @@
 package com.alibaba.cloud.ai.studio.admin.service.client;
 
 import com.alibaba.cloud.ai.observation.model.ObservationMetadataAwareOptions;
+import com.alibaba.cloud.ai.studio.admin.utils.ObservationOptionsCopyUtils;
 import org.springframework.ai.deepseek.DeepSeekChatOptions;
-import org.springframework.beans.BeanUtils;
 
 import java.util.Map;
 
@@ -12,7 +12,7 @@ public class DeepSeekObservationMetadataChatOptions extends DeepSeekChatOptions 
     
     public static DeepSeekObservationMetadataChatOptions fromDeepSeekOptions(DeepSeekChatOptions fromOptions) {
         DeepSeekObservationMetadataChatOptions options = new DeepSeekObservationMetadataChatOptions();
-        BeanUtils.copyProperties(fromOptions, options);
+        ObservationOptionsCopyUtils.copySafely(fromOptions, options);
         return options;
     }
     

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/OpenAiObservationMetadataChatOptions.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/service/client/OpenAiObservationMetadataChatOptions.java
@@ -1,8 +1,8 @@
 package com.alibaba.cloud.ai.studio.admin.service.client;
 
 import com.alibaba.cloud.ai.observation.model.ObservationMetadataAwareOptions;
+import com.alibaba.cloud.ai.studio.admin.utils.ObservationOptionsCopyUtils;
 import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.beans.BeanUtils;
 
 import java.util.Map;
 
@@ -15,7 +15,7 @@ public class OpenAiObservationMetadataChatOptions extends OpenAiChatOptions impl
     
     public static OpenAiObservationMetadataChatOptions fromOpenAiOptions(OpenAiChatOptions fromOptions) {
         OpenAiObservationMetadataChatOptions options = new OpenAiObservationMetadataChatOptions();
-        BeanUtils.copyProperties(fromOptions, options);
+        ObservationOptionsCopyUtils.copySafely(fromOptions, options);
         return options;
     }
     

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/utils/ObservationOptionsCopyUtils.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/utils/ObservationOptionsCopyUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.admin.utils;
+
+import java.beans.PropertyDescriptor;
+
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+
+/**
+ * Reflectively copies bean properties from source to target, skipping any property whose
+ * copy fails, instead of aborting the whole copy.
+ *
+ * <p>Used to clone a provider ChatOptions into a metadata-aware subclass (see the
+ * {@code *ObservationMetadataChatOptions} classes in
+ * {@code admin.service.client}). Unlike {@link org.springframework.beans.BeanUtils#copyProperties},
+ * it tolerates properties inherited from a spring-ai interface that are not safely
+ * invokable on the subclass - e.g. {@code outputSchema}, added to
+ * {@code StructuredOutputChatOptions} in spring-ai 1.1.2, which previously made the bulk
+ * copy throw {@code FatalBeanException("Could not copy property 'outputSchema' from source
+ * to target")}.
+ *
+ * <p>Only the scalar model parameters plus the caller-supplied observation metadata need
+ * to survive; vendor structured-output / tooling options are out of scope and silently
+ * skipped.
+ *
+ * @since 1.0.0.3
+ */
+public final class ObservationOptionsCopyUtils {
+
+    private ObservationOptionsCopyUtils() {
+    }
+
+    /**
+     * Copy readable, non-null properties from source to target, skipping any property
+     * that cannot be reflectively copied.
+     * @param source the bean to copy from
+     * @param target the bean to copy into
+     */
+    public static void copySafely(Object source, Object target) {
+        if (source == null || target == null) {
+            return;
+        }
+        BeanWrapper src = new BeanWrapperImpl(source);
+        BeanWrapper dst = new BeanWrapperImpl(target);
+        for (PropertyDescriptor pd : dst.getPropertyDescriptors()) {
+            String name = pd.getName();
+            if (pd.getWriteMethod() == null || "class".equals(name)) {
+                continue;
+            }
+            try {
+                Object value = src.getPropertyValue(name);
+                if (value == null) {
+                    continue; // unset inherited properties (e.g. outputSchema) are irrelevant
+                }
+                dst.setPropertyValue(name, value);
+            }
+            catch (Exception ignored) {
+                // skip a property that cannot be reflectively copied
+            }
+        }
+    }
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/test/java/com/alibaba/cloud/ai/studio/admin/service/client/ObservationMetadataChatOptionsTest.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/test/java/com/alibaba/cloud/ai/studio/admin/service/client/ObservationMetadataChatOptionsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.admin.service.client;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.deepseek.DeepSeekChatOptions;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression tests for the spring-ai 1.1.2 {@code outputSchema} copy failure: wrapping a
+ * provider ChatOptions into the metadata-aware subclass must not throw
+ * {@code FatalBeanException} and must preserve scalar model params.
+ *
+ * @since 1.0.0.3
+ */
+class ObservationMetadataChatOptionsTest {
+
+    @Test
+    void deepSeekOptionsCanBeWrappedWithoutThrowing() {
+        DeepSeekChatOptions base = DeepSeekChatOptions.builder()
+            .model("deepseek-chat")
+            .temperature(0.3)
+            .maxTokens(1024)
+            .build();
+
+        DeepSeekObservationMetadataChatOptions wrapped =
+                DeepSeekObservationMetadataChatOptions.fromDeepSeekOptions(base);
+
+        assertThatCode(() -> wrapped.copy()).doesNotThrowAnyException();
+        assertThat(wrapped.getModel()).isEqualTo("deepseek-chat");
+        assertThat(wrapped.getTemperature()).isEqualTo(0.3);
+        assertThat(wrapped.getMaxTokens()).isEqualTo(1024);
+    }
+
+    @Test
+    void deepSeekWrapPreservesObservationMetadata() {
+        DeepSeekChatOptions base = DeepSeekChatOptions.builder().model("deepseek-chat").build();
+
+        DeepSeekObservationMetadataChatOptions wrapped =
+                DeepSeekObservationMetadataChatOptions.fromDeepSeekOptions(base);
+        wrapped.setObservationMetadata(Map.of("studioSource", "test"));
+
+        assertThat(wrapped.getObservationMetadata()).containsEntry("studioSource", "test");
+    }
+
+    @Test
+    void openAiOptionsCanBeWrappedWithoutThrowing() {
+        OpenAiChatOptions base = OpenAiChatOptions.builder().model("gpt-4o").temperature(0.5).build();
+
+        OpenAiObservationMetadataChatOptions wrapped =
+                OpenAiObservationMetadataChatOptions.fromOpenAiOptions(base);
+
+        assertThatCode(() -> wrapped.copy()).doesNotThrowAnyException();
+        assertThat(wrapped.getModel()).isEqualTo("gpt-4o");
+    }
+
+    // Note: add an equivalent case for DashScopeObservationMetadataChatOptions once its
+    // builder API is confirmed; the same fromXxxOptions -> copySafely path is exercised.
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes the spring-ai 1.1.2 regression reported in #4733: after the spring-ai bump, running a Prompt in Playground / an Evaluator debug / an Experiment throws `处理请求失败: Could not copy property 'outputSchema' from source to target` **before any model call**, breaking the whole evaluation axis (Prompt → Dataset → Evaluator → Experiment).

Root cause: spring-ai 1.1.2 introduced `StructuredOutputChatOptions` (declares `outputSchema`). The three `*ObservationMetadataChatOptions` helpers wrap a provider options object with `BeanUtils.copyProperties(from, target)`; the bulk copy now throws `FatalBeanException` on the inherited `outputSchema` property and aborts the whole copy.

### Does this pull request fix one issue?

Fixes #4733

### Describe how you did it

Replace the fragile bulk reflective copy with `ObservationOptionsCopyUtils.copySafely` (new, in `admin.utils`) — a `BeanWrapper`-based per-property copy that:

- skips `null` source values (so an unset inherited `outputSchema` is never even attempted),
- catches and skips any single property that cannot be reflectively copied,
- does **not** hardcode the property name, so the next non-copyable spring-ai property is tolerated instead of aborting the whole copy.

Changes:

- Add `ObservationOptionsCopyUtils.copySafely`.
- `DeepSeek` / `OpenAi` / `DashScope` `ObservationMetadataChatOptions`: use `copySafely` instead of `BeanUtils.copyProperties`.
- Add `ObservationMetadataChatOptionsTest` (regression guard; first test source root for admin-server-start).

### Describe how to verify it

1. Build & start the admin backend, configure at least one model.
2. Console → Prompt 工程 → Playground → pick the model → run any template + message.
3. No `Could not copy property 'outputSchema'` error; the model call proceeds. (Reproduces even with an unreachable model endpoint — the failure is at options-build time.)

### Special notes for reviews

- `spring-ai-alibaba-observation-extension` (where `ObservationMetadataAwareOptions` lives) is an **external published artifact**, not a module in this repo, so `copySafely` is kept in `admin.utils` rather than on the shared abstraction. A follow-up could expose it from the observation-extension source repo as `ObservationOptions.wrap(ChatOptions, Map)` for external reuse and to remove the three duplicated `fromXxxOptions` sites — left out of this PR since it would touch a separately-versioned module.
- The new util mirrors the intent of the old copy (carry scalar model params + caller-supplied metadata) while being resilient; vendor structured-output / tooling options are out of scope and silently skipped.
