### PR TITLE
docs: document DashScope multimodal configuration

### DIFF
--- a/examples/multimodal/README.md
+++ b/examples/multimodal/README.md
@@ -110,6 +110,7 @@ curl -X POST http://localhost:8080/api/audio/tts \
 |----------|---------|-------------|
 | `spring.ai.dashscope.api-key` | `${AI_DASHSCOPE_API_KEY}` | DashScope API key |
 | `spring.ai.dashscope.chat.options.model` | `qwen-vl-plus` | Vision model (use `-vl` models for multimodal) |
+| `spring.ai.dashscope.chat.options.multi-model` | `false` | Use the DashScope multimodal generation endpoint; set to `true` for vision models |
 
 Supported vision models: `qwen-vl-plus`, `qwen-vl-max`, `qwen2-vl-plus`, `qwen3-vl-plus`.
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

The multimodal example already configures DashScope with `spring.ai.dashscope.chat.options.multi-model=true`, but this property is missing from the README's Configuration section. This makes the configuration-file equivalent of `DashScopeChatOptions.multiModel(true)` difficult to discover.

This PR documents the property alongside the other DashScope chat options used by the example.

### Does this pull request fix one issue?

Fixes #4732

### Describe how you did it

Added `spring.ai.dashscope.chat.options.multi-model` to the multimodal example's configuration table, including its default value and its role in selecting the DashScope multimodal generation endpoint.

### Describe how to verify it

- Run `codespell` against `examples/multimodal/README.md`.
- Run `python tools/scripts/new-line-check.py check`.
- Run `git diff --check`.

### Special notes for reviews

Documentation-only change. No runtime behavior is modified.