### PR TITLE
fix(agent): support FlowAgent sub-agents in routing agent

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -68,15 +68,26 @@ public class RoutingMergeNode implements NodeAction {
 			""";
 
 	private final ChatModel chatModel;
+	private final String routingAgentName;
 	private final List<Agent> subAgents;
 	private final String mergedOutputKey;
 
 	public RoutingMergeNode(ChatModel chatModel, List<? extends Agent> subAgents) {
-		this(chatModel, subAgents, DEFAULT_MERGED_OUTPUT_KEY);
+		this(chatModel, null, subAgents, DEFAULT_MERGED_OUTPUT_KEY);
+	}
+
+	public RoutingMergeNode(ChatModel chatModel, Agent routingAgent, List<? extends Agent> subAgents) {
+		this(chatModel, routingAgent, subAgents, DEFAULT_MERGED_OUTPUT_KEY);
 	}
 
 	public RoutingMergeNode(ChatModel chatModel, List<? extends Agent> subAgents, String mergedOutputKey) {
+		this(chatModel, null, subAgents, mergedOutputKey);
+	}
+
+	public RoutingMergeNode(ChatModel chatModel, Agent routingAgent, List<? extends Agent> subAgents,
+			String mergedOutputKey) {
 		this.chatModel = chatModel;
+		this.routingAgentName = routingAgent != null ? routingAgent.name() : null;
 		this.subAgents = List.copyOf(subAgents);
 		this.mergedOutputKey = mergedOutputKey != null ? mergedOutputKey : DEFAULT_MERGED_OUTPUT_KEY;
 	}
@@ -267,7 +278,9 @@ public class RoutingMergeNode implements NodeAction {
 	}
 
 	private Optional<Set<String>> currentRoutedAgentNames(OverAllState state) {
-		Optional<Object> value = state.value(RoutingNode.ROUTED_AGENT_NAMES_KEY);
+		Optional<Object> value = routingAgentName != null
+				? state.value(RoutingNode.routedAgentNamesKey(routingAgentName))
+				: state.value(RoutingNode.ROUTED_AGENT_NAMES_KEY);
 		if (value.isEmpty()) {
 			return Optional.empty();
 		}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -18,9 +18,15 @@ package com.alibaba.cloud.ai.graph.agent.flow.node;
 import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
+import com.alibaba.cloud.ai.graph.agent.Agent;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -29,9 +35,13 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 
 /**
  * Dedicated node for merging routing results. Collects outputs from sub-agents routed by
@@ -45,6 +55,8 @@ public class RoutingMergeNode implements NodeAction {
 	/** Default key for the merged result in state. */
 	public static final String DEFAULT_MERGED_OUTPUT_KEY = "merged_result";
 
+	private static final String DEFAULT_MESSAGES_OUTPUT_KEY = "messages";
+
 	private static final String SYNTHESIZE_SYSTEM_TEMPLATE = """
 			Synthesize these search results to answer the original question: "%s"
 
@@ -55,16 +67,16 @@ public class RoutingMergeNode implements NodeAction {
 			""";
 
 	private final ChatModel chatModel;
-	private final List<BaseAgent> subAgents;
+	private final List<Agent> subAgents;
 	private final String mergedOutputKey;
 
-	public RoutingMergeNode(ChatModel chatModel, List<BaseAgent> subAgents) {
+	public RoutingMergeNode(ChatModel chatModel, List<? extends Agent> subAgents) {
 		this(chatModel, subAgents, DEFAULT_MERGED_OUTPUT_KEY);
 	}
 
-	public RoutingMergeNode(ChatModel chatModel, List<BaseAgent> subAgents, String mergedOutputKey) {
+	public RoutingMergeNode(ChatModel chatModel, List<? extends Agent> subAgents, String mergedOutputKey) {
 		this.chatModel = chatModel;
-		this.subAgents = subAgents;
+		this.subAgents = List.copyOf(subAgents);
 		this.mergedOutputKey = mergedOutputKey != null ? mergedOutputKey : DEFAULT_MERGED_OUTPUT_KEY;
 	}
 
@@ -73,21 +85,52 @@ public class RoutingMergeNode implements NodeAction {
 		logger.debug("RoutingMergeNode: merging results from {} sub-agents", subAgents.size());
 
 		List<String> formattedResults = new ArrayList<>();
+		Set<String> collectedOutputKeys = new HashSet<>();
 		String lastResult = null;
-		for (BaseAgent subAgent : subAgents) {
-			String outputKey = subAgent.getOutputKey();
-			if (outputKey == null) {
+		long routedAgentCount = countRoutedAgents(state);
+		boolean hasRoutingMarkers = routedAgentCount > 0;
+		long routingMergedOutputOwnerCount = countRoutingMergedOutputOwners(state, hasRoutingMarkers);
+		for (Agent subAgent : subAgents) {
+			boolean topLevelRoutedAgent = isTopLevelRoutedAgent(state, subAgent);
+			if (hasRoutingMarkers && !topLevelRoutedAgent) {
+				logger.debug("Skipping unrouted sub-agent {}", subAgent.name());
 				continue;
 			}
-			Optional<Object> outputOpt = state.value(outputKey);
-			if (outputOpt.isPresent()) {
-				String text = extractText(outputOpt.get(), outputKey);
-				if (text != null && !text.isBlank()) {
-					String source = capitalize(subAgent.name());
-					formattedResults.add("**From " + source + ":**\n" + text);
-					lastResult = text;
-					logger.debug("Collected result from {} (key: {})", subAgent.name(), outputKey);
+			boolean allowDefaultMessagesOutput = routedAgentCount == 1 && topLevelRoutedAgent;
+			boolean allowRoutingMergedOutput = routingMergedOutputOwnerCount == 1 && usesRoutingMergedOutput(subAgent);
+			boolean preferWrapperOutput = shouldPreferWrapperOutput(state, subAgent, routedAgentCount, topLevelRoutedAgent,
+					routingMergedOutputOwnerCount);
+			List<String> outputKeys = resolveOutputKeys(subAgent, allowDefaultMessagesOutput,
+					allowRoutingMergedOutput, preferWrapperOutput);
+			List<String> sourceTexts = new ArrayList<>();
+			boolean collectMultipleOutputs = collectsMultipleOutputs(subAgent);
+			for (String outputKey : outputKeys) {
+				if (collectedOutputKeys.contains(outputKey)) {
+					continue;
 				}
+				boolean wrapperOutputKey = outputKeyToParent(subAgent.name()).equals(outputKey);
+				if (collectMultipleOutputs && !sourceTexts.isEmpty()
+						&& wrapperOutputKey) {
+					continue;
+				}
+				Optional<Object> outputOpt = state.value(outputKey);
+				if (outputOpt.isPresent()) {
+					String text = extractText(outputOpt.get(), outputKey);
+					if (text != null && !text.isBlank()) {
+						collectedOutputKeys.add(outputKey);
+						sourceTexts.add(text);
+						logger.debug("Collected result from {} (key: {})", subAgent.name(), outputKey);
+						if (!collectMultipleOutputs || (preferWrapperOutput && wrapperOutputKey)) {
+							break;
+						}
+					}
+				}
+			}
+			if (!sourceTexts.isEmpty()) {
+				String text = String.join("\n\n", sourceTexts);
+				String source = capitalize(subAgent.name());
+				formattedResults.add("**From " + source + ":**\n" + text);
+				lastResult = text;
 			}
 		}
 
@@ -99,12 +142,156 @@ public class RoutingMergeNode implements NodeAction {
 			logger.debug("RoutingMergeNode: single routed result, returning it without re-synthesis");
 			return Map.of(mergedOutputKey, lastResult);
 		}
+		if (formattedResults.isEmpty()) {
+			logger.debug("RoutingMergeNode: no routed results found");
+			return Map.of(mergedOutputKey, "No results found from any knowledge source.");
+		}
 
 		String query = extractOriginalQuery(state);
 		String finalAnswer = synthesize(query, formattedResults);
 		logger.debug("RoutingMergeNode: synthesized {} sources into merged result", formattedResults.size());
 
 		return Map.of(mergedOutputKey, finalAnswer);
+	}
+
+	private List<String> resolveOutputKeys(Agent agent, boolean allowDefaultMessagesOutput,
+			boolean allowRoutingMergedOutput, boolean preferWrapperOutput) {
+		List<String> outputKeys = new ArrayList<>();
+		String wrapperOutputKey = outputKeyToParent(agent.name());
+		if (preferWrapperOutput) {
+			outputKeys.add(wrapperOutputKey);
+		}
+		if (agent instanceof BaseAgent baseAgent) {
+			String outputKey = baseAgent.getOutputKey();
+			if (outputKey != null) {
+				outputKeys.add(outputKey);
+			}
+			else if (allowDefaultMessagesOutput) {
+				outputKeys.add(DEFAULT_MESSAGES_OUTPUT_KEY);
+			}
+		}
+		else if (agent instanceof ParallelAgent parallelAgent) {
+			if (parallelAgent.mergeOutputKey() != null) {
+				outputKeys.add(parallelAgent.mergeOutputKey());
+			}
+			else {
+				List<Agent> nestedAgents = parallelAgent.subAgents();
+				if (nestedAgents != null) {
+					for (Agent nestedAgent : nestedAgents) {
+						outputKeys.addAll(resolveOutputKeys(nestedAgent, false, allowRoutingMergedOutput, false));
+					}
+				}
+			}
+		}
+		else if (agent instanceof LlmRoutingAgent) {
+			if (allowRoutingMergedOutput) {
+				outputKeys.add(DEFAULT_MERGED_OUTPUT_KEY);
+			}
+		}
+		else if (agent instanceof SequentialAgent sequentialAgent) {
+			List<Agent> nestedAgents = sequentialAgent.subAgents();
+			if (nestedAgents != null && !nestedAgents.isEmpty()) {
+				outputKeys.addAll(resolveOutputKeys(nestedAgents.get(nestedAgents.size() - 1),
+						allowDefaultMessagesOutput, allowRoutingMergedOutput, false));
+			}
+		}
+		else if (agent instanceof FlowAgent flowAgent) {
+			List<Agent> nestedAgents = flowAgent.subAgents();
+			if (nestedAgents != null) {
+				for (Agent nestedAgent : nestedAgents) {
+					outputKeys.addAll(resolveOutputKeys(nestedAgent, allowDefaultMessagesOutput,
+							allowRoutingMergedOutput, false));
+				}
+			}
+		}
+		if (!preferWrapperOutput) {
+			outputKeys.add(wrapperOutputKey);
+		}
+		return outputKeys;
+	}
+
+	private boolean shouldPreferWrapperOutput(OverAllState state, Agent agent, long routedAgentCount,
+			boolean topLevelRoutedAgent, long routingMergedOutputOwnerCount) {
+		if (routedAgentCount <= 1 || !topLevelRoutedAgent || !(agent instanceof FlowAgent)
+				|| state.value(outputKeyToParent(agent.name())).isEmpty()) {
+			return false;
+		}
+
+		Set<String> outputKeys = resolvedNonWrapperOutputKeys(agent, routingMergedOutputOwnerCount);
+		if (outputKeys.isEmpty()) {
+			return true;
+		}
+
+		return subAgents.stream()
+			.filter(other -> other != agent)
+			.filter(other -> isTopLevelRoutedAgent(state, other))
+			.map(other -> resolvedNonWrapperOutputKeys(other, routingMergedOutputOwnerCount))
+			.anyMatch(otherOutputKeys -> otherOutputKeys.stream().anyMatch(outputKeys::contains));
+	}
+
+	private Set<String> resolvedNonWrapperOutputKeys(Agent agent, long routingMergedOutputOwnerCount) {
+		boolean allowRoutingMergedOutput = routingMergedOutputOwnerCount == 1 && usesRoutingMergedOutput(agent);
+		String wrapperOutputKey = outputKeyToParent(agent.name());
+		Set<String> outputKeys = new HashSet<>();
+		for (String outputKey : resolveOutputKeys(agent, false, allowRoutingMergedOutput, false)) {
+			if (!wrapperOutputKey.equals(outputKey)) {
+				outputKeys.add(outputKey);
+			}
+		}
+		return outputKeys;
+	}
+
+	private long countRoutedAgents(OverAllState state) {
+		return subAgents.stream().filter(agent -> isTopLevelRoutedAgent(state, agent)).count();
+	}
+
+	private long countRoutingMergedOutputOwners(OverAllState state, boolean hasRoutingMarkers) {
+		return subAgents.stream()
+			.filter(agent -> !hasRoutingMarkers || isTopLevelRoutedAgent(state, agent))
+			.filter(this::usesRoutingMergedOutput)
+			.count();
+	}
+
+	private boolean isTopLevelRoutedAgent(OverAllState state, Agent agent) {
+		return state.value(agent.name() + "_input").isPresent();
+	}
+
+	private boolean usesRoutingMergedOutput(Agent agent) {
+		if (agent instanceof LlmRoutingAgent) {
+			return true;
+		}
+		if (agent instanceof ParallelAgent parallelAgent && parallelAgent.mergeOutputKey() != null) {
+			return false;
+		}
+		if (agent instanceof SequentialAgent sequentialAgent) {
+			List<Agent> nestedAgents = sequentialAgent.subAgents();
+			return nestedAgents != null && !nestedAgents.isEmpty()
+					&& usesRoutingMergedOutput(nestedAgents.get(nestedAgents.size() - 1));
+		}
+		if (agent instanceof FlowAgent flowAgent) {
+			List<Agent> nestedAgents = flowAgent.subAgents();
+			return nestedAgents != null && nestedAgents.stream().anyMatch(this::usesRoutingMergedOutput);
+		}
+		return false;
+	}
+
+	private boolean collectsMultipleOutputs(Agent agent) {
+		if (agent instanceof ParallelAgent parallelAgent) {
+			return parallelAgent.mergeOutputKey() == null;
+		}
+		if (agent instanceof SequentialAgent sequentialAgent) {
+			List<Agent> nestedAgents = sequentialAgent.subAgents();
+			return nestedAgents != null && !nestedAgents.isEmpty()
+					&& collectsMultipleOutputs(nestedAgents.get(nestedAgents.size() - 1));
+		}
+		if (agent instanceof LlmRoutingAgent) {
+			return false;
+		}
+		if (agent instanceof FlowAgent flowAgent) {
+			List<Agent> nestedAgents = flowAgent.subAgents();
+			return nestedAgents != null && nestedAgents.size() == 1 && collectsMultipleOutputs(nestedAgents.get(0));
+		}
+		return false;
 	}
 
 	private String extractOriginalQuery(OverAllState state) {
@@ -118,9 +305,6 @@ public class RoutingMergeNode implements NodeAction {
 	}
 
 	private String synthesize(String query, List<String> formattedResults) {
-		if (formattedResults == null || formattedResults.isEmpty()) {
-			return "No results found from any knowledge source.";
-		}
 		String formatted = String.join("\n\n", formattedResults);
 		String systemPrompt = SYNTHESIZE_SYSTEM_TEMPLATE.formatted(query);
 		Prompt prompt = new Prompt(List.of(
@@ -134,25 +318,80 @@ public class RoutingMergeNode implements NodeAction {
 		if (output instanceof Message message) {
 			return message.getText();
 		}
+		if (output instanceof List<?> list) {
+			return extractListText(list, outputKey);
+		}
 		if (output instanceof GraphResponse<?> gr) {
 			Optional<?> val = gr.resultValue();
 			if (val.isPresent()) {
 				Object v = val.get();
 				if (v instanceof Map<?, ?> map) {
-					v = map.get(outputKey);
+					v = extractMapValue(map, outputKey);
 				}
 				if (v instanceof Message m) {
 					return m.getText();
 				}
-				return v.toString();
+				if (v instanceof List<?> list) {
+					return extractListText(list, outputKey);
+				}
+				return v != null ? v.toString() : "";
 			}
 			return "";
+		}
+		if (output instanceof Map<?, ?> map) {
+			Object v = extractMapValue(map, outputKey);
+			if (v instanceof Message m) {
+				return m.getText();
+			}
+			if (v instanceof List<?> list) {
+				return extractListText(list, outputKey);
+			}
+			return v != null ? v.toString() : "";
 		}
 		return output != null ? output.toString() : "";
 	}
 
+	private static String extractListText(List<?> list, String outputKey) {
+		if (DEFAULT_MESSAGES_OUTPUT_KEY.equals(outputKey)) {
+			return extractLastAssistantMessageText(list);
+		}
+		return list.toString();
+	}
+
+	private static String extractLastAssistantMessageText(List<?> list) {
+		for (int i = list.size() - 1; i >= 0; i--) {
+			Object value = list.get(i);
+			if (value instanceof AssistantMessage message) {
+				return message.getText();
+			}
+		}
+		return "";
+	}
+
+	private static Object extractMapValue(Map<?, ?> map, String outputKey) {
+		// A subgraph wrapper key namespaces a nested FlowAgent result in the parent graph.
+		// When the nested graph is itself a routing graph, its final answer is stored under
+		// the routing merge key inside that wrapper state.
+		if (isSubGraphWrapperKey(outputKey) && map.containsKey(DEFAULT_MERGED_OUTPUT_KEY)) {
+			return map.get(DEFAULT_MERGED_OUTPUT_KEY);
+		}
+		if (map.containsKey(outputKey)) {
+			return map.get(outputKey);
+		}
+		if (map.size() == 1) {
+			return map.values().iterator().next();
+		}
+		return map;
+	}
+
+	private static boolean isSubGraphWrapperKey(String outputKey) {
+		return outputKey != null && outputKey.startsWith("subgraph_") && outputKey.endsWith("_compiled_graph");
+	}
+
 	private static String capitalize(String s) {
-		if (s == null || s.isEmpty()) return s;
+		if (s == null || s.isEmpty()) {
+			return s;
+		}
 		return s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
 	}
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -36,6 +36,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -87,11 +88,12 @@ public class RoutingMergeNode implements NodeAction {
 		List<String> formattedResults = new ArrayList<>();
 		Set<String> collectedOutputKeys = new HashSet<>();
 		String lastResult = null;
-		long routedAgentCount = countRoutedAgents(state);
-		boolean hasRoutingMarkers = routedAgentCount > 0;
-		long routingMergedOutputOwnerCount = countRoutingMergedOutputOwners(state, hasRoutingMarkers);
+		Optional<Set<String>> routedAgentNames = currentRoutedAgentNames(state);
+		long routedAgentCount = countRoutedAgents(state, routedAgentNames);
+		boolean hasRoutingMarkers = routedAgentNames.isPresent() || routedAgentCount > 0;
+		long routingMergedOutputOwnerCount = countRoutingMergedOutputOwners(state, hasRoutingMarkers, routedAgentNames);
 		for (Agent subAgent : subAgents) {
-			boolean topLevelRoutedAgent = isTopLevelRoutedAgent(state, subAgent);
+			boolean topLevelRoutedAgent = isTopLevelRoutedAgent(state, subAgent, routedAgentNames);
 			if (hasRoutingMarkers && !topLevelRoutedAgent) {
 				logger.debug("Skipping unrouted sub-agent {}", subAgent.name());
 				continue;
@@ -99,7 +101,7 @@ public class RoutingMergeNode implements NodeAction {
 			boolean allowDefaultMessagesOutput = routedAgentCount == 1 && topLevelRoutedAgent;
 			boolean allowRoutingMergedOutput = routingMergedOutputOwnerCount == 1 && usesRoutingMergedOutput(subAgent);
 			boolean preferWrapperOutput = shouldPreferWrapperOutput(state, subAgent, routedAgentCount, topLevelRoutedAgent,
-					routingMergedOutputOwnerCount);
+					routingMergedOutputOwnerCount, routedAgentNames);
 			List<String> outputKeys = resolveOutputKeys(subAgent, allowDefaultMessagesOutput,
 					allowRoutingMergedOutput, preferWrapperOutput);
 			List<String> sourceTexts = new ArrayList<>();
@@ -211,7 +213,7 @@ public class RoutingMergeNode implements NodeAction {
 	}
 
 	private boolean shouldPreferWrapperOutput(OverAllState state, Agent agent, long routedAgentCount,
-			boolean topLevelRoutedAgent, long routingMergedOutputOwnerCount) {
+			boolean topLevelRoutedAgent, long routingMergedOutputOwnerCount, Optional<Set<String>> routedAgentNames) {
 		if (routedAgentCount <= 1 || !topLevelRoutedAgent || !(agent instanceof FlowAgent)
 				|| state.value(outputKeyToParent(agent.name())).isEmpty()) {
 			return false;
@@ -224,7 +226,7 @@ public class RoutingMergeNode implements NodeAction {
 
 		return subAgents.stream()
 			.filter(other -> other != agent)
-			.filter(other -> isTopLevelRoutedAgent(state, other))
+			.filter(other -> isTopLevelRoutedAgent(state, other, routedAgentNames))
 			.map(other -> resolvedNonWrapperOutputKeys(other, routingMergedOutputOwnerCount))
 			.anyMatch(otherOutputKeys -> otherOutputKeys.stream().anyMatch(outputKeys::contains));
 	}
@@ -241,19 +243,48 @@ public class RoutingMergeNode implements NodeAction {
 		return outputKeys;
 	}
 
-	private long countRoutedAgents(OverAllState state) {
-		return subAgents.stream().filter(agent -> isTopLevelRoutedAgent(state, agent)).count();
+	private long countRoutedAgents(OverAllState state, Optional<Set<String>> routedAgentNames) {
+		if (routedAgentNames.isPresent()) {
+			Set<String> selectedAgents = routedAgentNames.get();
+			return subAgents.stream().filter(agent -> selectedAgents.contains(agent.name())).count();
+		}
+		return subAgents.stream().filter(agent -> isTopLevelRoutedAgent(state, agent, routedAgentNames)).count();
 	}
 
-	private long countRoutingMergedOutputOwners(OverAllState state, boolean hasRoutingMarkers) {
+	private long countRoutingMergedOutputOwners(OverAllState state, boolean hasRoutingMarkers,
+			Optional<Set<String>> routedAgentNames) {
 		return subAgents.stream()
-			.filter(agent -> !hasRoutingMarkers || isTopLevelRoutedAgent(state, agent))
+			.filter(agent -> !hasRoutingMarkers || isTopLevelRoutedAgent(state, agent, routedAgentNames))
 			.filter(this::usesRoutingMergedOutput)
 			.count();
 	}
 
-	private boolean isTopLevelRoutedAgent(OverAllState state, Agent agent) {
+	private boolean isTopLevelRoutedAgent(OverAllState state, Agent agent, Optional<Set<String>> routedAgentNames) {
+		if (routedAgentNames.isPresent()) {
+			return routedAgentNames.get().contains(agent.name());
+		}
 		return state.value(agent.name() + "_input").isPresent();
+	}
+
+	private Optional<Set<String>> currentRoutedAgentNames(OverAllState state) {
+		Optional<Object> value = state.value(RoutingNode.ROUTED_AGENT_NAMES_KEY);
+		if (value.isEmpty()) {
+			return Optional.empty();
+		}
+
+		Set<String> agentNames = new LinkedHashSet<>();
+		Object routedAgents = value.get();
+		if (routedAgents instanceof Iterable<?> iterable) {
+			for (Object agentName : iterable) {
+				if (agentName instanceof String name && !name.isBlank()) {
+					agentNames.add(name);
+				}
+			}
+		}
+		else if (routedAgents instanceof String name && !name.isBlank()) {
+			agentNames.add(name);
+		}
+		return Optional.of(agentNames);
 	}
 
 	private boolean usesRoutingMergedOutput(Agent agent) {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -19,11 +19,6 @@ import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.action.NodeAction;
 import com.alibaba.cloud.ai.graph.agent.Agent;
-import com.alibaba.cloud.ai.graph.agent.BaseAgent;
-import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
-import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
-import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
-import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -35,14 +30,12 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 
 /**
  * Dedicated node for merging routing results. Collects outputs from sub-agents routed by
@@ -56,7 +49,7 @@ public class RoutingMergeNode implements NodeAction {
 	/** Default key for the merged result in state. */
 	public static final String DEFAULT_MERGED_OUTPUT_KEY = "merged_result";
 
-	private static final String DEFAULT_MESSAGES_OUTPUT_KEY = "messages";
+	static final String DEFAULT_MESSAGES_OUTPUT_KEY = "messages";
 
 	private static final String SYNTHESIZE_SYSTEM_TEMPLATE = """
 			Synthesize these search results to answer the original question: "%s"
@@ -68,8 +61,9 @@ public class RoutingMergeNode implements NodeAction {
 			""";
 
 	private final ChatModel chatModel;
-	private final String routingAgentName;
-	private final List<Agent> subAgents;
+
+	private final RoutingOutputResolver outputResolver;
+
 	private final String mergedOutputKey;
 
 	public RoutingMergeNode(ChatModel chatModel, List<? extends Agent> subAgents) {
@@ -87,63 +81,29 @@ public class RoutingMergeNode implements NodeAction {
 	public RoutingMergeNode(ChatModel chatModel, Agent routingAgent, List<? extends Agent> subAgents,
 			String mergedOutputKey) {
 		this.chatModel = chatModel;
-		this.routingAgentName = routingAgent != null ? routingAgent.name() : null;
-		this.subAgents = List.copyOf(subAgents);
+		String routingAgentName = routingAgent != null ? routingAgent.name() : null;
+		this.outputResolver = new RoutingOutputResolver(routingAgentName, subAgents);
 		this.mergedOutputKey = mergedOutputKey != null ? mergedOutputKey : DEFAULT_MERGED_OUTPUT_KEY;
 	}
 
 	@Override
 	public Map<String, Object> apply(OverAllState state) throws Exception {
-		logger.debug("RoutingMergeNode: merging results from {} sub-agents", subAgents.size());
+		logger.debug("RoutingMergeNode: merging results from {} sub-agents", outputResolver.subAgentCount());
 
+		RoutingOutputResolver.MergeContext context = outputResolver.createContext(state);
 		List<String> formattedResults = new ArrayList<>();
 		Set<String> collectedOutputKeys = new HashSet<>();
+		Set<String> staleWrapperOutputKeys = new HashSet<>();
 		String lastResult = null;
-		Optional<Set<String>> routedAgentNames = currentRoutedAgentNames(state);
-		long routedAgentCount = countRoutedAgents(state, routedAgentNames);
-		boolean hasRoutingMarkers = routedAgentNames.isPresent() || routedAgentCount > 0;
-		long routingMergedOutputOwnerCount = countRoutingMergedOutputOwners(state, hasRoutingMarkers, routedAgentNames);
-		for (Agent subAgent : subAgents) {
-			boolean topLevelRoutedAgent = isTopLevelRoutedAgent(state, subAgent, routedAgentNames);
-			if (hasRoutingMarkers && !topLevelRoutedAgent) {
-				logger.debug("Skipping unrouted sub-agent {}", subAgent.name());
-				continue;
-			}
-			boolean allowDefaultMessagesOutput = routedAgentCount == 1 && topLevelRoutedAgent;
-			boolean allowRoutingMergedOutput = routingMergedOutputOwnerCount == 1 && usesRoutingMergedOutput(subAgent);
-			boolean preferWrapperOutput = shouldPreferWrapperOutput(state, subAgent, routedAgentCount, topLevelRoutedAgent,
-					routingMergedOutputOwnerCount, routedAgentNames);
-			List<String> outputKeys = resolveOutputKeys(subAgent, allowDefaultMessagesOutput,
-					allowRoutingMergedOutput, preferWrapperOutput);
-			List<String> sourceTexts = new ArrayList<>();
-			boolean collectMultipleOutputs = collectsMultipleOutputs(subAgent);
-			for (String outputKey : outputKeys) {
-				if (collectedOutputKeys.contains(outputKey)) {
-					continue;
-				}
-				boolean wrapperOutputKey = outputKeyToParent(subAgent.name()).equals(outputKey);
-				if (collectMultipleOutputs && !sourceTexts.isEmpty()
-						&& wrapperOutputKey) {
-					continue;
-				}
-				Optional<Object> outputOpt = state.value(outputKey);
-				if (outputOpt.isPresent()) {
-					String text = extractText(outputOpt.get(), outputKey);
-					if (text != null && !text.isBlank()) {
-						collectedOutputKeys.add(outputKey);
-						sourceTexts.add(text);
-						logger.debug("Collected result from {} (key: {})", subAgent.name(), outputKey);
-						if (!collectMultipleOutputs || (preferWrapperOutput && wrapperOutputKey)) {
-							break;
-						}
-					}
-				}
-			}
-			if (!sourceTexts.isEmpty()) {
-				String text = String.join("\n\n", sourceTexts);
-				String source = capitalize(subAgent.name());
-				formattedResults.add("**From " + source + ":**\n" + text);
-				lastResult = text;
+
+		for (Agent subAgent : outputResolver.subAgents()) {
+			Optional<RoutingOutputResolver.CollectedAgentResult> collectedResult = outputResolver.collectAgentResult(
+					state, subAgent, context, collectedOutputKeys);
+			if (collectedResult.isPresent()) {
+				RoutingOutputResolver.CollectedAgentResult result = collectedResult.get();
+				formattedResults.add("**From " + capitalize(subAgent.name()) + ":**\n" + result.text());
+				lastResult = result.text();
+				outputResolver.markStaleWrapperIfNeeded(state, subAgent, result, staleWrapperOutputKeys);
 			}
 		}
 
@@ -153,191 +113,54 @@ public class RoutingMergeNode implements NodeAction {
 		// single result through unchanged; only genuinely multi-source results need synthesis.
 		if (formattedResults.size() == 1) {
 			logger.debug("RoutingMergeNode: single routed result, returning it without re-synthesis");
-			return Map.of(mergedOutputKey, lastResult);
+			return mergeResult(lastResult, staleWrapperOutputKeys, context.exposeMergedResultToParent());
 		}
 		if (formattedResults.isEmpty()) {
 			logger.debug("RoutingMergeNode: no routed results found");
-			return Map.of(mergedOutputKey, "No results found from any knowledge source.");
+			return mergeResult("No results found from any knowledge source.", staleWrapperOutputKeys,
+					context.exposeMergedResultToParent());
 		}
 
 		String query = extractOriginalQuery(state);
 		String finalAnswer = synthesize(query, formattedResults);
 		logger.debug("RoutingMergeNode: synthesized {} sources into merged result", formattedResults.size());
 
-		return Map.of(mergedOutputKey, finalAnswer);
+		return mergeResult(finalAnswer, staleWrapperOutputKeys, context.exposeMergedResultToParent());
 	}
 
-	private List<String> resolveOutputKeys(Agent agent, boolean allowDefaultMessagesOutput,
-			boolean allowRoutingMergedOutput, boolean preferWrapperOutput) {
-		List<String> outputKeys = new ArrayList<>();
-		String wrapperOutputKey = outputKeyToParent(agent.name());
-		if (preferWrapperOutput) {
-			outputKeys.add(wrapperOutputKey);
+	/**
+	 * Builds the state update returned by the merge node.
+	 * <p>
+	 * Nested routing graphs also expose their merged answer through the subgraph wrapper
+	 * key so a parent router can collect the child's synthesized answer instead of a raw
+	 * inner-agent output.
+	 * @param result the final text produced by the merge node
+	 * @param staleWrapperOutputKeys wrapper keys that should be removed from state
+	 * @param exposeMergedResultToParent whether to also write the result to this router's
+	 * wrapper key
+	 * @return the graph state update emitted by this node
+	 */
+	private Map<String, Object> mergeResult(String result, Set<String> staleWrapperOutputKeys,
+			boolean exposeMergedResultToParent) {
+		Map<String, Object> output = new HashMap<>();
+		output.put(mergedOutputKey, result);
+		if (exposeMergedResultToParent) {
+			String wrapperOutputKey = outputResolver.wrapperOutputKey();
+			logger.debug("RoutingMergeNode: exposing merged result through wrapper key {}", wrapperOutputKey);
+			output.put(wrapperOutputKey, result);
 		}
-		if (agent instanceof BaseAgent baseAgent) {
-			String outputKey = baseAgent.getOutputKey();
-			if (outputKey != null) {
-				outputKeys.add(outputKey);
-			}
-			else if (allowDefaultMessagesOutput) {
-				outputKeys.add(DEFAULT_MESSAGES_OUTPUT_KEY);
-			}
+		for (String outputKey : staleWrapperOutputKeys) {
+			logger.debug("RoutingMergeNode: marking stale wrapper output {} for removal", outputKey);
+			output.put(outputKey, OverAllState.MARK_FOR_REMOVAL);
 		}
-		else if (agent instanceof ParallelAgent parallelAgent) {
-			if (parallelAgent.mergeOutputKey() != null) {
-				outputKeys.add(parallelAgent.mergeOutputKey());
-			}
-			else {
-				List<Agent> nestedAgents = parallelAgent.subAgents();
-				if (nestedAgents != null) {
-					for (Agent nestedAgent : nestedAgents) {
-						outputKeys.addAll(resolveOutputKeys(nestedAgent, false, allowRoutingMergedOutput, false));
-					}
-				}
-			}
-		}
-		else if (agent instanceof LlmRoutingAgent) {
-			if (allowRoutingMergedOutput) {
-				outputKeys.add(DEFAULT_MERGED_OUTPUT_KEY);
-			}
-		}
-		else if (agent instanceof SequentialAgent sequentialAgent) {
-			List<Agent> nestedAgents = sequentialAgent.subAgents();
-			if (nestedAgents != null && !nestedAgents.isEmpty()) {
-				outputKeys.addAll(resolveOutputKeys(nestedAgents.get(nestedAgents.size() - 1),
-						allowDefaultMessagesOutput, allowRoutingMergedOutput, false));
-			}
-		}
-		else if (agent instanceof FlowAgent flowAgent) {
-			List<Agent> nestedAgents = flowAgent.subAgents();
-			if (nestedAgents != null) {
-				for (Agent nestedAgent : nestedAgents) {
-					outputKeys.addAll(resolveOutputKeys(nestedAgent, allowDefaultMessagesOutput,
-							allowRoutingMergedOutput, false));
-				}
-			}
-		}
-		if (!preferWrapperOutput) {
-			outputKeys.add(wrapperOutputKey);
-		}
-		return outputKeys;
+		return output;
 	}
 
-	private boolean shouldPreferWrapperOutput(OverAllState state, Agent agent, long routedAgentCount,
-			boolean topLevelRoutedAgent, long routingMergedOutputOwnerCount, Optional<Set<String>> routedAgentNames) {
-		if (routedAgentCount <= 1 || !topLevelRoutedAgent || !(agent instanceof FlowAgent)
-				|| state.value(outputKeyToParent(agent.name())).isEmpty()) {
-			return false;
-		}
-
-		Set<String> outputKeys = resolvedNonWrapperOutputKeys(agent, routingMergedOutputOwnerCount);
-		if (outputKeys.isEmpty()) {
-			return true;
-		}
-
-		return subAgents.stream()
-			.filter(other -> other != agent)
-			.filter(other -> isTopLevelRoutedAgent(state, other, routedAgentNames))
-			.map(other -> resolvedNonWrapperOutputKeys(other, routingMergedOutputOwnerCount))
-			.anyMatch(otherOutputKeys -> otherOutputKeys.stream().anyMatch(outputKeys::contains));
-	}
-
-	private Set<String> resolvedNonWrapperOutputKeys(Agent agent, long routingMergedOutputOwnerCount) {
-		boolean allowRoutingMergedOutput = routingMergedOutputOwnerCount == 1 && usesRoutingMergedOutput(agent);
-		String wrapperOutputKey = outputKeyToParent(agent.name());
-		Set<String> outputKeys = new HashSet<>();
-		for (String outputKey : resolveOutputKeys(agent, false, allowRoutingMergedOutput, false)) {
-			if (!wrapperOutputKey.equals(outputKey)) {
-				outputKeys.add(outputKey);
-			}
-		}
-		return outputKeys;
-	}
-
-	private long countRoutedAgents(OverAllState state, Optional<Set<String>> routedAgentNames) {
-		if (routedAgentNames.isPresent()) {
-			Set<String> selectedAgents = routedAgentNames.get();
-			return subAgents.stream().filter(agent -> selectedAgents.contains(agent.name())).count();
-		}
-		return subAgents.stream().filter(agent -> isTopLevelRoutedAgent(state, agent, routedAgentNames)).count();
-	}
-
-	private long countRoutingMergedOutputOwners(OverAllState state, boolean hasRoutingMarkers,
-			Optional<Set<String>> routedAgentNames) {
-		return subAgents.stream()
-			.filter(agent -> !hasRoutingMarkers || isTopLevelRoutedAgent(state, agent, routedAgentNames))
-			.filter(this::usesRoutingMergedOutput)
-			.count();
-	}
-
-	private boolean isTopLevelRoutedAgent(OverAllState state, Agent agent, Optional<Set<String>> routedAgentNames) {
-		if (routedAgentNames.isPresent()) {
-			return routedAgentNames.get().contains(agent.name());
-		}
-		return state.value(agent.name() + "_input").isPresent();
-	}
-
-	private Optional<Set<String>> currentRoutedAgentNames(OverAllState state) {
-		Optional<Object> value = routingAgentName != null
-				? state.value(RoutingNode.routedAgentNamesKey(routingAgentName))
-				: state.value(RoutingNode.ROUTED_AGENT_NAMES_KEY);
-		if (value.isEmpty()) {
-			return Optional.empty();
-		}
-
-		Set<String> agentNames = new LinkedHashSet<>();
-		Object routedAgents = value.get();
-		if (routedAgents instanceof Iterable<?> iterable) {
-			for (Object agentName : iterable) {
-				if (agentName instanceof String name && !name.isBlank()) {
-					agentNames.add(name);
-				}
-			}
-		}
-		else if (routedAgents instanceof String name && !name.isBlank()) {
-			agentNames.add(name);
-		}
-		return Optional.of(agentNames);
-	}
-
-	private boolean usesRoutingMergedOutput(Agent agent) {
-		if (agent instanceof LlmRoutingAgent) {
-			return true;
-		}
-		if (agent instanceof ParallelAgent parallelAgent && parallelAgent.mergeOutputKey() != null) {
-			return false;
-		}
-		if (agent instanceof SequentialAgent sequentialAgent) {
-			List<Agent> nestedAgents = sequentialAgent.subAgents();
-			return nestedAgents != null && !nestedAgents.isEmpty()
-					&& usesRoutingMergedOutput(nestedAgents.get(nestedAgents.size() - 1));
-		}
-		if (agent instanceof FlowAgent flowAgent) {
-			List<Agent> nestedAgents = flowAgent.subAgents();
-			return nestedAgents != null && nestedAgents.stream().anyMatch(this::usesRoutingMergedOutput);
-		}
-		return false;
-	}
-
-	private boolean collectsMultipleOutputs(Agent agent) {
-		if (agent instanceof ParallelAgent parallelAgent) {
-			return parallelAgent.mergeOutputKey() == null;
-		}
-		if (agent instanceof SequentialAgent sequentialAgent) {
-			List<Agent> nestedAgents = sequentialAgent.subAgents();
-			return nestedAgents != null && !nestedAgents.isEmpty()
-					&& collectsMultipleOutputs(nestedAgents.get(nestedAgents.size() - 1));
-		}
-		if (agent instanceof LlmRoutingAgent) {
-			return false;
-		}
-		if (agent instanceof FlowAgent flowAgent) {
-			List<Agent> nestedAgents = flowAgent.subAgents();
-			return nestedAgents != null && nestedAgents.size() == 1 && collectsMultipleOutputs(nestedAgents.get(0));
-		}
-		return false;
-	}
-
+	/**
+	 * Uses the latest message as the synthesis question for multi-source routing results.
+	 * @param state graph state that contains the shared messages list
+	 * @return the text of the latest message, or an empty string when unavailable
+	 */
 	private String extractOriginalQuery(OverAllState state) {
 		@SuppressWarnings("unchecked")
 		List<Message> messages = (List<Message>) state.value("messages").orElse(List.of());
@@ -348,6 +171,12 @@ public class RoutingMergeNode implements NodeAction {
 		return last.getText() != null ? last.getText() : "";
 	}
 
+	/**
+	 * Asks the configured chat model to combine multiple routed results into one answer.
+	 * @param query original user query used as synthesis context
+	 * @param formattedResults formatted routed results grouped by source agent
+	 * @return synthesized answer text
+	 */
 	private String synthesize(String query, List<String> formattedResults) {
 		String formatted = String.join("\n\n", formattedResults);
 		String systemPrompt = SYNTHESIZE_SYSTEM_TEMPLATE.formatted(query);
@@ -395,6 +224,12 @@ public class RoutingMergeNode implements NodeAction {
 		return output != null ? output.toString() : "";
 	}
 
+	/**
+	 * Converts list outputs into text, treating the shared messages key specially.
+	 * @param list output list from graph state
+	 * @param outputKey candidate output key being extracted
+	 * @return extracted text for the list output
+	 */
 	private static String extractListText(List<?> list, String outputKey) {
 		if (DEFAULT_MESSAGES_OUTPUT_KEY.equals(outputKey)) {
 			return extractLastAssistantMessageText(list);
@@ -402,6 +237,11 @@ public class RoutingMergeNode implements NodeAction {
 		return list.toString();
 	}
 
+	/**
+	 * Reads the last assistant answer from the shared messages list.
+	 * @param list message history stored under the shared messages key
+	 * @return the latest assistant message text, or an empty string if none exists
+	 */
 	private static String extractLastAssistantMessageText(List<?> list) {
 		for (int i = list.size() - 1; i >= 0; i--) {
 			Object value = list.get(i);
@@ -412,6 +252,12 @@ public class RoutingMergeNode implements NodeAction {
 		return "";
 	}
 
+	/**
+	 * Extracts the value that corresponds to a candidate output key from graph state maps.
+	 * @param map graph state map or subgraph wrapper map
+	 * @param outputKey candidate output key being extracted
+	 * @return the selected value, the only map value, or the original map as fallback
+	 */
 	private static Object extractMapValue(Map<?, ?> map, String outputKey) {
 		// A subgraph wrapper key namespaces a nested FlowAgent result in the parent graph.
 		// When the nested graph is itself a routing graph, its final answer is stored under
@@ -428,10 +274,20 @@ public class RoutingMergeNode implements NodeAction {
 		return map;
 	}
 
+	/**
+	 * Detects the parent-state wrapper key used for embedded subgraph results.
+	 * @param outputKey candidate output key
+	 * @return true if the key is a subgraph wrapper key
+	 */
 	private static boolean isSubGraphWrapperKey(String outputKey) {
 		return outputKey != null && outputKey.startsWith("subgraph_") && outputKey.endsWith("_compiled_graph");
 	}
 
+	/**
+	 * Formats source labels used in synthesized multi-agent results.
+	 * @param s source label to format
+	 * @return capitalized source label
+	 */
 	private static String capitalize(String s) {
 		if (s == null || s.isEmpty()) {
 			return s;

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -197,6 +197,11 @@ public class RoutingMergeNode implements NodeAction {
 
 	static String extractText(Object output, String outputKey, boolean allowWrapperMergedOutput,
 			List<String> preferredInnerOutputKeys) {
+		return extractText(output, outputKey, allowWrapperMergedOutput, preferredInnerOutputKeys, true);
+	}
+
+	static String extractText(Object output, String outputKey, boolean allowWrapperMergedOutput,
+			List<String> preferredInnerOutputKeys, boolean allowSingleVisibleWrapperFallback) {
 		if (output instanceof Message message) {
 			return message.getText();
 		}
@@ -208,7 +213,8 @@ public class RoutingMergeNode implements NodeAction {
 			if (val.isPresent()) {
 				Object v = val.get();
 				if (v instanceof Map<?, ?> map) {
-					v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKeys);
+					v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKeys,
+							allowSingleVisibleWrapperFallback);
 				}
 				if (v instanceof Message m) {
 					return m.getText();
@@ -221,7 +227,8 @@ public class RoutingMergeNode implements NodeAction {
 			return "";
 		}
 		if (output instanceof Map<?, ?> map) {
-			Object v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKeys);
+			Object v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKeys,
+					allowSingleVisibleWrapperFallback);
 			if (v instanceof Message m) {
 				return m.getText();
 			}
@@ -247,15 +254,19 @@ public class RoutingMergeNode implements NodeAction {
 	}
 
 	/**
-	 * Reads the last assistant answer from the shared messages list.
+	 * Reads the assistant answer produced after the latest user request. An assistant
+	 * message from an earlier checkpointed turn is not a current output.
 	 * @param list message history stored under the shared messages key
-	 * @return the latest assistant message text, or an empty string if none exists
+	 * @return the current assistant message text, or an empty string if none exists
 	 */
 	private static String extractLastAssistantMessageText(List<?> list) {
 		for (int i = list.size() - 1; i >= 0; i--) {
 			Object value = list.get(i);
 			if (value instanceof AssistantMessage message) {
 				return message.getText();
+			}
+			if (value instanceof UserMessage) {
+				return "";
 			}
 		}
 		return "";
@@ -269,11 +280,13 @@ public class RoutingMergeNode implements NodeAction {
 	 * merged result
 	 * @param preferredInnerOutputKeys ordered output keys to collect inside a wrapper
 	 * snapshot
+	 * @param allowSingleVisibleWrapperFallback whether an unresolved wrapper may expose
+	 * its only non-internal state value
 	 * @return the selected value, a single visible wrapper value, the only non-wrapper map
 	 * value, or the original map as fallback
 	 */
 	private static Object extractMapValue(Map<?, ?> map, String outputKey, boolean allowWrapperMergedOutput,
-			List<String> preferredInnerOutputKeys) {
+			List<String> preferredInnerOutputKeys, boolean allowSingleVisibleWrapperFallback) {
 		boolean wrapperOutput = isSubGraphWrapperKey(outputKey);
 		// A subgraph wrapper key namespaces a nested FlowAgent result in the parent graph.
 		// Only wrappers that belong to routing graphs may read their internal merged result;
@@ -299,8 +312,11 @@ public class RoutingMergeNode implements NodeAction {
 		if (!wrapperOutput && map.containsKey(outputKey)) {
 			return map.get(outputKey);
 		}
-		if (wrapperOutput) {
+		if (wrapperOutput && allowSingleVisibleWrapperFallback) {
 			return extractSingleVisibleWrapperValue(map);
+		}
+		if (wrapperOutput) {
+			return null;
 		}
 		if (map.size() == 1) {
 			return map.values().iterator().next();

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -113,19 +113,18 @@ public class RoutingMergeNode implements NodeAction {
 		// single result through unchanged; only genuinely multi-source results need synthesis.
 		if (formattedResults.size() == 1) {
 			logger.debug("RoutingMergeNode: single routed result, returning it without re-synthesis");
-			return mergeResult(lastResult, staleWrapperOutputKeys, context.exposeMergedResultToParent());
+			return mergeResult(lastResult, staleWrapperOutputKeys, context);
 		}
 		if (formattedResults.isEmpty()) {
 			logger.debug("RoutingMergeNode: no routed results found");
-			return mergeResult("No results found from any knowledge source.", staleWrapperOutputKeys,
-					context.exposeMergedResultToParent());
+			return mergeResult("No results found from any knowledge source.", staleWrapperOutputKeys, context);
 		}
 
 		String query = extractOriginalQuery(state);
 		String finalAnswer = synthesize(query, formattedResults);
 		logger.debug("RoutingMergeNode: synthesized {} sources into merged result", formattedResults.size());
 
-		return mergeResult(finalAnswer, staleWrapperOutputKeys, context.exposeMergedResultToParent());
+		return mergeResult(finalAnswer, staleWrapperOutputKeys, context);
 	}
 
 	/**
@@ -136,15 +135,15 @@ public class RoutingMergeNode implements NodeAction {
 	 * inner-agent output.
 	 * @param result the final text produced by the merge node
 	 * @param staleWrapperOutputKeys wrapper keys that should be removed from state
-	 * @param exposeMergedResultToParent whether to also write the result to this router's
-	 * wrapper key
+	 * @param context routing context used to expose nested results and restore the parent
+	 * routing marker
 	 * @return the graph state update emitted by this node
 	 */
 	private Map<String, Object> mergeResult(String result, Set<String> staleWrapperOutputKeys,
-			boolean exposeMergedResultToParent) {
+			RoutingOutputResolver.MergeContext context) {
 		Map<String, Object> output = new HashMap<>();
 		output.put(mergedOutputKey, result);
-		if (exposeMergedResultToParent) {
+		if (context.exposeMergedResultToParent()) {
 			String wrapperOutputKey = outputResolver.wrapperOutputKey();
 			logger.debug("RoutingMergeNode: exposing merged result through wrapper key {}", wrapperOutputKey);
 			output.put(wrapperOutputKey, result);
@@ -153,6 +152,7 @@ public class RoutingMergeNode implements NodeAction {
 			logger.debug("RoutingMergeNode: marking stale wrapper output {} for removal", outputKey);
 			output.put(outputKey, OverAllState.MARK_FOR_REMOVAL);
 		}
+		outputResolver.restoreRoutingMarker(output, context);
 		return output;
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -188,6 +188,15 @@ public class RoutingMergeNode implements NodeAction {
 	}
 
 	public static String extractText(Object output, String outputKey) {
+		return extractText(output, outputKey, false);
+	}
+
+	static String extractText(Object output, String outputKey, boolean allowWrapperMergedOutput) {
+		return extractText(output, outputKey, allowWrapperMergedOutput, null);
+	}
+
+	static String extractText(Object output, String outputKey, boolean allowWrapperMergedOutput,
+			String preferredInnerOutputKey) {
 		if (output instanceof Message message) {
 			return message.getText();
 		}
@@ -199,7 +208,7 @@ public class RoutingMergeNode implements NodeAction {
 			if (val.isPresent()) {
 				Object v = val.get();
 				if (v instanceof Map<?, ?> map) {
-					v = extractMapValue(map, outputKey);
+					v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKey);
 				}
 				if (v instanceof Message m) {
 					return m.getText();
@@ -212,7 +221,7 @@ public class RoutingMergeNode implements NodeAction {
 			return "";
 		}
 		if (output instanceof Map<?, ?> map) {
-			Object v = extractMapValue(map, outputKey);
+			Object v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKey);
 			if (v instanceof Message m) {
 				return m.getText();
 			}
@@ -256,22 +265,100 @@ public class RoutingMergeNode implements NodeAction {
 	 * Extracts the value that corresponds to a candidate output key from graph state maps.
 	 * @param map graph state map or subgraph wrapper map
 	 * @param outputKey candidate output key being extracted
-	 * @return the selected value, the only map value, or the original map as fallback
+	 * @param allowWrapperMergedOutput whether a wrapper may read its internal routing
+	 * merged result
+	 * @param preferredInnerOutputKey preferred output key inside a wrapper snapshot
+	 * @return the selected value, a single visible wrapper value, the only non-wrapper map
+	 * value, or the original map as fallback
 	 */
-	private static Object extractMapValue(Map<?, ?> map, String outputKey) {
+	private static Object extractMapValue(Map<?, ?> map, String outputKey, boolean allowWrapperMergedOutput,
+			String preferredInnerOutputKey) {
+		boolean wrapperOutput = isSubGraphWrapperKey(outputKey);
 		// A subgraph wrapper key namespaces a nested FlowAgent result in the parent graph.
-		// When the nested graph is itself a routing graph, its final answer is stored under
-		// the routing merge key inside that wrapper state.
-		if (isSubGraphWrapperKey(outputKey) && map.containsKey(DEFAULT_MERGED_OUTPUT_KEY)) {
+		// Only wrappers that belong to routing graphs may read their internal merged result;
+		// ordinary workflow wrappers can inherit a stale parent merged_result from checkpoints.
+		if (allowWrapperMergedOutput && wrapperOutput && map.containsKey(DEFAULT_MERGED_OUTPUT_KEY)) {
 			return map.get(DEFAULT_MERGED_OUTPUT_KEY);
 		}
-		if (map.containsKey(outputKey)) {
+		if (wrapperOutput && preferredInnerOutputKey != null && map.containsKey(preferredInnerOutputKey)) {
+			return map.get(preferredInnerOutputKey);
+		}
+		if (wrapperOutput && map.containsKey(DEFAULT_MESSAGES_OUTPUT_KEY)) {
+			Object messages = map.get(DEFAULT_MESSAGES_OUTPUT_KEY);
+			if (messages instanceof List<?> list) {
+				String messageText = extractLastAssistantMessageText(list);
+				if (!messageText.isBlank()) {
+					return messageText;
+				}
+			}
+		}
+		if (!wrapperOutput && map.containsKey(outputKey)) {
 			return map.get(outputKey);
+		}
+		if (wrapperOutput) {
+			return extractSingleVisibleWrapperValue(map);
 		}
 		if (map.size() == 1) {
 			return map.values().iterator().next();
 		}
 		return map;
+	}
+
+	/**
+	 * Extracts a single explicit agent output from a subgraph wrapper snapshot.
+	 * @param map subgraph wrapper snapshot
+	 * @return the only visible agent output, or null when the wrapper only contains
+	 * internal state or ambiguous values
+	 */
+	private static Object extractSingleVisibleWrapperValue(Map<?, ?> map) {
+		Object result = null;
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			if (!(entry.getKey() instanceof String key) || isInternalWrapperStateKey(key)) {
+				continue;
+			}
+			Object value = entry.getValue();
+			if (isBlankOutput(value)) {
+				continue;
+			}
+			if (result != null) {
+				return null;
+			}
+			result = value;
+		}
+		return result;
+	}
+
+	/**
+	 * Detects wrapper snapshot keys that belong to graph execution state rather than
+	 * agent-visible output.
+	 * @param key wrapper snapshot key
+	 * @return true when the key should not be treated as an answer
+	 */
+	private static boolean isInternalWrapperStateKey(String key) {
+		return DEFAULT_MESSAGES_OUTPUT_KEY.equals(key)
+				|| DEFAULT_MERGED_OUTPUT_KEY.equals(key)
+				|| "input".equals(key)
+				|| key.startsWith("_")
+				|| key.endsWith("_input")
+				|| isSubGraphWrapperKey(key);
+	}
+
+	/**
+	 * Checks whether a candidate wrapper value has no visible answer text.
+	 * @param value candidate wrapper value
+	 * @return true when the value should be ignored
+	 */
+	private static boolean isBlankOutput(Object value) {
+		if (value == null) {
+			return true;
+		}
+		if (value instanceof String text) {
+			return text.isBlank();
+		}
+		if (value instanceof Message message) {
+			return message.getText() == null || message.getText().isBlank();
+		}
+		return false;
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNode.java
@@ -192,11 +192,11 @@ public class RoutingMergeNode implements NodeAction {
 	}
 
 	static String extractText(Object output, String outputKey, boolean allowWrapperMergedOutput) {
-		return extractText(output, outputKey, allowWrapperMergedOutput, null);
+		return extractText(output, outputKey, allowWrapperMergedOutput, List.of());
 	}
 
 	static String extractText(Object output, String outputKey, boolean allowWrapperMergedOutput,
-			String preferredInnerOutputKey) {
+			List<String> preferredInnerOutputKeys) {
 		if (output instanceof Message message) {
 			return message.getText();
 		}
@@ -208,7 +208,7 @@ public class RoutingMergeNode implements NodeAction {
 			if (val.isPresent()) {
 				Object v = val.get();
 				if (v instanceof Map<?, ?> map) {
-					v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKey);
+					v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKeys);
 				}
 				if (v instanceof Message m) {
 					return m.getText();
@@ -221,7 +221,7 @@ public class RoutingMergeNode implements NodeAction {
 			return "";
 		}
 		if (output instanceof Map<?, ?> map) {
-			Object v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKey);
+			Object v = extractMapValue(map, outputKey, allowWrapperMergedOutput, preferredInnerOutputKeys);
 			if (v instanceof Message m) {
 				return m.getText();
 			}
@@ -267,12 +267,13 @@ public class RoutingMergeNode implements NodeAction {
 	 * @param outputKey candidate output key being extracted
 	 * @param allowWrapperMergedOutput whether a wrapper may read its internal routing
 	 * merged result
-	 * @param preferredInnerOutputKey preferred output key inside a wrapper snapshot
+	 * @param preferredInnerOutputKeys ordered output keys to collect inside a wrapper
+	 * snapshot
 	 * @return the selected value, a single visible wrapper value, the only non-wrapper map
 	 * value, or the original map as fallback
 	 */
 	private static Object extractMapValue(Map<?, ?> map, String outputKey, boolean allowWrapperMergedOutput,
-			String preferredInnerOutputKey) {
+			List<String> preferredInnerOutputKeys) {
 		boolean wrapperOutput = isSubGraphWrapperKey(outputKey);
 		// A subgraph wrapper key namespaces a nested FlowAgent result in the parent graph.
 		// Only wrappers that belong to routing graphs may read their internal merged result;
@@ -280,8 +281,11 @@ public class RoutingMergeNode implements NodeAction {
 		if (allowWrapperMergedOutput && wrapperOutput && map.containsKey(DEFAULT_MERGED_OUTPUT_KEY)) {
 			return map.get(DEFAULT_MERGED_OUTPUT_KEY);
 		}
-		if (wrapperOutput && preferredInnerOutputKey != null && map.containsKey(preferredInnerOutputKey)) {
-			return map.get(preferredInnerOutputKey);
+		if (wrapperOutput && preferredInnerOutputKeys != null && !preferredInnerOutputKeys.isEmpty()) {
+			String preferredOutput = extractPreferredWrapperOutput(map, preferredInnerOutputKeys);
+			if (!preferredOutput.isBlank()) {
+				return preferredOutput;
+			}
 		}
 		if (wrapperOutput && map.containsKey(DEFAULT_MESSAGES_OUTPUT_KEY)) {
 			Object messages = map.get(DEFAULT_MESSAGES_OUTPUT_KEY);
@@ -302,6 +306,26 @@ public class RoutingMergeNode implements NodeAction {
 			return map.values().iterator().next();
 		}
 		return map;
+	}
+
+	/**
+	 * Collects the explicit workflow outputs stored in one namespaced wrapper snapshot.
+	 * @param map subgraph wrapper snapshot
+	 * @param preferredInnerOutputKeys configured output keys in workflow order
+	 * @return combined non-blank output text, or an empty string when none is present
+	 */
+	private static String extractPreferredWrapperOutput(Map<?, ?> map, List<String> preferredInnerOutputKeys) {
+		List<String> outputTexts = new ArrayList<>();
+		for (String preferredInnerOutputKey : preferredInnerOutputKeys) {
+			if (!map.containsKey(preferredInnerOutputKey)) {
+				continue;
+			}
+			String text = extractText(map.get(preferredInnerOutputKey), preferredInnerOutputKey, false);
+			if (text != null && !text.isBlank()) {
+				outputTexts.add(text);
+			}
+		}
+		return String.join("\n\n", outputTexts);
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -20,6 +20,7 @@ import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.MultiCommand;
 import com.alibaba.cloud.ai.graph.action.MultiCommandAction;
 import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -39,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 
 /**
  * Routing node that makes LLM-based routing decisions.
@@ -129,6 +132,7 @@ public class RoutingNode implements MultiCommandAction {
 			// Each agent's query is stored as independent key: agentName_input
 			Map<String, Object> stateUpdate = new HashMap<>();
 			stateUpdate.put(routedAgentNamesKey(rootAgent.name()), new ArrayList<>(decisionValues));
+			removeStaleSelectedWrapperOutputs(stateUpdate, decisionValues);
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));
 			return new MultiCommand(decisionValues, stateUpdate);
@@ -138,6 +142,14 @@ public class RoutingNode implements MultiCommandAction {
 					rootAgent.name(), DEFAULT_MAX_RETRIES, invalidAgents);
 			throw new IllegalStateException(
 					"RoutingAgent " + rootAgent.name() + " failed to get valid decision after retries. Invalid agents: " + invalidAgents + ".");
+		}
+	}
+
+	private void removeStaleSelectedWrapperOutputs(Map<String, Object> stateUpdate, List<String> decisionValues) {
+		for (Agent subAgent : subAgents) {
+			if (subAgent instanceof FlowAgent && decisionValues.contains(subAgent.name())) {
+				stateUpdate.put(outputKeyToParent(subAgent.name()), OverAllState.MARK_FOR_REMOVAL);
+			}
 		}
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -52,6 +52,10 @@ public class RoutingNode implements MultiCommandAction {
 
 	static final String ROUTED_AGENT_NAMES_KEY = "_routing_selected_agents";
 
+	static String routedAgentNamesKey(String routingAgentName) {
+		return ROUTED_AGENT_NAMES_KEY + "_" + routingAgentName;
+	}
+
 	private final ChatClient chatClient;
 	private final BeanOutputConverter<RoutingDecision> outputConverter;
 	private final Agent rootAgent;
@@ -124,7 +128,7 @@ public class RoutingNode implements MultiCommandAction {
 			// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
 			// Each agent's query is stored as independent key: agentName_input
 			Map<String, Object> stateUpdate = new HashMap<>();
-			stateUpdate.put(ROUTED_AGENT_NAMES_KEY, new ArrayList<>(decisionValues));
+			stateUpdate.put(routedAgentNamesKey(rootAgent.name()), new ArrayList<>(decisionValues));
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));
 			return new MultiCommand(decisionValues, stateUpdate);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -50,6 +50,8 @@ public class RoutingNode implements MultiCommandAction {
 	private static final Logger logger = LoggerFactory.getLogger(RoutingNode.class);
 	private static final int DEFAULT_MAX_RETRIES = 2;
 
+	static final String ROUTED_AGENT_NAMES_KEY = "_routing_selected_agents";
+
 	private final ChatClient chatClient;
 	private final BeanOutputConverter<RoutingDecision> outputConverter;
 	private final Agent rootAgent;
@@ -122,6 +124,7 @@ public class RoutingNode implements MultiCommandAction {
 			// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
 			// Each agent's query is stored as independent key: agentName_input
 			Map<String, Object> stateUpdate = new HashMap<>();
+			stateUpdate.put(ROUTED_AGENT_NAMES_KEY, new ArrayList<>(decisionValues));
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));
 			return new MultiCommand(decisionValues, stateUpdate);
@@ -296,4 +299,3 @@ public class RoutingNode implements MultiCommandAction {
 	public record AgentRouting(String agent, String query) {
 	}
 }
-

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -145,6 +145,17 @@ public class RoutingNode implements MultiCommandAction {
 		}
 	}
 
+	/**
+	 * Clears wrapper outputs for selected FlowAgent branches before they run.
+	 * <p>
+	 * Checkpointed graph state may still contain a previous
+	 * {@code subgraph_<agent>_compiled_graph} value. If the selected workflow writes its
+	 * current answer under {@code messages} or a child output key, leaving that wrapper in
+	 * state can make the merge node collect the previous turn's answer.
+	 * @param stateUpdate the state update map that will be returned with the routing
+	 * decision
+	 * @param decisionValues the sub-agent names selected by the current routing decision
+	 */
 	private void removeStaleSelectedWrapperOutputs(Map<String, Object> stateUpdate, List<String> decisionValues) {
 		for (Agent subAgent : subAgents) {
 			if (subAgent instanceof FlowAgent && decisionValues.contains(subAgent.name())) {
@@ -156,6 +167,8 @@ public class RoutingNode implements MultiCommandAction {
 	/**
 	 * Prepares messages with instruction. If rootAgent has instruction, adds it as UserMessage.
 	 * Otherwise, adds a default instruction message.
+	 * @param messages the original conversation messages from graph state
+	 * @return a new message list with the routing instruction appended
 	 */
 	private List<Message> prepareMessagesWithInstruction(List<Message> messages) {
 		List<Message> messagesWithInstruction = new ArrayList<>(messages);
@@ -182,6 +195,10 @@ public class RoutingNode implements MultiCommandAction {
 	/**
 	 * Gets a valid routing decision with retry logic.
 	 * Returns RoutingDecision containing agent names and their targeted sub-queries.
+	 * @param messages messages sent to the routing model
+	 * @param maxRetries maximum number of retry attempts after the initial call
+	 * @return a routing decision containing selected agent names and sub-queries
+	 * @throws Exception if the model call fails on the final attempt
 	 */
 	private RoutingDecision getDecisionWithRetry(List<Message> messages, int maxRetries) throws Exception {
 		List<String> lastInvalidDecision = null;

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -206,6 +206,8 @@ public class RoutingNode implements MultiCommandAction {
 	/**
 	 * Prepares messages with instruction. If rootAgent has instruction, adds it as UserMessage.
 	 * Otherwise, adds a default instruction message.
+	 * @param messages the original conversation messages from graph state
+	 * @return a new message list with the routing instruction appended
 	 */
 	private List<Message> prepareMessagesWithInstruction(List<Message> messages) {
 		List<Message> messagesWithInstruction = new ArrayList<>(messages);
@@ -232,6 +234,10 @@ public class RoutingNode implements MultiCommandAction {
 	/**
 	 * Gets a valid routing decision with retry logic.
 	 * Returns RoutingDecision containing agent names and their targeted sub-queries.
+	 * @param messages messages sent to the routing model
+	 * @param maxRetries maximum number of retry attempts after the initial call
+	 * @return a routing decision containing selected agent names and sub-queries
+	 * @throws Exception if the model call fails on the final attempt
 	 */
 	private RoutingDecision getDecisionWithRetry(List<Message> messages, int maxRetries) throws Exception {
 		List<String> lastInvalidDecision = null;

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -144,10 +144,10 @@ public class RoutingNode implements MultiCommandAction {
 						rootAgent.name(), decisionValues.size(), String.join(", ", decisionValues));
 			}
 			
-				// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
-				// Each agent's query is stored as independent key: agentName_input
-				Map<String, Object> stateUpdate = new HashMap<>();
-				stateUpdate.put(routedAgentNamesKey(rootAgent.name()), createRoutingMarker(state, decisionValues));
+			// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
+			// Each agent's query is stored as independent key: agentName_input
+			Map<String, Object> stateUpdate = new HashMap<>();
+			stateUpdate.put(routedAgentNamesKey(rootAgent.name()), createRoutingMarker(state, decisionValues));
 			removeStaleSelectedWrapperOutputs(stateUpdate, decisionValues);
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -55,6 +55,10 @@ public class RoutingNode implements MultiCommandAction {
 
 	static final String ROUTED_AGENT_NAMES_KEY = "_routing_selected_agents";
 
+	static final String SELECTED_AGENT_NAMES_FIELD = "selected_agent_names";
+
+	static final String PARENT_ROUTING_MARKER_FIELD = "parent_routing_marker";
+
 	static String routedAgentNamesKey(String routingAgentName) {
 		return ROUTED_AGENT_NAMES_KEY + "_" + routingAgentName;
 	}
@@ -140,10 +144,10 @@ public class RoutingNode implements MultiCommandAction {
 						rootAgent.name(), decisionValues.size(), String.join(", ", decisionValues));
 			}
 			
-			// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
-			// Each agent's query is stored as independent key: agentName_input
-			Map<String, Object> stateUpdate = new HashMap<>();
-			stateUpdate.put(routedAgentNamesKey(rootAgent.name()), new ArrayList<>(decisionValues));
+				// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
+				// Each agent's query is stored as independent key: agentName_input
+				Map<String, Object> stateUpdate = new HashMap<>();
+				stateUpdate.put(routedAgentNamesKey(rootAgent.name()), createRoutingMarker(state, decisionValues));
 			removeStaleSelectedWrapperOutputs(stateUpdate, decisionValues);
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));
@@ -178,10 +182,36 @@ public class RoutingNode implements MultiCommandAction {
 		});
 		Map<String, Object> stateUpdate = new HashMap<>();
 		List<String> decisionValues = List.of(fallbackAgent);
-		stateUpdate.put(routedAgentNamesKey(rootAgent.name()), new ArrayList<>(decisionValues));
+		stateUpdate.put(routedAgentNamesKey(rootAgent.name()), createRoutingMarker(state, decisionValues));
 		removeStaleSelectedWrapperOutputs(stateUpdate, decisionValues);
 		stateUpdate.put(fallbackAgent + "_input", fallbackInput);
 		return new MultiCommand(decisionValues, stateUpdate);
+	}
+
+	/**
+	 * Creates a scoped routing marker and retains an active marker from an enclosing
+	 * same-named router. The merge node restores that parent marker when this routing
+	 * scope completes.
+	 * @param state current graph state
+	 * @param selectedAgentNames sub-agents selected by this router invocation
+	 * @return serializable marker for the current routing scope
+	 */
+	private Map<String, Object> createRoutingMarker(OverAllState state, List<String> selectedAgentNames) {
+		Map<String, Object> marker = new HashMap<>();
+		marker.put(SELECTED_AGENT_NAMES_FIELD, new ArrayList<>(selectedAgentNames));
+		state.value(routedAgentNamesKey(rootAgent.name()))
+			.filter(RoutingNode::isScopedRoutingMarker)
+			.ifPresent(parentMarker -> marker.put(PARENT_ROUTING_MARKER_FIELD, parentMarker));
+		return marker;
+	}
+
+	/**
+	 * Checks whether a state value uses the scoped routing-marker representation.
+	 * @param marker candidate state value
+	 * @return true when the marker contains a current routing selection
+	 */
+	static boolean isScopedRoutingMarker(Object marker) {
+		return marker instanceof Map<?, ?> map && map.containsKey(SELECTED_AGENT_NAMES_FIELD);
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -50,6 +50,8 @@ public class RoutingNode implements MultiCommandAction {
 	private static final Logger logger = LoggerFactory.getLogger(RoutingNode.class);
 	private static final int DEFAULT_MAX_RETRIES = 2;
 
+	static final String ROUTED_AGENT_NAMES_KEY = "_routing_selected_agents";
+
 	private final ChatClient chatClient;
 	private final BeanOutputConverter<RoutingDecision> outputConverter;
 	private final Agent rootAgent;
@@ -134,6 +136,7 @@ public class RoutingNode implements MultiCommandAction {
 			// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
 			// Each agent's query is stored as independent key: agentName_input
 			Map<String, Object> stateUpdate = new HashMap<>();
+			stateUpdate.put(ROUTED_AGENT_NAMES_KEY, new ArrayList<>(decisionValues));
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));
 			return new MultiCommand(decisionValues, stateUpdate);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -20,6 +20,7 @@ import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.MultiCommand;
 import com.alibaba.cloud.ai.graph.action.MultiCommandAction;
 import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -39,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 
 /**
  * Routing node that makes LLM-based routing decisions.
@@ -141,6 +144,7 @@ public class RoutingNode implements MultiCommandAction {
 			// Each agent's query is stored as independent key: agentName_input
 			Map<String, Object> stateUpdate = new HashMap<>();
 			stateUpdate.put(routedAgentNamesKey(rootAgent.name()), new ArrayList<>(decisionValues));
+			removeStaleSelectedWrapperOutputs(stateUpdate, decisionValues);
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));
 			return new MultiCommand(decisionValues, stateUpdate);
@@ -172,7 +176,31 @@ public class RoutingNode implements MultiCommandAction {
 			}
 			return "";
 		});
-		return new MultiCommand(List.of(fallbackAgent), Map.of(fallbackAgent + "_input", fallbackInput));
+		Map<String, Object> stateUpdate = new HashMap<>();
+		List<String> decisionValues = List.of(fallbackAgent);
+		stateUpdate.put(routedAgentNamesKey(rootAgent.name()), new ArrayList<>(decisionValues));
+		removeStaleSelectedWrapperOutputs(stateUpdate, decisionValues);
+		stateUpdate.put(fallbackAgent + "_input", fallbackInput);
+		return new MultiCommand(decisionValues, stateUpdate);
+	}
+
+	/**
+	 * Clears wrapper outputs for selected FlowAgent branches before they run.
+	 * <p>
+	 * Checkpointed graph state may still contain a previous
+	 * {@code subgraph_<agent>_compiled_graph} value. If the selected workflow writes its
+	 * current answer under {@code messages} or a child output key, leaving that wrapper in
+	 * state can make the merge node collect the previous turn's answer.
+	 * @param stateUpdate the state update map that will be returned with the routing
+	 * decision
+	 * @param decisionValues the sub-agent names selected by the current routing decision
+	 */
+	private void removeStaleSelectedWrapperOutputs(Map<String, Object> stateUpdate, List<String> decisionValues) {
+		for (Agent subAgent : subAgents) {
+			if (subAgent instanceof FlowAgent && decisionValues.contains(subAgent.name())) {
+				stateUpdate.put(outputKeyToParent(subAgent.name()), OverAllState.MARK_FOR_REMOVAL);
+			}
+		}
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -52,6 +52,10 @@ public class RoutingNode implements MultiCommandAction {
 
 	static final String ROUTED_AGENT_NAMES_KEY = "_routing_selected_agents";
 
+	static String routedAgentNamesKey(String routingAgentName) {
+		return ROUTED_AGENT_NAMES_KEY + "_" + routingAgentName;
+	}
+
 	private final ChatClient chatClient;
 	private final BeanOutputConverter<RoutingDecision> outputConverter;
 	private final Agent rootAgent;
@@ -136,7 +140,7 @@ public class RoutingNode implements MultiCommandAction {
 			// Return MultiCommand with the routing decisions as gotoNodes and agent queries in state.
 			// Each agent's query is stored as independent key: agentName_input
 			Map<String, Object> stateUpdate = new HashMap<>();
-			stateUpdate.put(ROUTED_AGENT_NAMES_KEY, new ArrayList<>(decisionValues));
+			stateUpdate.put(routedAgentNamesKey(rootAgent.name()), new ArrayList<>(decisionValues));
 			decision.getAgentQueries().forEach((agentName, query) ->
 					stateUpdate.put(agentName + "_input", query));
 			return new MultiCommand(decisionValues, stateUpdate);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.flow.node;
+
+/**
+ * A state key that may contain the visible result for one routed agent.
+ * <p>
+ * Wrapper candidates are namespaced subgraph outputs such as
+ * {@code subgraph_<agent>_compiled_graph}; non-wrapper candidates are raw output
+ * keys written by nested agents.
+ * @param outputKey state key to probe
+ * @param wrapperOutput whether the key is a subgraph wrapper key
+ */
+record RoutingOutputCandidate(String outputKey, boolean wrapperOutput) {
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.cloud.ai.graph.agent.flow.node;
 
+import java.util.List;
+
 /**
  * A state key that may contain the visible result for one routed agent.
  * <p>
@@ -25,17 +27,24 @@ package com.alibaba.cloud.ai.graph.agent.flow.node;
  * @param wrapperOutput whether the key is a subgraph wrapper key
  * @param routingWrapperOutput whether the wrapper belongs to a routing graph whose
  * merged result is valid inside the wrapper snapshot
- * @param preferredInnerOutputKey preferred output key inside a wrapper snapshot
+ * @param preferredInnerOutputKeys ordered output keys to collect inside a wrapper
+ * snapshot; more than one key represents the visible outputs of a workflow such as a
+ * {@code ParallelAgent} without a merge output key
  */
 record RoutingOutputCandidate(String outputKey, boolean wrapperOutput, boolean routingWrapperOutput,
-		String preferredInnerOutputKey) {
+			List<String> preferredInnerOutputKeys) {
+
+	RoutingOutputCandidate {
+		preferredInnerOutputKeys = preferredInnerOutputKeys != null
+				? List.copyOf(preferredInnerOutputKeys) : List.of();
+	}
 
 	RoutingOutputCandidate(String outputKey, boolean wrapperOutput) {
-		this(outputKey, wrapperOutput, false, null);
+		this(outputKey, wrapperOutput, false, List.of());
 	}
 
 	RoutingOutputCandidate(String outputKey, boolean wrapperOutput, boolean routingWrapperOutput) {
-		this(outputKey, wrapperOutput, routingWrapperOutput, null);
+		this(outputKey, wrapperOutput, routingWrapperOutput, List.of());
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.cloud.ai.graph.agent.flow.node;
 
+import com.alibaba.cloud.ai.graph.agent.Agent;
+
 import java.util.List;
 
 /**
@@ -24,6 +26,7 @@ import java.util.List;
  * {@code subgraph_<agent>_compiled_graph}; non-wrapper candidates are raw output
  * keys written by nested agents.
  * @param outputKey state key to probe
+ * @param outputOwner agent whose raw output or wrapper fallback produced this candidate
  * @param wrapperOutput whether the key is a subgraph wrapper key
  * @param routingWrapperOutput whether the wrapper belongs to a routing graph whose
  * merged result is valid inside the wrapper snapshot
@@ -31,20 +34,21 @@ import java.util.List;
  * snapshot; more than one key represents the visible outputs of a workflow such as a
  * {@code ParallelAgent} without a merge output key
  */
-record RoutingOutputCandidate(String outputKey, boolean wrapperOutput, boolean routingWrapperOutput,
-			List<String> preferredInnerOutputKeys) {
+record RoutingOutputCandidate(String outputKey, Agent outputOwner, boolean wrapperOutput,
+			boolean routingWrapperOutput, List<String> preferredInnerOutputKeys) {
 
 	RoutingOutputCandidate {
 		preferredInnerOutputKeys = preferredInnerOutputKeys != null
 				? List.copyOf(preferredInnerOutputKeys) : List.of();
 	}
 
-	RoutingOutputCandidate(String outputKey, boolean wrapperOutput) {
-		this(outputKey, wrapperOutput, false, List.of());
+	RoutingOutputCandidate(String outputKey, Agent outputOwner, boolean wrapperOutput) {
+		this(outputKey, outputOwner, wrapperOutput, false, List.of());
 	}
 
-	RoutingOutputCandidate(String outputKey, boolean wrapperOutput, boolean routingWrapperOutput) {
-		this(outputKey, wrapperOutput, routingWrapperOutput, List.of());
+	RoutingOutputCandidate(String outputKey, Agent outputOwner, boolean wrapperOutput,
+			boolean routingWrapperOutput) {
+		this(outputKey, outputOwner, wrapperOutput, routingWrapperOutput, List.of());
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
@@ -23,6 +23,19 @@ package com.alibaba.cloud.ai.graph.agent.flow.node;
  * keys written by nested agents.
  * @param outputKey state key to probe
  * @param wrapperOutput whether the key is a subgraph wrapper key
+ * @param routingWrapperOutput whether the wrapper belongs to a routing graph whose
+ * merged result is valid inside the wrapper snapshot
+ * @param preferredInnerOutputKey preferred output key inside a wrapper snapshot
  */
-record RoutingOutputCandidate(String outputKey, boolean wrapperOutput) {
+record RoutingOutputCandidate(String outputKey, boolean wrapperOutput, boolean routingWrapperOutput,
+		String preferredInnerOutputKey) {
+
+	RoutingOutputCandidate(String outputKey, boolean wrapperOutput) {
+		this(outputKey, wrapperOutput, false, null);
+	}
+
+	RoutingOutputCandidate(String outputKey, boolean wrapperOutput, boolean routingWrapperOutput) {
+		this(outputKey, wrapperOutput, routingWrapperOutput, null);
+	}
+
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputCandidate.java
@@ -33,9 +33,12 @@ import java.util.List;
  * @param preferredInnerOutputKeys ordered output keys to collect inside a wrapper
  * snapshot; more than one key represents the visible outputs of a workflow such as a
  * {@code ParallelAgent} without a merge output key
+ * @param allowSingleVisibleWrapperFallback whether an otherwise unresolved wrapper may
+ * expose its only non-internal state value
  */
 record RoutingOutputCandidate(String outputKey, Agent outputOwner, boolean wrapperOutput,
-			boolean routingWrapperOutput, List<String> preferredInnerOutputKeys) {
+			boolean routingWrapperOutput, List<String> preferredInnerOutputKeys,
+			boolean allowSingleVisibleWrapperFallback) {
 
 	RoutingOutputCandidate {
 		preferredInnerOutputKeys = preferredInnerOutputKeys != null
@@ -43,12 +46,12 @@ record RoutingOutputCandidate(String outputKey, Agent outputOwner, boolean wrapp
 	}
 
 	RoutingOutputCandidate(String outputKey, Agent outputOwner, boolean wrapperOutput) {
-		this(outputKey, outputOwner, wrapperOutput, false, List.of());
+		this(outputKey, outputOwner, wrapperOutput, false, List.of(), true);
 	}
 
 	RoutingOutputCandidate(String outputKey, Agent outputOwner, boolean wrapperOutput,
 			boolean routingWrapperOutput) {
-		this(outputKey, outputOwner, wrapperOutput, routingWrapperOutput, List.of());
+		this(outputKey, outputOwner, wrapperOutput, routingWrapperOutput, List.of(), true);
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolutionStep.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolutionStep.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.flow.node;
+
+import com.alibaba.cloud.ai.graph.agent.Agent;
+
+/**
+ * One item on the explicit output-resolution stack.
+ * <p>
+ * The resolver uses a stack instead of recursion so wrapper outputs can be delayed
+ * until after nested agent outputs have been tried.
+ */
+interface RoutingOutputResolutionStep {
+}
+
+/**
+ * Expands an agent through the matching {@link RoutingOutputStrategy}.
+ * @param agent agent being expanded
+ * @param allowDefaultMessagesOutput whether default messages output can be used
+ * @param allowRoutingMergedOutput whether nested routing merged output can be used
+ * @param preferWrapperOutput whether wrapper output should be emitted first
+ */
+record ExpandAgentOutputStep(Agent agent, boolean allowDefaultMessagesOutput,
+		boolean allowRoutingMergedOutput, boolean preferWrapperOutput) implements RoutingOutputResolutionStep {
+
+	/**
+	 * Creates a nested expansion step while preserving routing-merge permissions.
+	 * @param nestedAgent nested agent to expand next
+	 * @param allowDefaultOutput whether the nested agent may use default messages output
+	 * @return nested agent expansion step
+	 */
+	ExpandAgentOutputStep forNestedAgent(Agent nestedAgent, boolean allowDefaultOutput) {
+		return new ExpandAgentOutputStep(nestedAgent, allowDefaultOutput, allowRoutingMergedOutput, false);
+	}
+
+}
+
+/**
+ * Emits one concrete state key candidate in the current stack order.
+ * @param candidate output candidate to append
+ */
+record EmitOutputCandidateStep(RoutingOutputCandidate candidate) implements RoutingOutputResolutionStep {
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.flow.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
+
+/**
+ * Resolves the parent-state output keys a routed agent may expose.
+ */
+final class RoutingOutputResolver {
+
+	private static final Logger logger = LoggerFactory.getLogger(RoutingOutputResolver.class);
+
+	private final String routingAgentName;
+
+	private final List<Agent> subAgents;
+
+	private final List<RoutingOutputStrategy> strategies;
+
+	RoutingOutputResolver(String routingAgentName, List<? extends Agent> subAgents) {
+		this.routingAgentName = routingAgentName;
+		this.subAgents = List.copyOf(subAgents);
+		// Keep this order from specific to generic because several agent types inherit
+		// from FlowAgent.
+		this.strategies = List.of(
+				new BaseAgentOutputStrategy(),
+				new ParallelAgentOutputStrategy(),
+				new LlmRoutingAgentOutputStrategy(),
+				new SequentialAgentOutputStrategy(),
+				new FlowAgentOutputStrategy());
+	}
+
+	int subAgentCount() {
+		return subAgents.size();
+	}
+
+	List<Agent> subAgents() {
+		return subAgents;
+	}
+
+	/**
+	 * Captures route-selection facts that must stay consistent during one merge pass.
+	 * @param state current graph state
+	 * @return immutable context for this merge pass
+	 */
+	MergeContext createContext(OverAllState state) {
+		Optional<Set<String>> routedAgentNames = currentRoutedAgentNames(state);
+		long routedAgentCount = countRoutedAgents(state, routedAgentNames);
+		boolean hasRoutingMarkers = routedAgentNames.isPresent() || routedAgentCount > 0;
+		long routingMergedOutputOwnerCount = countRoutingMergedOutputOwners(state, hasRoutingMarkers,
+				routedAgentNames);
+		boolean exposeMergedResultToParent = routingAgentName != null
+				&& state.value(routingAgentName + "_input").isPresent();
+		return new MergeContext(routedAgentNames, routedAgentCount, hasRoutingMarkers,
+				routingMergedOutputOwnerCount, exposeMergedResultToParent);
+	}
+
+	/**
+	 * Collects the best attributable output for one top-level routed sub-agent.
+	 * @param state current graph state
+	 * @param subAgent top-level sub-agent being collected
+	 * @param context merge context created for this pass
+	 * @param collectedOutputKeys output keys already attributed to earlier sub-agents
+	 * @return collected text when the sub-agent has an attributable result
+	 */
+	Optional<CollectedAgentResult> collectAgentResult(OverAllState state, Agent subAgent,
+			MergeContext context, Set<String> collectedOutputKeys) {
+		boolean topLevelRoutedAgent = isTopLevelRoutedAgent(state, subAgent, context.routedAgentNames());
+		if (context.hasRoutingMarkers() && !topLevelRoutedAgent) {
+			logger.debug("Skipping unrouted sub-agent {}", subAgent.name());
+			return Optional.empty();
+		}
+
+		boolean allowDefaultMessagesOutput = context.routedAgentCount() == 1 && topLevelRoutedAgent;
+		boolean allowRoutingMergedOutput = context.routingMergedOutputOwnerCount() == 1
+				&& usesRoutingMergedOutput(subAgent);
+		boolean preferWrapperOutput = shouldPreferWrapperOutput(state, subAgent, context.routedAgentCount(),
+				topLevelRoutedAgent, context.routingMergedOutputOwnerCount(), context.routedAgentNames());
+		List<RoutingOutputCandidate> candidates = resolveCandidates(subAgent, allowDefaultMessagesOutput,
+				allowRoutingMergedOutput, preferWrapperOutput);
+
+		List<String> sourceTexts = new ArrayList<>();
+		boolean collectMultipleOutputs = collectsMultipleOutputs(subAgent);
+		boolean collectedWrapperOutput = false;
+		for (RoutingOutputCandidate candidate : candidates) {
+			if (collectedOutputKeys.contains(candidate.outputKey())) {
+				continue;
+			}
+			if (collectMultipleOutputs && !sourceTexts.isEmpty() && candidate.wrapperOutput()) {
+				continue;
+			}
+			Optional<Object> outputOpt = state.value(candidate.outputKey());
+			if (outputOpt.isEmpty()) {
+				continue;
+			}
+			String text = RoutingMergeNode.extractText(outputOpt.get(), candidate.outputKey());
+			if (text == null || text.isBlank()) {
+				continue;
+			}
+			collectedOutputKeys.add(candidate.outputKey());
+			sourceTexts.add(text);
+			collectedWrapperOutput = collectedWrapperOutput || candidate.wrapperOutput();
+			logger.debug("Collected result from {} (key: {})", subAgent.name(), candidate.outputKey());
+			if (!collectMultipleOutputs || (preferWrapperOutput && candidate.wrapperOutput())) {
+				break;
+			}
+		}
+		if (sourceTexts.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(new CollectedAgentResult(String.join("\n\n", sourceTexts), collectedWrapperOutput));
+	}
+
+	/**
+	 * Clears a stale wrapper when the current answer came from a nested routing merge key.
+	 * @param state current graph state
+	 * @param subAgent sub-agent whose wrapper may be stale
+	 * @param result collected result for the sub-agent
+	 * @param staleWrapperOutputKeys removal set updated by this method
+	 */
+	void markStaleWrapperIfNeeded(OverAllState state, Agent subAgent, CollectedAgentResult result,
+			Set<String> staleWrapperOutputKeys) {
+		String staleWrapperOutputKey = outputKeyToParent(subAgent.name());
+		if (!usesRoutingMergedOutput(subAgent) || result.fromWrapperOutput()
+				|| state.value(staleWrapperOutputKey).isEmpty()) {
+			return;
+		}
+		staleWrapperOutputKeys.add(staleWrapperOutputKey);
+		logger.debug("RoutingMergeNode: routing result for {} came from merged output; clearing stale wrapper key {}",
+				subAgent.name(), staleWrapperOutputKey);
+	}
+
+	/**
+	 * Returns the parent-state wrapper key for this routing graph.
+	 * @return wrapper key for this router's compiled subgraph result
+	 */
+	String wrapperOutputKey() {
+		return outputKeyToParent(routingAgentName);
+	}
+
+	/**
+	 * Resolves candidate output keys in the exact order they should be probed.
+	 * @param agent agent whose outputs are being resolved
+	 * @param allowDefaultMessagesOutput whether the shared messages key can be used
+	 * @param allowRoutingMergedOutput whether nested router merged output can be used
+	 * @param preferWrapperOutput whether the wrapper key should be probed first
+	 * @return ordered output candidates
+	 */
+	private List<RoutingOutputCandidate> resolveCandidates(Agent agent, boolean allowDefaultMessagesOutput,
+			boolean allowRoutingMergedOutput, boolean preferWrapperOutput) {
+		List<RoutingOutputCandidate> candidates = new ArrayList<>();
+		Deque<RoutingOutputResolutionStep> steps = new ArrayDeque<>();
+		steps.push(new ExpandAgentOutputStep(agent, allowDefaultMessagesOutput, allowRoutingMergedOutput,
+				preferWrapperOutput));
+		while (!steps.isEmpty()) {
+			RoutingOutputResolutionStep step = steps.pop();
+			if (step instanceof EmitOutputCandidateStep emitStep) {
+				candidates.add(emitStep.candidate());
+				continue;
+			}
+			ExpandAgentOutputStep expandStep = (ExpandAgentOutputStep) step;
+			if (expandStep.preferWrapperOutput()) {
+				candidates.add(wrapperCandidate(expandStep.agent()));
+			}
+			else {
+				// Delay wrapper output so explicit nested outputs win unless wrapper
+				// isolation is required for multi-routed workflows with shared keys.
+				steps.push(new EmitOutputCandidateStep(wrapperCandidate(expandStep.agent())));
+			}
+			strategyFor(expandStep.agent())
+				.ifPresent(strategy -> strategy.appendCandidates(expandStep, steps, candidates));
+		}
+		return candidates;
+	}
+
+	/**
+	 * Creates the namespaced wrapper candidate for a nested FlowAgent.
+	 * @param agent agent whose wrapper key should be created
+	 * @return wrapper output candidate
+	 */
+	private RoutingOutputCandidate wrapperCandidate(Agent agent) {
+		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), true);
+	}
+
+	/**
+	 * Finds the output strategy for an agent without exposing a default no-op strategy.
+	 * @param agent agent to match
+	 * @return matching strategy, or empty when the agent type has no output strategy
+	 */
+	private Optional<RoutingOutputStrategy> strategyFor(Agent agent) {
+		return strategies.stream()
+			.filter(strategy -> strategy.supports(agent))
+			.findFirst();
+	}
+
+	/**
+	 * Prefers wrapper output when raw nested keys are ambiguous across routed workflows.
+	 * @param state current graph state
+	 * @param agent agent being evaluated
+	 * @param routedAgentCount number of currently selected top-level sub-agents
+	 * @param topLevelRoutedAgent whether the agent belongs to the current route
+	 * @param routingMergedOutputOwnerCount selected agents that may expose nested routing
+	 * merge output
+	 * @param routedAgentNames optional namespaced routing selection marker
+	 * @return true when wrapper output should be probed before raw nested keys
+	 */
+	private boolean shouldPreferWrapperOutput(OverAllState state, Agent agent, long routedAgentCount,
+			boolean topLevelRoutedAgent, long routingMergedOutputOwnerCount, Optional<Set<String>> routedAgentNames) {
+		if (routedAgentCount <= 1 || !topLevelRoutedAgent || !(agent instanceof FlowAgent)
+				|| state.value(outputKeyToParent(agent.name())).isEmpty()) {
+			return false;
+		}
+
+		Set<String> outputKeys = resolvedNonWrapperOutputKeys(agent, routingMergedOutputOwnerCount);
+		if (outputKeys.isEmpty()) {
+			return true;
+		}
+
+		return subAgents.stream()
+			.filter(other -> other != agent)
+			.filter(other -> isTopLevelRoutedAgent(state, other, routedAgentNames))
+			.map(other -> resolvedNonWrapperOutputKeys(other, routingMergedOutputOwnerCount))
+			.anyMatch(otherOutputKeys -> otherOutputKeys.stream().anyMatch(outputKeys::contains));
+	}
+
+	/**
+	 * Collects raw candidate keys so sibling workflows can be checked for shared keys.
+	 * @param agent agent whose non-wrapper output keys should be resolved
+	 * @param routingMergedOutputOwnerCount selected agents that may expose nested routing
+	 * merge output
+	 * @return raw non-wrapper output keys
+	 */
+	private Set<String> resolvedNonWrapperOutputKeys(Agent agent, long routingMergedOutputOwnerCount) {
+		boolean allowRoutingMergedOutput = routingMergedOutputOwnerCount == 1 && usesRoutingMergedOutput(agent);
+		Set<String> outputKeys = new HashSet<>();
+		for (RoutingOutputCandidate candidate : resolveCandidates(agent, false, allowRoutingMergedOutput, false)) {
+			if (!candidate.wrapperOutput()) {
+				outputKeys.add(candidate.outputKey());
+			}
+		}
+		return outputKeys;
+	}
+
+	/**
+	 * Counts only currently selected top-level agents, ignoring stale checkpoint inputs.
+	 * @param state current graph state
+	 * @param routedAgentNames optional namespaced routing selection marker
+	 * @return number of selected top-level sub-agents
+	 */
+	private long countRoutedAgents(OverAllState state, Optional<Set<String>> routedAgentNames) {
+		if (routedAgentNames.isPresent()) {
+			Set<String> selectedAgents = routedAgentNames.get();
+			return subAgents.stream().filter(agent -> selectedAgents.contains(agent.name())).count();
+		}
+		return subAgents.stream().filter(agent -> isTopLevelRoutedAgent(state, agent, routedAgentNames)).count();
+	}
+
+	/**
+	 * Counts selected agents whose visible answer may come from a nested router merge.
+	 * @param state current graph state
+	 * @param hasRoutingMarkers whether the state contains current routing markers
+	 * @param routedAgentNames optional namespaced routing selection marker
+	 * @return number of selected agents that may use routing merged output
+	 */
+	private long countRoutingMergedOutputOwners(OverAllState state, boolean hasRoutingMarkers,
+			Optional<Set<String>> routedAgentNames) {
+		return subAgents.stream()
+			.filter(agent -> !hasRoutingMarkers || isTopLevelRoutedAgent(state, agent, routedAgentNames))
+			.filter(this::usesRoutingMergedOutput)
+			.count();
+	}
+
+	/**
+	 * Checks whether a top-level sub-agent belongs to the current routing decision.
+	 * @param state current graph state
+	 * @param agent top-level sub-agent being checked
+	 * @param routedAgentNames optional namespaced routing selection marker
+	 * @return true if the agent is selected in the current route
+	 */
+	private boolean isTopLevelRoutedAgent(OverAllState state, Agent agent, Optional<Set<String>> routedAgentNames) {
+		if (routedAgentNames.isPresent()) {
+			return routedAgentNames.get().contains(agent.name());
+		}
+		return state.value(agent.name() + "_input").isPresent();
+	}
+
+	/**
+	 * Reads the namespaced routing marker written by RoutingNode for this router.
+	 * @param state current graph state
+	 * @return selected top-level agent names when a routing marker exists
+	 */
+	private Optional<Set<String>> currentRoutedAgentNames(OverAllState state) {
+		Optional<Object> value = routingAgentName != null
+				? state.value(RoutingNode.routedAgentNamesKey(routingAgentName))
+				: state.value(RoutingNode.ROUTED_AGENT_NAMES_KEY);
+		if (value.isEmpty()) {
+			return Optional.empty();
+		}
+
+		Set<String> agentNames = new LinkedHashSet<>();
+		Object routedAgents = value.get();
+		if (routedAgents instanceof Iterable<?> iterable) {
+			for (Object agentName : iterable) {
+				if (agentName instanceof String name && !name.isBlank()) {
+					agentNames.add(name);
+				}
+			}
+		}
+		else if (routedAgents instanceof String name && !name.isBlank()) {
+			agentNames.add(name);
+		}
+		return Optional.of(agentNames);
+	}
+
+	/**
+	 * Detects whether an agent tree contains a routing graph whose merged answer matters.
+	 * @param agent root of the agent tree to inspect
+	 * @return true if the tree contains a nested routing agent
+	 */
+	private boolean usesRoutingMergedOutput(Agent agent) {
+		Deque<Agent> stack = new ArrayDeque<>();
+		stack.push(agent);
+		while (!stack.isEmpty()) {
+			Agent current = stack.pop();
+			if (current instanceof LlmRoutingAgent) {
+				return true;
+			}
+			if (current instanceof ParallelAgent parallelAgent && parallelAgent.mergeOutputKey() != null) {
+				continue;
+			}
+			if (current instanceof SequentialAgent sequentialAgent) {
+				List<Agent> nestedAgents = sequentialAgent.subAgents();
+				if (nestedAgents != null && !nestedAgents.isEmpty()) {
+					stack.push(nestedAgents.get(nestedAgents.size() - 1));
+				}
+			}
+			else if (current instanceof FlowAgent flowAgent) {
+				pushAll(flowAgent.subAgents(), stack);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks whether one routed workflow should contribute multiple child outputs.
+	 * @param agent routed agent or workflow to inspect
+	 * @return true if the workflow should contribute more than one output
+	 */
+	private boolean collectsMultipleOutputs(Agent agent) {
+		Agent current = agent;
+		while (true) {
+			if (current instanceof ParallelAgent parallelAgent) {
+				return parallelAgent.mergeOutputKey() == null;
+			}
+			if (current instanceof LlmRoutingAgent) {
+				return false;
+			}
+			if (current instanceof SequentialAgent sequentialAgent) {
+				List<Agent> nestedAgents = sequentialAgent.subAgents();
+				if (nestedAgents == null || nestedAgents.isEmpty()) {
+					return false;
+				}
+				current = nestedAgents.get(nestedAgents.size() - 1);
+			}
+			else if (current instanceof FlowAgent flowAgent) {
+				List<Agent> nestedAgents = flowAgent.subAgents();
+				if (nestedAgents == null || nestedAgents.size() != 1) {
+					return false;
+				}
+				current = nestedAgents.get(0);
+			}
+			else {
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * Pushes agents in reverse order so stack traversal preserves list order.
+	 * @param agents agents to push
+	 * @param stack stack receiving the agents
+	 */
+	private static void pushAll(List<Agent> agents, Deque<Agent> stack) {
+		if (agents == null) {
+			return;
+		}
+		for (int i = agents.size() - 1; i >= 0; i--) {
+			stack.push(agents.get(i));
+		}
+	}
+
+	record MergeContext(Optional<Set<String>> routedAgentNames, long routedAgentCount,
+			boolean hasRoutingMarkers, long routingMergedOutputOwnerCount, boolean exposeMergedResultToParent) {
+	}
+
+	record CollectedAgentResult(String text, boolean fromWrapperOutput) {
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
@@ -260,12 +260,18 @@ final class RoutingOutputResolver {
 
 	/**
 	 * Creates the namespaced wrapper candidate for a nested FlowAgent.
+	 * <p>
+	 * Opaque custom flows cannot expand their configured children because those
+	 * branches may not have executed in the current invocation, so a wrapper with a
+	 * single visible value is their only attributable explicit output. Ambiguous
+	 * wrapper snapshots are still rejected during extraction, which returns null when
+	 * more than one visible value exists.
 	 * @param agent agent whose wrapper key should be created
 	 * @return wrapper output candidate
 	 */
 	private RoutingOutputCandidate wrapperCandidate(Agent agent) {
 		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), agent, true, usesRoutingMergedOutput(agent),
-				preferredWrapperOutputKeys(agent), !isOpaqueCustomFlow(agent));
+				preferredWrapperOutputKeys(agent), true);
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
@@ -31,6 +31,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -76,7 +77,8 @@ final class RoutingOutputResolver {
 	 * @return immutable context for this merge pass
 	 */
 	MergeContext createContext(OverAllState state) {
-		Optional<Set<String>> routedAgentNames = currentRoutedAgentNames(state);
+		Optional<RoutingSelection> routingSelection = currentRoutingSelection(state);
+		Optional<Set<String>> routedAgentNames = routingSelection.map(RoutingSelection::agentNames);
 		long routedAgentCount = countRoutedAgents(state, routedAgentNames);
 		boolean hasRoutingMarkers = routedAgentNames.isPresent() || routedAgentCount > 0;
 		long routingMergedOutputOwnerCount = countRoutingMergedOutputOwners(state, hasRoutingMarkers,
@@ -84,7 +86,24 @@ final class RoutingOutputResolver {
 		boolean exposeMergedResultToParent = routingAgentName != null
 				&& state.value(routingAgentName + "_input").isPresent();
 		return new MergeContext(routedAgentNames, routedAgentCount, hasRoutingMarkers,
-				routingMergedOutputOwnerCount, exposeMergedResultToParent);
+				routingMergedOutputOwnerCount, exposeMergedResultToParent, routingSelection.isPresent(),
+				routingSelection.flatMap(RoutingSelection::parentMarker));
+	}
+
+	/**
+	 * Restores the enclosing same-named router marker after this merge, or removes the
+	 * marker when this invocation is the outermost routing scope.
+	 * @param output merge-node state update
+	 * @param context routing context captured before result collection
+	 */
+	void restoreRoutingMarker(Map<String, Object> output, MergeContext context) {
+		if (!context.routingMarkerPresent()) {
+			return;
+		}
+		String markerKey = routingMarkerKey();
+		Object restoredMarker = context.parentRoutingMarker().orElse(OverAllState.MARK_FOR_REMOVAL);
+		output.put(markerKey, restoredMarker);
+		logger.debug("RoutingMergeNode: restoring routing marker {} to its enclosing scope", markerKey);
 	}
 
 	/**
@@ -366,27 +385,41 @@ final class RoutingOutputResolver {
 	 * @param state current graph state
 	 * @return selected top-level agent names when a routing marker exists
 	 */
-	private Optional<Set<String>> currentRoutedAgentNames(OverAllState state) {
-		Optional<Object> value = routingAgentName != null
-				? state.value(RoutingNode.routedAgentNamesKey(routingAgentName))
-				: state.value(RoutingNode.ROUTED_AGENT_NAMES_KEY);
+	private Optional<RoutingSelection> currentRoutingSelection(OverAllState state) {
+		Optional<Object> value = state.value(routingMarkerKey());
 		if (value.isEmpty()) {
 			return Optional.empty();
 		}
 
+		Object marker = value.get();
+		Object selectedAgents = marker;
+		Optional<Object> parentMarker = Optional.empty();
+		if (marker instanceof Map<?, ?> map && map.containsKey(RoutingNode.SELECTED_AGENT_NAMES_FIELD)) {
+			selectedAgents = map.get(RoutingNode.SELECTED_AGENT_NAMES_FIELD);
+			parentMarker = Optional.ofNullable(map.get(RoutingNode.PARENT_ROUTING_MARKER_FIELD));
+		}
+
 		Set<String> agentNames = new LinkedHashSet<>();
-		Object routedAgents = value.get();
-		if (routedAgents instanceof Iterable<?> iterable) {
+		if (selectedAgents instanceof Iterable<?> iterable) {
 			for (Object agentName : iterable) {
 				if (agentName instanceof String name && !name.isBlank()) {
 					agentNames.add(name);
 				}
 			}
 		}
-		else if (routedAgents instanceof String name && !name.isBlank()) {
+		else if (selectedAgents instanceof String name && !name.isBlank()) {
 			agentNames.add(name);
 		}
-		return Optional.of(agentNames);
+		return Optional.of(new RoutingSelection(Set.copyOf(agentNames), parentMarker));
+	}
+
+	/**
+	 * Returns the state key used by this routing graph's scoped selection marker.
+	 * @return namespaced marker key, or the legacy global key for test-only constructors
+	 */
+	private String routingMarkerKey() {
+		return routingAgentName != null
+				? RoutingNode.routedAgentNamesKey(routingAgentName) : RoutingNode.ROUTED_AGENT_NAMES_KEY;
 	}
 
 	/**
@@ -467,7 +500,16 @@ final class RoutingOutputResolver {
 	}
 
 	record MergeContext(Optional<Set<String>> routedAgentNames, long routedAgentCount,
-			boolean hasRoutingMarkers, long routingMergedOutputOwnerCount, boolean exposeMergedResultToParent) {
+			boolean hasRoutingMarkers, long routingMergedOutputOwnerCount, boolean exposeMergedResultToParent,
+			boolean routingMarkerPresent, Optional<Object> parentRoutingMarker) {
+	}
+
+	/**
+	 * Parsed view of the current serializable routing marker.
+	 * @param agentNames sub-agents selected in the innermost routing scope
+	 * @param parentMarker marker to restore for an enclosing same-named router
+	 */
+	record RoutingSelection(Set<String> agentNames, Optional<Object> parentMarker) {
 	}
 
 	record CollectedAgentResult(String text, boolean fromWrapperOutput) {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
@@ -126,7 +126,7 @@ final class RoutingOutputResolver {
 				continue;
 			}
 			String text = RoutingMergeNode.extractText(outputOpt.get(), candidate.outputKey(),
-					candidate.routingWrapperOutput(), candidate.preferredInnerOutputKey());
+					candidate.routingWrapperOutput(), candidate.preferredInnerOutputKeys());
 			if (text == null || text.isBlank()) {
 				continue;
 			}
@@ -212,45 +212,51 @@ final class RoutingOutputResolver {
 	 */
 	private RoutingOutputCandidate wrapperCandidate(Agent agent) {
 		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), true, usesRoutingMergedOutput(agent),
-				preferredWrapperOutputKey(agent));
+				preferredWrapperOutputKeys(agent));
 	}
 
 	/**
-	 * Finds the single output key a wrapper should prefer over shared messages.
+	 * Finds the ordered output keys a wrapper should prefer over shared messages.
+	 * <p>
+	 * Sequential workflows expose their final child. Parallel workflows with an
+	 * aggregate expose that key, while parallel workflows without one expose every
+	 * attributable child output in configured order.
 	 * @param agent agent whose wrapper snapshot will be inspected
-	 * @return preferred inner output key, or null when the workflow has no single
-	 * aggregate output
+	 * @return preferred inner output keys; empty when no explicit output is attributable
 	 */
-	private String preferredWrapperOutputKey(Agent agent) {
-		Agent current = agent;
-		while (true) {
+	private List<String> preferredWrapperOutputKeys(Agent agent) {
+		LinkedHashSet<String> outputKeys = new LinkedHashSet<>();
+		Deque<Agent> agents = new ArrayDeque<>();
+		agents.push(agent);
+		while (!agents.isEmpty()) {
+			Agent current = agents.pop();
 			if (current instanceof BaseAgent baseAgent) {
-				return baseAgent.getOutputKey();
+				if (baseAgent.getOutputKey() != null) {
+					outputKeys.add(baseAgent.getOutputKey());
+				}
 			}
-			if (current instanceof LlmRoutingAgent) {
-				return RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY;
+			else if (current instanceof LlmRoutingAgent) {
+				outputKeys.add(RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY);
 			}
-			if (current instanceof ParallelAgent parallelAgent) {
-				return parallelAgent.mergeOutputKey();
+			else if (current instanceof ParallelAgent parallelAgent) {
+				if (parallelAgent.mergeOutputKey() != null) {
+					outputKeys.add(parallelAgent.mergeOutputKey());
+				}
+				else {
+					pushAll(parallelAgent.subAgents(), agents);
+				}
 			}
-			if (current instanceof SequentialAgent sequentialAgent) {
+			else if (current instanceof SequentialAgent sequentialAgent) {
 				List<Agent> nestedAgents = sequentialAgent.subAgents();
-				if (nestedAgents == null || nestedAgents.isEmpty()) {
-					return null;
+				if (nestedAgents != null && !nestedAgents.isEmpty()) {
+					agents.push(nestedAgents.get(nestedAgents.size() - 1));
 				}
-				current = nestedAgents.get(nestedAgents.size() - 1);
-				continue;
 			}
-			if (current instanceof FlowAgent flowAgent) {
-				List<Agent> nestedAgents = flowAgent.subAgents();
-				if (nestedAgents == null || nestedAgents.size() != 1) {
-					return null;
-				}
-				current = nestedAgents.get(0);
-				continue;
+			else if (current instanceof FlowAgent flowAgent) {
+				pushAll(flowAgent.subAgents(), agents);
 			}
-			return null;
 		}
+		return List.copyOf(outputKeys);
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
@@ -27,8 +27,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -81,12 +83,12 @@ final class RoutingOutputResolver {
 		Optional<Set<String>> routedAgentNames = routingSelection.map(RoutingSelection::agentNames);
 		long routedAgentCount = countRoutedAgents(state, routedAgentNames);
 		boolean hasRoutingMarkers = routedAgentNames.isPresent() || routedAgentCount > 0;
-		long routingMergedOutputOwnerCount = countRoutingMergedOutputOwners(state, hasRoutingMarkers,
+		long routingMergedOutputProducerCount = countRoutingMergedOutputProducers(state, hasRoutingMarkers,
 				routedAgentNames);
 		boolean exposeMergedResultToParent = routingAgentName != null
 				&& state.value(routingAgentName + "_input").isPresent();
 		return new MergeContext(routedAgentNames, routedAgentCount, hasRoutingMarkers,
-				routingMergedOutputOwnerCount, exposeMergedResultToParent, routingSelection.isPresent(),
+				routingMergedOutputProducerCount, exposeMergedResultToParent, routingSelection.isPresent(),
 				routingSelection.flatMap(RoutingSelection::parentMarker));
 	}
 
@@ -122,22 +124,25 @@ final class RoutingOutputResolver {
 			return Optional.empty();
 		}
 
-		boolean allowDefaultMessagesOutput = context.routedAgentCount() == 1 && topLevelRoutedAgent;
-		boolean allowRoutingMergedOutput = context.routingMergedOutputOwnerCount() == 1
-				&& usesRoutingMergedOutput(subAgent);
+		boolean collectMultipleOutputs = collectsMultipleOutputs(subAgent);
+		boolean allowDefaultMessagesOutput = context.routedAgentCount() == 1
+				&& topLevelRoutedAgent && !collectMultipleOutputs;
+		boolean allowRoutingMergedOutput = context.routingMergedOutputProducerCount() == 1
+				&& usesRoutingMergedOutput(subAgent) && !collectMultipleOutputs;
 		boolean preferWrapperOutput = shouldPreferWrapperOutput(state, subAgent, context.routedAgentCount(),
-				topLevelRoutedAgent, context.routingMergedOutputOwnerCount(), context.routedAgentNames());
+				topLevelRoutedAgent, context.routingMergedOutputProducerCount(), context.routedAgentNames());
 		List<RoutingOutputCandidate> candidates = resolveCandidates(subAgent, allowDefaultMessagesOutput,
 				allowRoutingMergedOutput, preferWrapperOutput);
 
 		List<String> sourceTexts = new ArrayList<>();
-		boolean collectMultipleOutputs = collectsMultipleOutputs(subAgent);
 		boolean collectedWrapperOutput = false;
+		Set<Agent> collectedOutputOwners = Collections.newSetFromMap(new IdentityHashMap<>());
 		for (RoutingOutputCandidate candidate : candidates) {
 			if (collectedOutputKeys.contains(candidate.outputKey())) {
 				continue;
 			}
-			if (collectMultipleOutputs && !sourceTexts.isEmpty() && candidate.wrapperOutput()) {
+			if (candidate.wrapperOutput()
+					&& hasCollectedOutputInTree(candidate.outputOwner(), collectedOutputOwners)) {
 				continue;
 			}
 			Optional<Object> outputOpt = state.value(candidate.outputKey());
@@ -150,6 +155,7 @@ final class RoutingOutputResolver {
 				continue;
 			}
 			collectedOutputKeys.add(candidate.outputKey());
+			collectedOutputOwners.add(candidate.outputOwner());
 			sourceTexts.add(text);
 			collectedWrapperOutput = collectedWrapperOutput || candidate.wrapperOutput();
 			logger.debug("Collected result from {} (key: {})", subAgent.name(), candidate.outputKey());
@@ -161,6 +167,32 @@ final class RoutingOutputResolver {
 			return Optional.empty();
 		}
 		return Optional.of(new CollectedAgentResult(String.join("\n\n", sourceTexts), collectedWrapperOutput));
+	}
+
+	/**
+	 * Checks whether a wrapper would repeat an output already collected from its own
+	 * agent branch. Outputs from sibling branches do not suppress one another.
+	 * @param agent wrapper owner whose agent tree should be inspected
+	 * @param collectedOutputOwners agents that already supplied an output
+	 * @return true when the wrapper owns an already collected output
+	 */
+	private boolean hasCollectedOutputInTree(Agent agent, Set<Agent> collectedOutputOwners) {
+		Deque<Agent> stack = new ArrayDeque<>();
+		Set<Agent> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+		stack.push(agent);
+		while (!stack.isEmpty()) {
+			Agent current = stack.pop();
+			if (!visited.add(current)) {
+				continue;
+			}
+			if (collectedOutputOwners.contains(current)) {
+				return true;
+			}
+			if (current instanceof FlowAgent flowAgent) {
+				pushAll(flowAgent.subAgents(), stack);
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -230,7 +262,7 @@ final class RoutingOutputResolver {
 	 * @return wrapper output candidate
 	 */
 	private RoutingOutputCandidate wrapperCandidate(Agent agent) {
-		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), true, usesRoutingMergedOutput(agent),
+		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), agent, true, usesRoutingMergedOutput(agent),
 				preferredWrapperOutputKeys(agent));
 	}
 
@@ -295,19 +327,25 @@ final class RoutingOutputResolver {
 	 * @param agent agent being evaluated
 	 * @param routedAgentCount number of currently selected top-level sub-agents
 	 * @param topLevelRoutedAgent whether the agent belongs to the current route
-	 * @param routingMergedOutputOwnerCount selected agents that may expose nested routing
-	 * merge output
+	 * @param routingMergedOutputProducerCount nested routing merge producers that contribute
+	 * to selected-agent outputs
 	 * @param routedAgentNames optional namespaced routing selection marker
 	 * @return true when wrapper output should be probed before raw nested keys
 	 */
 	private boolean shouldPreferWrapperOutput(OverAllState state, Agent agent, long routedAgentCount,
-			boolean topLevelRoutedAgent, long routingMergedOutputOwnerCount, Optional<Set<String>> routedAgentNames) {
+			boolean topLevelRoutedAgent, long routingMergedOutputProducerCount,
+			Optional<Set<String>> routedAgentNames) {
 		if (routedAgentCount <= 1 || !topLevelRoutedAgent || !(agent instanceof FlowAgent)
 				|| state.value(outputKeyToParent(agent.name())).isEmpty()) {
 			return false;
 		}
+		// A single workflow wrapper cannot attribute several nested routers because each
+		// router uses merged_result internally. Resolve their namespaced wrappers instead.
+		if (countRoutingMergedOutputProducers(agent) > 1) {
+			return false;
+		}
 
-		Set<String> outputKeys = resolvedNonWrapperOutputKeys(agent, routingMergedOutputOwnerCount);
+		Set<String> outputKeys = resolvedNonWrapperOutputKeys(agent, routingMergedOutputProducerCount);
 		if (outputKeys.isEmpty()) {
 			return true;
 		}
@@ -315,19 +353,20 @@ final class RoutingOutputResolver {
 		return subAgents.stream()
 			.filter(other -> other != agent)
 			.filter(other -> isTopLevelRoutedAgent(state, other, routedAgentNames))
-			.map(other -> resolvedNonWrapperOutputKeys(other, routingMergedOutputOwnerCount))
+			.map(other -> resolvedNonWrapperOutputKeys(other, routingMergedOutputProducerCount))
 			.anyMatch(otherOutputKeys -> otherOutputKeys.stream().anyMatch(outputKeys::contains));
 	}
 
 	/**
 	 * Collects raw candidate keys so sibling workflows can be checked for shared keys.
 	 * @param agent agent whose non-wrapper output keys should be resolved
-	 * @param routingMergedOutputOwnerCount selected agents that may expose nested routing
-	 * merge output
+	 * @param routingMergedOutputProducerCount nested routing merge producers that contribute
+	 * to selected-agent outputs
 	 * @return raw non-wrapper output keys
 	 */
-	private Set<String> resolvedNonWrapperOutputKeys(Agent agent, long routingMergedOutputOwnerCount) {
-		boolean allowRoutingMergedOutput = routingMergedOutputOwnerCount == 1 && usesRoutingMergedOutput(agent);
+	private Set<String> resolvedNonWrapperOutputKeys(Agent agent, long routingMergedOutputProducerCount) {
+		boolean allowRoutingMergedOutput = routingMergedOutputProducerCount == 1
+				&& usesRoutingMergedOutput(agent) && !collectsMultipleOutputs(agent);
 		Set<String> outputKeys = new HashSet<>();
 		for (RoutingOutputCandidate candidate : resolveCandidates(agent, false, allowRoutingMergedOutput, false)) {
 			if (!candidate.wrapperOutput()) {
@@ -352,18 +391,18 @@ final class RoutingOutputResolver {
 	}
 
 	/**
-	 * Counts selected agents whose visible answer may come from a nested router merge.
+	 * Counts nested routing merge producers that contribute to selected-agent outputs.
 	 * @param state current graph state
 	 * @param hasRoutingMarkers whether the state contains current routing markers
 	 * @param routedAgentNames optional namespaced routing selection marker
-	 * @return number of selected agents that may use routing merged output
+	 * @return number of contributing nested routing merge producers
 	 */
-	private long countRoutingMergedOutputOwners(OverAllState state, boolean hasRoutingMarkers,
+	private long countRoutingMergedOutputProducers(OverAllState state, boolean hasRoutingMarkers,
 			Optional<Set<String>> routedAgentNames) {
 		return subAgents.stream()
 			.filter(agent -> !hasRoutingMarkers || isTopLevelRoutedAgent(state, agent, routedAgentNames))
-			.filter(this::usesRoutingMergedOutput)
-			.count();
+			.mapToLong(this::countRoutingMergedOutputProducers)
+			.sum();
 	}
 
 	/**
@@ -428,12 +467,25 @@ final class RoutingOutputResolver {
 	 * @return true if the tree contains a nested routing agent
 	 */
 	private boolean usesRoutingMergedOutput(Agent agent) {
+		return countRoutingMergedOutputProducers(agent) > 0;
+	}
+
+	/**
+	 * Counts routing merge producers whose outputs contribute to an agent's visible result.
+	 * Sequential workflows only expose their final child, while generic fan-out flows may
+	 * expose multiple nested routers.
+	 * @param agent root of the agent tree to inspect
+	 * @return number of contributing routing merge producers
+	 */
+	private long countRoutingMergedOutputProducers(Agent agent) {
+		long producerCount = 0;
 		Deque<Agent> stack = new ArrayDeque<>();
 		stack.push(agent);
 		while (!stack.isEmpty()) {
 			Agent current = stack.pop();
 			if (current instanceof LlmRoutingAgent) {
-				return true;
+				producerCount++;
+				continue;
 			}
 			if (current instanceof ParallelAgent parallelAgent && parallelAgent.mergeOutputKey() != null) {
 				continue;
@@ -448,7 +500,7 @@ final class RoutingOutputResolver {
 				pushAll(flowAgent.subAgents(), stack);
 			}
 		}
-		return false;
+		return producerCount;
 	}
 
 	/**
@@ -474,8 +526,11 @@ final class RoutingOutputResolver {
 			}
 			else if (current instanceof FlowAgent flowAgent) {
 				List<Agent> nestedAgents = flowAgent.subAgents();
-				if (nestedAgents == null || nestedAgents.size() != 1) {
+				if (nestedAgents == null || nestedAgents.isEmpty()) {
 					return false;
+				}
+				if (nestedAgents.size() > 1) {
+					return true;
 				}
 				current = nestedAgents.get(0);
 			}
@@ -500,7 +555,7 @@ final class RoutingOutputResolver {
 	}
 
 	record MergeContext(Optional<Set<String>> routedAgentNames, long routedAgentCount,
-			boolean hasRoutingMarkers, long routingMergedOutputOwnerCount, boolean exposeMergedResultToParent,
+			boolean hasRoutingMarkers, long routingMergedOutputProducerCount, boolean exposeMergedResultToParent,
 			boolean routingMarkerPresent, Optional<Object> parentRoutingMarker) {
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
@@ -20,6 +20,7 @@ import com.alibaba.cloud.ai.graph.agent.Agent;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LoopAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
 import org.slf4j.Logger;
@@ -62,7 +63,7 @@ final class RoutingOutputResolver {
 				new ParallelAgentOutputStrategy(),
 				new LlmRoutingAgentOutputStrategy(),
 				new SequentialAgentOutputStrategy(),
-				new FlowAgentOutputStrategy());
+				new LoopAgentOutputStrategy());
 	}
 
 	int subAgentCount() {
@@ -150,7 +151,8 @@ final class RoutingOutputResolver {
 				continue;
 			}
 			String text = RoutingMergeNode.extractText(outputOpt.get(), candidate.outputKey(),
-					candidate.routingWrapperOutput(), candidate.preferredInnerOutputKeys());
+					candidate.routingWrapperOutput(), candidate.preferredInnerOutputKeys(),
+					candidate.allowSingleVisibleWrapperFallback());
 			if (text == null || text.isBlank()) {
 				continue;
 			}
@@ -263,7 +265,7 @@ final class RoutingOutputResolver {
 	 */
 	private RoutingOutputCandidate wrapperCandidate(Agent agent) {
 		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), agent, true, usesRoutingMergedOutput(agent),
-				preferredWrapperOutputKeys(agent));
+				preferredWrapperOutputKeys(agent), !isOpaqueCustomFlow(agent));
 	}
 
 	/**
@@ -303,8 +305,15 @@ final class RoutingOutputResolver {
 					agents.push(nestedAgents.get(nestedAgents.size() - 1));
 				}
 			}
-			else if (current instanceof FlowAgent flowAgent) {
-				pushAll(flowAgent.subAgents(), agents);
+			else if (current instanceof LoopAgent loopAgent) {
+				List<Agent> nestedAgents = loopAgent.subAgents();
+				if (nestedAgents != null && !nestedAgents.isEmpty()) {
+					agents.push(nestedAgents.get(0));
+				}
+			}
+			else if (current instanceof FlowAgent) {
+				// Custom flow execution semantics are opaque. Its configured children do
+				// not identify which conditional branches executed in this invocation.
 			}
 		}
 		return List.copyOf(outputKeys);
@@ -338,6 +347,9 @@ final class RoutingOutputResolver {
 		if (routedAgentCount <= 1 || !topLevelRoutedAgent || !(agent instanceof FlowAgent)
 				|| state.value(outputKeyToParent(agent.name())).isEmpty()) {
 			return false;
+		}
+		if (isOpaqueCustomFlow(agent)) {
+			return true;
 		}
 		// A single workflow wrapper cannot attribute several nested routers because each
 		// router uses merged_result internally. Resolve their namespaced wrappers instead.
@@ -496,8 +508,11 @@ final class RoutingOutputResolver {
 					stack.push(nestedAgents.get(nestedAgents.size() - 1));
 				}
 			}
-			else if (current instanceof FlowAgent flowAgent) {
-				pushAll(flowAgent.subAgents(), stack);
+			else if (current instanceof LoopAgent loopAgent) {
+				List<Agent> nestedAgents = loopAgent.subAgents();
+				if (nestedAgents != null && !nestedAgents.isEmpty()) {
+					stack.push(nestedAgents.get(0));
+				}
 			}
 		}
 		return producerCount;
@@ -524,13 +539,10 @@ final class RoutingOutputResolver {
 				}
 				current = nestedAgents.get(nestedAgents.size() - 1);
 			}
-			else if (current instanceof FlowAgent flowAgent) {
-				List<Agent> nestedAgents = flowAgent.subAgents();
+			else if (current instanceof LoopAgent loopAgent) {
+				List<Agent> nestedAgents = loopAgent.subAgents();
 				if (nestedAgents == null || nestedAgents.isEmpty()) {
 					return false;
-				}
-				if (nestedAgents.size() > 1) {
-					return true;
 				}
 				current = nestedAgents.get(0);
 			}
@@ -538,6 +550,20 @@ final class RoutingOutputResolver {
 				return false;
 			}
 		}
+	}
+
+	/**
+	 * Detects custom FlowAgent implementations whose child execution semantics are not
+	 * described by one of the framework's built-in flow types.
+	 * @param agent agent to inspect
+	 * @return true when only the completed workflow wrapper is safely attributable
+	 */
+	private boolean isOpaqueCustomFlow(Agent agent) {
+		return agent instanceof FlowAgent
+				&& !(agent instanceof SequentialAgent)
+				&& !(agent instanceof ParallelAgent)
+				&& !(agent instanceof LlmRoutingAgent)
+				&& !(agent instanceof LoopAgent);
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputResolver.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph.agent.flow.node;
 
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.BaseAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
@@ -124,7 +125,8 @@ final class RoutingOutputResolver {
 			if (outputOpt.isEmpty()) {
 				continue;
 			}
-			String text = RoutingMergeNode.extractText(outputOpt.get(), candidate.outputKey());
+			String text = RoutingMergeNode.extractText(outputOpt.get(), candidate.outputKey(),
+					candidate.routingWrapperOutput(), candidate.preferredInnerOutputKey());
 			if (text == null || text.isBlank()) {
 				continue;
 			}
@@ -143,7 +145,7 @@ final class RoutingOutputResolver {
 	}
 
 	/**
-	 * Clears a stale wrapper when the current answer came from a nested routing merge key.
+	 * Clears a stale wrapper when the current answer came from a non-wrapper key.
 	 * @param state current graph state
 	 * @param subAgent sub-agent whose wrapper may be stale
 	 * @param result collected result for the sub-agent
@@ -152,12 +154,11 @@ final class RoutingOutputResolver {
 	void markStaleWrapperIfNeeded(OverAllState state, Agent subAgent, CollectedAgentResult result,
 			Set<String> staleWrapperOutputKeys) {
 		String staleWrapperOutputKey = outputKeyToParent(subAgent.name());
-		if (!usesRoutingMergedOutput(subAgent) || result.fromWrapperOutput()
-				|| state.value(staleWrapperOutputKey).isEmpty()) {
+		if (result.fromWrapperOutput() || state.value(staleWrapperOutputKey).isEmpty()) {
 			return;
 		}
 		staleWrapperOutputKeys.add(staleWrapperOutputKey);
-		logger.debug("RoutingMergeNode: routing result for {} came from merged output; clearing stale wrapper key {}",
+		logger.debug("RoutingMergeNode: routing result for {} came from non-wrapper output; clearing wrapper key {}",
 				subAgent.name(), staleWrapperOutputKey);
 	}
 
@@ -210,7 +211,46 @@ final class RoutingOutputResolver {
 	 * @return wrapper output candidate
 	 */
 	private RoutingOutputCandidate wrapperCandidate(Agent agent) {
-		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), true);
+		return new RoutingOutputCandidate(outputKeyToParent(agent.name()), true, usesRoutingMergedOutput(agent),
+				preferredWrapperOutputKey(agent));
+	}
+
+	/**
+	 * Finds the single output key a wrapper should prefer over shared messages.
+	 * @param agent agent whose wrapper snapshot will be inspected
+	 * @return preferred inner output key, or null when the workflow has no single
+	 * aggregate output
+	 */
+	private String preferredWrapperOutputKey(Agent agent) {
+		Agent current = agent;
+		while (true) {
+			if (current instanceof BaseAgent baseAgent) {
+				return baseAgent.getOutputKey();
+			}
+			if (current instanceof LlmRoutingAgent) {
+				return RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY;
+			}
+			if (current instanceof ParallelAgent parallelAgent) {
+				return parallelAgent.mergeOutputKey();
+			}
+			if (current instanceof SequentialAgent sequentialAgent) {
+				List<Agent> nestedAgents = sequentialAgent.subAgents();
+				if (nestedAgents == null || nestedAgents.isEmpty()) {
+					return null;
+				}
+				current = nestedAgents.get(nestedAgents.size() - 1);
+				continue;
+			}
+			if (current instanceof FlowAgent flowAgent) {
+				List<Agent> nestedAgents = flowAgent.subAgents();
+				if (nestedAgents == null || nestedAgents.size() != 1) {
+					return null;
+				}
+				current = nestedAgents.get(0);
+				continue;
+			}
+			return null;
+		}
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputStrategy.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.flow.node;
+
+import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.BaseAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Appends output-key candidates for one supported agent type.
+ * <p>
+ * Implementations do not read state. They only describe where an agent would
+ * publish its result, leaving attribution and stale-state checks to
+ * {@link RoutingOutputResolver}.
+ */
+interface RoutingOutputStrategy {
+
+	/**
+	 * Checks whether this strategy can resolve output candidates for the agent.
+	 * @param agent agent to inspect
+	 * @return true when this strategy supports the agent type
+	 */
+	boolean supports(Agent agent);
+
+	/**
+	 * Appends output candidates or nested resolution steps for the agent.
+	 * @param step current agent expansion step
+	 * @param steps stack used to continue nested output resolution
+	 * @param candidates ordered output candidates collected so far
+	 */
+	void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
+			List<RoutingOutputCandidate> candidates);
+
+	/**
+	 * Pushes nested agents in reverse order so stack traversal preserves list order.
+	 * @param agents nested agents to push
+	 * @param source current expansion step used as a template
+	 * @param steps stack receiving nested expansion steps
+	 * @param allowDefaultMessagesOutput whether nested base agents may use messages
+	 * fallback
+	 */
+	static void pushAllAgentSteps(List<Agent> agents, ExpandAgentOutputStep source,
+			Deque<RoutingOutputResolutionStep> steps, boolean allowDefaultMessagesOutput) {
+		if (agents == null) {
+			return;
+		}
+		for (int i = agents.size() - 1; i >= 0; i--) {
+			steps.push(source.forNestedAgent(agents.get(i), allowDefaultMessagesOutput));
+		}
+	}
+
+}
+
+/**
+ * Base agents publish either their explicit output key or the shared messages key.
+ */
+final class BaseAgentOutputStrategy implements RoutingOutputStrategy {
+
+	@Override
+	public boolean supports(Agent agent) {
+		return agent instanceof BaseAgent;
+	}
+
+	@Override
+	public void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
+			List<RoutingOutputCandidate> candidates) {
+		BaseAgent baseAgent = (BaseAgent) step.agent();
+		String outputKey = baseAgent.getOutputKey();
+		if (outputKey != null) {
+			candidates.add(new RoutingOutputCandidate(outputKey, false));
+		}
+		else if (step.allowDefaultMessagesOutput()) {
+			candidates.add(new RoutingOutputCandidate(RoutingMergeNode.DEFAULT_MESSAGES_OUTPUT_KEY, false));
+		}
+	}
+
+}
+
+/**
+ * Parallel agents use their configured merge output or collect each child output.
+ */
+final class ParallelAgentOutputStrategy implements RoutingOutputStrategy {
+
+	@Override
+	public boolean supports(Agent agent) {
+		return agent instanceof ParallelAgent;
+	}
+
+	@Override
+	public void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
+			List<RoutingOutputCandidate> candidates) {
+		ParallelAgent parallelAgent = (ParallelAgent) step.agent();
+		if (parallelAgent.mergeOutputKey() != null) {
+			candidates.add(new RoutingOutputCandidate(parallelAgent.mergeOutputKey(), false));
+		}
+		else {
+			RoutingOutputStrategy.pushAllAgentSteps(parallelAgent.subAgents(), step, steps, false);
+		}
+	}
+
+}
+
+/**
+ * Nested routers publish their synthesized answer through the routing merge key.
+ */
+final class LlmRoutingAgentOutputStrategy implements RoutingOutputStrategy {
+
+	@Override
+	public boolean supports(Agent agent) {
+		return agent instanceof LlmRoutingAgent;
+	}
+
+	@Override
+	public void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
+			List<RoutingOutputCandidate> candidates) {
+		if (step.allowRoutingMergedOutput()) {
+			candidates.add(new RoutingOutputCandidate(RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY, false));
+		}
+	}
+
+}
+
+/**
+ * Sequential agents expose the final child output as the workflow result.
+ */
+final class SequentialAgentOutputStrategy implements RoutingOutputStrategy {
+
+	@Override
+	public boolean supports(Agent agent) {
+		return agent instanceof SequentialAgent;
+	}
+
+	@Override
+	public void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
+			List<RoutingOutputCandidate> candidates) {
+		SequentialAgent sequentialAgent = (SequentialAgent) step.agent();
+		List<Agent> nestedAgents = sequentialAgent.subAgents();
+		if (nestedAgents != null && !nestedAgents.isEmpty()) {
+			steps.push(step.forNestedAgent(nestedAgents.get(nestedAgents.size() - 1),
+					step.allowDefaultMessagesOutput()));
+		}
+	}
+
+}
+
+/**
+ * Generic flow agents may expose outputs from any nested child.
+ */
+final class FlowAgentOutputStrategy implements RoutingOutputStrategy {
+
+	@Override
+	public boolean supports(Agent agent) {
+		return agent instanceof FlowAgent;
+	}
+
+	@Override
+	public void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
+			List<RoutingOutputCandidate> candidates) {
+		FlowAgent flowAgent = (FlowAgent) step.agent();
+		RoutingOutputStrategy.pushAllAgentSteps(flowAgent.subAgents(), step, steps,
+				step.allowDefaultMessagesOutput());
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputStrategy.java
@@ -17,8 +17,8 @@ package com.alibaba.cloud.ai.graph.agent.flow.node;
 
 import com.alibaba.cloud.ai.graph.agent.Agent;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
-import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LoopAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
 
@@ -163,21 +163,23 @@ final class SequentialAgentOutputStrategy implements RoutingOutputStrategy {
 }
 
 /**
- * Generic flow agents may expose outputs from any nested child.
+ * Loop agents expose the output produced by their single repeated child.
  */
-final class FlowAgentOutputStrategy implements RoutingOutputStrategy {
+final class LoopAgentOutputStrategy implements RoutingOutputStrategy {
 
 	@Override
 	public boolean supports(Agent agent) {
-		return agent instanceof FlowAgent;
+		return agent instanceof LoopAgent;
 	}
 
 	@Override
 	public void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
 			List<RoutingOutputCandidate> candidates) {
-		FlowAgent flowAgent = (FlowAgent) step.agent();
-		RoutingOutputStrategy.pushAllAgentSteps(flowAgent.subAgents(), step, steps,
-				step.allowDefaultMessagesOutput());
+		LoopAgent loopAgent = (LoopAgent) step.agent();
+		List<Agent> nestedAgents = loopAgent.subAgents();
+		if (nestedAgents != null && !nestedAgents.isEmpty()) {
+			steps.push(step.forNestedAgent(nestedAgents.get(0), step.allowDefaultMessagesOutput()));
+		}
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingOutputStrategy.java
@@ -86,10 +86,10 @@ final class BaseAgentOutputStrategy implements RoutingOutputStrategy {
 		BaseAgent baseAgent = (BaseAgent) step.agent();
 		String outputKey = baseAgent.getOutputKey();
 		if (outputKey != null) {
-			candidates.add(new RoutingOutputCandidate(outputKey, false));
+			candidates.add(new RoutingOutputCandidate(outputKey, baseAgent, false));
 		}
 		else if (step.allowDefaultMessagesOutput()) {
-			candidates.add(new RoutingOutputCandidate(RoutingMergeNode.DEFAULT_MESSAGES_OUTPUT_KEY, false));
+			candidates.add(new RoutingOutputCandidate(RoutingMergeNode.DEFAULT_MESSAGES_OUTPUT_KEY, baseAgent, false));
 		}
 	}
 
@@ -110,7 +110,7 @@ final class ParallelAgentOutputStrategy implements RoutingOutputStrategy {
 			List<RoutingOutputCandidate> candidates) {
 		ParallelAgent parallelAgent = (ParallelAgent) step.agent();
 		if (parallelAgent.mergeOutputKey() != null) {
-			candidates.add(new RoutingOutputCandidate(parallelAgent.mergeOutputKey(), false));
+			candidates.add(new RoutingOutputCandidate(parallelAgent.mergeOutputKey(), parallelAgent, false));
 		}
 		else {
 			RoutingOutputStrategy.pushAllAgentSteps(parallelAgent.subAgents(), step, steps, false);
@@ -133,7 +133,7 @@ final class LlmRoutingAgentOutputStrategy implements RoutingOutputStrategy {
 	public void appendCandidates(ExpandAgentOutputStep step, Deque<RoutingOutputResolutionStep> steps,
 			List<RoutingOutputCandidate> candidates) {
 		if (step.allowRoutingMergedOutput()) {
-			candidates.add(new RoutingOutputCandidate(RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY, false));
+			candidates.add(new RoutingOutputCandidate(RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY, step.agent(), false));
 		}
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/strategy/RoutingGraphBuildingStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/strategy/RoutingGraphBuildingStrategy.java
@@ -75,7 +75,8 @@ public class RoutingGraphBuildingStrategy extends AbstractFlowGraphBuildingStrat
 
 		// Step 4: Add merge node for result synthesis
 		String mergeNodeName = rootAgent.name() + "_merge";
-		graph.addNode(mergeNodeName, node_async(new RoutingMergeNode(config.getChatModel(), config.getSubAgents())));
+		graph.addNode(mergeNodeName, node_async(new RoutingMergeNode(config.getChatModel(), rootAgent,
+				config.getSubAgents())));
 
 		// Step 5: Process sub-agents for routing
 		Map<String, String> edgeRoutingMap = new HashMap<>();

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/strategy/RoutingGraphBuildingStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/strategy/RoutingGraphBuildingStrategy.java
@@ -15,15 +15,12 @@
  */
 package com.alibaba.cloud.ai.graph.agent.flow.strategy;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
 import com.alibaba.cloud.ai.graph.action.AsyncMultiCommandAction;
 import com.alibaba.cloud.ai.graph.agent.Agent;
-import com.alibaba.cloud.ai.graph.agent.BaseAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.builder.FlowGraphBuilder;
 import com.alibaba.cloud.ai.graph.agent.flow.enums.FlowAgentEnum;
@@ -78,14 +75,7 @@ public class RoutingGraphBuildingStrategy extends AbstractFlowGraphBuildingStrat
 
 		// Step 4: Add merge node for result synthesis
 		String mergeNodeName = rootAgent.name() + "_merge";
-		List<BaseAgent> baseAgentList = new ArrayList<>(config.getSubAgents().size());
-		for (Agent subAgent : config.getSubAgents()) {
-			if (!(subAgent instanceof BaseAgent)) {
-				throw new IllegalArgumentException("Routing sub-agents must be BaseAgent for merge support");
-			}
-			baseAgentList.add((BaseAgent) subAgent);
-		}
-		graph.addNode(mergeNodeName, node_async(new RoutingMergeNode(config.getChatModel(), baseAgentList)));
+		graph.addNode(mergeNodeName, node_async(new RoutingMergeNode(config.getChatModel(), config.getSubAgents())));
 
 		// Step 5: Process sub-agents for routing
 		Map<String, String> edgeRoutingMap = new HashMap<>();

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/FlowAgentArchitectureTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/FlowAgentArchitectureTest.java
@@ -39,6 +39,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -106,6 +107,26 @@ class FlowAgentArchitectureTest {
 		assertEquals("intelligentRouter", agent.name());
 		assertEquals("Routes tasks intelligently", agent.description());
 		assertEquals(2, agent.subAgents().size());
+	}
+
+	@Test
+	void testLlmRoutingAgentSupportsFlowAgentSubAgent() throws Exception {
+		ReactAgent writerAgent = createMockReactAgent("writerAgent", "draft");
+		ReactAgent reviewerAgent = createMockReactAgent("reviewerAgent", "reviewed");
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writingWorkflow")
+			.description("Writes and reviews content")
+			.subAgents(List.of(writerAgent, reviewerAgent))
+			.build();
+
+		LlmRoutingAgent router = LlmRoutingAgent.builder()
+			.name("router")
+			.description("Routes tasks to workflows")
+			.subAgents(List.of(writingWorkflow))
+			.model(chatModel)
+			.build();
+
+		assertDoesNotThrow(router::getGraph);
 	}
 
 	@Test

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.agent.flow;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.alibaba.cloud.ai.graph.agent.flow.node.RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for routing to nested flow agents.
+ */
+class LlmRoutingFlowAgentIntegrationTest {
+
+	@Test
+	void llmRoutingAgentCanInvokeSequentialFlowAgentSubAgent() throws Exception {
+		// The scripted responses drive the full graph without a remote model:
+		// route to the workflow, generate a draft, then return the reviewed final answer.
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of(
+				"{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write and review article\"}]}",
+				"Draft article",
+				"Reviewed article"));
+
+		ReactAgent writerAgent = ReactAgent.builder()
+			.name("writer_agent")
+			.model(chatModel)
+			.description("Writes draft articles")
+			.instruction("Write a draft for: {writing_workflow_input}")
+			.outputKey("draft_article")
+			.build();
+
+		ReactAgent reviewerAgent = ReactAgent.builder()
+			.name("reviewer_agent")
+			.model(chatModel)
+			.description("Reviews draft articles")
+			.instruction("Review this draft: {draft_article}")
+			.outputKey("reviewed_article")
+			.build();
+
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writes and reviews an article")
+			.subAgents(List.of(writerAgent, reviewerAgent))
+			.build();
+
+		LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.model(chatModel)
+			.description("Routes writing tasks")
+			.subAgents(List.of(writingWorkflow))
+			.build();
+
+		Optional<OverAllState> result = routingAgent.invoke("Please write an article");
+
+		assertTrue(result.isPresent());
+		// These assertions prove the routed SequentialAgent actually ran both nested agents.
+		assertMessageText(result.get().value("draft_article"), "Draft article");
+		assertMessageText(result.get().value("reviewed_article"), "Reviewed article");
+		// The routing merge should expose the workflow's final nested output as the merged result.
+		assertEquals("Reviewed article", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+		assertEquals(3, chatModel.callCount());
+	}
+
+	private static void assertMessageText(Optional<Object> value, String expectedText) {
+		assertTrue(value.isPresent());
+		AssistantMessage message = assertInstanceOf(AssistantMessage.class, value.get());
+		assertEquals(expectedText, message.getText());
+	}
+
+	private static final class ScriptedChatModel implements ChatModel {
+
+		private final List<String> responses;
+
+		private final AtomicInteger calls = new AtomicInteger();
+
+		private ScriptedChatModel(List<String> responses) {
+			this.responses = responses;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int index = calls.getAndIncrement();
+			if (index >= responses.size()) {
+				throw new IllegalStateException("No scripted response for call " + index);
+			}
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(responses.get(index)))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		private int callCount() {
+			return calls.get();
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
@@ -45,6 +45,7 @@ import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.o
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -293,8 +294,53 @@ class LlmRoutingFlowAgentIntegrationTest {
 
 		assertTrue(result.isPresent());
 		assertEquals("Current child merged answer", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
-		assertFalse(result.get().data().containsValue("Stale child router wrapper"),
+		assertNotEquals("Stale child router wrapper",
+				result.get().value(outputKeyToParent("child_router")).orElse(null),
 				"Nested router wrappers from earlier checkpoint turns must not be reused");
+	}
+
+	@Test
+	void multipleNestedRoutingAgentsUseCurrentMergedResultsFromRealSubgraphs() throws Exception {
+		NestedRoutingChatModel chatModel = new NestedRoutingChatModel();
+
+		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
+			.name("first_router")
+			.model(chatModel)
+			.description("Routes first nested task")
+			.subAgents(List.of(
+					outputAgent("first_inner_agent", chatModel, "first_inner_answer", "Return FIRST_INNER"),
+					outputAgent("second_inner_agent", chatModel, "second_inner_answer", "Return SECOND_INNER")))
+			.build();
+		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
+			.name("second_router")
+			.model(chatModel)
+			.description("Routes second nested task")
+			.subAgents(List.of(
+					outputAgent("third_inner_agent", chatModel, "third_inner_answer", "Return THIRD_INNER"),
+					outputAgent("fourth_inner_agent", chatModel, "fourth_inner_answer", "Return FOURTH_INNER")))
+			.build();
+		LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.model(chatModel)
+			.description("Routes to nested routers")
+			.subAgents(List.of(firstRouter, secondRouter))
+			.build();
+
+		Optional<OverAllState> result = routingAgent.invoke(Map.of(
+				"input", "Route to both nested routers",
+				"messages", List.<Message>of(new UserMessage("Route to both nested routers")),
+				outputKeyToParent("first_router"), "Stale first router wrapper",
+				outputKeyToParent("second_router"), "Stale second router wrapper"));
+
+		assertTrue(result.isPresent());
+		assertEquals("Parent merged answer", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+		String parentSynthesisPrompt = chatModel.prompts().get(chatModel.prompts().size() - 1).getContents();
+		assertTrue(parentSynthesisPrompt.contains("First router merged answer"));
+		assertTrue(parentSynthesisPrompt.contains("Second router merged answer"));
+		assertFalse(parentSynthesisPrompt.contains("Stale first router wrapper"));
+		assertFalse(parentSynthesisPrompt.contains("Stale second router wrapper"));
+		assertFalse(parentSynthesisPrompt.contains("First inner answer"));
+		assertFalse(parentSynthesisPrompt.contains("Third inner answer"));
 	}
 
 	private static void assertMessageText(Optional<Object> value, String expectedText) {
@@ -308,11 +354,15 @@ class LlmRoutingFlowAgentIntegrationTest {
 	}
 
 	private static ReactAgent outputAgent(String name, ChatModel chatModel, String outputKey) {
+		return outputAgent(name, chatModel, outputKey, "Return a scripted answer");
+	}
+
+	private static ReactAgent outputAgent(String name, ChatModel chatModel, String outputKey, String instruction) {
 		return ReactAgent.builder()
 			.name(name)
 			.model(chatModel)
 			.description("Returns a scripted answer")
-			.instruction("Return a scripted answer")
+			.instruction(instruction)
 			.outputKey(outputKey)
 			.build();
 	}
@@ -346,6 +396,78 @@ class LlmRoutingFlowAgentIntegrationTest {
 
 		private int callCount() {
 			return calls.get();
+		}
+
+		private List<Prompt> prompts() {
+			return prompts;
+		}
+
+	}
+
+	private static final class NestedRoutingChatModel implements ChatModel {
+
+		private final List<Prompt> prompts = new ArrayList<>();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			prompts.add(prompt);
+			String contents = prompt.getContents();
+			String response;
+			if (contents.contains("Available names: first_router, second_router")) {
+				response = """
+						{"agents":[
+						  {"agent":"first_router","query":"route first nested task"},
+						  {"agent":"second_router","query":"route second nested task"}
+						]}
+						""";
+			}
+			else if (contents.contains("Available names: first_inner_agent, second_inner_agent")) {
+				response = """
+						{"agents":[
+						  {"agent":"first_inner_agent","query":"answer first"},
+						  {"agent":"second_inner_agent","query":"answer second"}
+						]}
+						""";
+			}
+			else if (contents.contains("Available names: third_inner_agent, fourth_inner_agent")) {
+				response = """
+						{"agents":[
+						  {"agent":"third_inner_agent","query":"answer third"},
+						  {"agent":"fourth_inner_agent","query":"answer fourth"}
+						]}
+						""";
+			}
+			else if (contents.contains("FIRST_INNER")) {
+				response = "First inner answer";
+			}
+			else if (contents.contains("SECOND_INNER")) {
+				response = "Second inner answer";
+			}
+			else if (contents.contains("THIRD_INNER")) {
+				response = "Third inner answer";
+			}
+			else if (contents.contains("FOURTH_INNER")) {
+				response = "Fourth inner answer";
+			}
+			else if (contents.contains("First inner answer") && contents.contains("Second inner answer")) {
+				response = "First router merged answer";
+			}
+			else if (contents.contains("Third inner answer") && contents.contains("Fourth inner answer")) {
+				response = "Second router merged answer";
+			}
+			else if (contents.contains("First router merged answer")
+					&& contents.contains("Second router merged answer")) {
+				response = "Parent merged answer";
+			}
+			else {
+				throw new IllegalStateException("Unexpected prompt: " + contents);
+			}
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(response))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
 		}
 
 		private List<Prompt> prompts() {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
@@ -17,12 +17,16 @@
 package com.alibaba.cloud.ai.graph.agent.flow;
 
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -30,12 +34,16 @@ import org.springframework.ai.chat.prompt.Prompt;
 
 import reactor.core.publisher.Flux;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.alibaba.cloud.ai.graph.agent.flow.node.RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -93,10 +101,220 @@ class LlmRoutingFlowAgentIntegrationTest {
 		assertEquals(3, chatModel.callCount());
 	}
 
+	@Test
+	void routedDefaultOutputFlowAgentIgnoresCheckpointedWrapperOutput() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of(
+				"{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write article\"}]}",
+				"Current workflow answer"));
+
+		ReactAgent writerAgent = ReactAgent.builder()
+			.name("writer_agent")
+			.model(chatModel)
+			.description("Writes articles")
+			.instruction("Write the current answer")
+			.build();
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writes an article")
+			.subAgents(List.of(writerAgent))
+			.build();
+		LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.model(chatModel)
+			.description("Routes writing tasks")
+			.subAgents(List.of(writingWorkflow))
+			.build();
+
+		Optional<OverAllState> result = routingAgent.invoke(Map.of(
+				"input", "Please write an article",
+				"messages", List.<Message>of(new UserMessage("Please write an article")),
+				outputKeyToParent("writing_workflow"), "Stale wrapper answer"));
+
+		assertTrue(result.isPresent());
+		assertEquals("Current workflow answer", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+		assertFalse(result.get().data().containsValue("Stale wrapper answer"),
+				"Checkpointed workflow wrappers must not be reused as current routed output");
+	}
+
+	@Test
+	void routedDefaultOutputFlowAgentIgnoresWrapperOutputFromPreviousCheckpointTurn() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of(
+				"{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write old article\"}]}",
+				"Old workflow answer",
+				"{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write current article\"}]}",
+				"Current workflow answer"));
+
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writes an article")
+			.subAgents(List.of(defaultOutputAgent("writer_agent", chatModel)))
+			.build();
+		LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.model(chatModel)
+			.description("Routes writing tasks")
+			.subAgents(List.of(writingWorkflow))
+			.saver(new MemorySaver())
+			.build();
+		RunnableConfig sameThread = RunnableConfig.builder().threadId("routing-thread").build();
+
+		Optional<OverAllState> first = routingAgent.invoke("Please write the old article", sameThread);
+		Optional<OverAllState> second = routingAgent.invoke("Please write the current article", sameThread);
+
+		assertTrue(first.isPresent());
+		assertTrue(second.isPresent());
+		assertEquals("Old workflow answer", first.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+		assertEquals("Current workflow answer", second.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+	}
+
+	@Test
+	void multipleRoutedDefaultOutputFlowAgentsIgnoreCheckpointedWrapperOutputs() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of(
+				"""
+				{"agents":[
+				  {"agent":"first_workflow","query":"write first"},
+				  {"agent":"second_workflow","query":"write second"}
+				]}
+				""",
+				"Current first answer",
+				"Current second answer",
+				"Merged current answer"));
+
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("Writes the first answer")
+			.subAgents(List.of(defaultOutputAgent("first_writer", chatModel)))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Writes the second answer")
+			.subAgents(List.of(defaultOutputAgent("second_writer", chatModel)))
+			.build();
+		LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.model(chatModel)
+			.description("Routes writing tasks")
+			.subAgents(List.of(firstWorkflow, secondWorkflow))
+			.build();
+
+		Optional<OverAllState> result = routingAgent.invoke(Map.of(
+				"input", "Please write both answers",
+				"messages", List.<Message>of(new UserMessage("Please write both answers")),
+				outputKeyToParent("first_workflow"), "Stale first wrapper",
+				outputKeyToParent("second_workflow"), "Stale second wrapper"));
+
+		assertTrue(result.isPresent());
+		assertEquals("Merged current answer", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+		String synthesizedPrompt = chatModel.prompts().get(chatModel.prompts().size() - 1).getContents();
+		assertTrue(synthesizedPrompt.contains("Current first answer"));
+		assertTrue(synthesizedPrompt.contains("Current second answer"));
+		assertFalse(synthesizedPrompt.contains("Stale first wrapper"));
+		assertFalse(synthesizedPrompt.contains("Stale second wrapper"));
+	}
+
+	@Test
+	void multipleRoutedWorkflowsWithSharedOutputKeyIgnoreCheckpointedWrapperOutputs() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of(
+				"""
+				{"agents":[
+				  {"agent":"first_workflow","query":"write first"},
+				  {"agent":"second_workflow","query":"write second"}
+				]}
+				""",
+				"Current first explicit answer",
+				"Current second explicit answer",
+				"Merged explicit answer"));
+
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("Writes the first answer")
+			.subAgents(List.of(outputAgent("first_writer", chatModel, "shared_answer")))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Writes the second answer")
+			.subAgents(List.of(outputAgent("second_writer", chatModel, "shared_answer")))
+			.build();
+		LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.model(chatModel)
+			.description("Routes writing tasks")
+			.subAgents(List.of(firstWorkflow, secondWorkflow))
+			.build();
+
+		Optional<OverAllState> result = routingAgent.invoke(Map.of(
+				"input", "Please write both answers",
+				"messages", List.<Message>of(new UserMessage("Please write both answers")),
+				outputKeyToParent("first_workflow"), "Stale first explicit wrapper",
+				outputKeyToParent("second_workflow"), "Stale second explicit wrapper"));
+
+		assertTrue(result.isPresent());
+		assertEquals("Merged explicit answer", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+		String synthesizedPrompt = chatModel.prompts().get(chatModel.prompts().size() - 1).getContents();
+		assertTrue(synthesizedPrompt.contains("Current first explicit answer"));
+		assertTrue(synthesizedPrompt.contains("Current second explicit answer"));
+		assertFalse(synthesizedPrompt.contains("Stale first explicit wrapper"));
+		assertFalse(synthesizedPrompt.contains("Stale second explicit wrapper"));
+	}
+
+	@Test
+	void routedNestedRoutingAgentIgnoresCheckpointedWrapperOutput() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of(
+				"{\"agents\":[{\"agent\":\"child_router\",\"query\":\"route inside child\"}]}",
+				"""
+				{"agents":[
+				  {"agent":"first_inner_agent","query":"answer first"},
+				  {"agent":"second_inner_agent","query":"answer second"}
+				]}
+				""",
+				"Current first inner answer",
+				"Current second inner answer",
+				"Current child merged answer"));
+
+		LlmRoutingAgent childRouter = LlmRoutingAgent.builder()
+			.name("child_router")
+			.model(chatModel)
+			.description("Routes inside the selected workflow")
+			.subAgents(List.of(
+					outputAgent("first_inner_agent", chatModel, "first_inner_answer"),
+					outputAgent("second_inner_agent", chatModel, "second_inner_answer")))
+			.build();
+		LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.model(chatModel)
+			.description("Routes to a nested router")
+			.subAgents(List.of(childRouter))
+			.build();
+
+		Optional<OverAllState> result = routingAgent.invoke(Map.of(
+				"input", "Please route inside child",
+				"messages", List.<Message>of(new UserMessage("Please route inside child")),
+				outputKeyToParent("child_router"), "Stale child router wrapper"));
+
+		assertTrue(result.isPresent());
+		assertEquals("Current child merged answer", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null));
+		assertFalse(result.get().data().containsValue("Stale child router wrapper"),
+				"Nested router wrappers from earlier checkpoint turns must not be reused");
+	}
+
 	private static void assertMessageText(Optional<Object> value, String expectedText) {
 		assertTrue(value.isPresent());
 		AssistantMessage message = assertInstanceOf(AssistantMessage.class, value.get());
 		assertEquals(expectedText, message.getText());
+	}
+
+	private static ReactAgent defaultOutputAgent(String name, ChatModel chatModel) {
+		return outputAgent(name, chatModel, null);
+	}
+
+	private static ReactAgent outputAgent(String name, ChatModel chatModel, String outputKey) {
+		return ReactAgent.builder()
+			.name(name)
+			.model(chatModel)
+			.description("Returns a scripted answer")
+			.instruction("Return a scripted answer")
+			.outputKey(outputKey)
+			.build();
 	}
 
 	private static final class ScriptedChatModel implements ChatModel {
@@ -105,12 +323,15 @@ class LlmRoutingFlowAgentIntegrationTest {
 
 		private final AtomicInteger calls = new AtomicInteger();
 
+		private final List<Prompt> prompts = new ArrayList<>();
+
 		private ScriptedChatModel(List<String> responses) {
 			this.responses = responses;
 		}
 
 		@Override
 		public ChatResponse call(Prompt prompt) {
+			prompts.add(prompt);
 			int index = calls.getAndIncrement();
 			if (index >= responses.size()) {
 				throw new IllegalStateException("No scripted response for call " + index);
@@ -125,6 +346,10 @@ class LlmRoutingFlowAgentIntegrationTest {
 
 		private int callCount() {
 			return calls.get();
+		}
+
+		private List<Prompt> prompts() {
+			return prompts;
 		}
 
 	}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/LlmRoutingFlowAgentIntegrationTest.java
@@ -300,6 +300,42 @@ class LlmRoutingFlowAgentIntegrationTest {
 	}
 
 	@Test
+	void sameNamedNestedRoutingAgentsKeepSelectionsIsolatedInRealSubgraphs() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of(
+				"{\"agents\":[{\"agent\":\"outer_workflow\",\"query\":\"route inside child\"}]}",
+				"{\"agents\":[{\"agent\":\"inner_agent\",\"query\":\"produce answer\"}]}",
+				"Same-name nested answer"));
+
+		LlmRoutingAgent nestedRouter = LlmRoutingAgent.builder()
+			.name("shared_router")
+			.model(chatModel)
+			.description("Nested router with the same name as its parent")
+			.subAgents(List.of(outputAgent("inner_agent", chatModel, "inner_answer")))
+			.build();
+		SequentialAgent outerWorkflow = SequentialAgent.builder()
+			.name("outer_workflow")
+			.description("Places the same-named router in a separate nested graph")
+			.subAgents(List.of(nestedRouter))
+			.build();
+		LlmRoutingAgent outerRouter = LlmRoutingAgent.builder()
+			.name("shared_router")
+			.model(chatModel)
+			.description("Outer router")
+			.subAgents(List.of(outerWorkflow))
+			.build();
+
+		Optional<OverAllState> result = outerRouter.invoke("Route through the same-named child");
+
+		assertTrue(result.isPresent());
+		assertMessageText(result.get().value("inner_answer"), "Same-name nested answer");
+		assertEquals("Same-name nested answer", result.get().value(DEFAULT_MERGED_OUTPUT_KEY).orElse(null),
+				"The child routing marker must not replace the outer router's current selection");
+		assertFalse(result.get().data().containsKey("_routing_selected_agents_shared_router"),
+				"The outermost router must remove its scoped selection marker after merging");
+		assertEquals(3, chatModel.callCount());
+	}
+
+	@Test
 	void multipleNestedRoutingAgentsUseCurrentMergedResultsFromRealSubgraphs() throws Exception {
 		NestedRoutingChatModel chatModel = new NestedRoutingChatModel();
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -15,9 +15,14 @@
  */
 package com.alibaba.cloud.ai.graph.agent.flow.node;
 
+import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -30,7 +35,10 @@ import java.util.List;
 import java.util.Map;
 
 import static com.alibaba.cloud.ai.graph.agent.flow.node.RoutingMergeNode.DEFAULT_MERGED_OUTPUT_KEY;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -98,6 +106,593 @@ class RoutingMergeNodeTest {
 		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Multiple results must be synthesized via the LLM");
 		verify(chatModel, times(1)).call(any(Prompt.class));
+	}
+
+	@Test
+	void explicitListOutputPreservesAllEntries() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+		BaseAgent searchAgent = mockAgent("search_agent", "search_results");
+		List<String> searchResults = List.of("First search hit.", "Second search hit.");
+
+		OverAllState state = new OverAllState(Map.of(
+				"search_results", searchResults,
+				"messages", List.<Message>of(new UserMessage("Search for routing results"))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(searchAgent));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals(searchResults.toString(), result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Explicit list outputs should preserve every entry, not only the last one");
+		assertEquals(searchResults.toString(),
+				RoutingMergeNode.extractText(Map.of("search_results", searchResults), "search_results"));
+		assertEquals(searchResults.toString(),
+				RoutingMergeNode.extractText(GraphResponse.done(Map.of("search_results", searchResults)),
+						"search_results"));
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void flowAgentResultIsResolvedFromNestedFinalOutputKey() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		BaseAgent draftAgent = mockAgent("draft_agent", "draft_article");
+		BaseAgent reviewAgent = mockAgent("review_agent", "reviewed_article");
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writes and reviews an article")
+			.subAgents(List.of(draftAgent, reviewAgent))
+			.build();
+
+		// The wrapper output can coexist with the nested final output after subgraph execution.
+		// The merge node must count this as one routed source and avoid an unnecessary synthesis call.
+		OverAllState state = new OverAllState(Map.of(
+				"draft_article", new AssistantMessage("Draft that should not be returned."),
+				"reviewed_article", new AssistantMessage("Reviewed final article."),
+				outputKeyToParent("writing_workflow"), new AssistantMessage("Wrapped workflow result."),
+				"messages", List.<Message>of(new UserMessage("Write an article"))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(writingWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Reviewed final article.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Sequential FlowAgent result should use its final nested output");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void flowAgentResultFallsBackToMessagesForNestedAgentWithoutOutputKey() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		BaseAgent draftAgent = mockAgent("draft_agent", "draft_article");
+		BaseAgent reviewerAgent = mockAgent("reviewer_agent", null);
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writes and reviews an article")
+			.subAgents(List.of(draftAgent, reviewerAgent))
+			.build();
+
+		// AgentLlmNode and the ReactAgent subgraph adapter use messages as the default output
+		// when a nested agent has no explicit outputKey.
+		OverAllState state = new OverAllState(Map.of(
+				"writing_workflow_input", "Write and review an article",
+				"draft_article", new AssistantMessage("Draft that should not be returned."),
+				"messages", List.<Message>of(
+						new UserMessage("Write an article"),
+						new AssistantMessage("Reviewed final article from messages."))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(writingWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Reviewed final article from messages.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Sequential FlowAgent result should fall back to messages for default agent output");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void messagesFallbackDoesNotCollectUnselectedAgents() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		SequentialAgent selectedWorkflow = SequentialAgent.builder()
+			.name("selected_workflow")
+			.description("Selected workflow")
+			.subAgents(List.of(mockAgent("selected_final_agent", null)))
+			.build();
+		SequentialAgent skippedWorkflow = SequentialAgent.builder()
+			.name("skipped_workflow")
+			.description("Skipped workflow")
+			.subAgents(List.of(mockAgent("skipped_final_agent", null)))
+			.build();
+
+		// messages is shared state, so only the routed workflow may use it as a default output.
+		OverAllState state = new OverAllState(Map.of(
+				"selected_workflow_input", "Run the selected workflow",
+				"messages", List.<Message>of(
+						new UserMessage("Run one workflow"),
+						new AssistantMessage("Selected workflow answer."))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(selectedWorkflow, skippedWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Selected workflow answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Shared messages must not be collected for unselected agents");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void unroutedFlowAgentsAreNotResolvedFromSharedExplicitOutputKeys() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		SequentialAgent selectedWorkflow = SequentialAgent.builder()
+			.name("selected_workflow")
+			.description("Selected workflow")
+			.subAgents(List.of(mockAgent("selected_final_agent", "shared_answer")))
+			.build();
+		SequentialAgent skippedWorkflow = SequentialAgent.builder()
+			.name("skipped_workflow")
+			.description("Skipped workflow")
+			.subAgents(List.of(mockAgent("skipped_final_agent", "shared_answer")))
+			.build();
+
+		// Top-level routing markers define which workflow actually ran; unselected workflows
+		// must not resolve shared parent-state keys even when their nested outputKey matches.
+		OverAllState state = new OverAllState(Map.of(
+				"selected_workflow_input", "Run the selected workflow",
+				"shared_answer", new AssistantMessage("Selected workflow answer."))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(selectedWorkflow, skippedWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Selected workflow answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Unrouted workflows must not collect shared explicit output keys");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void sharedExplicitOutputKeyIsCollectedOnlyOnceForMultipleRoutedAgents() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("First workflow")
+			.subAgents(List.of(mockAgent("first_final_agent", "shared_answer")))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Second workflow")
+			.subAgents(List.of(mockAgent("second_final_agent", "shared_answer")))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"first_workflow_input", "Run the first workflow",
+				"second_workflow_input", "Run the second workflow",
+				"shared_answer", new AssistantMessage("Only one shared answer exists in state."))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstWorkflow, secondWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Only one shared answer exists in state.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"A shared explicit output key represents one parent-state value and must not be duplicated");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void multipleRoutedWorkflowsPreferWrapperOverSharedChildOutputKey() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class)))
+				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("First workflow")
+			.subAgents(List.of(mockAgent("first_final_agent", "shared_answer")))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Second workflow")
+			.subAgents(List.of(mockAgent("second_final_agent", "shared_answer")))
+			.build();
+
+		// The child output key is shared and replace-merged in the parent state, while each
+		// workflow wrapper carries the answer produced by that workflow branch.
+		OverAllState state = new OverAllState(Map.of(
+				"first_workflow_input", "Run the first workflow",
+				"second_workflow_input", "Run the second workflow",
+				"shared_answer", new AssistantMessage("Shared child value that must not be attributed."),
+				outputKeyToParent("first_workflow"), new AssistantMessage("First workflow wrapper answer."),
+				outputKeyToParent("second_workflow"), new AssistantMessage("Second workflow wrapper answer."),
+				"messages", List.<Message>of(new UserMessage("Run both workflows")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstWorkflow, secondWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Multiple routed workflows should synthesize their namespaced wrapper outputs");
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(chatModel, times(1)).call(promptCaptor.capture());
+		String promptContent = promptCaptor.getValue().getContents();
+		assertTrue(promptContent.contains("First workflow wrapper answer."));
+		assertTrue(promptContent.contains("Second workflow wrapper answer."));
+		assertFalse(promptContent.contains("Shared child value that must not be attributed."));
+	}
+
+	@Test
+	void multipleRoutedParallelWorkflowsPreferMergeOutputKeyOverWrapper() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class)))
+				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+
+		ParallelAgent firstParallel = ParallelAgent.builder()
+			.name("first_parallel")
+			.description("First parallel workflow")
+			.subAgents(List.of(
+					mockAgent("first_parallel_search", "first_search_result"),
+					mockAgent("first_parallel_summary", "first_summary_result")))
+			.mergeOutputKey("first_merged_result")
+			.build();
+		ParallelAgent secondParallel = ParallelAgent.builder()
+			.name("second_parallel")
+			.description("Second parallel workflow")
+			.subAgents(List.of(
+					mockAgent("second_parallel_search", "second_search_result"),
+					mockAgent("second_parallel_summary", "second_summary_result")))
+			.mergeOutputKey("second_merged_result")
+			.build();
+
+		// A ParallelAgent with mergeOutputKey has an explicit aggregate result. The workflow
+		// wrapper may also be present, but it must not hide that aggregate output.
+		OverAllState state = new OverAllState(Map.of(
+				"first_parallel_input", "Run the first parallel workflow",
+				"second_parallel_input", "Run the second parallel workflow",
+				"first_merged_result", new AssistantMessage("First merged answer."),
+				"second_merged_result", new AssistantMessage("Second merged answer."),
+				outputKeyToParent("first_parallel"), new AssistantMessage("First wrapper answer that must not be used."),
+				outputKeyToParent("second_parallel"), new AssistantMessage("Second wrapper answer that must not be used."),
+				"messages", List.<Message>of(new UserMessage("Run both parallel workflows")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstParallel, secondParallel));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Multiple routed parallel workflows should synthesize their mergeOutputKey results");
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(chatModel, times(1)).call(promptCaptor.capture());
+		String promptContent = promptCaptor.getValue().getContents();
+		assertTrue(promptContent.contains("First merged answer."));
+		assertTrue(promptContent.contains("Second merged answer."));
+		assertFalse(promptContent.contains("First wrapper answer that must not be used."));
+		assertFalse(promptContent.contains("Second wrapper answer that must not be used."));
+	}
+
+	@Test
+	void multipleRoutedParallelWorkflowsPreferWrapperWhenMergeOutputKeyIsShared() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class)))
+				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+
+		ParallelAgent firstParallel = ParallelAgent.builder()
+			.name("first_parallel")
+			.description("First parallel workflow")
+			.subAgents(List.of(
+					mockAgent("first_parallel_search", "first_search_result"),
+					mockAgent("first_parallel_summary", "first_summary_result")))
+			.mergeOutputKey("shared_merged_result")
+			.build();
+		ParallelAgent secondParallel = ParallelAgent.builder()
+			.name("second_parallel")
+			.description("Second parallel workflow")
+			.subAgents(List.of(
+					mockAgent("second_parallel_search", "second_search_result"),
+					mockAgent("second_parallel_summary", "second_summary_result")))
+			.mergeOutputKey("shared_merged_result")
+			.build();
+
+		// Reused mergeOutputKey values are shared in the parent state, so each workflow must
+		// fall back to its namespaced wrapper to avoid attributing one result to both sources.
+		OverAllState state = new OverAllState(Map.of(
+				"first_parallel_input", "Run the first parallel workflow",
+				"second_parallel_input", "Run the second parallel workflow",
+				"shared_merged_result", new AssistantMessage("Shared merge value that must not be attributed."),
+				outputKeyToParent("first_parallel"), new AssistantMessage("First parallel wrapper answer."),
+				outputKeyToParent("second_parallel"), new AssistantMessage("Second parallel wrapper answer."),
+				"messages", List.<Message>of(new UserMessage("Run both parallel workflows")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstParallel, secondParallel));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Shared mergeOutputKey values should be resolved through workflow wrappers");
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(chatModel, times(1)).call(promptCaptor.capture());
+		String promptContent = promptCaptor.getValue().getContents();
+		assertTrue(promptContent.contains("First parallel wrapper answer."));
+		assertTrue(promptContent.contains("Second parallel wrapper answer."));
+		assertFalse(promptContent.contains("Shared merge value that must not be attributed."));
+	}
+
+	@Test
+	void multipleRoutedParallelWorkflowsPreferWrapperWhenChildOutputKeysAreShared() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class)))
+				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+
+		ParallelAgent firstParallel = ParallelAgent.builder()
+			.name("first_parallel")
+			.description("First parallel workflow")
+			.subAgents(List.of(
+					mockAgent("first_parallel_search", "shared_search_result"),
+					mockAgent("first_parallel_summary", "shared_summary_result")))
+			.build();
+		ParallelAgent secondParallel = ParallelAgent.builder()
+			.name("second_parallel")
+			.description("Second parallel workflow")
+			.subAgents(List.of(
+					mockAgent("second_parallel_search", "shared_search_result"),
+					mockAgent("second_parallel_summary", "shared_summary_result")))
+			.build();
+
+		// Without a mergeOutputKey, ParallelAgent exposes child outputs. If those keys are
+		// reused by another routed workflow, only the workflow wrapper is safely attributable.
+		OverAllState state = new OverAllState(Map.of(
+				"first_parallel_input", "Run the first parallel workflow",
+				"second_parallel_input", "Run the second parallel workflow",
+				"shared_search_result", new AssistantMessage("Shared search value that must not be attributed."),
+				"shared_summary_result", new AssistantMessage("Shared summary value that must not be attributed."),
+				outputKeyToParent("first_parallel"), new AssistantMessage("First parallel wrapper answer."),
+				outputKeyToParent("second_parallel"), new AssistantMessage("Second parallel wrapper answer."),
+				"messages", List.<Message>of(new UserMessage("Run both parallel workflows")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstParallel, secondParallel));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Shared child output keys should be resolved through workflow wrappers");
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(chatModel, times(1)).call(promptCaptor.capture());
+		String promptContent = promptCaptor.getValue().getContents();
+		assertTrue(promptContent.contains("First parallel wrapper answer."));
+		assertTrue(promptContent.contains("Second parallel wrapper answer."));
+		assertFalse(promptContent.contains("Shared search value that must not be attributed."));
+		assertFalse(promptContent.contains("Shared summary value that must not be attributed."));
+	}
+
+	@Test
+	void parallelAgentWithoutMergeOutputKeyCollectsAllChildOutputs() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		BaseAgent firstAgent = mockAgent("first_agent", "first_answer");
+		BaseAgent secondAgent = mockAgent("second_agent", "second_answer");
+		ParallelAgent parallelWorkflow = ParallelAgent.builder()
+			.name("parallel_workflow")
+			.description("Runs child agents in parallel")
+			.subAgents(List.of(firstAgent, secondAgent))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"parallel_workflow_input", "Run the parallel workflow",
+				"first_answer", new AssistantMessage("First child answer."),
+				"second_answer", new AssistantMessage("Second child answer."))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(parallelWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("First child answer.\n\nSecond child answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"ParallelAgent without mergeOutputKey should expose all child outputs as one routed source");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void sequentialAgentWithFinalParallelAgentCollectsAllChildOutputs() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		BaseAgent draftAgent = mockAgent("draft_agent", "draft_answer");
+		BaseAgent styleReviewer = mockAgent("style_reviewer", "style_answer");
+		BaseAgent factReviewer = mockAgent("fact_reviewer", "fact_answer");
+		ParallelAgent reviewParallel = ParallelAgent.builder()
+			.name("review_parallel")
+			.description("Runs final reviewers in parallel")
+			.subAgents(List.of(styleReviewer, factReviewer))
+			.build();
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writes and reviews an article")
+			.subAgents(List.of(draftAgent, reviewParallel))
+			.build();
+
+		// A SequentialAgent's effective result comes from its final agent. If that final
+		// agent is a ParallelAgent without a mergeOutputKey, all child outputs form one
+		// routed source and none of them should be dropped.
+		OverAllState state = new OverAllState(Map.of(
+				"writing_workflow_input", "Write and review an article",
+				"draft_answer", new AssistantMessage("Draft that should not be returned."),
+				"style_answer", new AssistantMessage("Style review."),
+				"fact_answer", new AssistantMessage("Fact review."))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(writingWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Style review.\n\nFact review.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"SequentialAgent should preserve all outputs from a final ParallelAgent");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void messagesFallbackIsNotUsedForMultipleRoutedAgents() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("First workflow")
+			.subAgents(List.of(mockAgent("first_final_agent", null)))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Second workflow")
+			.subAgents(List.of(mockAgent("second_final_agent", null)))
+			.build();
+
+		// With more than one routed workflow, messages cannot be attributed to a single source.
+		OverAllState state = new OverAllState(Map.of(
+				"first_workflow_input", "Run the first workflow",
+				"second_workflow_input", "Run the second workflow",
+				"messages", List.<Message>of(
+						new UserMessage("Run both workflows"),
+						new AssistantMessage("Shared last answer."))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstWorkflow, secondWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Shared messages must not be duplicated across multiple routed agents");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void messagesFallbackIgnoresUserOnlyHistory() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writes an article")
+			.subAgents(List.of(mockAgent("writer_agent", null)))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"writing_workflow_input", "Write an article",
+				"messages", List.<Message>of(new UserMessage("Write an article")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(writingWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"User-only message history must not be treated as an agent answer");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void nestedRoutingAgentResultUsesItsMergedOutputBeforeChildOutputs() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		BaseAgent firstAgent = mockAgent("first_agent", "first_answer");
+		BaseAgent secondAgent = mockAgent("second_agent", "second_answer");
+		LlmRoutingAgent childRouter = LlmRoutingAgent.builder()
+			.name("child_router")
+			.description("Routes to child agents")
+			.model(chatModel)
+			.subAgents(List.of(firstAgent, secondAgent))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"child_router_input", "Route inside the child router",
+				DEFAULT_MERGED_OUTPUT_KEY, "Child router synthesized answer.",
+				"first_answer", new AssistantMessage("First child raw answer."),
+				"second_answer", new AssistantMessage("Second child raw answer."))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(childRouter));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Child router synthesized answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Nested routing agents should expose their own merged output to the parent merge");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void routingMergedOutputIsNotDuplicatedForMultipleNestedRoutingAgents() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
+			.name("first_router")
+			.description("First child router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
+			.build();
+		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
+			.name("second_router")
+			.description("Second child router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"first_router_input", "Run the first router",
+				"second_router_input", "Run the second router",
+				DEFAULT_MERGED_OUTPUT_KEY, "Shared routing merge answer.")
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstRouter, secondRouter));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Shared routing merge output must not be duplicated across multiple routed child routers");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void multipleNestedRoutingAgentsUseNamespacedWrapperResults() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class)))
+				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+
+		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
+			.name("first_router")
+			.description("First child router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
+			.build();
+		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
+			.name("second_router")
+			.description("Second child router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
+			.build();
+
+		// Each routed subgraph has its own wrapper key, so the nested routing result can
+		// be read from that wrapper map without attributing the shared parent merged_result
+		// to every router.
+		OverAllState state = new OverAllState(Map.of(
+				"first_router_input", "Run the first router",
+				"second_router_input", "Run the second router",
+				DEFAULT_MERGED_OUTPUT_KEY, "Shared parent merge result that must not be used.",
+				outputKeyToParent("first_router"), GraphResponse.done(Map.of(
+						outputKeyToParent("first_router"), "First router raw fallback answer.",
+						DEFAULT_MERGED_OUTPUT_KEY, "First router synthesized answer.",
+						"first_answer", new AssistantMessage("First raw answer."))),
+				outputKeyToParent("second_router"), GraphResponse.done(Map.of(
+						outputKeyToParent("second_router"), "Second router raw fallback answer.",
+						DEFAULT_MERGED_OUTPUT_KEY, "Second router synthesized answer.",
+						"second_answer", new AssistantMessage("Second raw answer."))),
+				"messages", List.<Message>of(new UserMessage("Run both routers")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstRouter, secondRouter));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Multiple nested routing results should be synthesized from namespaced wrapper outputs");
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		verify(chatModel, times(1)).call(promptCaptor.capture());
+		String promptContent = promptCaptor.getValue().getContents();
+		assertTrue(promptContent.contains("First router synthesized answer."));
+		assertTrue(promptContent.contains("Second router synthesized answer."));
+		assertFalse(promptContent.contains("Shared parent merge result that must not be used."));
+		assertFalse(promptContent.contains("First router raw fallback answer."));
+		assertFalse(promptContent.contains("Second router raw fallback answer."));
+		assertFalse(promptContent.contains("First raw answer."));
+		assertFalse(promptContent.contains("Second raw answer."));
 	}
 
 	private static BaseAgent mockAgent(String name, String outputKey) {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -729,6 +729,71 @@ class RoutingMergeNodeTest {
 		assertFalse(promptContent.contains("Second raw answer."));
 	}
 
+	@Test
+	void parentRoutingSelectionIsNamespacedFromChildRoutingSelection() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		BaseAgent parentRouter = mockAgent("parent_router", null);
+		LlmRoutingAgent childRouter = LlmRoutingAgent.builder()
+			.name("child_router")
+			.description("Child router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("inner_agent", "inner_answer")))
+			.build();
+
+		// Subgraphs merge state back into the parent. The child router may update its own
+		// route marker after the parent has selected child_router, so the parent merge must
+		// read the marker namespaced by parent_router rather than the child's selection.
+		OverAllState state = new OverAllState(Map.of(
+				RoutingNode.routedAgentNamesKey("parent_router"), List.of("child_router"),
+				RoutingNode.routedAgentNamesKey("child_router"), List.of("inner_agent"),
+				RoutingNode.ROUTED_AGENT_NAMES_KEY, List.of("inner_agent"),
+				"child_router_input", "Run child router",
+				"inner_agent_input", "Run inner agent",
+				outputKeyToParent("child_router"), GraphResponse.done(Map.of(
+						outputKeyToParent("child_router"), "Child router raw fallback answer.",
+						DEFAULT_MERGED_OUTPUT_KEY, "Child router synthesized answer.")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, parentRouter, List.of(childRouter));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Child router synthesized answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Parent routing merge should ignore child-router selection markers");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
+	void parentRoutingMergeIgnoresGlobalMarkerWhenNamespacedMarkerIsAbsent() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		BaseAgent parentRouter = mockAgent("parent_router", null);
+		LlmRoutingAgent childRouter = LlmRoutingAgent.builder()
+			.name("child_router")
+			.description("Child router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("inner_agent", "inner_answer")))
+			.build();
+
+		// The production merge node knows its parent router name. If an old or nested
+		// un-namespaced marker is present without the parent marker, it must not be treated
+		// as the parent router's current selection.
+		OverAllState state = new OverAllState(Map.of(
+				RoutingNode.ROUTED_AGENT_NAMES_KEY, List.of("inner_agent"),
+				"child_router_input", "Run child router",
+				"inner_agent_input", "Run inner agent",
+				outputKeyToParent("child_router"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Child router synthesized answer.")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, parentRouter, List.of(childRouter));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Child router synthesized answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Parent routing merge should fall back to top-level route inputs, not stale global markers");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
 	private static BaseAgent mockAgent(String name, String outputKey) {
 		BaseAgent agent = mock(BaseAgent.class);
 		when(agent.name()).thenReturn(name);

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -223,6 +223,40 @@ class RoutingMergeNodeTest {
 	}
 
 	@Test
+	void currentRouteSelectionIgnoresStaleCheckpointInputMarkers() throws Exception {
+		ChatModel chatModel = mock(ChatModel.class);
+
+		SequentialAgent selectedWorkflow = SequentialAgent.builder()
+			.name("selected_workflow")
+			.description("Selected workflow")
+			.subAgents(List.of(mockAgent("selected_final_agent", null)))
+			.build();
+		SequentialAgent skippedWorkflow = SequentialAgent.builder()
+			.name("skipped_workflow")
+			.description("Skipped workflow")
+			.subAgents(List.of(mockAgent("skipped_final_agent", null)))
+			.build();
+
+		// Checkpointed graph state can retain old <agent>_input keys across turns.
+		// The explicit current-route marker must be authoritative for this run.
+		OverAllState state = new OverAllState(Map.of(
+				RoutingNode.ROUTED_AGENT_NAMES_KEY, List.of("selected_workflow"),
+				"selected_workflow_input", "Run the selected workflow",
+				"skipped_workflow_input", "Stale input from a previous checkpointed turn",
+				"messages", List.<Message>of(
+						new UserMessage("Run one workflow"),
+						new AssistantMessage("Selected workflow answer.")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(selectedWorkflow, skippedWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Selected workflow answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Stale route inputs from checkpoints must not disable the single-agent messages fallback");
+		verify(chatModel, never()).call(any(Prompt.class));
+	}
+
+	@Test
 	void unroutedFlowAgentsAreNotResolvedFromSharedExplicitOutputKeys() throws Exception {
 		ChatModel chatModel = mock(ChatModel.class);
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -17,12 +17,14 @@ package com.alibaba.cloud.ai.graph.agent.flow.node;
 
 import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+import com.alibaba.cloud.ai.graph.exception.GraphStateException;
+import com.alibaba.cloud.ai.graph.internal.node.Node;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -31,6 +33,9 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -39,12 +44,6 @@ import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.o
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link RoutingMergeNode}.
@@ -62,7 +61,7 @@ class RoutingMergeNodeTest {
 	 */
 	@Test
 	void singleRoutedResultIsPassedThroughWithoutSynthesis() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent poemAgent = mockAgent("poem_writer_agent", "poem_article");
 		BaseAgent proseAgent = mockAgent("prose_writer_agent", "prose_article");
@@ -78,7 +77,7 @@ class RoutingMergeNodeTest {
 
 		assertEquals("A short modern poem about spring.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Single routed result must be returned verbatim, not re-synthesized");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	/**
@@ -87,9 +86,7 @@ class RoutingMergeNodeTest {
 	 */
 	@Test
 	void multipleResultsAreSynthesizedViaLlm() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
-		when(chatModel.call(any(Prompt.class)))
-				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
 
 		BaseAgent poemAgent = mockAgent("poem_writer_agent", "poem_article");
 		BaseAgent proseAgent = mockAgent("prose_writer_agent", "prose_article");
@@ -105,12 +102,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Multiple results must be synthesized via the LLM");
-		verify(chatModel, times(1)).call(any(Prompt.class));
+		assertEquals(1, chatModel.callCount());
 	}
 
 	@Test
 	void explicitListOutputPreservesAllEntries() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 		BaseAgent searchAgent = mockAgent("search_agent", "search_results");
 		List<String> searchResults = List.of("First search hit.", "Second search hit.");
 
@@ -129,12 +126,12 @@ class RoutingMergeNodeTest {
 		assertEquals(searchResults.toString(),
 				RoutingMergeNode.extractText(GraphResponse.done(Map.of("search_results", searchResults)),
 						"search_results"));
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void flowAgentResultIsResolvedFromNestedFinalOutputKey() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent draftAgent = mockAgent("draft_agent", "draft_article");
 		BaseAgent reviewAgent = mockAgent("review_agent", "reviewed_article");
@@ -158,12 +155,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Reviewed final article.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Sequential FlowAgent result should use its final nested output");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void flowAgentResultFallsBackToMessagesForNestedAgentWithoutOutputKey() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent draftAgent = mockAgent("draft_agent", "draft_article");
 		BaseAgent reviewerAgent = mockAgent("reviewer_agent", null);
@@ -188,12 +185,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Reviewed final article from messages.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Sequential FlowAgent result should fall back to messages for default agent output");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void messagesFallbackDoesNotCollectUnselectedAgents() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		SequentialAgent selectedWorkflow = SequentialAgent.builder()
 			.name("selected_workflow")
@@ -219,12 +216,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Selected workflow answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Shared messages must not be collected for unselected agents");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void currentRouteSelectionIgnoresStaleCheckpointInputMarkers() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		SequentialAgent selectedWorkflow = SequentialAgent.builder()
 			.name("selected_workflow")
@@ -253,12 +250,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Selected workflow answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Stale route inputs from checkpoints must not disable the single-agent messages fallback");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void unroutedFlowAgentsAreNotResolvedFromSharedExplicitOutputKeys() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		SequentialAgent selectedWorkflow = SequentialAgent.builder()
 			.name("selected_workflow")
@@ -283,12 +280,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Selected workflow answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Unrouted workflows must not collect shared explicit output keys");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void sharedExplicitOutputKeyIsCollectedOnlyOnceForMultipleRoutedAgents() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		SequentialAgent firstWorkflow = SequentialAgent.builder()
 			.name("first_workflow")
@@ -312,14 +309,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Only one shared answer exists in state.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"A shared explicit output key represents one parent-state value and must not be duplicated");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void multipleRoutedWorkflowsPreferWrapperOverSharedChildOutputKey() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
-		when(chatModel.call(any(Prompt.class)))
-				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
 
 		SequentialAgent firstWorkflow = SequentialAgent.builder()
 			.name("first_workflow")
@@ -348,9 +343,8 @@ class RoutingMergeNodeTest {
 
 		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Multiple routed workflows should synthesize their namespaced wrapper outputs");
-		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
-		verify(chatModel, times(1)).call(promptCaptor.capture());
-		String promptContent = promptCaptor.getValue().getContents();
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
 		assertTrue(promptContent.contains("First workflow wrapper answer."));
 		assertTrue(promptContent.contains("Second workflow wrapper answer."));
 		assertFalse(promptContent.contains("Shared child value that must not be attributed."));
@@ -358,9 +352,7 @@ class RoutingMergeNodeTest {
 
 	@Test
 	void multipleRoutedParallelWorkflowsPreferMergeOutputKeyOverWrapper() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
-		when(chatModel.call(any(Prompt.class)))
-				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
 
 		ParallelAgent firstParallel = ParallelAgent.builder()
 			.name("first_parallel")
@@ -396,9 +388,8 @@ class RoutingMergeNodeTest {
 
 		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Multiple routed parallel workflows should synthesize their mergeOutputKey results");
-		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
-		verify(chatModel, times(1)).call(promptCaptor.capture());
-		String promptContent = promptCaptor.getValue().getContents();
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
 		assertTrue(promptContent.contains("First merged answer."));
 		assertTrue(promptContent.contains("Second merged answer."));
 		assertFalse(promptContent.contains("First wrapper answer that must not be used."));
@@ -407,9 +398,7 @@ class RoutingMergeNodeTest {
 
 	@Test
 	void multipleRoutedParallelWorkflowsPreferWrapperWhenMergeOutputKeyIsShared() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
-		when(chatModel.call(any(Prompt.class)))
-				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
 
 		ParallelAgent firstParallel = ParallelAgent.builder()
 			.name("first_parallel")
@@ -444,9 +433,8 @@ class RoutingMergeNodeTest {
 
 		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Shared mergeOutputKey values should be resolved through workflow wrappers");
-		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
-		verify(chatModel, times(1)).call(promptCaptor.capture());
-		String promptContent = promptCaptor.getValue().getContents();
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
 		assertTrue(promptContent.contains("First parallel wrapper answer."));
 		assertTrue(promptContent.contains("Second parallel wrapper answer."));
 		assertFalse(promptContent.contains("Shared merge value that must not be attributed."));
@@ -454,9 +442,7 @@ class RoutingMergeNodeTest {
 
 	@Test
 	void multipleRoutedParallelWorkflowsPreferWrapperWhenChildOutputKeysAreShared() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
-		when(chatModel.call(any(Prompt.class)))
-				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
 
 		ParallelAgent firstParallel = ParallelAgent.builder()
 			.name("first_parallel")
@@ -490,9 +476,8 @@ class RoutingMergeNodeTest {
 
 		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Shared child output keys should be resolved through workflow wrappers");
-		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
-		verify(chatModel, times(1)).call(promptCaptor.capture());
-		String promptContent = promptCaptor.getValue().getContents();
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
 		assertTrue(promptContent.contains("First parallel wrapper answer."));
 		assertTrue(promptContent.contains("Second parallel wrapper answer."));
 		assertFalse(promptContent.contains("Shared search value that must not be attributed."));
@@ -501,7 +486,7 @@ class RoutingMergeNodeTest {
 
 	@Test
 	void parallelAgentWithoutMergeOutputKeyCollectsAllChildOutputs() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent firstAgent = mockAgent("first_agent", "first_answer");
 		BaseAgent secondAgent = mockAgent("second_agent", "second_answer");
@@ -522,12 +507,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("First child answer.\n\nSecond child answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"ParallelAgent without mergeOutputKey should expose all child outputs as one routed source");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void sequentialAgentWithFinalParallelAgentCollectsAllChildOutputs() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent draftAgent = mockAgent("draft_agent", "draft_answer");
 		BaseAgent styleReviewer = mockAgent("style_reviewer", "style_answer");
@@ -558,12 +543,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Style review.\n\nFact review.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"SequentialAgent should preserve all outputs from a final ParallelAgent");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void messagesFallbackIsNotUsedForMultipleRoutedAgents() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		SequentialAgent firstWorkflow = SequentialAgent.builder()
 			.name("first_workflow")
@@ -590,12 +575,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Shared messages must not be duplicated across multiple routed agents");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void messagesFallbackIgnoresUserOnlyHistory() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		SequentialAgent writingWorkflow = SequentialAgent.builder()
 			.name("writing_workflow")
@@ -613,12 +598,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"User-only message history must not be treated as an agent answer");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void nestedRoutingAgentResultUsesItsMergedOutputBeforeChildOutputs() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent firstAgent = mockAgent("first_agent", "first_answer");
 		BaseAgent secondAgent = mockAgent("second_agent", "second_answer");
@@ -641,12 +626,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Child router synthesized answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Nested routing agents should expose their own merged output to the parent merge");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void routingMergedOutputIsNotDuplicatedForMultipleNestedRoutingAgents() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
 			.name("first_router")
@@ -672,14 +657,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Shared routing merge output must not be duplicated across multiple routed child routers");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void multipleNestedRoutingAgentsUseNamespacedWrapperResults() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
-		when(chatModel.call(any(Prompt.class)))
-				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("SYNTHESIZED ANSWER")))));
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
 
 		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
 			.name("first_router")
@@ -717,9 +700,8 @@ class RoutingMergeNodeTest {
 
 		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Multiple nested routing results should be synthesized from namespaced wrapper outputs");
-		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
-		verify(chatModel, times(1)).call(promptCaptor.capture());
-		String promptContent = promptCaptor.getValue().getContents();
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
 		assertTrue(promptContent.contains("First router synthesized answer."));
 		assertTrue(promptContent.contains("Second router synthesized answer."));
 		assertFalse(promptContent.contains("Shared parent merge result that must not be used."));
@@ -731,7 +713,7 @@ class RoutingMergeNodeTest {
 
 	@Test
 	void parentRoutingSelectionIsNamespacedFromChildRoutingSelection() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent parentRouter = mockAgent("parent_router", null);
 		LlmRoutingAgent childRouter = LlmRoutingAgent.builder()
@@ -760,12 +742,12 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Child router synthesized answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Parent routing merge should ignore child-router selection markers");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
 	void parentRoutingMergeIgnoresGlobalMarkerWhenNamespacedMarkerIsAbsent() throws Exception {
-		ChatModel chatModel = mock(ChatModel.class);
+		RecordingChatModel chatModel = new RecordingChatModel();
 
 		BaseAgent parentRouter = mockAgent("parent_router", null);
 		LlmRoutingAgent childRouter = LlmRoutingAgent.builder()
@@ -791,14 +773,64 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Child router synthesized answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Parent routing merge should fall back to top-level route inputs, not stale global markers");
-		verify(chatModel, never()).call(any(Prompt.class));
+		assertEquals(0, chatModel.callCount());
 	}
 
 	private static BaseAgent mockAgent(String name, String outputKey) {
-		BaseAgent agent = mock(BaseAgent.class);
-		when(agent.name()).thenReturn(name);
-		when(agent.getOutputKey()).thenReturn(outputKey);
-		return agent;
+		return new StubBaseAgent(name, outputKey);
+	}
+
+	private static final class StubBaseAgent extends BaseAgent {
+
+		private StubBaseAgent(String name, String outputKey) {
+			super(name, "Test agent", false, false, outputKey, null);
+		}
+
+		@Override
+		public Node asNode(boolean includeContents, boolean returnReasoningContents) {
+			throw new UnsupportedOperationException("RoutingMergeNodeTest only needs agent metadata");
+		}
+
+		@Override
+		protected StateGraph initGraph() throws GraphStateException {
+			throw new UnsupportedOperationException("RoutingMergeNodeTest only needs agent metadata");
+		}
+
+	}
+
+	private static final class RecordingChatModel implements ChatModel {
+
+		private final String response;
+
+		private final List<Prompt> prompts = new ArrayList<>();
+
+		private RecordingChatModel() {
+			this("UNUSED");
+		}
+
+		private RecordingChatModel(String response) {
+			this.response = response;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			prompts.add(prompt);
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(response))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		private int callCount() {
+			return prompts.size();
+		}
+
+		private Prompt lastPrompt() {
+			return prompts.get(prompts.size() - 1);
+		}
+
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -43,6 +43,7 @@ import static com.alibaba.cloud.ai.graph.agent.flow.node.RoutingMergeNode.DEFAUL
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -1001,6 +1002,53 @@ class RoutingMergeNodeTest {
 
 		assertEquals("Child router synthesized answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
 				"Parent routing merge should ignore child-router selection markers");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
+	void sameNamedNestedRouterRestoresTheEnclosingRoutingMarker() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+		BaseAgent innerAgent = mockAgent("inner_agent", "inner_answer");
+		LlmRoutingAgent nestedRouter = LlmRoutingAgent.builder()
+			.name("shared_router")
+			.description("Nested router")
+			.model(chatModel)
+			.subAgents(List.of(innerAgent))
+			.build();
+		SequentialAgent outerWorkflow = SequentialAgent.builder()
+			.name("outer_workflow")
+			.description("Workflow ending in the same-named nested router")
+			.subAgents(List.of(nestedRouter))
+			.build();
+		BaseAgent outerRouter = mockAgent("shared_router", null);
+
+		Map<String, Object> outerMarker = Map.of(
+				RoutingNode.SELECTED_AGENT_NAMES_FIELD, List.of("outer_workflow"));
+		Map<String, Object> nestedMarker = Map.of(
+				RoutingNode.SELECTED_AGENT_NAMES_FIELD, List.of("inner_agent"),
+				RoutingNode.PARENT_ROUTING_MARKER_FIELD, outerMarker);
+		String markerKey = RoutingNode.routedAgentNamesKey("shared_router");
+		OverAllState nestedState = new OverAllState(Map.of(
+				markerKey, nestedMarker,
+				"inner_answer", new AssistantMessage("Nested router answer.")));
+
+		RoutingMergeNode nestedMerge = new RoutingMergeNode(chatModel, nestedRouter, List.of(innerAgent));
+		Map<String, Object> nestedResult = nestedMerge.apply(nestedState);
+
+		assertEquals("Nested router answer.", nestedResult.get(DEFAULT_MERGED_OUTPUT_KEY));
+		assertEquals(outerMarker, nestedResult.get(markerKey),
+				"Nested merge must restore the enclosing same-named router marker");
+
+		OverAllState outerState = new OverAllState(Map.of(
+				markerKey, nestedResult.get(markerKey),
+				outputKeyToParent("outer_workflow"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Nested router answer."))));
+		RoutingMergeNode outerMerge = new RoutingMergeNode(chatModel, outerRouter, List.of(outerWorkflow));
+		Map<String, Object> outerResult = outerMerge.apply(outerState);
+
+		assertEquals("Nested router answer.", outerResult.get(DEFAULT_MERGED_OUTPUT_KEY));
+		assertSame(OverAllState.MARK_FOR_REMOVAL, outerResult.get(markerKey),
+				"Outermost merge must clear its routing marker after collection");
 		assertEquals(0, chatModel.callCount());
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -22,8 +22,10 @@ import com.alibaba.cloud.ai.graph.agent.Agent;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LoopAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.loop.LoopMode;
 import com.alibaba.cloud.ai.graph.agent.flow.builder.FlowGraphBuilder;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.internal.node.Node;
@@ -865,188 +867,83 @@ class RoutingMergeNodeTest {
 	}
 
 	@Test
-	void singleFanOutWorkflowCollectsEachNestedRoutingWrapper() throws Exception {
+	void opaqueCustomFlowUsesCurrentWrapperMessageInsteadOfConfiguredBranchOutputs() throws Exception {
 		RecordingChatModel chatModel = new RecordingChatModel();
-		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
-			.name("first_router")
-			.description("First nested router")
-			.model(chatModel)
-			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
-			.build();
-		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
-			.name("second_router")
-			.description("Second nested router")
-			.model(chatModel)
-			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
-			.build();
-		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("fan_out_workflow",
-				List.of(firstRouter, secondRouter));
+		BaseAgent firstBranch = mockAgent("first_branch", "first_answer");
+		BaseAgent secondBranch = mockAgent("second_branch", "second_answer");
+		FlowAgent conditionalWorkflow = new StubConditionalFlowAgent("conditional_workflow",
+				List.of(firstBranch, secondBranch));
 
-		// Both child routers publish merged_result inside their own wrapper. The raw
-		// parent key is shared and must never be attributed to either child.
+		// The first branch output is inherited from a checkpoint while only the second
+		// branch ran now. Configured children are not proof that both branches executed.
 		OverAllState state = new OverAllState(Map.of(
-				"fan_out_workflow_input", "Run both nested routers",
-				DEFAULT_MERGED_OUTPUT_KEY, "Shared merge result that must not be used.",
-				outputKeyToParent("first_router"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
-				outputKeyToParent("second_router"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "Second nested router result.")),
-				outputKeyToParent("fan_out_workflow"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "Top-level wrapper result that must not be duplicated."))
+				"conditional_workflow_input", "Run the selected branch",
+				"first_answer", new AssistantMessage("Stale first-branch answer."),
+				"second_answer", new AssistantMessage("Current second-branch answer."),
+				outputKeyToParent("conditional_workflow"), GraphResponse.done(Map.of(
+						"first_answer", new AssistantMessage("Stale first-branch answer."),
+						"second_answer", new AssistantMessage("Current second-branch answer."),
+						"messages", List.<Message>of(
+								new UserMessage("Run the selected branch"),
+								new AssistantMessage("Current second-branch answer."))))
 		));
 
-		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(conditionalWorkflow));
 		Map<String, Object> result = node.apply(state);
 
-		assertEquals("First nested router result.\n\nSecond nested router result.",
-				result.get(DEFAULT_MERGED_OUTPUT_KEY),
-				"A fan-out workflow should preserve every namespaced nested router result");
+		assertEquals("Current second-branch answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Custom flows should expose their current wrapper answer without probing stale branch keys");
 		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
-	void multiRouteKeepsNestedRouterWrappersInsideFanOutWorkflow() throws Exception {
-		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
-		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
-			.name("first_router")
-			.description("First nested router")
-			.model(chatModel)
-			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
-			.build();
-		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
-			.name("second_router")
-			.description("Second nested router")
-			.model(chatModel)
-			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
-			.build();
-		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("fan_out_workflow",
-				List.of(firstRouter, secondRouter));
-		BaseAgent directAgent = mockAgent("direct_agent", "direct_answer");
-
-		OverAllState state = new OverAllState(Map.of(
-				"fan_out_workflow_input", "Run both nested routers",
-				"direct_agent_input", "Run the direct agent",
-				"direct_answer", new AssistantMessage("Direct routed result."),
-				outputKeyToParent("first_router"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
-				outputKeyToParent("second_router"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "Second nested router result.")),
-				outputKeyToParent("fan_out_workflow"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "Collapsed root wrapper result that must not be used.")),
-				"messages", List.<Message>of(new UserMessage("Run all selected agents"))
-		));
-
-		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow, directAgent));
-		Map<String, Object> result = node.apply(state);
-
-		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY));
-		assertEquals(1, chatModel.callCount());
-		String promptContent = chatModel.lastPrompt().getContents();
-		assertTrue(promptContent.contains("First nested router result."));
-		assertTrue(promptContent.contains("Second nested router result."));
-		assertTrue(promptContent.contains("Direct routed result."));
-		assertFalse(promptContent.contains("Collapsed root wrapper result that must not be used."));
-	}
-
-	@Test
-	void fanOutWorkflowDoesNotSkipNestedRouterWrapperAfterRawChildOutput() throws Exception {
+	void opaqueCustomFlowRejectsAmbiguousWrapperOutputsWithoutExecutionEvidence() throws Exception {
 		RecordingChatModel chatModel = new RecordingChatModel();
-		BaseAgent directAgent = mockAgent("direct_agent", "direct_answer");
-		LlmRoutingAgent nestedRouter = LlmRoutingAgent.builder()
-			.name("nested_router")
-			.description("Nested router")
-			.model(chatModel)
-			.subAgents(List.of(mockAgent("nested_agent", "nested_answer")))
-			.build();
-		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("mixed_fan_out",
-				List.of(directAgent, nestedRouter));
+		FlowAgent conditionalWorkflow = new StubConditionalFlowAgent("conditional_workflow",
+				List.of(
+						mockAgent("first_branch", "first_answer"),
+						mockAgent("second_branch", "second_answer")));
 
 		OverAllState state = new OverAllState(Map.of(
-				"mixed_fan_out_input", "Run the direct agent and nested router",
-				"direct_answer", new AssistantMessage("Direct agent result."),
-				DEFAULT_MERGED_OUTPUT_KEY, "Inherited parent merge result that must not be used.",
-				outputKeyToParent("nested_router"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "Nested router result."))
+				"conditional_workflow_input", "Run the selected branch",
+				"first_answer", new AssistantMessage("Stale first-branch answer."),
+				"second_answer", new AssistantMessage("Current second-branch answer."),
+				outputKeyToParent("conditional_workflow"), GraphResponse.done(Map.of(
+						"first_answer", new AssistantMessage("Stale first-branch answer."),
+						"second_answer", new AssistantMessage("Current second-branch answer."),
+						"messages", List.<Message>of(
+								new UserMessage("Previous request"),
+								new AssistantMessage("Stale previous answer."),
+								new UserMessage("Run the selected branch"))))
 		));
 
-		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(conditionalWorkflow));
 		Map<String, Object> result = node.apply(state);
 
-		assertEquals("Direct agent result.\n\nNested router result.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
-				"A raw child output must not suppress another child's namespaced wrapper output");
+		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Ambiguous custom-flow state must not be guessed or concatenated across checkpointed branches");
 		assertEquals(0, chatModel.callCount());
 	}
 
 	@Test
-	void fanOutWorkflowDoesNotAttributeSharedMessagesToDefaultOutputChildren() throws Exception {
+	void loopAgentUsesItsRepeatedChildOutput() throws Exception {
 		RecordingChatModel chatModel = new RecordingChatModel();
-		BaseAgent firstAgent = mockAgent("first_agent", null);
-		BaseAgent secondAgent = mockAgent("second_agent", null);
-		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("default_output_fan_out",
-				List.of(firstAgent, secondAgent));
+		LoopAgent loopAgent = LoopAgent.builder()
+			.name("revision_loop")
+			.description("Revises an answer")
+			.loopStrategy(LoopMode.count(2))
+			.subAgent(mockAgent("revision_agent", "revised_answer"))
+			.build();
 
 		OverAllState state = new OverAllState(Map.of(
-				"default_output_fan_out_input", "Run both default-output agents",
-				"messages", List.<Message>of(
-						new UserMessage("Run both agents"),
-						new AssistantMessage("Shared message that must not be attributed.")),
-				outputKeyToParent("first_agent"), new AssistantMessage("First default-output result."),
-				outputKeyToParent("second_agent"), new AssistantMessage("Second default-output result.")
-		));
+				"revision_loop_input", "Revise twice",
+				"revised_answer", new AssistantMessage("Final revised answer."))
+		);
 
-		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(loopAgent));
 		Map<String, Object> result = node.apply(state);
 
-		assertEquals("First default-output result.\n\nSecond default-output result.",
-				result.get(DEFAULT_MERGED_OUTPUT_KEY),
-				"Shared messages must not be attributed when multiple workflow children produce outputs");
-		assertEquals(0, chatModel.callCount());
-	}
-
-	@Test
-	void fanOutWorkflowDoesNotDuplicateNestedAndEnclosingWrappers() throws Exception {
-		RecordingChatModel chatModel = new RecordingChatModel();
-		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
-			.name("first_router")
-			.description("First nested router")
-			.model(chatModel)
-			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
-			.build();
-		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
-			.name("second_router")
-			.description("Second nested router")
-			.model(chatModel)
-			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
-			.build();
-		SequentialAgent firstWorkflow = SequentialAgent.builder()
-			.name("first_workflow")
-			.description("First workflow")
-			.subAgents(List.of(firstRouter))
-			.build();
-		SequentialAgent secondWorkflow = SequentialAgent.builder()
-			.name("second_workflow")
-			.description("Second workflow")
-			.subAgents(List.of(secondRouter))
-			.build();
-		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("nested_fan_out",
-				List.of(firstWorkflow, secondWorkflow));
-
-		OverAllState state = new OverAllState(Map.of(
-				"nested_fan_out_input", "Run both workflows",
-				outputKeyToParent("first_router"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
-				outputKeyToParent("first_workflow"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
-				outputKeyToParent("second_workflow"), GraphResponse.done(Map.of(
-						DEFAULT_MERGED_OUTPUT_KEY, "Second nested router result."))
-		));
-
-		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
-		Map<String, Object> result = node.apply(state);
-
-		assertEquals("First nested router result.\n\nSecond nested router result.",
-				result.get(DEFAULT_MERGED_OUTPUT_KEY),
-				"An enclosing workflow wrapper must not duplicate an already collected descendant output");
+		assertEquals("Final revised answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY));
 		assertEquals(0, chatModel.callCount());
 	}
 
@@ -1295,18 +1192,18 @@ class RoutingMergeNodeTest {
 	}
 
 	/**
-	 * Metadata-only flow used to model a custom workflow where every child contributes
-	 * an output. Graph construction is outside the scope of merge-node unit tests.
+	 * Metadata-only flow used to model a custom conditional workflow. Graph construction
+	 * is outside the scope of merge-node unit tests.
 	 */
-	private static final class StubFanOutFlowAgent extends FlowAgent {
+	private static final class StubConditionalFlowAgent extends FlowAgent {
 
 		/**
-		 * Creates a fan-out workflow with the supplied child agents.
+		 * Creates a conditional workflow with the supplied possible branch agents.
 		 * @param name workflow name used for routing and wrapper keys
-		 * @param subAgents child agents whose outputs contribute to the workflow result
+		 * @param subAgents child agents that may be selected by the workflow
 		 */
-		private StubFanOutFlowAgent(String name, List<Agent> subAgents) {
-			super(name, "Test fan-out workflow", null, subAgents);
+		private StubConditionalFlowAgent(String name, List<Agent> subAgents) {
+			super(name, "Test conditional workflow", null, subAgents);
 		}
 
 		@Override

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -897,6 +897,34 @@ class RoutingMergeNodeTest {
 	}
 
 	@Test
+	void opaqueCustomFlowExposesSingleExplicitWrapperOutput() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+		FlowAgent conditionalWorkflow = new StubConditionalFlowAgent("conditional_workflow",
+				List.of(
+						mockAgent("first_branch", "first_answer"),
+						mockAgent("second_branch", "second_answer")));
+
+		// A custom graph may end in a deterministic node that writes an explicit state key
+		// without appending an assistant message. The single visible wrapper value is the
+		// attributable result; the stale parent-state branch key must not be probed.
+		OverAllState state = new OverAllState(Map.of(
+				"conditional_workflow_input", "Run the selected branch",
+				"first_answer", new AssistantMessage("Stale first-branch answer."),
+				outputKeyToParent("conditional_workflow"), GraphResponse.done(Map.of(
+						"input", "Run the selected branch",
+						"deterministic_result", "Deterministic branch result.",
+						"messages", List.<Message>of(new UserMessage("Run the selected branch"))))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(conditionalWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Deterministic branch result.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Custom flows ending in deterministic nodes should expose their explicit wrapper output");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
 	void opaqueCustomFlowRejectsAmbiguousWrapperOutputsWithoutExecutionEvidence() throws Exception {
 		RecordingChatModel chatModel = new RecordingChatModel();
 		FlowAgent conditionalWorkflow = new StubConditionalFlowAgent("conditional_workflow",

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -351,6 +351,106 @@ class RoutingMergeNodeTest {
 	}
 
 	@Test
+	void ordinaryWorkflowWrappersIgnoreInheritedParentMergedResult() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
+
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("First workflow")
+			.subAgents(List.of(mockAgent("first_final_agent", null)))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Second workflow")
+			.subAgents(List.of(mockAgent("second_final_agent", null)))
+			.build();
+
+		// Ordinary workflow subgraphs inherit the parent's merged_result from checkpointed
+		// state. Only nested routing wrappers may treat merged_result as their own answer.
+		OverAllState state = new OverAllState(Map.of(
+				"first_workflow_input", "Run the first workflow",
+				"second_workflow_input", "Run the second workflow",
+				outputKeyToParent("first_workflow"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Previous parent merged answer.",
+						"messages", List.<Message>of(new AssistantMessage("Current first workflow answer.")))),
+				outputKeyToParent("second_workflow"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Previous parent merged answer.",
+						"messages", List.<Message>of(new AssistantMessage("Current second workflow answer.")))),
+				"messages", List.<Message>of(new UserMessage("Run both workflows")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstWorkflow, secondWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Ordinary workflow wrappers should synthesize their current message outputs");
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
+		assertTrue(promptContent.contains("Current first workflow answer."));
+		assertTrue(promptContent.contains("Current second workflow answer."));
+		assertFalse(promptContent.contains("Previous parent merged answer."));
+	}
+
+	@Test
+	void workflowWrapperMapsWithoutVisibleOutputAreIgnored() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writing workflow")
+			.subAgents(List.of(mockAgent("writer_agent", "final_answer")))
+			.build();
+
+		// Wrapper snapshots can contain parent inputs, route markers, and user-only messages
+		// after checkpoint merging. Those internal values are not attributable agent answers.
+		OverAllState state = new OverAllState(Map.of(
+				"writing_workflow_input", "Write an article",
+				outputKeyToParent("writing_workflow"), GraphResponse.done(Map.of(
+						"input", "Write an article",
+						"writer_agent_input", "Write an article",
+						"_routing_selected_agents_router", List.of("writing_workflow"),
+						outputKeyToParent("older_workflow"), Map.of("previous", "snapshot"),
+						"messages", List.<Message>of(new UserMessage("Write an article")))),
+				"messages", List.<Message>of(new UserMessage("Write an article")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(writingWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("No results found from any knowledge source.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Internal wrapper state must not be stringified as an agent answer");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
+	void workflowWrapperMapsUseSingleVisibleOutputValue() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+
+		SequentialAgent writingWorkflow = SequentialAgent.builder()
+			.name("writing_workflow")
+			.description("Writing workflow")
+			.subAgents(List.of(mockAgent("writer_agent", "final_answer")))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"writing_workflow_input", "Write an article",
+				outputKeyToParent("writing_workflow"), GraphResponse.done(Map.of(
+						"input", "Write an article",
+						"writer_agent_input", "Write an article",
+						"final_answer", new AssistantMessage("Current workflow answer."),
+						"messages", List.<Message>of(new UserMessage("Write an article")))),
+				"messages", List.<Message>of(new UserMessage("Write an article")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(writingWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Current workflow answer.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"A wrapper snapshot with one visible output should still be usable");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
 	void multipleRoutedParallelWorkflowsPreferMergeOutputKeyOverWrapper() throws Exception {
 		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
 
@@ -423,8 +523,16 @@ class RoutingMergeNodeTest {
 				"first_parallel_input", "Run the first parallel workflow",
 				"second_parallel_input", "Run the second parallel workflow",
 				"shared_merged_result", new AssistantMessage("Shared merge value that must not be attributed."),
-				outputKeyToParent("first_parallel"), new AssistantMessage("First parallel wrapper answer."),
-				outputKeyToParent("second_parallel"), new AssistantMessage("Second parallel wrapper answer."),
+				outputKeyToParent("first_parallel"), GraphResponse.done(Map.of(
+						"shared_merged_result", new AssistantMessage("First parallel aggregate answer."),
+						"messages", List.<Message>of(
+								new AssistantMessage("First child response that must not be used."),
+								new AssistantMessage("First last child response that must not be used.")))),
+				outputKeyToParent("second_parallel"), GraphResponse.done(Map.of(
+						"shared_merged_result", new AssistantMessage("Second parallel aggregate answer."),
+						"messages", List.<Message>of(
+								new AssistantMessage("Second child response that must not be used."),
+								new AssistantMessage("Second last child response that must not be used.")))),
 				"messages", List.<Message>of(new UserMessage("Run both parallel workflows")))
 		);
 
@@ -435,9 +543,71 @@ class RoutingMergeNodeTest {
 				"Shared mergeOutputKey values should be resolved through workflow wrappers");
 		assertEquals(1, chatModel.callCount());
 		String promptContent = chatModel.lastPrompt().getContents();
-		assertTrue(promptContent.contains("First parallel wrapper answer."));
-		assertTrue(promptContent.contains("Second parallel wrapper answer."));
+		assertTrue(promptContent.contains("First parallel aggregate answer."));
+		assertTrue(promptContent.contains("Second parallel aggregate answer."));
 		assertFalse(promptContent.contains("Shared merge value that must not be attributed."));
+		assertFalse(promptContent.contains("First last child response that must not be used."));
+		assertFalse(promptContent.contains("Second last child response that must not be used."));
+	}
+
+	@Test
+	void multipleRoutedSequentialWorkflowsPreferFinalParallelMergeKeyInsideWrappers() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
+
+		ParallelAgent firstFinalParallel = ParallelAgent.builder()
+			.name("first_final_parallel")
+			.description("First final parallel")
+			.subAgents(List.of(
+					mockAgent("first_final_search", "first_search_result"),
+					mockAgent("first_final_summary", "first_summary_result")))
+			.mergeOutputKey("shared_merged_result")
+			.build();
+		ParallelAgent secondFinalParallel = ParallelAgent.builder()
+			.name("second_final_parallel")
+			.description("Second final parallel")
+			.subAgents(List.of(
+					mockAgent("second_final_search", "second_search_result"),
+					mockAgent("second_final_summary", "second_summary_result")))
+			.mergeOutputKey("shared_merged_result")
+			.build();
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("First workflow")
+			.subAgents(List.of(firstFinalParallel))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Second workflow")
+			.subAgents(List.of(secondFinalParallel))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"first_workflow_input", "Run the first workflow",
+				"second_workflow_input", "Run the second workflow",
+				"shared_merged_result", new AssistantMessage("Shared merge value that must not be attributed."),
+				outputKeyToParent("first_workflow"), GraphResponse.done(Map.of(
+						"shared_merged_result", new AssistantMessage("First workflow aggregate answer."),
+						"messages", List.<Message>of(
+								new AssistantMessage("First workflow child response that must not be used.")))),
+				outputKeyToParent("second_workflow"), GraphResponse.done(Map.of(
+						"shared_merged_result", new AssistantMessage("Second workflow aggregate answer."),
+						"messages", List.<Message>of(
+								new AssistantMessage("Second workflow child response that must not be used.")))),
+				"messages", List.<Message>of(new UserMessage("Run both workflows")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstWorkflow, secondWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Sequential workflows ending in ParallelAgent should read the wrapper aggregate output");
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
+		assertTrue(promptContent.contains("First workflow aggregate answer."));
+		assertTrue(promptContent.contains("Second workflow aggregate answer."));
+		assertFalse(promptContent.contains("Shared merge value that must not be attributed."));
+		assertFalse(promptContent.contains("First workflow child response that must not be used."));
+		assertFalse(promptContent.contains("Second workflow child response that must not be used."));
 	}
 
 	@Test

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -18,10 +18,13 @@ package com.alibaba.cloud.ai.graph.agent.flow.node;
 import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.agent.Agent;
 import com.alibaba.cloud.ai.graph.agent.BaseAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.FlowAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.ParallelAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.builder.FlowGraphBuilder;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.internal.node.Node;
 import org.junit.jupiter.api.Test;
@@ -862,6 +865,192 @@ class RoutingMergeNodeTest {
 	}
 
 	@Test
+	void singleFanOutWorkflowCollectsEachNestedRoutingWrapper() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
+			.name("first_router")
+			.description("First nested router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
+			.build();
+		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
+			.name("second_router")
+			.description("Second nested router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
+			.build();
+		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("fan_out_workflow",
+				List.of(firstRouter, secondRouter));
+
+		// Both child routers publish merged_result inside their own wrapper. The raw
+		// parent key is shared and must never be attributed to either child.
+		OverAllState state = new OverAllState(Map.of(
+				"fan_out_workflow_input", "Run both nested routers",
+				DEFAULT_MERGED_OUTPUT_KEY, "Shared merge result that must not be used.",
+				outputKeyToParent("first_router"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
+				outputKeyToParent("second_router"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Second nested router result.")),
+				outputKeyToParent("fan_out_workflow"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Top-level wrapper result that must not be duplicated."))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("First nested router result.\n\nSecond nested router result.",
+				result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"A fan-out workflow should preserve every namespaced nested router result");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
+	void multiRouteKeepsNestedRouterWrappersInsideFanOutWorkflow() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
+		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
+			.name("first_router")
+			.description("First nested router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
+			.build();
+		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
+			.name("second_router")
+			.description("Second nested router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
+			.build();
+		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("fan_out_workflow",
+				List.of(firstRouter, secondRouter));
+		BaseAgent directAgent = mockAgent("direct_agent", "direct_answer");
+
+		OverAllState state = new OverAllState(Map.of(
+				"fan_out_workflow_input", "Run both nested routers",
+				"direct_agent_input", "Run the direct agent",
+				"direct_answer", new AssistantMessage("Direct routed result."),
+				outputKeyToParent("first_router"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
+				outputKeyToParent("second_router"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Second nested router result.")),
+				outputKeyToParent("fan_out_workflow"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Collapsed root wrapper result that must not be used.")),
+				"messages", List.<Message>of(new UserMessage("Run all selected agents"))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow, directAgent));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY));
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
+		assertTrue(promptContent.contains("First nested router result."));
+		assertTrue(promptContent.contains("Second nested router result."));
+		assertTrue(promptContent.contains("Direct routed result."));
+		assertFalse(promptContent.contains("Collapsed root wrapper result that must not be used."));
+	}
+
+	@Test
+	void fanOutWorkflowDoesNotSkipNestedRouterWrapperAfterRawChildOutput() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+		BaseAgent directAgent = mockAgent("direct_agent", "direct_answer");
+		LlmRoutingAgent nestedRouter = LlmRoutingAgent.builder()
+			.name("nested_router")
+			.description("Nested router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("nested_agent", "nested_answer")))
+			.build();
+		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("mixed_fan_out",
+				List.of(directAgent, nestedRouter));
+
+		OverAllState state = new OverAllState(Map.of(
+				"mixed_fan_out_input", "Run the direct agent and nested router",
+				"direct_answer", new AssistantMessage("Direct agent result."),
+				DEFAULT_MERGED_OUTPUT_KEY, "Inherited parent merge result that must not be used.",
+				outputKeyToParent("nested_router"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Nested router result."))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("Direct agent result.\n\nNested router result.", result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"A raw child output must not suppress another child's namespaced wrapper output");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
+	void fanOutWorkflowDoesNotAttributeSharedMessagesToDefaultOutputChildren() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+		BaseAgent firstAgent = mockAgent("first_agent", null);
+		BaseAgent secondAgent = mockAgent("second_agent", null);
+		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("default_output_fan_out",
+				List.of(firstAgent, secondAgent));
+
+		OverAllState state = new OverAllState(Map.of(
+				"default_output_fan_out_input", "Run both default-output agents",
+				"messages", List.<Message>of(
+						new UserMessage("Run both agents"),
+						new AssistantMessage("Shared message that must not be attributed.")),
+				outputKeyToParent("first_agent"), new AssistantMessage("First default-output result."),
+				outputKeyToParent("second_agent"), new AssistantMessage("Second default-output result.")
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("First default-output result.\n\nSecond default-output result.",
+				result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"Shared messages must not be attributed when multiple workflow children produce outputs");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
+	void fanOutWorkflowDoesNotDuplicateNestedAndEnclosingWrappers() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel();
+		LlmRoutingAgent firstRouter = LlmRoutingAgent.builder()
+			.name("first_router")
+			.description("First nested router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("first_agent", "first_answer")))
+			.build();
+		LlmRoutingAgent secondRouter = LlmRoutingAgent.builder()
+			.name("second_router")
+			.description("Second nested router")
+			.model(chatModel)
+			.subAgents(List.of(mockAgent("second_agent", "second_answer")))
+			.build();
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("First workflow")
+			.subAgents(List.of(firstRouter))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Second workflow")
+			.subAgents(List.of(secondRouter))
+			.build();
+		FlowAgent fanOutWorkflow = new StubFanOutFlowAgent("nested_fan_out",
+				List.of(firstWorkflow, secondWorkflow));
+
+		OverAllState state = new OverAllState(Map.of(
+				"nested_fan_out_input", "Run both workflows",
+				outputKeyToParent("first_router"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
+				outputKeyToParent("first_workflow"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "First nested router result.")),
+				outputKeyToParent("second_workflow"), GraphResponse.done(Map.of(
+						DEFAULT_MERGED_OUTPUT_KEY, "Second nested router result."))
+		));
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(fanOutWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("First nested router result.\n\nSecond nested router result.",
+				result.get(DEFAULT_MERGED_OUTPUT_KEY),
+				"An enclosing workflow wrapper must not duplicate an already collected descendant output");
+		assertEquals(0, chatModel.callCount());
+	}
+
+	@Test
 	void nestedRoutingAgentResultUsesItsMergedOutputBeforeChildOutputs() throws Exception {
 		RecordingChatModel chatModel = new RecordingChatModel();
 
@@ -1100,6 +1289,28 @@ class RoutingMergeNodeTest {
 
 		@Override
 		protected StateGraph initGraph() throws GraphStateException {
+			throw new UnsupportedOperationException("RoutingMergeNodeTest only needs agent metadata");
+		}
+
+	}
+
+	/**
+	 * Metadata-only flow used to model a custom workflow where every child contributes
+	 * an output. Graph construction is outside the scope of merge-node unit tests.
+	 */
+	private static final class StubFanOutFlowAgent extends FlowAgent {
+
+		/**
+		 * Creates a fan-out workflow with the supplied child agents.
+		 * @param name workflow name used for routing and wrapper keys
+		 * @param subAgents child agents whose outputs contribute to the workflow result
+		 */
+		private StubFanOutFlowAgent(String name, List<Agent> subAgents) {
+			super(name, "Test fan-out workflow", null, subAgents);
+		}
+
+		@Override
+		protected StateGraph buildSpecificGraph(FlowGraphBuilder.FlowGraphConfig config) {
 			throw new UnsupportedOperationException("RoutingMergeNodeTest only needs agent metadata");
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingMergeNodeTest.java
@@ -130,6 +130,22 @@ class RoutingMergeNodeTest {
 	}
 
 	@Test
+	void wrapperPreferredOutputsUseConfiguredOrderAndIgnoreUnrelatedMessages() {
+		String wrapperKey = outputKeyToParent("parallel_workflow");
+		GraphResponse<Object> wrapper = GraphResponse.done(Map.of(
+				"second_result", new AssistantMessage("Second result."),
+				"first_result", new AssistantMessage("First result."),
+				"messages", List.<Message>of(new AssistantMessage("Unrelated wrapper message."))
+		));
+
+		String text = RoutingMergeNode.extractText(wrapper, wrapperKey, false,
+				List.of("first_result", "missing_result", "second_result"));
+
+		assertEquals("First result.\n\nSecond result.", text,
+				"Wrapper outputs should follow agent configuration, skip missing outputs, and not fall back to messages");
+	}
+
+	@Test
 	void flowAgentResultIsResolvedFromNestedFinalOutputKey() throws Exception {
 		RecordingChatModel chatModel = new RecordingChatModel();
 
@@ -636,8 +652,16 @@ class RoutingMergeNodeTest {
 				"second_parallel_input", "Run the second parallel workflow",
 				"shared_search_result", new AssistantMessage("Shared search value that must not be attributed."),
 				"shared_summary_result", new AssistantMessage("Shared summary value that must not be attributed."),
-				outputKeyToParent("first_parallel"), new AssistantMessage("First parallel wrapper answer."),
-				outputKeyToParent("second_parallel"), new AssistantMessage("Second parallel wrapper answer."),
+				outputKeyToParent("first_parallel"), GraphResponse.done(Map.of(
+						"shared_search_result", new AssistantMessage("First parallel search answer."),
+						"shared_summary_result", new AssistantMessage("First parallel summary answer."),
+						"messages", List.<Message>of(
+								new AssistantMessage("First unrelated wrapper message.")))),
+				outputKeyToParent("second_parallel"), GraphResponse.done(Map.of(
+						"shared_search_result", new AssistantMessage("Second parallel search answer."),
+						"shared_summary_result", new AssistantMessage("Second parallel summary answer."),
+						"messages", List.<Message>of(
+								new AssistantMessage("Second unrelated wrapper message.")))),
 				"messages", List.<Message>of(new UserMessage("Run both parallel workflows")))
 		);
 
@@ -648,10 +672,75 @@ class RoutingMergeNodeTest {
 				"Shared child output keys should be resolved through workflow wrappers");
 		assertEquals(1, chatModel.callCount());
 		String promptContent = chatModel.lastPrompt().getContents();
-		assertTrue(promptContent.contains("First parallel wrapper answer."));
-		assertTrue(promptContent.contains("Second parallel wrapper answer."));
+		assertTrue(promptContent.contains("First parallel search answer."));
+		assertTrue(promptContent.contains("First parallel summary answer."));
+		assertTrue(promptContent.contains("Second parallel search answer."));
+		assertTrue(promptContent.contains("Second parallel summary answer."));
 		assertFalse(promptContent.contains("Shared search value that must not be attributed."));
 		assertFalse(promptContent.contains("Shared summary value that must not be attributed."));
+		assertFalse(promptContent.contains("First unrelated wrapper message."));
+		assertFalse(promptContent.contains("Second unrelated wrapper message."));
+	}
+
+	@Test
+	void multipleRoutedSequentialWorkflowsPreserveFinalParallelChildOutputsInsideWrappers() throws Exception {
+		RecordingChatModel chatModel = new RecordingChatModel("SYNTHESIZED ANSWER");
+
+		ParallelAgent firstFinalParallel = ParallelAgent.builder()
+			.name("first_final_parallel")
+			.description("First final parallel")
+			.subAgents(List.of(
+					mockAgent("first_search", "shared_search_result"),
+					mockAgent("first_summary", "shared_summary_result")))
+			.build();
+		ParallelAgent secondFinalParallel = ParallelAgent.builder()
+			.name("second_final_parallel")
+			.description("Second final parallel")
+			.subAgents(List.of(
+					mockAgent("second_search", "shared_search_result"),
+					mockAgent("second_summary", "shared_summary_result")))
+			.build();
+		SequentialAgent firstWorkflow = SequentialAgent.builder()
+			.name("first_workflow")
+			.description("First workflow")
+			.subAgents(List.of(firstFinalParallel))
+			.build();
+		SequentialAgent secondWorkflow = SequentialAgent.builder()
+			.name("second_workflow")
+			.description("Second workflow")
+			.subAgents(List.of(secondFinalParallel))
+			.build();
+
+		OverAllState state = new OverAllState(Map.of(
+				"first_workflow_input", "Run the first workflow",
+				"second_workflow_input", "Run the second workflow",
+				"shared_search_result", new AssistantMessage("Shared search value that must not be attributed."),
+				"shared_summary_result", new AssistantMessage("Shared summary value that must not be attributed."),
+				outputKeyToParent("first_workflow"), GraphResponse.done(Map.of(
+						"shared_search_result", new AssistantMessage("First workflow search answer."),
+						"shared_summary_result", new AssistantMessage("First workflow summary answer."),
+						"messages", List.<Message>of(new AssistantMessage("First unrelated wrapper message.")))),
+				outputKeyToParent("second_workflow"), GraphResponse.done(Map.of(
+						"shared_search_result", new AssistantMessage("Second workflow search answer."),
+						"shared_summary_result", new AssistantMessage("Second workflow summary answer."),
+						"messages", List.<Message>of(new AssistantMessage("Second unrelated wrapper message.")))),
+				"messages", List.<Message>of(new UserMessage("Run both workflows")))
+		);
+
+		RoutingMergeNode node = new RoutingMergeNode(chatModel, List.of(firstWorkflow, secondWorkflow));
+		Map<String, Object> result = node.apply(state);
+
+		assertEquals("SYNTHESIZED ANSWER", result.get(DEFAULT_MERGED_OUTPUT_KEY));
+		assertEquals(1, chatModel.callCount());
+		String promptContent = chatModel.lastPrompt().getContents();
+		assertTrue(promptContent.contains("First workflow search answer."));
+		assertTrue(promptContent.contains("First workflow summary answer."));
+		assertTrue(promptContent.contains("Second workflow search answer."));
+		assertTrue(promptContent.contains("Second workflow summary answer."));
+		assertFalse(promptContent.contains("Shared search value that must not be attributed."));
+		assertFalse(promptContent.contains("Shared summary value that must not be attributed."));
+		assertFalse(promptContent.contains("First unrelated wrapper message."));
+		assertFalse(promptContent.contains("Second unrelated wrapper message."));
 	}
 
 	@Test

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.flow.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.action.MultiCommand;
+import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoutingNodeTest {
+
+	@Test
+	void selectedFlowAgentWrapperOutputIsClearedBeforeRouteExecution() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write and review article\"}]}"));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Please write an article")),
+				outputKeyToParent("writing_workflow"), "stale wrapper answer"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(List.of("writing_workflow"), command.gotoNodes());
+		assertEquals(List.of("writing_workflow"),
+				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent")));
+		assertEquals("write and review article", command.update().get("writing_workflow_input"));
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("writing_workflow")));
+		assertTrue(command.update().containsKey(outputKeyToParent("writing_workflow")),
+				"Selected FlowAgent wrapper output must be cleared so checkpointed wrappers are not reused");
+	}
+
+	@Test
+	void staleSelectedFlowAgentWrapperIsRemovedFromCheckpointedState() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write and review article\"}]}"));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Please write an article")),
+				outputKeyToParent("writing_workflow"), "stale wrapper answer"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+		state.updateState(command.update());
+
+		assertFalse(state.value(outputKeyToParent("writing_workflow")).isPresent(),
+				"The route update must remove checkpointed wrapper output before the selected subgraph runs");
+		assertEquals("write and review article", state.value("writing_workflow_input").orElse(null));
+		assertEquals(List.of("writing_workflow"),
+				state.value(RoutingNode.routedAgentNamesKey("routing_agent")).orElse(null));
+	}
+
+	@Test
+	void multipleSelectedFlowAgentWrappersAreClearedBeforeParallelRouteExecution() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of("""
+				{"agents":[
+				  {"agent":"writing_workflow","query":"write article"},
+				  {"agent":"review_workflow","query":"review article"}
+				]}
+				"""));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		SequentialAgent reviewWorkflow = workflow("review_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow, reviewWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow, reviewWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Write and review")),
+				outputKeyToParent("writing_workflow"), "old writing wrapper",
+				outputKeyToParent("review_workflow"), "old review wrapper"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(List.of("writing_workflow", "review_workflow"), command.gotoNodes());
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("writing_workflow")));
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("review_workflow")));
+		assertEquals("write article", command.update().get("writing_workflow_input"));
+		assertEquals("review article", command.update().get("review_workflow_input"));
+	}
+
+	@Test
+	void unselectedFlowAgentWrapperOutputIsNotTouched() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write article\"}]}"));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		SequentialAgent skippedWorkflow = workflow("skipped_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow, skippedWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow, skippedWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Write only")),
+				outputKeyToParent("writing_workflow"), "old writing wrapper",
+				outputKeyToParent("skipped_workflow"), "old skipped wrapper"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("writing_workflow")));
+		assertFalse(command.update().containsKey(outputKeyToParent("skipped_workflow")),
+				"Unselected workflow wrappers are ignored by the merge marker and do not need mutation");
+		assertFalse(command.update().containsKey("skipped_workflow_input"));
+	}
+
+	@Test
+	void selectedBaseAgentDoesNotEmitSubgraphWrapperRemoval() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writer_agent\",\"query\":\"write article\"}]}"));
+		ReactAgent writerAgent = reactAgent("writer_agent", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writerAgent));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writerAgent));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Please write"))));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(List.of("writer_agent"), command.gotoNodes());
+		assertEquals("write article", command.update().get("writer_agent_input"));
+		assertFalse(command.update().containsKey(outputKeyToParent("writer_agent")),
+				"Only FlowAgent subgraphs have parent wrapper output to clear");
+	}
+
+	private static ReactAgent reactAgent(String name, ChatModel chatModel) {
+		return ReactAgent.builder()
+			.name(name)
+			.description("Scripted base agent")
+			.model(chatModel)
+			.instruction("Return a scripted answer")
+			.outputKey(name + "_answer")
+			.build();
+	}
+
+	private static SequentialAgent workflow(String name, ChatModel chatModel) {
+		return SequentialAgent.builder()
+			.name(name)
+			.description("Scripted workflow")
+			.subAgents(List.of(reactAgent(name + "_writer", chatModel)))
+			.build();
+	}
+
+	private static LlmRoutingAgent routingAgent(ChatModel chatModel, List<Agent> subAgents) {
+		return LlmRoutingAgent.builder()
+			.name("routing_agent")
+			.description("Routes writing tasks")
+			.model(chatModel)
+			.subAgents(subAgents)
+			.build();
+	}
+
+	private static final class ScriptedChatModel implements ChatModel {
+
+		private final List<String> responses;
+
+		private final AtomicInteger calls = new AtomicInteger();
+
+		private ScriptedChatModel(List<String> responses) {
+			this.responses = responses;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int index = calls.getAndIncrement();
+			if (index >= responses.size()) {
+				throw new IllegalStateException("No scripted response for call " + index);
+			}
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(responses.get(index)))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
@@ -19,7 +19,9 @@ import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.MultiCommand;
 import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.SequentialAgent;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -29,16 +31,19 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+
 import reactor.core.publisher.Flux;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RoutingNodeTest {
 
@@ -46,8 +51,8 @@ class RoutingNodeTest {
 	void routesToConfiguredFallbackAfterInvalidDecisions() throws Exception {
 		AtomicInteger modelCalls = new AtomicInteger();
 		ChatModel chatModel = invalidRoutingModel(modelCalls);
-		Agent writerAgent = mockAgent();
-		LlmRoutingAgent routingAgent = routingAgent(chatModel, writerAgent, "writer_agent");
+		ReactAgent writerAgent = reactAgent("writer_agent", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writerAgent), "writer_agent");
 		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writerAgent));
 		OverAllState state = new OverAllState(Map.of(
 				"input", "write a summary",
@@ -57,20 +62,162 @@ class RoutingNodeTest {
 
 		assertEquals(3, modelCalls.get());
 		assertEquals(List.of("writer_agent"), command.gotoNodes());
+		assertEquals(List.of("writer_agent"),
+				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent")));
 		assertEquals("write a summary", command.update().get("writer_agent_input"));
+	}
+
+	@Test
+	void fallbackFlowAgentWrapperOutputIsClearedAfterInvalidDecisions() throws Exception {
+		AtomicInteger modelCalls = new AtomicInteger();
+		ChatModel chatModel = invalidRoutingModel(modelCalls);
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow), "writing_workflow");
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"input", "write a summary",
+				"messages", List.<Message>of(new UserMessage("write a summary")),
+				outputKeyToParent("writing_workflow"), "stale wrapper answer"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(3, modelCalls.get());
+		assertEquals(List.of("writing_workflow"), command.gotoNodes());
+		assertEquals(List.of("writing_workflow"),
+				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent")));
+		assertEquals("write a summary", command.update().get("writing_workflow_input"));
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("writing_workflow")));
 	}
 
 	@Test
 	void throwsAfterInvalidDecisionsWhenFallbackIsNotConfigured() {
 		ChatModel chatModel = invalidRoutingModel(new AtomicInteger());
-		Agent writerAgent = mockAgent();
-		LlmRoutingAgent routingAgent = routingAgent(chatModel, writerAgent, null);
+		ReactAgent writerAgent = reactAgent("writer_agent", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writerAgent), null);
 		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writerAgent));
 		OverAllState state = new OverAllState(Map.of(
 				"messages", List.<Message>of(new UserMessage("write a summary"))));
 
 		assertThrows(IllegalStateException.class,
 				() -> node.apply(state, RunnableConfig.builder().build()));
+	}
+
+	@Test
+	void selectedFlowAgentWrapperOutputIsClearedBeforeRouteExecution() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write and review article\"}]}"));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Please write an article")),
+				outputKeyToParent("writing_workflow"), "stale wrapper answer"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(List.of("writing_workflow"), command.gotoNodes());
+		assertEquals(List.of("writing_workflow"),
+				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent")));
+		assertEquals("write and review article", command.update().get("writing_workflow_input"));
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("writing_workflow")));
+		assertTrue(command.update().containsKey(outputKeyToParent("writing_workflow")),
+				"Selected FlowAgent wrapper output must be cleared so checkpointed wrappers are not reused");
+	}
+
+	@Test
+	void staleSelectedFlowAgentWrapperIsRemovedFromCheckpointedState() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write and review article\"}]}"));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Please write an article")),
+				outputKeyToParent("writing_workflow"), "stale wrapper answer"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+		state.updateState(command.update());
+
+		assertFalse(state.value(outputKeyToParent("writing_workflow")).isPresent(),
+				"The route update must remove checkpointed wrapper output before the selected subgraph runs");
+		assertEquals("write and review article", state.value("writing_workflow_input").orElse(null));
+		assertEquals(List.of("writing_workflow"),
+				state.value(RoutingNode.routedAgentNamesKey("routing_agent")).orElse(null));
+	}
+
+	@Test
+	void multipleSelectedFlowAgentWrappersAreClearedBeforeParallelRouteExecution() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(List.of("""
+				{"agents":[
+				  {"agent":"writing_workflow","query":"write article"},
+				  {"agent":"review_workflow","query":"review article"}
+				]}
+				"""));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		SequentialAgent reviewWorkflow = workflow("review_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow, reviewWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow, reviewWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Write and review")),
+				outputKeyToParent("writing_workflow"), "old writing wrapper",
+				outputKeyToParent("review_workflow"), "old review wrapper"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(List.of("writing_workflow", "review_workflow"), command.gotoNodes());
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("writing_workflow")));
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("review_workflow")));
+		assertEquals("write article", command.update().get("writing_workflow_input"));
+		assertEquals("review article", command.update().get("review_workflow_input"));
+	}
+
+	@Test
+	void unselectedFlowAgentWrapperOutputIsNotTouched() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writing_workflow\",\"query\":\"write article\"}]}"));
+		SequentialAgent writingWorkflow = workflow("writing_workflow", chatModel);
+		SequentialAgent skippedWorkflow = workflow("skipped_workflow", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writingWorkflow, skippedWorkflow));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writingWorkflow, skippedWorkflow));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Write only")),
+				outputKeyToParent("writing_workflow"), "old writing wrapper",
+				outputKeyToParent("skipped_workflow"), "old skipped wrapper"));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertSame(OverAllState.MARK_FOR_REMOVAL,
+				command.update().get(outputKeyToParent("writing_workflow")));
+		assertFalse(command.update().containsKey(outputKeyToParent("skipped_workflow")),
+				"Unselected workflow wrappers are ignored by the merge marker and do not need mutation");
+		assertFalse(command.update().containsKey("skipped_workflow_input"));
+	}
+
+	@Test
+	void selectedBaseAgentDoesNotEmitSubgraphWrapperRemoval() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writer_agent\",\"query\":\"write article\"}]}"));
+		ReactAgent writerAgent = reactAgent("writer_agent", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writerAgent));
+
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writerAgent));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("Please write"))));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(List.of("writer_agent"), command.gotoNodes());
+		assertEquals("write article", command.update().get("writer_agent_input"));
+		assertFalse(command.update().containsKey(outputKeyToParent("writer_agent")),
+				"Only FlowAgent subgraphs have parent wrapper output to clear");
 	}
 
 	private static ChatModel invalidRoutingModel(AtomicInteger modelCalls) {
@@ -89,23 +236,64 @@ class RoutingNodeTest {
 		};
 	}
 
-	private static Agent mockAgent() {
-		Agent writerAgent = mock(Agent.class);
-		when(writerAgent.name()).thenReturn("writer_agent");
-		when(writerAgent.description()).thenReturn("Writes text");
-		return writerAgent;
+	private static ReactAgent reactAgent(String name, ChatModel chatModel) {
+		return ReactAgent.builder()
+			.name(name)
+			.description("Scripted base agent")
+			.model(chatModel)
+			.instruction("Return a scripted answer")
+			.outputKey(name + "_answer")
+			.build();
 	}
 
-	private static LlmRoutingAgent routingAgent(ChatModel chatModel, Agent writerAgent, String fallbackAgent) {
+	private static SequentialAgent workflow(String name, ChatModel chatModel) {
+		return SequentialAgent.builder()
+			.name(name)
+			.description("Scripted workflow")
+			.subAgents(List.of(reactAgent(name + "_writer", chatModel)))
+			.build();
+	}
+
+	private static LlmRoutingAgent routingAgent(ChatModel chatModel, List<Agent> subAgents) {
+		return routingAgent(chatModel, subAgents, null);
+	}
+
+	private static LlmRoutingAgent routingAgent(ChatModel chatModel, List<Agent> subAgents, String fallbackAgent) {
 		LlmRoutingAgent.LlmRoutingAgentBuilder builder = LlmRoutingAgent.builder()
-				.name("router")
-				.description("Routes requests")
-				.model(chatModel)
-				.subAgents(List.of(writerAgent));
+			.name("routing_agent")
+			.description("Routes writing tasks")
+			.model(chatModel)
+			.subAgents(subAgents);
 		if (fallbackAgent != null) {
 			builder.fallbackAgent(fallbackAgent);
 		}
 		return builder.build();
+	}
+
+	private static final class ScriptedChatModel implements ChatModel {
+
+		private final List<String> responses;
+
+		private final AtomicInteger calls = new AtomicInteger();
+
+		private ScriptedChatModel(List<String> responses) {
+			this.responses = responses;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int index = calls.getAndIncrement();
+			if (index >= responses.size()) {
+				throw new IllegalStateException("No scripted response for call " + index);
+			}
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(responses.get(index)))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
@@ -62,8 +62,8 @@ class RoutingNodeTest {
 
 		assertEquals(3, modelCalls.get());
 		assertEquals(List.of("writer_agent"), command.gotoNodes());
-		assertEquals(List.of("writer_agent"),
-				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent")));
+		assertEquals(List.of("writer_agent"), selectedAgentNames(
+				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent"))));
 		assertEquals("write a summary", command.update().get("writer_agent_input"));
 	}
 
@@ -83,8 +83,8 @@ class RoutingNodeTest {
 
 		assertEquals(3, modelCalls.get());
 		assertEquals(List.of("writing_workflow"), command.gotoNodes());
-		assertEquals(List.of("writing_workflow"),
-				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent")));
+		assertEquals(List.of("writing_workflow"), selectedAgentNames(
+				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent"))));
 		assertEquals("write a summary", command.update().get("writing_workflow_input"));
 		assertSame(OverAllState.MARK_FOR_REMOVAL,
 				command.update().get(outputKeyToParent("writing_workflow")));
@@ -118,8 +118,8 @@ class RoutingNodeTest {
 		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
 
 		assertEquals(List.of("writing_workflow"), command.gotoNodes());
-		assertEquals(List.of("writing_workflow"),
-				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent")));
+		assertEquals(List.of("writing_workflow"), selectedAgentNames(
+				command.update().get(RoutingNode.routedAgentNamesKey("routing_agent"))));
 		assertEquals("write and review article", command.update().get("writing_workflow_input"));
 		assertSame(OverAllState.MARK_FOR_REMOVAL,
 				command.update().get(outputKeyToParent("writing_workflow")));
@@ -145,8 +145,29 @@ class RoutingNodeTest {
 		assertFalse(state.value(outputKeyToParent("writing_workflow")).isPresent(),
 				"The route update must remove checkpointed wrapper output before the selected subgraph runs");
 		assertEquals("write and review article", state.value("writing_workflow_input").orElse(null));
-		assertEquals(List.of("writing_workflow"),
-				state.value(RoutingNode.routedAgentNamesKey("routing_agent")).orElse(null));
+		assertEquals(List.of("writing_workflow"), selectedAgentNames(
+				state.value(RoutingNode.routedAgentNamesKey("routing_agent")).orElse(null)));
+	}
+
+	@Test
+	void sameNamedNestedRouterRetainsTheEnclosingRoutingMarker() throws Exception {
+		ScriptedChatModel chatModel = new ScriptedChatModel(
+				List.of("{\"agents\":[{\"agent\":\"writer_agent\",\"query\":\"write article\"}]}"));
+		ReactAgent writerAgent = reactAgent("writer_agent", chatModel);
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, List.of(writerAgent));
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writerAgent));
+		Map<String, Object> parentMarker = Map.of(
+				RoutingNode.SELECTED_AGENT_NAMES_FIELD, List.of("outer_workflow"));
+		OverAllState state = new OverAllState(Map.of(
+				RoutingNode.routedAgentNamesKey("routing_agent"), parentMarker,
+				"messages", List.<Message>of(new UserMessage("Please write"))));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		Object marker = command.update().get(RoutingNode.routedAgentNamesKey("routing_agent"));
+		assertEquals(List.of("writer_agent"), selectedAgentNames(marker));
+		assertEquals(parentMarker, ((Map<?, ?>) marker).get(RoutingNode.PARENT_ROUTING_MARKER_FIELD),
+				"A same-named nested router must retain the enclosing router marker for restoration");
 	}
 
 	@Test
@@ -234,6 +255,10 @@ class RoutingNodeTest {
 				return Flux.just(call(prompt));
 			}
 		};
+	}
+
+	private static Object selectedAgentNames(Object marker) {
+		return ((Map<?, ?>) marker).get(RoutingNode.SELECTED_AGENT_NAMES_FIELD);
 	}
 
 	private static ReactAgent reactAgent(String name, ChatModel chatModel) {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -341,11 +341,15 @@ public class NodeExecutor extends BaseGraphExecutor {
 						}
 
 						if (result instanceof Map resultMap) {
-							if (!resultMap.containsKey(key) && resultMap.containsKey("messages")) {
-								List<Object> messages = (List<Object>) resultMap.get("messages");
-								Object lastMessage = messages.get(messages.size() - 1);
-								if (lastMessage instanceof AssistantMessage lastAssistantMessage) {
-									resultMap.put(key, lastAssistantMessage.getText());
+							if ((!resultMap.containsKey(key) || isSubGraphWrapperKey(key))
+									&& resultMap.containsKey("messages")) {
+								Object messagesValue = resultMap.get("messages");
+								if (messagesValue instanceof List<?> messages && !messages.isEmpty()) {
+									Object lastMessage = messages.get(messages.size() - 1);
+									if (lastMessage instanceof AssistantMessage lastAssistantMessage) {
+										// Replace checkpointed subgraph wrapper output with the current subgraph answer.
+										resultMap.put(key, lastAssistantMessage.getText());
+									}
 								}
 							}
 						}
@@ -789,7 +793,12 @@ public class NodeExecutor extends BaseGraphExecutor {
 			if (resultValue.isPresent()) {
 				Object value = resultValue.get();
 				if (value instanceof Map<?, ?> resultMap) {
-					return copyStateMap(resultMap);
+					Map<String, Object> state = copyStateMap(resultMap);
+					String stateKey = graphFluxStateKey(graphFlux);
+					if (isSubGraphWrapperKey(stateKey)) {
+						state.put(stateKey, copyStateMapWithoutSubGraphWrappers(resultMap));
+					}
+					return state;
 				}
 			}
 		}
@@ -803,11 +812,36 @@ public class NodeExecutor extends BaseGraphExecutor {
 		return StringUtils.hasText(graphFlux.getKey()) ? graphFlux.getKey() : "result";
 	}
 
+	private static boolean isSubGraphWrapperKey(String outputKey) {
+		return outputKey != null && outputKey.startsWith("subgraph_") && outputKey.endsWith("_compiled_graph");
+	}
+
 	private static Map<String, Object> copyStateMap(Map<?, ?> resultMap) {
 		Map<String, Object> state = new HashMap<>();
 		for (Map.Entry<?, ?> entry : resultMap.entrySet()) {
 			if (!(entry.getKey() instanceof String key)) {
 				throw new IllegalArgumentException("GraphFlux done result map keys must be String");
+			}
+			state.put(key, entry.getValue());
+		}
+		return state;
+	}
+
+	/**
+	 * Copies the current subgraph state into its parent wrapper snapshot without
+	 * inherited subgraph wrapper snapshots.
+	 * @param resultMap completed subgraph state
+	 * @return wrapper snapshot that keeps current ordinary outputs but avoids recursive
+	 * wrapper growth across checkpointed runs
+	 */
+	private static Map<String, Object> copyStateMapWithoutSubGraphWrappers(Map<?, ?> resultMap) {
+		Map<String, Object> state = new HashMap<>();
+		for (Map.Entry<?, ?> entry : resultMap.entrySet()) {
+			if (!(entry.getKey() instanceof String key)) {
+				throw new IllegalArgumentException("GraphFlux done result map keys must be String");
+			}
+			if (isSubGraphWrapperKey(key)) {
+				continue;
 			}
 			state.put(key, entry.getValue());
 		}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -30,6 +30,7 @@ import com.alibaba.cloud.ai.graph.exception.RunnableErrors;
 import com.alibaba.cloud.ai.graph.streaming.GraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.ParallelGraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
+import com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -813,7 +814,9 @@ public class NodeExecutor extends BaseGraphExecutor {
 	}
 
 	private static boolean isSubGraphWrapperKey(String outputKey) {
-		return outputKey != null && outputKey.startsWith("subgraph_") && outputKey.endsWith("_compiled_graph");
+		// The prefix matches ResumableSubGraphAction.subGraphId, which has no public constant.
+		return outputKey != null && outputKey.startsWith("subgraph_")
+				&& outputKey.endsWith(ResumableSubGraphAction.OUTPUT_KEY_TO_PARENT_SUFFIX);
 	}
 
 	private static Map<String, Object> copyStateMap(Map<?, ?> resultMap) {

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/NodeExecutorTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/NodeExecutorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.executor;
+
+import com.alibaba.cloud.ai.graph.GraphResponse;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.streaming.GraphFlux;
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Flux;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link NodeExecutor} state mapping.
+ */
+class NodeExecutorTest {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void subgraphWrapperSnapshotExcludesInheritedWrapperValues() throws Exception {
+		String wrapperKey = "subgraph_weather_workflow_compiled_graph";
+		String ancestorWrapperKey = "subgraph_parent_router_compiled_graph";
+		String siblingWrapperKey = "subgraph_other_workflow_compiled_graph";
+		GraphFlux<NodeOutput> graphFlux = GraphFlux.of("weather_workflow", wrapperKey, Flux.empty());
+		GraphResponse<NodeOutput> lastData = GraphResponse.done(Map.of(
+				wrapperKey, Map.of("previous", "snapshot"),
+				ancestorWrapperKey, Map.of("previous", "ancestor snapshot"),
+				siblingWrapperKey, Map.of("previous", "sibling snapshot"),
+				"messages", "current answer"));
+
+		Map<String, Object> state = (Map<String, Object>) graphFluxResultState(graphFlux, lastData);
+
+		assertTrue(state.containsKey(ancestorWrapperKey));
+		assertTrue(state.containsKey(siblingWrapperKey));
+		assertTrue(state.containsKey(wrapperKey));
+		Map<String, Object> wrapperSnapshot = assertInstanceOf(Map.class, state.get(wrapperKey));
+		assertFalse(wrapperSnapshot.containsKey(wrapperKey),
+				"Subgraph wrapper snapshots must not nest the previous wrapper value");
+		assertFalse(wrapperSnapshot.containsKey(ancestorWrapperKey),
+				"Subgraph wrapper snapshots must not nest inherited ancestor wrappers");
+		assertFalse(wrapperSnapshot.containsKey(siblingWrapperKey),
+				"Subgraph wrapper snapshots must not nest inherited sibling wrappers");
+		assertTrue(wrapperSnapshot.containsKey("messages"));
+	}
+
+	private Object graphFluxResultState(GraphFlux<?> graphFlux, Object lastData) throws Exception {
+		NodeExecutor executor = new NodeExecutor(null);
+		Method method = NodeExecutor.class.getDeclaredMethod("graphFluxResultState", GraphFlux.class, Object.class);
+		method.setAccessible(true);
+		return method.invoke(executor, graphFlux, lastData);
+	}
+
+}


### PR DESCRIPTION
## Summary
- allow routing agents to accept FlowAgent sub-agents instead of only BaseAgent instances
- resolve routed FlowAgent outputs from nested final outputs, parallel merge outputs, or subgraph wrapper outputs
- add regression coverage for routing to a SequentialAgent workflow and merge behavior

Fixes #4553

## Tests
- ./mvnw -pl :spring-ai-alibaba-agent-framework -am -Dtest=FlowAgentArchitectureTest,RoutingMergeNodeTest,LlmRoutingFlowAgentIntegrationTest test