### PR TITLE
fix(agent): handle shell marker after no-newline output

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
@@ -387,17 +387,39 @@ public class ShellSessionManager {
 
 					String line = outputLine.content;
 
-					// Check for completion marker (only in stdout)
-					if ("stdout".equals(outputLine.source) && line.startsWith(marker)) {
-						String[] parts = line.split(" ", 2);
-						if (parts.length > 1) {
-							try {
-								exitCode = Integer.parseInt(parts[1].trim());
-							} catch (NumberFormatException e) {
-								// Ignore
+					// Check for completion marker (only in stdout). If the previous command
+					// does not print a trailing newline, the marker can be appended to the
+					// same line and should not be treated as command output.
+					if ("stdout".equals(outputLine.source)) {
+						int markerIndex = line.indexOf(marker);
+						if (markerIndex >= 0) {
+							String outputBeforeMarker = line.substring(0, markerIndex);
+							if (!outputBeforeMarker.isEmpty()) {
+								totalLines++;
+								totalBytes += outputBeforeMarker.getBytes().length;
+
+								if (totalLines <= maxOutputLines) {
+									if (maxOutputBytes == null || totalBytes <= maxOutputBytes) {
+										lines.add(outputBeforeMarker);
+									} else {
+										truncatedByBytes = true;
+									}
+								} else {
+									truncatedByLines = true;
+								}
 							}
+
+							String exitCodePart = line.substring(markerIndex + marker.length()).trim();
+							if (!exitCodePart.isEmpty()) {
+								String[] parts = exitCodePart.split("\\s+", 2);
+								try {
+									exitCode = Integer.parseInt(parts[0]);
+								} catch (NumberFormatException e) {
+									// Ignore
+								}
+							}
+							break;
 						}
-						break;
 					}
 
 					totalLines++;
@@ -672,4 +694,3 @@ public class ShellSessionManager {
 		}
 	}
 }
-

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManagerTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManagerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.tools;
+
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+class ShellSessionManagerTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void executeCommandShouldCompleteWhenOutputHasNoTrailingNewline() throws Exception {
+		Path file = tempDir.resolve("without-newline.txt");
+		Files.writeString(file, "content-without-newline");
+		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
+		String command = isWindows ? "echo|set /p=content-without-newline&ver >nul"
+				: "cat without-newline.txt || true";
+		RunnableConfig config = RunnableConfig.builder().build();
+		ShellSessionManager manager = ShellSessionManager.builder()
+			.workspaceRoot(tempDir)
+			.shellCommand(isWindows ? Arrays.asList("cmd.exe", "/Q") : Arrays.asList("/bin/sh"))
+			.commandTimeout(5000)
+			.build();
+
+		manager.initialize(config);
+		try {
+			ShellSessionManager.CommandResult result = manager.executeCommand(command, config);
+
+			assertFalse(result.isTimedOut());
+			assertTrue(result.isSuccess());
+			assertEquals(0, result.getExitCode());
+			assertFalse(result.getOutput().contains("__LC_SHELL_DONE__"));
+			if (isWindows) {
+				// Interactive cmd.exe may emit banner or prompt text to stdout.
+				assertTrue(result.getOutput().contains("content-without-newline"));
+			}
+			else {
+				assertEquals("content-without-newline", result.getOutput());
+			}
+		}
+		finally {
+			manager.cleanup(config);
+		}
+	}
+
+	@Test
+	void executeCommandShouldNotTruncateNoNewlineOutputAtExactByteLimit() throws Exception {
+		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
+		assumeFalse(isWindows, "cmd.exe emits banner or prompt text in interactive mode");
+		Path file = tempDir.resolve("one-byte.txt");
+		Files.writeString(file, "x");
+		RunnableConfig config = RunnableConfig.builder().build();
+		ShellSessionManager manager = ShellSessionManager.builder()
+			.workspaceRoot(tempDir)
+			.shellCommand(Arrays.asList("/bin/sh"))
+			.commandTimeout(5000)
+			.maxOutputBytes(1)
+			.build();
+
+		manager.initialize(config);
+		try {
+			ShellSessionManager.CommandResult result = manager.executeCommand("cat one-byte.txt || true", config);
+
+			assertFalse(result.isTimedOut());
+			assertTrue(result.isSuccess());
+			assertFalse(result.isTruncatedByBytes());
+			assertEquals("x", result.getOutput());
+			assertEquals(1, result.getTotalBytes());
+		}
+		finally {
+			manager.cleanup(config);
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary
- Preserve command output that appears before the shell completion marker when stdout has no trailing newline
- Parse the exit code from the marker suffix and avoid leaking the marker into command output
- Add regression coverage for no-trailing-newline output and the exact maxOutputBytes boundary

Fixes #4740

## Tests
- mvn -f spring-ai-alibaba-agent-framework\\pom.xml -Dtest=ShellSessionManagerTest test