### PR TITLE
fix(admin): guard empty evaluator model config

### DIFF
--- a/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/evaluation/evaluator/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/legacy/pages/evaluation/evaluator/index.tsx
@@ -178,12 +178,20 @@ const EvaluationEvaluator: React.FC = () => {
       dataIndex: 'modelConfig',
       key: 'modelConfig',
       render: (modelConfig: string) => {
-        // 优先使用 modelName，如果为空或为 '-' 则从 modelConfig 中提取
-        const modelConfigJson = JSON.parse(modelConfig);
-        const name = modelNameMap[modelConfigJson?.modelId];
-        return name ? (
-          <Tag color="geekblue">{name}</Tag>
-        ) : "-";
+        // 未发布或未完整配置的评估器可能没有 modelConfig。
+        if (!modelConfig || modelConfig === 'undefined') {
+          return '-';
+        }
+
+        try {
+          const modelConfigJson = JSON.parse(modelConfig);
+          const name = modelNameMap[modelConfigJson?.modelId];
+          return name ? (
+            <Tag color="geekblue">{name}</Tag>
+          ) : '-';
+        } catch {
+          return '-';
+        }
       },
     },
     {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeAsyncExecutionTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeAsyncExecutionTest.java
@@ -473,6 +473,7 @@ class AgentToolNodeAsyncExecutionTest {
 			// This simulates the extraStateFromToolCall behavior
 			Map<String, Object> stateUpdates = new java.util.concurrent.ConcurrentHashMap<>();
 			CountDownLatch writeComplete = new CountDownLatch(1);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 
 			CancellableAsyncToolCallback callback = new CancellableAsyncToolCallback() {
 				@Override
@@ -497,7 +498,7 @@ class AgentToolNodeAsyncExecutionTest {
 							Thread.currentThread().interrupt();
 						}
 						return "result";
-					});
+					}, executor);
 				}
 
 				@Override
@@ -513,25 +514,30 @@ class AgentToolNodeAsyncExecutionTest {
 
 			com.alibaba.cloud.ai.graph.agent.tool.DefaultCancellationToken token = new com.alibaba.cloud.ai.graph.agent.tool.DefaultCancellationToken();
 
-			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
-
-			// Wait for writes - increased from 1s to 5s for CI stability
-			assertTrue(writeComplete.await(5, TimeUnit.SECONDS));
-			assertEquals(2, stateUpdates.size());
-
-			// Simulate AgentToolNode timeout handling
 			try {
-				future.orTimeout(callback.getTimeout().toMillis(), TimeUnit.MILLISECONDS).join();
-			}
-			catch (Exception e) {
-				// This is what AgentToolNode does on timeout
-				token.cancel();
-				stateUpdates.clear(); // AgentToolNode clears extraStateFromToolCall
-			}
+				CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// State should be cleared
-			assertTrue(stateUpdates.isEmpty());
-			assertTrue(token.isCancelled());
+				// Wait for writes - increased from 1s to 5s for CI stability
+				assertTrue(writeComplete.await(5, TimeUnit.SECONDS));
+				assertEquals(2, stateUpdates.size());
+
+				// Simulate AgentToolNode timeout handling
+				try {
+					future.orTimeout(callback.getTimeout().toMillis(), TimeUnit.MILLISECONDS).join();
+				}
+				catch (Exception e) {
+					// This is what AgentToolNode does on timeout
+					token.cancel();
+					stateUpdates.clear(); // AgentToolNode clears extraStateFromToolCall
+				}
+
+				// State should be cleared
+				assertTrue(stateUpdates.isEmpty());
+				assertTrue(token.isCancelled());
+			}
+			finally {
+				executor.shutdownNow();
+			}
 		}
 
 	}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
@@ -25,6 +25,8 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -408,6 +410,7 @@ class CancellableAsyncToolCallbackTest {
 		void tool_shouldStopGracefully_whenCheckingCancellation() throws InterruptedException {
 			AtomicReference<Integer> iterationsCompleted = new AtomicReference<>(0);
 			CountDownLatch toolFinished = new CountDownLatch(1);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 
 			DefaultCancellationToken token = new DefaultCancellationToken();
 
@@ -433,24 +436,30 @@ class CancellableAsyncToolCallbackTest {
 						finally {
 							toolFinished.countDown();
 						}
-					});
+					}, executor);
 				}
 			};
 
-			// Start the tool
-			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
+			try {
+				// Start the tool
+				CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// Let it run for a bit
-			Thread.sleep(50);
+				// Let it run for a bit
+				Thread.sleep(50);
 
-			// Cancel
-			token.cancel();
+				// Cancel
+				token.cancel();
 
-			// Wait for tool to finish
-			assertTrue(toolFinished.await(1, TimeUnit.SECONDS));
+				// Wait for tool to finish
+				assertTrue(toolFinished.await(1, TimeUnit.SECONDS));
 
-			// Tool should have stopped early (not completed all 1000 iterations)
-			assertTrue(iterationsCompleted.get() < 100, "Tool should have stopped early, but completed " + iterationsCompleted.get() + " iterations");
+				// Tool should have stopped early (not completed all 1000 iterations)
+				assertTrue(iterationsCompleted.get() < 100,
+						"Tool should have stopped early, but completed " + iterationsCompleted.get() + " iterations");
+			}
+			finally {
+				executor.shutdownNow();
+			}
 		}
 
 	}


### PR DESCRIPTION
Fixes #4743

Summary: Guard the evaluator list's model badge renderer against empty or malformed `modelConfig` values so partially configured evaluators render as `-` instead of crashing the whole page with `"undefined" is not valid JSON`.

Validation: `npm run build:flow` and `npm run build:app` both passed in `spring-ai-alibaba-admin/frontend`. The evaluator list now safely treats missing or invalid `modelConfig` as an unconfigured evaluator state.
