### PR TITLE
fix(a2a): populate message/chunk/outputType on A2A streaming outputs

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
@@ -23,8 +23,10 @@ import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.NodeActionWithConfig;
 import com.alibaba.cloud.ai.graph.async.AsyncGenerator;
 import com.alibaba.cloud.ai.graph.async.AsyncGeneratorQueue;
+import com.alibaba.cloud.ai.graph.streaming.OutputType;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 
 import org.springframework.util.StringUtils;
@@ -227,7 +229,7 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 		return AsyncGeneratorQueue.of(queue, q -> {
 			String baseUrl = resolveAgentBaseUrl(this.agentCard);
 			if (baseUrl == null || baseUrl.isBlank()) {
-				StreamingOutput errorOutput = new StreamingOutput("Error: AgentCard.url is empty", "a2aNode", agentName, state);
+				StreamingOutput errorOutput = buildStreamingOutput("Error: AgentCard.url is empty", state);
 				queue.add(AsyncGenerator.Data.of(errorOutput));
 				return;
 			}
@@ -241,15 +243,14 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 				try (CloseableHttpResponse response = httpClient.execute(post)) {
 					int statusCode = response.getStatusLine().getStatusCode();
 					if (statusCode != 200) {
-						StreamingOutput errorOutput = new StreamingOutput("HTTP request failed, status: " + statusCode,
-								"a2aNode", agentName, state);
+						StreamingOutput errorOutput = buildStreamingOutput("HTTP request failed, status: " + statusCode, state);
 						queue.add(AsyncGenerator.Data.of(errorOutput));
 						return;
 					}
 
 					HttpEntity entity = response.getEntity();
 					if (entity == null) {
-						StreamingOutput errorOutput = new StreamingOutput("Empty HTTP entity", "a2aNode", agentName, state);
+						StreamingOutput errorOutput = buildStreamingOutput("Empty HTTP entity", state);
 						queue.add(AsyncGenerator.Data.of(errorOutput));
 						return;
 					}
@@ -280,7 +281,7 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 										if (text != null && !text.isEmpty()) {
 											accumulated.append(text);
 											queue.add(AsyncGenerator.Data
-												.of(new StreamingOutput(text, "a2aNode", agentName, state)));
+												.of(buildStreamingOutput(text, state)));
 										}
 									}
 								}
@@ -300,18 +301,18 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 							String text = extractResponseText(result);
 							if (text != null && !text.isEmpty()) {
 								accumulated.append(text);
-								queue.add(AsyncGenerator.Data.of(new StreamingOutput(text, "a2aNode", agentName, state)));
+								queue.add(AsyncGenerator.Data.of(buildStreamingOutput(text, state)));
 							}
 						}
 						catch (Exception ex) {
 							queue.add(AsyncGenerator.Data
-								.of(new StreamingOutput("Error: " + ex.getMessage(), "a2aNode", agentName, state)));
+								.of(buildStreamingOutput("Error: " + ex.getMessage(), state)));
 						}
 					}
 				}
 			}
 			catch (Exception e) {
-				StreamingOutput errorOutput = new StreamingOutput("Error: " + e.getMessage(), "a2aNode", agentName, state);
+				StreamingOutput errorOutput = buildStreamingOutput("Error: " + e.getMessage(), state);
 				queue.add(AsyncGenerator.Data.of(errorOutput));
 			}
 			finally {
@@ -387,7 +388,7 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 			}
 			catch (Exception e) {
 				// On error, emit an error message and signal completion
-				StreamingOutput errorOutput = new StreamingOutput("Error: " + e.getMessage(), "a2aNode", agentName, state);
+				StreamingOutput errorOutput = buildStreamingOutput("Error: " + e.getMessage(), state);
 				queue.add(AsyncGenerator.Data.of(errorOutput));
 				queue.add(AsyncGenerator.Data.done(Map.of(outputKey, accumulated.toString())));
 			}
@@ -410,13 +411,13 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 
 			if (responseText2 != null && !responseText2.isEmpty()) {
 				accumulated.append(responseText2);
-				StreamingOutput streamingOutput = new StreamingOutput(responseText2, "a2aNode", agentName, state);
+				StreamingOutput streamingOutput = buildStreamingOutput(responseText2, state);
 				queue.add(AsyncGenerator.Data.of(streamingOutput));
 			}
 		}
 		catch (Exception e) {
 			// On parse failure, emit an error message
-			StreamingOutput errorOutput = new StreamingOutput("Error: " + e.getMessage(), "a2aNode", agentName, state);
+			StreamingOutput errorOutput = buildStreamingOutput("Error: " + e.getMessage(), state);
 			queue.add(AsyncGenerator.Data.of(errorOutput));
 		}
 
