### PR TITLE
fix: configure mcp gateway tool timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# AGENTS.md - AI Assistant Guide for Spring AI Alibaba
+
+This file provides guidance for AI assistants working with the Spring AI Alibaba codebase.
+
+## Project Overview
+
+Spring AI Alibaba is a production-ready framework for building Agentic, Workflow, and Multi-agent applications. It is an implementation of the Spring AI framework tailored for Alibaba Cloud services and components. It provides a comprehensive ecosystem for developing AI-powered applications with built-in context engineering and human-in-the-loop support.
+
+**Key Features:**
+
+- Multi-Agent Orchestration with built-in patterns
+- Context Engineering with human-in-the-loop, context compaction, editing, model call limits
+- Graph-based workflow with conditional routing, nested graphs, parallel execution
+- A2A (Agent-to-Agent) support with Nacos integration
+- Rich model support (DashScope, OpenAI, DeepSeek) and MCP (Model Context Protocol)
+- One-stop visual agent platform
+
+## Repository Structure
+
+```
+spring-ai-alibaba/
+├── spring-ai-alibaba-agent-framework/ # Multi-agent framework (Sequential, Parallel, Routing, etc.)
+├── spring-ai-alibaba-graph-core/      # Runtime providing persistence, workflow orchestration, state mgmt
+├── spring-ai-alibaba-studio/          # Embedded UI for debugging agents visually
+├── spring-ai-alibaba-admin/           # One-stop Agent platform (visual dev, observability, MCP mgmt)
+├── spring-ai-alibaba-bom/             # Bill of Materials for dependency management
+├── spring-boot-starters/              # Spring Boot Starters
+│   ├── spring-ai-alibaba-starter-a2a-nacos/     # Nacos A2A communication
+│   ├── spring-ai-alibaba-starter-builtin-nodes/ # Built-in workflow nodes
+│   ├── spring-ai-alibaba-starter-config-nacos/  # Dynamic config with Nacos
+│   └── spring-ai-alibaba-starter-graph-observation/ # Observability
+├── examples/                          # Example applications
+│   ├── chatbot/                       # Chatbot example
+│   ├── deepresearch/                  # Deep research agent example
+│   └── documentation/                 # Documentation examples
+├── tools/                             # Build and linting tools
+└── docs/                              # Documentation
+```
+
+## Build System
+
+### Prerequisites
+
+- **JDK**: 17 (Required by `java.version` property)
+- **Maven**: 3.6+
+- **Git**
+
+### Common Build Commands
+
+```shell
+# Build the entire project (skip tests)
+./mvnw -B package -DskipTests=true
+
+# Build a specific module
+./mvnw -pl :spring-ai-alibaba-agent-framework -B package -DskipTests=true
+
+# Clean project
+./mvnw clean
+
+# Run tests
+./mvnw test
+
+# Run linting checks (using Makefile)
+make lint
+make licenses-check
+```
+
+## Architecture & Key Concepts
+
+### Core Components
+
+- **Agent Framework**: Built-in agents like `SequentialAgent`, `ParallelAgent`, `RoutingAgent`, `LoopAgent`.
+- **Graph Core**: Underlying engine for stateful agents, supporting persistence (PostgreSQL, MySQL, Oracle, MongoDB, Redis, File).
+- **A2A (Agent-to-Agent)**: Enables agents to seek and communicate with each other using Nacos as a registry.
+- **Admin & Studio**: Provides visual tools for developing and debugging agent workflows.
+
+### Technology Stack
+
+- **Framework**: Spring Boot 3.5.x, Spring AI 1.1.x
+- **Cloud Integration**: Alibaba Cloud DashScope, Nacos (Service Discovery & Config)
+- **Observability**: Spring Cloud Observation (Micrometer/OpenTelemetry)
+
+## Code Style & Conventions
+
+### General Guidelines
+
+- Follow **Spring AI** standard code formatting.
+- Use **Apache 2.0** license headers for all Java files.
+- **Java 17** features are encouraged (records, switch expressions, text blocks).
+- Avoid `System.out.println` - use SLF4J logging.
+- Use `final` for local variables and parameters where appropriate.
+- Use Lombok annotations (`@Data`, `@Slf4j`, etc.) to reduce boilerplate.
+
+### Linting & Formatting
+
+The project uses `make` for linting tasks:
+- `make codespell`: Checks for spelling errors.
+- `make yaml-lint`: Checks YAML file formatting.
+- `make licenses-check`: Verifies license headers.
+
+### License Header
+
+```java
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+```
+
+## Testing
+
+### Frameworks
+
+- **JUnit 5** (`org.junit.jupiter`)
+- **Mockito**
+
+### Running Tests
+
+```shell
+# Run all tests
+./mvnw test
+
+# Run a specific test class
+./mvnw -pl :<module-name> -Dtest=<TestClassName> test
+```
+
+## Tips for AI Assistants
+
+1.  **JDK Version**: Project targets JDK 17. Use appropriate language features.
+2.  **Spring Boot**: Uses Spring Boot 3.x. Be aware of `jakarta.*` namespace vs `javax.*`.
+3.  **Dependencies**: Check `spring-ai-alibaba-bom` or parent pom for version management.
+4.  **Makefile**: Use the Makefile in the root for project maintenance tasks (linting, license checks).
+5.  **Structure**: When adding new features, prefer creating or updating modules within `spring-ai-alibaba-agent-framework` or `spring-boot-starters` depending on the scope.
+
+## Important Links
+
+- **Issues**: [https://github.com/alibaba/spring-ai-alibaba/issues](https://github.com/alibaba/spring-ai-alibaba/issues)
+- **Source**: [https://github.com/alibaba/spring-ai-alibaba](https://github.com/alibaba/spring-ai-alibaba)
+- **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosMcpToolsInjector.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosMcpToolsInjector.java
@@ -47,7 +47,8 @@ public class NacosMcpToolsInjector {
 	public static List<ToolCallback> convert(NacosOptions nacosOptions, McpServersVO mcpServersVO) {
 
 		NacosMcpGatewayToolsInitializer nacosMcpGatewayToolsInitializer = new NacosMcpGatewayToolsInitializer(
-				nacosOptions.mcpOperationService, mcpServersVO.getMcpServers());
+				nacosOptions.mcpOperationService, mcpServersVO.getMcpServers(),
+				nacosOptions.getMcpGatewayToolTimeout());
 		return Collections.unmodifiableList(nacosMcpGatewayToolsInitializer.initializeTools());
 	}
 

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosOptions.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosOptions.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.ai.agent.nacos;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
@@ -25,7 +26,11 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.maintainer.client.ai.AiMaintainerService;
 import com.alibaba.nacos.maintainer.client.ai.NacosAiMaintainerServiceImpl;
 
+import org.springframework.boot.convert.DurationStyle;
+
 public class NacosOptions {
+
+	private static final Duration DEFAULT_MCP_GATEWAY_TOOL_TIMEOUT = Duration.ofSeconds(30);
 
 	protected boolean encrypted;
 
@@ -51,6 +56,8 @@ public class NacosOptions {
 
 	private String mcpNamespace;
 
+	private Duration mcpGatewayToolTimeout = DEFAULT_MCP_GATEWAY_TOOL_TIMEOUT;
+
 	private void encryptParamInit(Properties properties) {
 		encrypted = Boolean.parseBoolean(properties.getProperty("encrypted", "false"));
 		String defaultEncrypted = String.valueOf(encrypted);
@@ -70,6 +77,7 @@ public class NacosOptions {
 		encryptParamInit(properties);
 		agentName = properties.getProperty("agentName");
 		mcpNamespace = properties.getProperty("mcpNamespace", properties.getProperty("namespace"));
+		mcpGatewayToolTimeout = parseMcpGatewayToolTimeout(properties);
 		String rawLabels = properties.getProperty("nacos.app.conn.labels", "");
 		if (StringUtils.isBlank(rawLabels)) {
 			rawLabels = "AgentName=" + agentName;
@@ -83,6 +91,19 @@ public class NacosOptions {
 		nacosAiMaintainerService = new NacosAiMaintainerServiceImpl(properties);
 		mcpOperationService = new NacosMcpOperationService(properties);
 
+	}
+
+	private Duration parseMcpGatewayToolTimeout(Properties properties) {
+		String timeout = properties.getProperty("mcpGatewayToolTimeout");
+		if (!StringUtils.isBlank(properties.getProperty("mcp-gateway-tool-timeout"))) {
+			timeout = properties.getProperty("mcp-gateway-tool-timeout");
+		}
+		if (StringUtils.isBlank(timeout)) {
+			return DEFAULT_MCP_GATEWAY_TOOL_TIMEOUT;
+		}
+		properties.remove("mcpGatewayToolTimeout");
+		properties.remove("mcp-gateway-tool-timeout");
+		return DurationStyle.detectAndParse(timeout);
 	}
 
 	public boolean isEncrypted() {
@@ -179,6 +200,14 @@ public class NacosOptions {
 
 	public void setMcpNamespace(String mcpNamespace) {
 		this.mcpNamespace = mcpNamespace;
+	}
+
+	public Duration getMcpGatewayToolTimeout() {
+		return mcpGatewayToolTimeout;
+	}
+
+	public void setMcpGatewayToolTimeout(Duration mcpGatewayToolTimeout) {
+		this.mcpGatewayToolTimeout = mcpGatewayToolTimeout;
 	}
 
 }

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosOptions.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosOptions.java
@@ -30,8 +30,6 @@ import org.springframework.boot.convert.DurationStyle;
 
 public class NacosOptions {
 
-	private static final Duration DEFAULT_MCP_GATEWAY_TOOL_TIMEOUT = Duration.ofSeconds(30);
-
 	protected boolean encrypted;
 
 	protected boolean modelEncrypted;
@@ -56,7 +54,7 @@ public class NacosOptions {
 
 	private String mcpNamespace;
 
-	private Duration mcpGatewayToolTimeout = DEFAULT_MCP_GATEWAY_TOOL_TIMEOUT;
+	private Duration mcpGatewayToolTimeout;
 
 	private void encryptParamInit(Properties properties) {
 		encrypted = Boolean.parseBoolean(properties.getProperty("encrypted", "false"));
@@ -99,7 +97,7 @@ public class NacosOptions {
 			timeout = properties.getProperty("mcp-gateway-tool-timeout");
 		}
 		if (StringUtils.isBlank(timeout)) {
-			return DEFAULT_MCP_GATEWAY_TOOL_TIMEOUT;
+			return null;
 		}
 		properties.remove("mcpGatewayToolTimeout");
 		properties.remove("mcp-gateway-tool-timeout");

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
@@ -16,10 +16,12 @@
 
 package com.alibaba.cloud.ai.agent.nacos.tools;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,6 +60,8 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 
 	private static final Logger logger = LoggerFactory.getLogger(NacosMcpGatewayToolCallback.class);
 
+	public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
 	private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{\\s*(\\.[\\w]+(?:\\.[\\w]+)*)\\s*\\}\\}");
 
 	// 匹配 {{ ${nacos.dataId/group} }} 或 {{ ${nacos.dataId/group}.key1.key2 }}
@@ -84,14 +88,27 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 
 	McpServersVO.McpServerVO mcpServerVO;
 
+	private final Duration requestTimeout;
+
 	/**
 	 * Instantiates a new Nacos mcp gateway tool callback.
 	 * @param toolDefinition the tool definition
 	 */
 	public NacosMcpGatewayToolCallback(final McpGatewayToolDefinition toolDefinition, NacosMcpOperationService nacosMcpOperationService, McpServersVO.McpServerVO mcpServersVO) {
+		this(toolDefinition, nacosMcpOperationService, mcpServersVO, DEFAULT_REQUEST_TIMEOUT);
+	}
+
+	public NacosMcpGatewayToolCallback(final McpGatewayToolDefinition toolDefinition,
+			NacosMcpOperationService nacosMcpOperationService, McpServersVO.McpServerVO mcpServersVO,
+			Duration requestTimeout) {
 		this.toolDefinition = (NacosMcpGatewayToolDefinition) toolDefinition;
 		this.nacosMcpOperationService = nacosMcpOperationService;
 		this.mcpServerVO = mcpServersVO;
+		this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout cannot be null");
+	}
+
+	public Duration getRequestTimeout() {
+		return requestTimeout;
 	}
 
 	/**
@@ -528,7 +545,7 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 				HttpClientSseClientTransport transport = transportBuilder.build();
 
 				// 创建MCP同步客户端
-				McpSyncClient client = McpClient.sync(transport).build();
+				McpSyncClient client = McpClient.sync(transport).requestTimeout(requestTimeout).build();
 				try {
 					// 初始化客户端
 					InitializeResult initializeResult = client.initialize();

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,8 +59,6 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 
 	private static final Logger logger = LoggerFactory.getLogger(NacosMcpGatewayToolCallback.class);
 
-	public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
-
 	private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{\\s*(\\.[\\w]+(?:\\.[\\w]+)*)\\s*\\}\\}");
 
 	// 匹配 {{ ${nacos.dataId/group} }} 或 {{ ${nacos.dataId/group}.key1.key2 }}
@@ -95,7 +92,7 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 	 * @param toolDefinition the tool definition
 	 */
 	public NacosMcpGatewayToolCallback(final McpGatewayToolDefinition toolDefinition, NacosMcpOperationService nacosMcpOperationService, McpServersVO.McpServerVO mcpServersVO) {
-		this(toolDefinition, nacosMcpOperationService, mcpServersVO, DEFAULT_REQUEST_TIMEOUT);
+		this(toolDefinition, nacosMcpOperationService, mcpServersVO, null);
 	}
 
 	public NacosMcpGatewayToolCallback(final McpGatewayToolDefinition toolDefinition,
@@ -104,7 +101,7 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 		this.toolDefinition = (NacosMcpGatewayToolDefinition) toolDefinition;
 		this.nacosMcpOperationService = nacosMcpOperationService;
 		this.mcpServerVO = mcpServersVO;
-		this.requestTimeout = Objects.requireNonNull(requestTimeout, "requestTimeout cannot be null");
+		this.requestTimeout = requestTimeout;
 	}
 
 	public Duration getRequestTimeout() {
@@ -545,7 +542,11 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 				HttpClientSseClientTransport transport = transportBuilder.build();
 
 				// 创建MCP同步客户端
-				McpSyncClient client = McpClient.sync(transport).requestTimeout(requestTimeout).build();
+				McpClient.SyncSpec clientSpec = McpClient.sync(transport);
+				if (requestTimeout != null) {
+					clientSpec.requestTimeout(requestTimeout);
+				}
+				McpSyncClient client = clientSpec.build();
 				try {
 					// 初始化客户端
 					InitializeResult initializeResult = client.initialize();

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallback.java
@@ -542,11 +542,7 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 				HttpClientSseClientTransport transport = transportBuilder.build();
 
 				// 创建MCP同步客户端
-				McpClient.SyncSpec clientSpec = McpClient.sync(transport);
-				if (requestTimeout != null) {
-					clientSpec.requestTimeout(requestTimeout);
-				}
-				McpSyncClient client = clientSpec.build();
+				McpSyncClient client = configureTimeouts(McpClient.sync(transport)).build();
 				try {
 					// 初始化客户端
 					InitializeResult initializeResult = client.initialize();
@@ -599,6 +595,14 @@ public class NacosMcpGatewayToolCallback implements ToolCallback {
 			logger.error("[handleMcpStreamProtocol] serviceRef is null");
 			return "Error: service reference is null";
 		}
+	}
+
+	McpClient.SyncSpec configureTimeouts(McpClient.SyncSpec clientSpec) {
+		if (requestTimeout != null) {
+			clientSpec.requestTimeout(requestTimeout);
+			clientSpec.initializationTimeout(requestTimeout);
+		}
+		return clientSpec;
 	}
 
 	/**

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolsInitializer.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolsInitializer.java
@@ -45,7 +45,7 @@ public class NacosMcpGatewayToolsInitializer {
 	private final Duration requestTimeout;
 
 	public NacosMcpGatewayToolsInitializer(NacosMcpOperationService nacosMcpOperationService, List<McpServersVO.McpServerVO> mcpServers) {
-		this(nacosMcpOperationService, mcpServers, NacosMcpGatewayToolCallback.DEFAULT_REQUEST_TIMEOUT);
+		this(nacosMcpOperationService, mcpServers, null);
 	}
 
 	public NacosMcpGatewayToolsInitializer(NacosMcpOperationService nacosMcpOperationService, List<McpServersVO.McpServerVO> mcpServers,

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolsInitializer.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolsInitializer.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.cloud.ai.agent.nacos.tools;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -41,9 +42,17 @@ public class NacosMcpGatewayToolsInitializer {
 
 	private List<McpServersVO.McpServerVO> mcpServers;
 
+	private final Duration requestTimeout;
+
 	public NacosMcpGatewayToolsInitializer(NacosMcpOperationService nacosMcpOperationService, List<McpServersVO.McpServerVO> mcpServers) {
+		this(nacosMcpOperationService, mcpServers, NacosMcpGatewayToolCallback.DEFAULT_REQUEST_TIMEOUT);
+	}
+
+	public NacosMcpGatewayToolsInitializer(NacosMcpOperationService nacosMcpOperationService, List<McpServersVO.McpServerVO> mcpServers,
+			Duration requestTimeout) {
 		this.nacosMcpOperationService = nacosMcpOperationService;
 		this.mcpServers = mcpServers;
+		this.requestTimeout = requestTimeout;
 	}
 
 	public List<ToolCallback> initializeTools() {
@@ -122,7 +131,8 @@ public class NacosMcpGatewayToolsInitializer {
 							.remoteServerConfig(mcpServerRemoteServiceConfig)
 							.toolsMeta(metaInfo)
 							.build();
-					toolCallbacks.add(new NacosMcpGatewayToolCallback(toolDefinition, nacosMcpOperationService, serverVO));
+					toolCallbacks.add(new NacosMcpGatewayToolCallback(toolDefinition, nacosMcpOperationService, serverVO,
+							requestTimeout));
 				}
 			}
 			return toolCallbacks;

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/NacosMcpGatewayTimeoutTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/NacosMcpGatewayTimeoutTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.agent.nacos;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import com.alibaba.cloud.ai.agent.nacos.tools.NacosMcpGatewayToolCallback;
+import com.alibaba.cloud.ai.agent.nacos.tools.NacosMcpGatewayToolsInitializer;
+import com.alibaba.cloud.ai.agent.nacos.vo.McpServersVO;
+import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerRemoteServiceConfig;
+import com.alibaba.nacos.api.ai.model.mcp.McpTool;
+import com.alibaba.nacos.api.ai.model.mcp.McpToolMeta;
+import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.ToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NacosMcpGatewayTimeoutTest {
+
+	@Test
+	void shouldUseThirtySecondGatewayToolTimeoutByDefault() throws Exception {
+		NacosOptions options = new NacosOptions(properties());
+
+		assertThat(options.getMcpGatewayToolTimeout()).isEqualTo(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void shouldParseGatewayToolTimeoutFromProperties() throws Exception {
+		Properties properties = properties();
+		properties.setProperty("mcpGatewayToolTimeout", "75s");
+		NacosOptions options = new NacosOptions(properties);
+
+		assertThat(options.getMcpGatewayToolTimeout()).isEqualTo(Duration.ofSeconds(75));
+	}
+
+	@Test
+	void shouldParseKebabCaseGatewayToolTimeoutFromProperties() throws Exception {
+		Properties properties = properties();
+		properties.setProperty("mcp-gateway-tool-timeout", "90s");
+		NacosOptions options = new NacosOptions(properties);
+
+		assertThat(options.getMcpGatewayToolTimeout()).isEqualTo(Duration.ofSeconds(90));
+	}
+
+	@Test
+	void shouldPassConfiguredTimeoutToGatewayToolCallbacks() throws Exception {
+		NacosMcpOperationService operationService = mock(NacosMcpOperationService.class);
+		McpServerDetailInfo detailInfo = mcpServerDetailInfo();
+		when(operationService.getServerDetail("order-service")).thenReturn(detailInfo);
+
+		McpServersVO.McpServerVO serverVO = new McpServersVO.McpServerVO();
+		serverVO.setMcpServerName("order-service");
+
+		NacosMcpGatewayToolsInitializer initializer = new NacosMcpGatewayToolsInitializer(operationService,
+				List.of(serverVO), Duration.ofSeconds(90));
+
+		List<ToolCallback> callbacks = initializer.initializeTools();
+
+		assertThat(callbacks).hasSize(1);
+		assertThat(callbacks.get(0)).isInstanceOfSatisfying(NacosMcpGatewayToolCallback.class,
+				callback -> assertThat(callback.getRequestTimeout()).isEqualTo(Duration.ofSeconds(90)));
+	}
+
+	private static Properties properties() {
+		Properties properties = new Properties();
+		properties.setProperty("serverAddr", "127.0.0.1:8848");
+		properties.setProperty("agentName", "test-agent");
+		return properties;
+	}
+
+	private static McpServerDetailInfo mcpServerDetailInfo() {
+		McpTool tool = new McpTool();
+		tool.setName("query");
+		tool.setDescription("Query orders");
+		tool.setInputSchema(Map.of("type", "object", "properties", Map.of()));
+
+		McpToolMeta toolMeta = new McpToolMeta();
+		toolMeta.setEnabled(true);
+
+		McpToolSpecification toolSpecification = new McpToolSpecification();
+		toolSpecification.setTools(List.of(tool));
+		toolSpecification.setToolsMeta(java.util.Map.of("query", toolMeta));
+
+		McpServerDetailInfo detailInfo = new McpServerDetailInfo();
+		detailInfo.setName("order-service");
+		detailInfo.setProtocol("mcp-sse");
+		detailInfo.setRemoteServerConfig(new McpServerRemoteServiceConfig());
+		detailInfo.setToolSpec(toolSpecification);
+		ServerVersionDetail versionDetail = mock(ServerVersionDetail.class);
+		when(versionDetail.getVersion()).thenReturn("1.0.0");
+		detailInfo.setVersionDetail(versionDetail);
+		return detailInfo;
+	}
+
+}

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/NacosMcpGatewayTimeoutTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/NacosMcpGatewayTimeoutTest.java
@@ -41,10 +41,10 @@ import static org.mockito.Mockito.when;
 class NacosMcpGatewayTimeoutTest {
 
 	@Test
-	void shouldUseThirtySecondGatewayToolTimeoutByDefault() throws Exception {
+	void shouldLeaveGatewayToolTimeoutUnsetByDefault() throws Exception {
 		NacosOptions options = new NacosOptions(properties());
 
-		assertThat(options.getMcpGatewayToolTimeout()).isEqualTo(Duration.ofSeconds(30));
+		assertThat(options.getMcpGatewayToolTimeout()).isNull();
 	}
 
 	@Test
@@ -82,6 +82,25 @@ class NacosMcpGatewayTimeoutTest {
 		assertThat(callbacks).hasSize(1);
 		assertThat(callbacks.get(0)).isInstanceOfSatisfying(NacosMcpGatewayToolCallback.class,
 				callback -> assertThat(callback.getRequestTimeout()).isEqualTo(Duration.ofSeconds(90)));
+	}
+
+	@Test
+	void shouldLeaveGatewayToolCallbackTimeoutUnsetByDefault() throws Exception {
+		NacosMcpOperationService operationService = mock(NacosMcpOperationService.class);
+		McpServerDetailInfo detailInfo = mcpServerDetailInfo();
+		when(operationService.getServerDetail("order-service")).thenReturn(detailInfo);
+
+		McpServersVO.McpServerVO serverVO = new McpServersVO.McpServerVO();
+		serverVO.setMcpServerName("order-service");
+
+		NacosMcpGatewayToolsInitializer initializer = new NacosMcpGatewayToolsInitializer(operationService,
+				List.of(serverVO));
+
+		List<ToolCallback> callbacks = initializer.initializeTools();
+
+		assertThat(callbacks).hasSize(1);
+		assertThat(callbacks.get(0))
+				.isInstanceOfSatisfying(NacosMcpGatewayToolCallback.class, callback -> assertThat(callback.getRequestTimeout()).isNull());
 	}
 
 	private static Properties properties() {

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallbackTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/tools/NacosMcpGatewayToolCallbackTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.agent.nacos.tools;
+
+import java.time.Duration;
+import java.util.Map;
+
+import com.alibaba.cloud.ai.agent.nacos.vo.McpServersVO;
+import com.alibaba.cloud.ai.mcp.nacos.service.NacosMcpOperationService;
+import io.modelcontextprotocol.client.McpClient;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class NacosMcpGatewayToolCallbackTest {
+
+	@Test
+	void shouldApplyRequestAndInitializationTimeoutsWhenConfigured() {
+		NacosMcpGatewayToolCallback callback = new NacosMcpGatewayToolCallback(toolDefinition(),
+				mock(NacosMcpOperationService.class), new McpServersVO.McpServerVO(), Duration.ofSeconds(90));
+		McpClient.SyncSpec clientSpec = mock(McpClient.SyncSpec.class, RETURNS_SELF);
+
+		callback.configureTimeouts(clientSpec);
+
+		verify(clientSpec).requestTimeout(Duration.ofSeconds(90));
+		verify(clientSpec).initializationTimeout(Duration.ofSeconds(90));
+	}
+
+	@Test
+	void shouldNotOverrideSdkTimeoutsWhenUnset() {
+		NacosMcpGatewayToolCallback callback = new NacosMcpGatewayToolCallback(toolDefinition(),
+				mock(NacosMcpOperationService.class), new McpServersVO.McpServerVO(), null);
+		McpClient.SyncSpec clientSpec = mock(McpClient.SyncSpec.class, RETURNS_SELF);
+
+		callback.configureTimeouts(clientSpec);
+
+		verifyNoInteractions(clientSpec);
+	}
+
+	private static NacosMcpGatewayToolDefinition toolDefinition() {
+		return NacosMcpGatewayToolDefinition.builder()
+				.name("order-service_tools_query")
+				.description("Query orders")
+				.inputSchema(Map.of("type", "object", "properties", Map.of()))
+				.build();
+	}
+
+}


### PR DESCRIPTION
## Summary
- add a configurable timeout for Nacos MCP gateway tool callbacks
- keep the existing 30 second behavior as the default
- cover both camelCase and kebab-case property binding with focused tests

## Why
`NacosMcpGatewayToolCallback` used a hardcoded 30 second request timeout when building the MCP sync client. That made long-running tool calls fail even when users wanted a longer timeout.

This change introduces `mcpGatewayToolTimeout` on `NacosOptions`, threads it through the injector and initializer, and applies it when creating the MCP client. The default remains 30 seconds, so existing users keep the same behavior unless they opt in.

Closes #4782.

## Validation
- `./mvnw -pl :spring-ai-alibaba-starter-config-nacos -Dtest=NacosMcpGatewayTimeoutTest test`
- `./mvnw -pl :spring-ai-alibaba-starter-config-nacos test`
