### PR TITLE
fix(graph): keep streamed tool-call argument fragments that are substrings of accumulated args

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -487,11 +487,14 @@ public class NodeExecutor extends BaseGraphExecutor {
         if (currentArguments.equals(previousArguments)) {
             return currentArguments;
         }
-        if (currentArguments.startsWith(previousArguments) || currentArguments.contains(previousArguments)) {
+        // Cumulative-snapshot providers resend the full arguments each chunk, so a later
+        // chunk is a prefix-extension of the earlier one: keep the longer snapshot.
+        // We must only test startsWith (a prefix), NOT contains: an incremental delta can
+        // legitimately be a substring of the already-accumulated arguments (e.g. streaming
+        // {"count": 100} digit-by-digit, where the final "0" is contained in "...10"), and
+        // a contains-based short-circuit would silently drop that fragment.
+        if (currentArguments.startsWith(previousArguments)) {
             return currentArguments;
-        }
-        if (previousArguments.startsWith(currentArguments) || previousArguments.contains(currentArguments)) {
-            return previousArguments;
         }
 
         // Typical streaming delta case: append incremental argument fragment.

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamFunctionCallTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamFunctionCallTest.java
@@ -86,6 +86,140 @@ public class StreamFunctionCallTest {
         assertEquals("{\"city\":\"Beijing\"}", toolCall.arguments());
     }
 
+    /**
+     * Issue #4066 regression: incremental argument fragments must never be dropped when a
+     * later fragment happens to be a substring of the already-accumulated arguments. Here
+     * {@code {"count": 100}} is streamed digit-by-digit; the final {@code "0"} is contained
+     * in the accumulated {@code ...10}, which previously triggered a contains-based
+     * short-circuit and produced {@code {"count": 10}}.
+     */
+    @Test
+    void testStreamingRepeatedDigitFragmentsShouldNotBeDropped() throws Exception {
+        ChatModel chatModel = createMockChatModelStreamingArgFragments(
+                "call_2", "do_count",
+                new String[] {"{\"count\": ", "1", "0", "0", "}"});
+
+        StateGraph stateGraph = new StateGraph(() -> {
+            Map<String, com.alibaba.cloud.ai.graph.KeyStrategy> keyStrategyMap = new HashMap<>();
+            keyStrategyMap.put("messages", new AppendStrategy());
+            return keyStrategyMap;
+        }).addNode("llmNode", node_async(new LLmNodeAction(chatModel, "llmNode")))
+                .addEdge(START, "llmNode")
+                .addEdge("llmNode", END);
+
+        CompiledGraph compiledGraph = stateGraph.compile();
+
+        Map<String, Object> input = new HashMap<>();
+        input.put(OverAllState.DEFAULT_INPUT_KEY, "count");
+
+        Optional<OverAllState> finalState = compiledGraph.invoke(input);
+        assertTrue(finalState.isPresent());
+
+        List<?> messages = finalState.get().value("messages", List.class).orElseThrow();
+        AssistantMessage assistantMessage = (AssistantMessage) messages.get(messages.size() - 1);
+        assertEquals(1, assistantMessage.getToolCalls().size());
+
+        AssistantMessage.ToolCall toolCall = assistantMessage.getToolCalls().get(0);
+        assertEquals("call_2", toolCall.id());
+        assertEquals("do_count", toolCall.name());
+        assertEquals("{\"count\": 100}", toolCall.arguments());
+    }
+
+    /**
+     * Incremental fragments must not be treated as stale snapshots merely because the
+     * accumulated arguments start with the new fragment. A standalone opening brace is a
+     * legitimate fragment when a nested object starts.
+     */
+    @Test
+    void testStreamingPrefixFragmentShouldNotBeDropped() throws Exception {
+        ChatModel chatModel = createMockChatModelStreamingArgFragments(
+                "call_3", "filter_items",
+                new String[] {"{\"filter\":", "{", "\"x\":1}}"});
+
+        StateGraph stateGraph = new StateGraph(() -> {
+            Map<String, com.alibaba.cloud.ai.graph.KeyStrategy> keyStrategyMap = new HashMap<>();
+            keyStrategyMap.put("messages", new AppendStrategy());
+            return keyStrategyMap;
+        }).addNode("llmNode", node_async(new LLmNodeAction(chatModel, "llmNode")))
+                .addEdge(START, "llmNode")
+                .addEdge("llmNode", END);
+
+        CompiledGraph compiledGraph = stateGraph.compile();
+
+        Map<String, Object> input = new HashMap<>();
+        input.put(OverAllState.DEFAULT_INPUT_KEY, "filter");
+
+        Optional<OverAllState> finalState = compiledGraph.invoke(input);
+        assertTrue(finalState.isPresent());
+
+        List<?> messages = finalState.get().value("messages", List.class).orElseThrow();
+        AssistantMessage assistantMessage = (AssistantMessage) messages.get(messages.size() - 1);
+        assertEquals(1, assistantMessage.getToolCalls().size());
+
+        AssistantMessage.ToolCall toolCall = assistantMessage.getToolCalls().get(0);
+        assertEquals("call_3", toolCall.id());
+        assertEquals("filter_items", toolCall.name());
+        assertEquals("{\"filter\":{\"x\":1}}", toolCall.arguments());
+    }
+
+    /**
+     * Cumulative-snapshot providers that resend the full arguments on every chunk must
+     * still collapse to a single (not concatenated) argument string.
+     */
+    @Test
+    void testStreamingCumulativeSnapshotFragmentsShouldNotBeConcatenated() throws Exception {
+        ChatModel chatModel = createMockChatModelStreamingArgFragments(
+                "call_4", "get_weather",
+                new String[] {"{\"city\":", "{\"city\":\"Bei", "{\"city\":\"Beijing\"}"});
+
+        StateGraph stateGraph = new StateGraph(() -> {
+            Map<String, com.alibaba.cloud.ai.graph.KeyStrategy> keyStrategyMap = new HashMap<>();
+            keyStrategyMap.put("messages", new AppendStrategy());
+            return keyStrategyMap;
+        }).addNode("llmNode", node_async(new LLmNodeAction(chatModel, "llmNode")))
+                .addEdge(START, "llmNode")
+                .addEdge("llmNode", END);
+
+        CompiledGraph compiledGraph = stateGraph.compile();
+
+        Map<String, Object> input = new HashMap<>();
+        input.put(OverAllState.DEFAULT_INPUT_KEY, "weather in beijing");
+
+        Optional<OverAllState> finalState = compiledGraph.invoke(input);
+        assertTrue(finalState.isPresent());
+
+        List<?> messages = finalState.get().value("messages", List.class).orElseThrow();
+        AssistantMessage assistantMessage = (AssistantMessage) messages.get(messages.size() - 1);
+        assertEquals(1, assistantMessage.getToolCalls().size());
+        assertEquals("{\"city\":\"Beijing\"}", assistantMessage.getToolCalls().get(0).arguments());
+    }
+
+    /**
+     * Streams a single tool call whose id/name arrive on the first chunk and whose
+     * argument fragments arrive one per subsequent chunk (id/name null after the first).
+     */
+    private static ChatModel createMockChatModelStreamingArgFragments(String id, String name, String[] argFragments) {
+        return new ChatModel() {
+            @Override
+            public ChatResponse call(Prompt prompt) {
+                return new ChatResponse(List.of(new Generation(new AssistantMessage("fallback"))));
+            }
+
+            @Override
+            public Flux<ChatResponse> stream(Prompt prompt) {
+                Flux<ChatResponse> flux = Flux.empty();
+                for (int i = 0; i < argFragments.length; i++) {
+                    AssistantMessage.ToolCall chunk = new AssistantMessage.ToolCall(
+                            i == 0 ? id : null, "function", i == 0 ? name : null, argFragments[i]);
+                    flux = flux.concatWith(Flux.just(new ChatResponse(List.of(new Generation(
+                            AssistantMessage.builder().content("").toolCalls(List.of(chunk)).build(),
+                            ChatGenerationMetadata.NULL)))));
+                }
+                return flux;
+            }
+        };
+    }
+
     private static ChatModel createMockChatModelWithSplitToolCallChunks() {
         return new ChatModel() {
             @Override


### PR DESCRIPTION
Closes #4066

## Problem

When a model streams a tool call, the argument JSON arrives split across chunks and `NodeExecutor.mergeToolArguments()` reassembles it. It short-circuited on `String.contains()`:

```java
if (currentArguments.startsWith(previousArguments) || currentArguments.contains(previousArguments)) return currentArguments;
if (previousArguments.startsWith(currentArguments) || previousArguments.contains(currentArguments)) return previousArguments;
```

An incremental delta can legitimately be a **substring** of the already-accumulated arguments, and the `contains()` branch then drops it. Concrete case: streaming `{"count": 100}` digit-by-digit as `{"count": ` / `1` / `0` / `0` / `}`. When merging the accumulated `{"count": 10` with the final `0`, `previousArguments.contains("0")` is true, so the fragment is dropped and the arguments become `{"count": 10}`.

This is the same class of failure as #4066 (`toolInput cannot be null or empty` / lost tool arguments): the merge already handles the name/args split (commit 5c2a0fb26), but the `contains()` heuristic silently corrupts arguments containing repeated characters.

## Fix

Only a **prefix** (`startsWith`) indicates a cumulative-snapshot chunk (some providers resend the full arguments each chunk) that should replace the accumulator. A mere substring does not. Removing the two `contains()` checks makes incremental fragments always append, while cumulative-snapshot providers are still handled by `startsWith`.

## Tests

Extends `StreamFunctionCallTest` (which already covers the split-chunk merge for #4406):
- `testStreamingRepeatedDigitFragmentsShouldNotBeDropped` — streams `{"count": 100}` digit-by-digit; asserts `{"count": 100}` (fails on pre-fix code: produced `{"count": 10}`).
- `testStreamingCumulativeSnapshotFragmentsShouldNotBeConcatenated` — a provider resending the full arguments each chunk still collapses to a single `{"city":"Beijing"}` (guards the retained `startsWith` path).

All `spring-ai-alibaba-graph-core` executor tests pass; `spotless:apply` run.

## Note on #4066

The original name/arguments split reported in #4066 is already handled by the current `mergeToolCalls` implementation; this PR fixes the remaining argument-corruption edge case and adds regression coverage, so #4066 can be closed.