### PR TITLE
AgentToolNode resovle messages

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -152,8 +152,15 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 	@Override
 	public Map<String, Object> apply(OverAllState state, RunnableConfig config) throws Exception {
-		List<Message> messages = (List<Message>) state.value("messages").orElseThrow();
-		Message lastMessage = messages.get(messages.size() - 1);
+
+		Object messages = state.value("messages").orElseThrow();
+		Message lastMessage = null;
+		if (messages instanceof List<?> messageList){
+			lastMessage = ((List<Message>) messageList).getLast();
+		}else{
+			// for streaming may only one message
+			lastMessage = (Message) messages;
+		}
 
 		if (lastMessage instanceof AssistantMessage assistantMessage) {
 			List<AssistantMessage.ToolCall> toolCalls = assistantMessage.getToolCalls();


### PR DESCRIPTION
### Describe what this PR does / why we need it
AgentToolNode not only for ReactAgent, but for custom agent may use compiled graph then call streaming method.
when llmNode -> agentToolNode by condition edge,  agentNode will resovle "messages" in state.It must exists but may not be a list.

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
either list or message it is, so judge it by instance of.

### Describe how to verify it
easy to verify

### Special notes for reviews
<img width="1182" height="473" alt="e8ca311784fa80f82422873298389ae7" src="https://github.com/user-attachments/assets/74f3d152-e2fc-45ca-8ce6-44f747325962" />
