### PR TITLE
fix(agent): 修正 ToolsExample 中 ToolContext 错误的 key

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/tutorials/ToolsExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/tutorials/ToolsExample.java
@@ -44,6 +44,9 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static com.alibaba.cloud.ai.graph.agent.tools.ToolContextConstants.AGENT_CONFIG_CONTEXT_KEY;
+import static com.alibaba.cloud.ai.graph.agent.tools.ToolContextConstants.AGENT_STATE_CONTEXT_KEY;
+
 /**
  * Tools Tutorial - 完整代码示例
  * 展示如何创建和使用Tools让Agent与外部系统交互
@@ -721,8 +724,8 @@ public class ToolsExample {
 
 		@Override
 		public String apply(String input, ToolContext toolContext) {
-			OverAllState state = (OverAllState) toolContext.getContext().get("state");
-			RunnableConfig config = (RunnableConfig) toolContext.getContext().get("config");
+			OverAllState state = (OverAllState) toolContext.getContext().get(AGENT_STATE_CONTEXT_KEY);
+			RunnableConfig config = (RunnableConfig) toolContext.getContext().get(AGENT_CONFIG_CONTEXT_KEY);
 
 			// 从state中获取消息
 			Optional<Object> messagesOpt = state.value("messages");
@@ -775,7 +778,7 @@ public class ToolsExample {
 
 		@Override
 		public String apply(String query, ToolContext toolContext) {
-			RunnableConfig config = (RunnableConfig) toolContext.getContext().get("config");
+			RunnableConfig config = (RunnableConfig) toolContext.getContext().get(AGENT_CONFIG_CONTEXT_KEY);
 			String userId = (String) config.metadata("user_id").orElse(null);
 
 			if (userId == null) {


### PR DESCRIPTION
文档站 PR spring-ai-alibaba/website#278 修复了 Tools 教程里 ToolContext 示例的错误 key，这里修复对应的**示例源码**（文档的「查看源码」链接指向它）。

`ToolsExample.java` 用字面量 `"state"` / `"config"` 从 ToolContext 取值，但框架实际用 `ToolContextConstants` 常量（`"_AGENT_STATE_"` / `"_AGENT_CONFIG_"`）存储，所以 `get("config")` 返回 null，运行 `config.metadata(...)` 会 NPE。

改用 `AGENT_STATE_CONTEXT_KEY` / `AGENT_CONFIG_CONTEXT_KEY` 常量（并补 static import）。本地编译通过。
