### PR TITLE
test(graph): add unit tests for CollectionsUtils and append/replace key strategies

### DIFF
--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategyTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategyTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.state.strategy;
+
+import com.alibaba.cloud.ai.graph.state.AppenderChannel;
+import com.alibaba.cloud.ai.graph.state.ReplaceAllWith;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Unit tests for {@link AppendStrategy}.
+ */
+class AppendStrategyTest {
+
+    private final AppendStrategy strategy = new AppendStrategy();
+
+    @Test
+    void nullNewValueReturnsOldValueUnchanged() {
+        Object oldValue = new ArrayList<>(List.of(1, 2));
+        assertSame(oldValue, strategy.apply(oldValue, null));
+    }
+
+    @Test
+    void nullOldValueWrapsScalarIntoNewList() {
+        assertEquals(List.of("x"), strategy.apply(null, "x"));
+    }
+
+    @Test
+    void nullOldValueExpandsListNewValue() {
+        assertEquals(List.of("a", "b"), strategy.apply(null, List.of("a", "b")));
+    }
+
+    @Test
+    void appendsScalarToExistingList() {
+        Object result = strategy.apply(new ArrayList<>(List.of(1, 2)), 3);
+        assertEquals(List.of(1, 2, 3), result);
+    }
+
+    @Test
+    void concatenatesTwoListsKeepingDuplicatesByDefault() {
+        Object result = strategy.apply(new ArrayList<>(List.of(1, 2)), List.of(2, 3));
+        assertEquals(List.of(1, 2, 2, 3), result);
+    }
+
+    @Test
+    void dropsDuplicatesWhenNotAllowed() {
+        AppendStrategy noDuplicates = new AppendStrategy(false);
+        Object result = noDuplicates.apply(new ArrayList<>(List.of(1, 2)), List.of(2, 3));
+        assertEquals(List.of(1, 2, 3), result);
+    }
+
+    @Test
+    void emptyNewListLeavesOldValueUnchanged() {
+        Object oldValue = new ArrayList<>(List.of(1, 2));
+        assertSame(oldValue, strategy.apply(oldValue, List.of()));
+    }
+
+    @Test
+    void replaceAllWithReplacesEntireValue() {
+        Object result = strategy.apply(new ArrayList<>(List.of(1, 2)), ReplaceAllWith.of(List.of("x", "y")));
+        assertEquals(List.of("x", "y"), result);
+    }
+
+    @Test
+    void unwrapsOptionalOldValueBeforeAppending() {
+        Object result = strategy.apply(Optional.of(new ArrayList<>(List.of(1, 2))), List.of(3));
+        assertEquals(List.of(1, 2, 3), result);
+    }
+
+    @Test
+    void acceptsArrayAsNewValue() {
+        Object result = strategy.apply(null, new String[] {"a", "b"});
+        assertEquals(List.of("a", "b"), result);
+    }
+
+    @Test
+    void acceptsCollectionAsNewValue() {
+        Object result = strategy.apply(null, Set.of("a"));
+        assertEquals(List.of("a"), result);
+    }
+
+    @Test
+    void removeIdentifierRemovesMatchingElementFromList() {
+        AppenderChannel.RemoveIdentifier<Object> removeB = (element, atIndex) -> "b".equals(element) ? 0 : 1;
+        Object result = strategy.apply(new ArrayList<>(List.of("a", "b", "c")), removeB);
+        assertEquals(List.of("a", "c"), result);
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/strategy/ReplaceStrategyTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/strategy/ReplaceStrategyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.state.strategy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link ReplaceStrategy}.
+ */
+class ReplaceStrategyTest {
+
+    private final ReplaceStrategy strategy = new ReplaceStrategy();
+
+    @Test
+    void newValueAlwaysReplacesOldValue() {
+        assertEquals("New", strategy.apply("Old", "New"));
+        assertEquals("New", strategy.apply(null, "New"));
+    }
+
+    @Test
+    void newValueWinsWithoutNullGuard() {
+        // Unlike AppendStrategy/MergeStrategy, ReplaceStrategy does not keep the old value on a null new value.
+        assertNull(strategy.apply("Old", null));
+    }
+
+    @Test
+    void oldOptionalIsNotUnwrappedAndIsSimplyOverwritten() {
+        assertEquals("New", strategy.apply(Optional.of("Old"), "New"));
+    }
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/utils/CollectionsUtilsTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/utils/CollectionsUtilsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CollectionsUtils}.
+ */
+class CollectionsUtilsTest {
+
+    @Test
+    void lastReturnsLastElementOrEmpty() {
+        assertEquals(Optional.of(3), CollectionsUtils.last(List.of(1, 2, 3)));
+        assertEquals(Optional.empty(), CollectionsUtils.last(List.of()));
+        assertEquals(Optional.empty(), CollectionsUtils.last(null));
+    }
+
+    @Test
+    void lastMinusReturnsElementCountedFromTheEnd() {
+        List<Integer> values = List.of(10, 20, 30);
+        assertEquals(Optional.of(30), CollectionsUtils.lastMinus(values, 0));
+        assertEquals(Optional.of(20), CollectionsUtils.lastMinus(values, 1));
+        assertEquals(Optional.of(10), CollectionsUtils.lastMinus(values, 2));
+    }
+
+    @Test
+    void lastMinusReturnsEmptyForOutOfRangeOrInvalidInput() {
+        List<Integer> values = List.of(10, 20, 30);
+        assertEquals(Optional.empty(), CollectionsUtils.lastMinus(values, 3));
+        assertEquals(Optional.empty(), CollectionsUtils.lastMinus(values, -1));
+        assertEquals(Optional.empty(), CollectionsUtils.lastMinus(List.of(), 0));
+        assertEquals(Optional.empty(), CollectionsUtils.lastMinus(null, 0));
+    }
+
+    @Test
+    void mergeMapCombinesEntriesFromBothMaps() {
+        Map<String, Integer> result = CollectionsUtils.mergeMap(Map.of("a", 1), Map.of("b", 2));
+        assertEquals(2, result.size());
+        assertEquals(1, result.get("a"));
+        assertEquals(2, result.get("b"));
+    }
+
+    @Test
+    void mergeMapWithoutMergeFunctionRejectsDuplicateKeys() {
+        Map<String, Integer> map1 = Map.of("a", 1);
+        Map<String, Integer> map2 = Map.of("a", 2);
+        assertThrows(IllegalStateException.class, () -> CollectionsUtils.mergeMap(map1, map2));
+    }
+
+    @Test
+    void mergeMapWithMergeFunctionResolvesCollisions() {
+        Map<String, Integer> result = CollectionsUtils.mergeMap(Map.of("a", 1), Map.of("a", 2), Integer::sum);
+        assertEquals(1, result.size());
+        assertEquals(3, result.get("a"));
+    }
+
+    @Test
+    void mergeMapRejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> CollectionsUtils.mergeMap(null, Map.of()));
+        assertThrows(NullPointerException.class, () -> CollectionsUtils.mergeMap(Map.of(), null));
+        assertThrows(NullPointerException.class, () -> CollectionsUtils.mergeMap(Map.of(), Map.of(), null));
+    }
+
+    @Test
+    void entryOfBuildsImmutableEntry() {
+        Map.Entry<String, Integer> entry = CollectionsUtils.entryOf("k", 7);
+        assertEquals("k", entry.getKey());
+        assertEquals(7, entry.getValue());
+        assertThrows(UnsupportedOperationException.class, () -> entry.setValue(9));
+    }
+
+    @Test
+    void listOfCreatesListFromElements() {
+        assertTrue(CollectionsUtils.listOf().isEmpty());
+        assertEquals(List.of("a"), CollectionsUtils.listOf("a"));
+        assertEquals(List.of("a", "b", "c"), CollectionsUtils.listOf("a", "b", "c"));
+    }
+
+    @Test
+    void mapOfCreatesMapsWithGivenPairs() {
+        assertTrue(CollectionsUtils.mapOf().isEmpty());
+        assertEquals(Map.of("k", "v"), CollectionsUtils.mapOf("k", "v"));
+        assertEquals(Map.of("a", 1, "b", 2), CollectionsUtils.mapOf("a", 1, "b", 2));
+        assertEquals(Map.of("a", 1, "b", 2, "c", 3), CollectionsUtils.mapOf("a", 1, "b", 2, "c", 3));
+    }
+
+    @Test
+    void toStringRendersEmptyCollectionAndMap() {
+        assertEquals("[]", CollectionsUtils.toString(List.of()));
+        assertEquals("{}", CollectionsUtils.toString(Map.of()));
+    }
+
+    @Test
+    void toStringRendersElementsForNonEmptyCollection() {
+        String rendered = CollectionsUtils.toString(List.of("x", "y"));
+        assertTrue(rendered.contains("x"));
+        assertTrue(rendered.contains("y"));
+        assertFalse(rendered.equals("[]"));
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adds focused unit tests for three previously untested pure-logic classes in `spring-ai-alibaba-graph-core`, increasing coverage with no production changes:

- `CollectionsUtils` (graph utils) — had no dedicated test.
- `AppendStrategy` (state key strategy) — had no dedicated test, although its sibling `MergeStrategy` already has `MergeStrategyTest`.
- `ReplaceStrategy` (state key strategy) — same gap.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- `CollectionsUtilsTest` (12 tests): `last` / `lastMinus`, `mergeMap` (with/without merge function, duplicate-key `IllegalStateException`, null-argument `NullPointerException`), `listOf`, `mapOf`, `entryOf` immutability, and `toString` rendering.
- `AppendStrategyTest` (12 tests): null pass-through, wrapping a scalar, expanding list/array/collection values, `allowDuplicate` on/off, `ReplaceAllWith`, `Optional` unwrapping, empty-list pass-through, and `RemoveIdentifier` removal.
- `ReplaceStrategyTest` (3 tests): new value always replaces the old one, including the no-null-guard behaviour that differs from `AppendStrategy` / `MergeStrategy`.

The tests follow the style of the existing `MergeStrategyTest`.

### Describe how to verify it

```
./mvnw -pl spring-ai-alibaba-graph-core -am -Dtest='CollectionsUtilsTest,AppendStrategyTest,ReplaceStrategyTest' test
```

All 27 tests pass and `checkstyle:check` reports 0 violations.

### Special notes for reviews

Pure test-only change; no production code is modified.