@@ -427,12 +428,29 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 	}
 
 	/**
+	 * Build a {@link StreamingOutput} for an A2A remote response chunk.
+	 *
+	 * <p>
+	 * The plain {@code (originData, node, agentName, state)} constructor leaves {@code message},
+	 * {@code chunk} and {@code outputType} unset, so the serialized streaming event is empty
+	 * ({@code data:{}}). The studio chat UI renders streaming text from the {@code chunk} /
+	 * {@code message} fields, so A2A remote-agent replies were never displayed. Wrapping the text
+	 * in an {@link AssistantMessage} populates both {@code message} and {@code chunk}, and tagging
+	 * the event {@link OutputType#AGENT_MODEL_STREAMING} restores the metadata expected by
+	 * downstream consumers of {@link StreamingOutput#getOutputType()}. See gh-4760.
+	 */
+	private StreamingOutput<?> buildStreamingOutput(String text, OverAllState state) {
+		return new StreamingOutput<>(new AssistantMessage(text), text, "a2aNode", agentName, state,
+				OutputType.AGENT_MODEL_STREAMING);
+	}
+
+	/**
 	 * Create a StreamingOutput from the parsed result map.
 	 */
 	private StreamingOutput createStreamingOutputFromResult(Map<String, Object> result, OverAllState state) {
 		String text = extractResponseText(result);
 		if (text != null && !text.isEmpty()) {
-			return new StreamingOutput(text, "a2aNode", agentName, state);
+			return buildStreamingOutput(text, state);
 		}
 		return null;
 	}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfigTests.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/a2a/A2aNodeActionWithConfigTests.java
@@ -19,7 +19,10 @@ import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.async.AsyncGenerator;
+import com.alibaba.cloud.ai.graph.streaming.OutputType;
+import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 
 import io.a2a.spec.AgentCard;
@@ -266,6 +269,45 @@ class A2aNodeActionWithConfigTests {
 	private static Method initExtractResponseTextMethod() {
 		try {
 			Method method = A2aNodeActionWithConfig.class.getDeclaredMethod("extractResponseText", Map.class);
+			method.setAccessible(true);
+			return method;
+		}
+		catch (NoSuchMethodException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	// ==================== Tests for gh-4760: A2A streaming output metadata ====================
+
+	private static final Method BUILD_STREAMING_OUTPUT = initBuildStreamingOutputMethod();
+
+	/**
+	 * The studio chat UI renders streaming text from the {@code chunk} / {@code message} fields of
+	 * {@link StreamingOutput}. Before gh-4760, A2A streaming events were built with the plain
+	 * {@code (text, node, agentName, state)} constructor, leaving {@code message}, {@code chunk} and
+	 * {@code outputType} unset, so the SSE payload serialized to {@code {}} and the remote agent's
+	 * reply was never displayed. The streaming output must now carry the text in both {@code chunk}
+	 * and {@code message} and be tagged {@link OutputType#AGENT_MODEL_STREAMING}.
+	 */
+	@Test
+	void buildStreamingOutput_populatesMessageChunkAndOutputType() throws Exception {
+		OverAllState state = new OverAllState();
+
+		StreamingOutput<?> output = (StreamingOutput<?>) BUILD_STREAMING_OUTPUT.invoke(this.action, "hello world",
+				state);
+
+		// chunk + message are the fields the studio chat UI reads to render streaming text
+		assertEquals("hello world", output.chunk(), "chunk must carry the streamed text");
+		assertInstanceOf(AssistantMessage.class, output.message(), "message must be an assistant message");
+		assertEquals("hello world", ((AssistantMessage) output.message()).getText());
+		// outputType restores metadata for downstream consumers of getOutputType()
+		assertEquals(OutputType.AGENT_MODEL_STREAMING, output.getOutputType());
+	}
+
+	private static Method initBuildStreamingOutputMethod() {
+		try {
+			Method method = A2aNodeActionWithConfig.class.getDeclaredMethod("buildStreamingOutput", String.class,
+					OverAllState.class);
 			method.setAccessible(true);
 			return method;
 		}


### PR DESCRIPTION
## 问题

当 supervisor（`LlmRoutingAgent`）通过 `A2aRemoteAgent` 调用远程子 Agent 时，studio 对话界面收到的 SSE 是 `data:{}`，远程 Agent 的回复完全不显示。

## 根因

`A2aNodeActionWithConfig` 的所有流式事件都用 `new StreamingOutput(text, "a2aNode", agentName, state)`（4 参）构造。该构造器把 `text` 放进 `originData`，而：

- `originData` 标了 `@JsonIgnore`，**不会序列化**；
- `message`、`chunk`、`outputType` 全部为 null。

我顺着 studio 前端 `agent-chat-ui` 的渲染逻辑确认（`providers/Stream.tsx`）：UI 是**按 `chunk` / `message` 字段**拼接流式文本的，并不读 `outputType`。所以 `message`/`chunk` 为 null → 序列化成 `{}` → 前端无内容可渲染。本地 `ReactAgent` 子 Agent 不受影响，因为它的流式事件由框架内部正确填充了这些字段。

## 修复

将文件内所有 A2A 流式构造统一收口到一个 `buildStreamingOutput(text, state)` helper：把文本包成 `AssistantMessage`，从而同时填充 `message` 与 `chunk`（`chunk` 由 `extractChunkFromMessage` 提取），并打上 `OutputType.AGENT_MODEL_STREAMING`，恢复 `getOutputType()` 等下游消费者所需的元数据。`createStreamingGenerator` 与 `createSingleStreamingGenerator` 两个方法的内容输出与错误输出均已覆盖。

## 测试

新增 `buildStreamingOutput_populatesMessageChunkAndOutputType`：断言产出的 `StreamingOutput` 的 `chunk()`、`message()`（assistant + 文本）、`getOutputType()` 均已正确填充——即前端真正消费的字段。修复前（4 参构造）该用例失败，修复后通过。

> 说明：单测覆盖的是「SSE 不再是空 `{}`、文本进入 `chunk`/`message`」这一根因；最终在 studio 浏览器里的视觉渲染依赖前端按 `chunk`/`message` 渲染的逻辑（已通过阅读前端代码确认契约）。

Closes #4760
