### PR TITLE
fix(agent): restore returnDirect tool routing in ReactAgent edge condition

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -90,8 +90,10 @@ import static com.alibaba.cloud.ai.graph.action.AsyncEdgeAction.edge_async;
 import static com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig.node_async;
 import static com.alibaba.cloud.ai.graph.agent.hook.InterruptionHook.INTERRUPTION_FEEDBACK_KEY;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
+import static com.alibaba.cloud.ai.graph.agent.hook.returndirect.ReturnDirectConstants.FINISH_REASON_METADATA_KEY;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
 import static java.lang.String.format;
+import static org.springframework.ai.model.tool.ToolExecutionResult.FINISH_REASON;
 
 
 public class ReactAgent extends BaseAgent {
@@ -837,11 +839,10 @@ public class ReactAgent extends BaseAgent {
 			// 1. Extract last AI message and corresponding tool messages
 			ToolResponseMessage toolResponseMessage = fetchLastToolResponseMessage(state);
 			// 2. Exit condition: All executed tools have return_direct=True
+			//    AgentToolNode sets FINISH_REASON metadata when all tools have returnDirect=true
 			if (toolResponseMessage != null && !toolResponseMessage.getResponses().isEmpty()) {
-				boolean allReturnDirect = toolResponseMessage.getResponses().stream().allMatch(toolResponse -> {
-					String toolName = toolResponse.name();
-					return false; // FIXME
-				});
+				boolean allReturnDirect = toolResponseMessage.getMetadata() != null
+						&& FINISH_REASON.equals(toolResponseMessage.getMetadata().get(FINISH_REASON_METADATA_KEY));
 				if (allReturnDirect) {
 					return endDestination;
 				}


### PR DESCRIPTION
Describe what this PR does / why we need it

Restores the returnDirect tool feature in ReactAgent. When a tool is annotated with returnDirect = true, the agent's
ReAct loop should exit immediately after that tool executes, returning the tool's output directly to the caller
instead of feeding it back to the model for another reasoning round.

The makeToolsToModelEdge edge condition —which runs after tool execution and determines whether to route back to the
model or exit to END —contained a hardcoded return false at ReactAgent.java:843 that permanently disabled this check.
The AgentToolNode already correctly computes returnDirect from toolCallback.getToolMetadata().returnDirect() and
stamps FINISH_REASON metadata onto the ToolResponseMessage. This fix reads that metadata so the routing decision
actually works.

Before (broken): tool →model →ReturnDirectModelHook jump to END (extra transition, requires the hook to be
explicitly registered)

After (fixed): tool →END directly when all executed tools have returnDirect = true

Does this pull request fix one issue?

NONE

Describe how you did it

Two changes in ReactAgent.java:

Added imports for the metadata constants already used by AgentToolNode and ReturnDirectModelHook:
- ReturnDirectConstants.FINISH_REASON_METADATA_KEY ("finishReason")
- ToolExecutionResult.FINISH_REASON ("finish_reason")
Replaced the dead check in makeToolsToModelEdge (line 841-848). The old code attempted to iterate ToolResponse
items and look up tool names but the stream lambda hardcoded return false. The new code checks the ToolResponseMessage
metadata that AgentToolNode already sets when all executed tools have returnDirect = true:
boolean allReturnDirect = toolResponseMessage.getMetadata() != null
&& FINISH_REASON.equals(toolResponseMessage.getMetadata().get(FINISH_REASON_METADATA_KEY));
Describe how to verify it

Run the existing returnDirect tests:
./mvnw -pl :spring-ai-alibaba-agent-framework test -Dtest=ReturnDirectMessagesModelHookTest
Create a ReactAgent with a tool annotated @tool(returnDirect = true). Invoke the agent with a query that triggers
that tool call. Without the fix, the agent makes an extra round-trip through the model node after tool execution. With
the fix, the agent routes directly to END after the tool returns.
Special notes for reviews

The ReturnDirectModelHook (a BEFORE_MODEL hook) provides a redundant safety net —it also checks the same metadata
and jumps to END. This fix doesn't break that path; it just makes it unnecessary for the returnDirect case. The hook
still fires for any edge case where the edge condition doesn't catch it.
The metadata-based approach is intentionally chosen over looking up ToolCallback instances by name because
AgentToolNode is the single source of truth for returnDirect computation at runtime —reading its output avoids
duplicating that logic in the edge condition.