### PR TITLE
fix(agent): detect shell completion marker on output without trailing newline

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
@@ -486,8 +486,16 @@ public class ShellSessionManager {
 				
 				// Send marker command based on shell type
 				if (isPowerShell) {
-					// PowerShell: use $LASTEXITCODE for exit code
-					stdin.write(String.format("Write-Output \"%s $LASTEXITCODE\"\n", marker));
+					// PowerShell only sets $LASTEXITCODE for native programs and scripts. Capture
+					// $? first so successful cmdlets still produce a numeric completion status,
+					// while preserving the native exit code when one is available.
+					stdin.write(String.format(
+							"$__lcSucceeded = $?; $__lcNativeExit = $LASTEXITCODE; "
+									+ "if ($__lcSucceeded) { $__lcExitCode = 0 } "
+									+ "elseif ($null -ne $__lcNativeExit) { $__lcExitCode = $__lcNativeExit } "
+									+ "else { $__lcExitCode = 1 }; "
+									+ "Write-Output \"%s $__lcExitCode\"\n",
+							marker));
 				} else if (isWindows) {
 					// Windows cmd.exe: use ERRORLEVEL
 					stdin.write(String.format("echo %s %%ERRORLEVEL%%\n", marker));
@@ -537,18 +545,36 @@ public class ShellSessionManager {
 					}
 
 					String line = outputLine.content;
+					boolean completed = false;
 
-					// Check for completion marker (only in stdout)
-					if ("stdout".equals(outputLine.source) && line.startsWith(marker)) {
-						String[] parts = line.split(" ", 2);
-						if (parts.length > 1) {
-							try {
-								exitCode = Integer.parseInt(parts[1].trim());
-							} catch (NumberFormatException e) {
-								// Ignore
+					// Detect the completion marker (only in stdout). The marker is emitted by a
+					// follow-up echo command, so it usually arrives on its own line. But when the
+					// command's output has no trailing newline (e.g. `cat` of a file without a final
+					// newline, or `printf` without `\n`), the line reader merges that trailing output
+					// and the marker into a single line, so we look for the marker anywhere in the
+					// line and preserve any real output that precedes it.
+					//
+					// We only treat the line as completion when the text following the marker parses
+					// as the expected exit-status integer. A command that reads from stdin (e.g.
+					// `cat`, `read`, `head -n1`) can consume and echo the injected marker command
+					// itself before it ever runs; that echoed line contains the marker substring but
+					// no valid trailing exit code, so it must NOT be treated as completion (otherwise
+					// the command would be falsely reported as a successful run while still owning the
+					// session). See #4740.
+					if ("stdout".equals(outputLine.source)) {
+						int markerIndex = line.indexOf(marker);
+						if (markerIndex >= 0) {
+							Integer parsedExitCode = parseExitCode(line.substring(markerIndex + marker.length()));
+							if (parsedExitCode != null) {
+								exitCode = parsedExitCode;
+								// Keep any real output that was merged onto the marker line.
+								line = line.substring(0, markerIndex);
+								completed = true;
+								if (line.isEmpty()) {
+									break;
+								}
 							}
 						}
-						break;
 					}
 
 					totalLines++;
@@ -571,6 +597,10 @@ public class ShellSessionManager {
 						truncatedByLines = true;
 					}
 
+					if (completed) {
+						break;
+					}
+
 				} catch (InterruptedException e) {
 					Thread.currentThread().interrupt();
 					break;
@@ -580,6 +610,24 @@ public class ShellSessionManager {
 			String output = String.join("\n", lines);
 			return new CommandResult(output, exitCode, timedOut, truncatedByLines,
 				truncatedByBytes, totalLines, totalBytes);
+		}
+
+		/**
+		 * Parse the exit status that the completion marker echoes after it (e.g. the {@code 0}
+		 * in {@code <marker> 0}). Returns {@code null} when the text is empty or its first token
+		 * is not an integer, which signals that this occurrence of the marker is not a genuine
+		 * completion line (for example the marker command echoed back by a stdin-reading command).
+		 */
+		private Integer parseExitCode(String afterMarker) {
+			String trimmed = afterMarker.trim();
+			if (trimmed.isEmpty()) {
+				return null;
+			}
+			try {
+				return Integer.parseInt(trimmed.split("\\s+")[0]);
+			} catch (NumberFormatException e) {
+				return null;
+			}
 		}
 	}
 
@@ -823,4 +871,3 @@ public class ShellSessionManager {
 		}
 	}
 }
-

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManagerTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManagerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024-2026 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,22 @@
 package com.alibaba.cloud.ai.graph.agent.tools;
 
 import com.alibaba.cloud.ai.graph.RunnableConfig;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -321,6 +329,175 @@ class ShellSessionManagerTest {
 				"Exception message should indicate uninitialized session");
 
 		config = null; // Prevent tearDown cleanup
+	}
+
+	// ==================== Output Collection Tests (#4740, non-Windows) ====================
+	// Reproduces #4740: a command whose output does not end with a newline (e.g. `cat` of a
+	// file without a trailing newline) caused the completion marker to be merged onto the last
+	// output line, so it was never detected and collectOutput hung until the command timed out.
+
+	private ShellSessionManager newManager(Path workspace) {
+		return ShellSessionManager.builder()
+				.workspaceRoot(workspace)
+				.commandTimeout(10000)
+				.build();
+	}
+
+	@Test
+	@Timeout(value = 20, unit = TimeUnit.SECONDS)
+	@DisabledOnOs(OS.WINDOWS)
+	void outputWithoutTrailingNewlineIsCapturedAndDoesNotHang() throws Exception {
+		Path workspace = Files.createTempDirectory("shell_session_test_");
+		ShellSessionManager manager = newManager(workspace);
+		RunnableConfig cfg = RunnableConfig.builder().threadId("test-thread").build();
+		manager.initialize(cfg);
+		try {
+			// printf without \n leaves no trailing newline, so the marker is merged onto
+			// this line. Before the fix this hung until the command timed out.
+			ShellSessionManager.CommandResult result = manager
+					.executeCommand("printf 'hello-no-newline'", cfg);
+
+			assertFalse(result.isTimedOut(), "command should not time out");
+			assertEquals("hello-no-newline", result.getOutput());
+			assertEquals(0, result.getExitCode());
+		}
+		finally {
+			manager.cleanup(cfg);
+		}
+	}
+
+	@Test
+	@Timeout(value = 20, unit = TimeUnit.SECONDS)
+	@DisabledOnOs(OS.WINDOWS)
+	void exitCodeIsParsedWhenMergedWithOutput() throws Exception {
+		Path workspace = Files.createTempDirectory("shell_session_test_");
+		ShellSessionManager manager = newManager(workspace);
+		RunnableConfig cfg = RunnableConfig.builder().threadId("test-thread").build();
+		manager.initialize(cfg);
+		try {
+			// Output has no trailing newline AND the command fails: the non-zero exit code
+			// must still be parsed from the line the marker was merged onto.
+			ShellSessionManager.CommandResult result = manager
+					.executeCommand("printf 'oops' && false", cfg);
+
+			assertFalse(result.isTimedOut(), "command should not time out");
+			assertEquals("oops", result.getOutput());
+			assertEquals(1, result.getExitCode());
+		}
+		finally {
+			manager.cleanup(cfg);
+		}
+	}
+
+	@Test
+	@Timeout(value = 20, unit = TimeUnit.SECONDS)
+	@DisabledOnOs(OS.WINDOWS)
+	void normalOutputWithTrailingNewlineStillWorks() throws Exception {
+		Path workspace = Files.createTempDirectory("shell_session_test_");
+		ShellSessionManager manager = newManager(workspace);
+		RunnableConfig cfg = RunnableConfig.builder().threadId("test-thread").build();
+		manager.initialize(cfg);
+		try {
+			ShellSessionManager.CommandResult result = manager.executeCommand("printf 'a\\nb\\n'", cfg);
+
+			assertFalse(result.isTimedOut(), "command should not time out");
+			assertEquals("a\nb", result.getOutput());
+			assertEquals(0, result.getExitCode());
+		}
+		finally {
+			manager.cleanup(cfg);
+		}
+	}
+
+	@Test
+	@Timeout(value = 30, unit = TimeUnit.SECONDS)
+	@DisabledOnOs(OS.WINDOWS)
+	void stdinReadingCommandDoesNotFalselyCompleteOnEchoedMarker() throws Exception {
+		Path workspace = Files.createTempDirectory("shell_session_test_");
+		// Short timeout: this command can never complete normally, so keep the expected
+		// timeout/restart fast.
+		ShellSessionManager manager = ShellSessionManager.builder()
+				.workspaceRoot(workspace)
+				.commandTimeout(3000)
+				.build();
+		RunnableConfig cfg = RunnableConfig.builder().threadId("test-thread").build();
+		manager.initialize(cfg);
+		try {
+			// `cat` with no argument reads from the session's stdin and consumes/echoes the
+			// injected marker command before it ever runs. The echoed line contains the marker
+			// substring but no valid trailing exit code, so it must NOT be treated as completion
+			// — otherwise the command would be falsely reported as a successful (exitCode == null)
+			// run while still owning the session. It should time out and restart instead.
+			ShellSessionManager.CommandResult result = manager.executeCommand("cat", cfg);
+
+			assertTrue(result.isTimedOut(), "stdin-consuming command must not falsely complete on echoed marker");
+		}
+		finally {
+			manager.cleanup(cfg);
+		}
+	}
+
+	// ==================== Output Collection Tests (#4740, Windows) ====================
+
+	@Test
+	@Timeout(value = 20, unit = TimeUnit.SECONDS)
+	@EnabledOnOs(OS.WINDOWS)
+	void powershellCmdletWithoutLastExitCodeCompletes() throws Exception {
+		Path workspace = Files.createTempDirectory("shell_session_test_");
+		ShellSessionManager manager = newManager(workspace);
+		RunnableConfig cfg = RunnableConfig.builder().threadId("test-thread").build();
+		manager.initialize(cfg);
+		try {
+			// PowerShell cmdlets do not necessarily set $LASTEXITCODE. The completion
+			// marker must still include a numeric status derived from $?.
+			ShellSessionManager.CommandResult result = manager.executeCommand("Get-Location | Out-Null", cfg);
+
+			assertFalse(result.isTimedOut(), "PowerShell cmdlet should not time out");
+			assertEquals(0, result.getExitCode());
+		}
+		finally {
+			manager.cleanup(cfg);
+		}
+	}
+
+	@Test
+	@Timeout(value = 20, unit = TimeUnit.SECONDS)
+	@EnabledOnOs(OS.WINDOWS)
+	void powershellOutputWithoutTrailingNewlineIsCaptured() throws Exception {
+		Path workspace = Files.createTempDirectory("shell_session_test_");
+		ShellSessionManager manager = newManager(workspace);
+		RunnableConfig cfg = RunnableConfig.builder().threadId("test-thread").build();
+		manager.initialize(cfg);
+		try {
+			ShellSessionManager.CommandResult result = manager
+					.executeCommand("[Console]::Write('hello-no-newline')", cfg);
+
+			assertFalse(result.isTimedOut(), "PowerShell command should not time out");
+			assertEquals("hello-no-newline", result.getOutput());
+			assertEquals(0, result.getExitCode());
+		}
+		finally {
+			manager.cleanup(cfg);
+		}
+	}
+
+	@Test
+	@Timeout(value = 20, unit = TimeUnit.SECONDS)
+	@EnabledOnOs(OS.WINDOWS)
+	void powershellPreservesNativeProgramExitCode() throws Exception {
+		Path workspace = Files.createTempDirectory("shell_session_test_");
+		ShellSessionManager manager = newManager(workspace);
+		RunnableConfig cfg = RunnableConfig.builder().threadId("test-thread").build();
+		manager.initialize(cfg);
+		try {
+			ShellSessionManager.CommandResult result = manager.executeCommand("cmd.exe /c \"exit /b 7\"", cfg);
+
+			assertFalse(result.isTimedOut(), "native command should not time out");
+			assertEquals(7, result.getExitCode());
+		}
+		finally {
+			manager.cleanup(cfg);
+		}
 	}
 
 }


