### PR TITLE
test(agent): loosen flaky async-timeout deadlines to survive loaded CI

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeAsyncExecutionTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNodeAsyncExecutionTest.java
@@ -515,8 +515,12 @@ class AgentToolNodeAsyncExecutionTest {
 
 			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// Wait for writes - increased from 1s to 5s for CI stability
-			assertTrue(writeComplete.await(5, TimeUnit.SECONDS));
+			// Wait for writes. This latch fires as soon as the async task performs its
+			// two writes, so the deadline is only an upper bound: a successful run returns
+			// immediately and never waits the full duration. It is generous (30s) because
+			// the task runs on the shared ForkJoinPool.commonPool(), whose start latency
+			// can spike under parallel test execution on loaded CI runners.
+			assertTrue(writeComplete.await(30, TimeUnit.SECONDS));
 			assertEquals(2, stateUpdates.size());
 
 			// Simulate AgentToolNode timeout handling

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
@@ -446,8 +446,12 @@ class CancellableAsyncToolCallbackTest {
 			// Cancel
 			token.cancel();
 
-			// Wait for tool to finish
-			assertTrue(toolFinished.await(1, TimeUnit.SECONDS));
+			// Wait for tool to finish. The latch fires as soon as the cancelled tool
+			// returns, so this deadline is only an upper bound (a successful run returns
+			// immediately). It is generous (30s) because the tool runs on the shared
+			// ForkJoinPool.commonPool(), whose start/scheduling latency can spike under
+			// parallel test execution on loaded CI runners.
+			assertTrue(toolFinished.await(30, TimeUnit.SECONDS));
 
 			// Tool should have stopped early (not completed all 1000 iterations)
 			assertTrue(iterationsCompleted.get() < 100, "Tool should have stopped early, but completed " + iterationsCompleted.get() + " iterations");


### PR DESCRIPTION
Two async tests fail intermittently on CI (the `test` job), turning the check red on unrelated PRs even though the behavior under test is correct and they pass locally:

- `AgentToolNodeAsyncExecutionTest.StateUpdateOnTimeoutTests.stateUpdates_shouldBeCleared_onTimeoutWithCancellableTool`
- `CancellableAsyncToolCallbackTest.TimeoutScenarioTests.tool_shouldStopGracefully_whenCheckingCancellation`

## Root cause

Both tests wait on a `CountDownLatch` that is counted down by a task submitted to `CompletableFuture.supplyAsync(...)` — i.e. the shared `ForkJoinPool.commonPool()`. On GitHub-hosted runners the common pool has very low parallelism, and under parallel test execution its start/scheduling latency can spike past the hard-coded `5s` / `1s` await deadlines. The latch is then not observed in time and `assertTrue(latch.await(...))` fails.

A previous attempt already bumped one knob (`// Increased from 100ms for CI stability` / `1s to 5s`), which reduced but did not eliminate the flakiness.

## Fix

Raise the two `await(...)` deadlines to `30s`. These deadlines are only **upper bounds**: a successful run returns the instant the latch fires and never waits the full duration, so a larger value has no effect on green runs — it only tolerates scheduling spikes before declaring failure. No assertion is weakened (the correctness checks — `stateUpdates.isEmpty()`, `token.isCancelled()`, `iterationsCompleted < 100` — are unchanged).

Local run: both classes green (`Tests run: 29, Failures: 0`); `spotless:apply` run.