### PR TITLE
fix(graph): avoid mutating append inputs

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
@@ -94,7 +94,9 @@ public class AppendStrategy implements KeyStrategy {
 				oldList.addAll(list);
 			}
 			else {
-				oldList.add(newValue);
+				var result = new ArrayList<>(oldList);
+				result.add(newValue);
+				return result;
 			}
 			return oldList;
 		}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/AppendStrategyMutationRegressionTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/AppendStrategyMutationRegressionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class AppendStrategyMutationRegressionTest {
+
+    // https://github.com/alibaba/spring-ai-alibaba/issues/4757
+    @Test
+    void issue4757_singleValueAppend_doesNotMutateExistingList() {
+        AppendStrategy strategy = new AppendStrategy();
+        List<Object> oldValues = new ArrayList<>(List.of("question"));
+
+        Object result = strategy.apply(oldValues, "user-answer");
+
+        assertEquals(List.of("question"), oldValues);
+        assertEquals(List.of("question", "user-answer"), result);
+        assertNotSame(oldValues, result);
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

This keeps `AppendStrategy.apply(oldValue, newValue)` side-effect free when `oldValue` is already a `List` and `newValue` is a single non-collection value.

Today that branch appends directly into the incoming `oldList` and returns the same instance. Any caller that still holds the original list reference can observe the mutation, which leaks state across history snapshots and checkpointed branches.

### Does this pull request fix one issue?

Fixes #4757

### Describe how you did it

- change the single-value append branch to copy `oldList` into a new `ArrayList`
- append the new value to the copied list instead of mutating the original reference
- add a focused regression test that proves `oldList` stays unchanged while the returned list contains the appended value

### Describe how to verify it

- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=AppendStrategyMutationRegressionTest test`
- `git diff --check`

### Special notes for reviews

This is intentionally scoped to the single-value append path only. Existing list/list merge behavior and remove-identifier handling are left unchanged.
