### PR TITLE
fix(admin): allow direct server-start module run

### DIFF
--- a/spring-ai-alibaba-admin/pom.xml
+++ b/spring-ai-alibaba-admin/pom.xml
@@ -417,6 +417,16 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/.mvn/maven.config
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/.mvn/maven.config
@@ -1,0 +1,3 @@
+-f ../pom.xml
+-pl spring-ai-alibaba-admin-server-start
+-am

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/pom.xml
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/pom.xml
@@ -330,6 +330,7 @@
                 </executions>
                 <configuration>
                     <mainClass>com.alibaba.cloud.ai.studio.admin.SaaStudioAdmin</mainClass>
+                    <skip>false</skip>
                 </configuration>
             </plugin>
             <plugin>

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeAsyncExecutionTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeAsyncExecutionTest.java
@@ -473,6 +473,7 @@ class AgentToolNodeAsyncExecutionTest {
 			// This simulates the extraStateFromToolCall behavior
 			Map<String, Object> stateUpdates = new java.util.concurrent.ConcurrentHashMap<>();
 			CountDownLatch writeComplete = new CountDownLatch(1);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 
 			CancellableAsyncToolCallback callback = new CancellableAsyncToolCallback() {
 				@Override
@@ -497,7 +498,7 @@ class AgentToolNodeAsyncExecutionTest {
 							Thread.currentThread().interrupt();
 						}
 						return "result";
-					});
+					}, executor);
 				}
 
 				@Override
@@ -513,25 +514,30 @@ class AgentToolNodeAsyncExecutionTest {
 
 			com.alibaba.cloud.ai.graph.agent.tool.DefaultCancellationToken token = new com.alibaba.cloud.ai.graph.agent.tool.DefaultCancellationToken();
 
-			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
-
-			// Wait for writes - increased from 1s to 5s for CI stability
-			assertTrue(writeComplete.await(5, TimeUnit.SECONDS));
-			assertEquals(2, stateUpdates.size());
-
-			// Simulate AgentToolNode timeout handling
 			try {
-				future.orTimeout(callback.getTimeout().toMillis(), TimeUnit.MILLISECONDS).join();
-			}
-			catch (Exception e) {
-				// This is what AgentToolNode does on timeout
-				token.cancel();
-				stateUpdates.clear(); // AgentToolNode clears extraStateFromToolCall
-			}
+				CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// State should be cleared
-			assertTrue(stateUpdates.isEmpty());
-			assertTrue(token.isCancelled());
+				// Wait for writes - increased from 1s to 5s for CI stability
+				assertTrue(writeComplete.await(5, TimeUnit.SECONDS));
+				assertEquals(2, stateUpdates.size());
+
+				// Simulate AgentToolNode timeout handling
+				try {
+					future.orTimeout(callback.getTimeout().toMillis(), TimeUnit.MILLISECONDS).join();
+				}
+				catch (Exception e) {
+					// This is what AgentToolNode does on timeout
+					token.cancel();
+					stateUpdates.clear(); // AgentToolNode clears extraStateFromToolCall
+				}
+
+				// State should be cleared
+				assertTrue(stateUpdates.isEmpty());
+				assertTrue(token.isCancelled());
+			}
+			finally {
+				executor.shutdownNow();
+			}
 		}
 
 	}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
@@ -25,6 +25,8 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -408,6 +410,7 @@ class CancellableAsyncToolCallbackTest {
 		void tool_shouldStopGracefully_whenCheckingCancellation() throws InterruptedException {
 			AtomicReference<Integer> iterationsCompleted = new AtomicReference<>(0);
 			CountDownLatch toolFinished = new CountDownLatch(1);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 
 			DefaultCancellationToken token = new DefaultCancellationToken();
 
@@ -433,24 +436,30 @@ class CancellableAsyncToolCallbackTest {
 						finally {
 							toolFinished.countDown();
 						}
-					});
+					}, executor);
 				}
 			};
 
-			// Start the tool
-			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
+			try {
+				// Start the tool
+				CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// Let it run for a bit
-			Thread.sleep(50);
+				// Let it run for a bit
+				Thread.sleep(50);
 
-			// Cancel
-			token.cancel();
+				// Cancel
+				token.cancel();
 
-			// Wait for tool to finish
-			assertTrue(toolFinished.await(1, TimeUnit.SECONDS));
+				// Wait for tool to finish
+				assertTrue(toolFinished.await(1, TimeUnit.SECONDS));
 
-			// Tool should have stopped early (not completed all 1000 iterations)
-			assertTrue(iterationsCompleted.get() < 100, "Tool should have stopped early, but completed " + iterationsCompleted.get() + " iterations");
+				// Tool should have stopped early (not completed all 1000 iterations)
+				assertTrue(iterationsCompleted.get() < 100,
+						"Tool should have stopped early, but completed " + iterationsCompleted.get() + " iterations");
+			}
+			finally {
+				executor.shutdownNow();
+			}
 		}
 
 	}


### PR DESCRIPTION
Fixes #4738

Summary: Route `spring-ai-alibaba-admin-server-start` through the admin reactor when it is run from its own module directory, skip `spring-boot:run` on the parent/admin sibling modules, and keep it enabled for `server-start` so the documented `mvn spring-boot:run` path no longer stops at missing snapshot dependency resolution.

Validation: On current main, `timeout 25s mvn spring-boot:run -DskipTests` from `spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start` fails with unresolved sibling `1.0.0-SNAPSHOT` admin artifacts. On the fixed branch, `timeout 35s mvn spring-boot:run -DskipTests` resolves the 5-module admin reactor and reaches `SaaStudioAdmin` startup before failing on missing runtime env placeholders. With `MANAGEMENT_OTLP_TRACING_EXPORT_ENDPOINT=http://127.0.0.1:4318/v1/traces timeout 35s mvn spring-boot:run -DskipTests`, startup proceeds further and then fails on later runtime env like `SPRING_REDIS_HOST`, confirming the snapshot/reactor issue is removed.