### PR DESCRIPTION
## What this PR does

Fixes #4740: `ShellSessionManager` hangs when a shell command's output has no trailing newline.

## Root cause

`ShellSession#collectOutput` detects command completion by checking whether a stdout line `startsWith` the marker that is echoed after each command (`echo <marker> $?`). The stdout reader splits on `BufferedReader.readLine()`, so when the user command's output does **not** end with a newline (e.g. `cat` of a file without a final newline, or `printf 'x'`), that trailing output and the marker are read as a **single** line:

```
<file content>__LC_SHELL_DONE__<uuid> 0
```

`startsWith(marker)` is then `false`, the marker is never matched, and `outputQueue.poll` blocks until the command times out and the session is restarted — observed as a hang.

## Fix

Detect the marker anywhere in the line via `indexOf`:
1. locate the marker in the line to recognize completion;
2. keep any real output that precedes the marker (so file content isn't lost);
3. parse the exit code from the part after the marker.

The marker is `__LC_SHELL_DONE__` + a random UUID, so an in-line search won't false-match normal output.

## Tests

Added `ShellSessionManagerTest` (no API key required):
- `printf 'hello-no-newline'` → output captured, no timeout;
- `printf 'oops' && false` → exit code still parsed from the merged line;
- normal trailing-newline output regression.

Verified before the fix the first two time out (reproducing the hang); after the fix all pass.
