### PR TITLE
fix(agent): enforce maxCacheSize in WebFetchTool to prevent unbounded cache growth

### DIFF
--- a/spring-ai-alibaba-agent-framework/pom.xml
+++ b/spring-ai-alibaba-agent-framework/pom.xml
@@ -82,6 +82,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchTool.java
@@ -23,13 +23,13 @@ import java.net.http.HttpResponse;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.function.BiFunction;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -120,25 +120,23 @@ public class WebFetchTool implements BiFunction<WebFetchTool.Request, ToolContex
 
 	private final FlexmarkHtmlConverter htmlToMarkdownConverter;
 
-	private final Map<String, CacheEntry> urlCache;
-
-	private final int maxCacheSize;
-
-	private final Object cacheLock = new Object();
+	private final Cache<String, String> urlCache;
 
 	private final int maxRetries;
 
 	private WebFetchTool(ChatClient chatClient, int maxContentLength, int maxCacheSize, int maxRetries) {
 		this.chatClient = chatClient;
 		this.maxContentLength = maxContentLength;
-		this.maxCacheSize = maxCacheSize;
 		this.maxRetries = maxRetries;
 		this.httpClient = HttpClient.newBuilder()
 			.followRedirects(HttpClient.Redirect.ALWAYS)
 			.connectTimeout(DEFAULT_CONNECT_TIMEOUT)
 			.build();
 		this.htmlToMarkdownConverter = FlexmarkHtmlConverter.builder().build();
-		this.urlCache = new ConcurrentHashMap<>();
+		this.urlCache = Caffeine.newBuilder()
+			.maximumSize(maxCacheSize)
+			.expireAfterWrite(CACHE_TTL)
+			.build();
 	}
 
 	@JsonClassDescription("Request to fetch and process web content")
@@ -182,7 +180,7 @@ public class WebFetchTool implements BiFunction<WebFetchTool.Request, ToolContex
 
 		// Check cache first
 		String cacheKey = buildCacheKey(url, prompt);
-		String content = getCachedContent(cacheKey);
+		String content = this.urlCache.getIfPresent(cacheKey);
 
 		if (content != null) {
 			logger.debug("Cache hit for URL: {} with prompt hash: {}", url, prompt.hashCode());
@@ -216,7 +214,7 @@ public class WebFetchTool implements BiFunction<WebFetchTool.Request, ToolContex
 		String summary = summarize(mdContent, prompt);
 
 		// Cache the content
-		cacheContent(cacheKey, summary);
+		this.urlCache.put(cacheKey, summary);
 
 		return summary;
 	}
@@ -388,37 +386,6 @@ public class WebFetchTool implements BiFunction<WebFetchTool.Request, ToolContex
 			return content.substring(0, this.maxContentLength);
 		}
 		return content;
-	}
-
-	private String getCachedContent(String url) {
-		CacheEntry entry = this.urlCache.get(url);
-		if (entry != null && !entry.isExpired()) {
-			return entry.content();
-		}
-		if (entry != null) {
-			this.urlCache.remove(url);
-		}
-		return null;
-	}
-
-	private void cacheContent(String cacheKey, String content) {
-		if (this.urlCache.size() > this.maxCacheSize) {
-			synchronized (this.cacheLock) {
-				if (this.urlCache.size() > this.maxCacheSize) {
-					this.urlCache.entrySet().removeIf(entry -> entry.getValue().isExpired());
-					logger.debug("Cleaned up expired cache entries. Current cache size: {}", this.urlCache.size());
-				}
-			}
-		}
-		this.urlCache.put(cacheKey, new CacheEntry(content, System.currentTimeMillis()));
-	}
-
-	private record CacheEntry(String content, long timestamp) {
-
-		boolean isExpired() {
-			return System.currentTimeMillis() - timestamp > CACHE_TTL.toMillis();
-		}
-
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchToolTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchToolTest.java
@@ -15,9 +15,11 @@
  */
 package com.alibaba.cloud.ai.graph.agent.tools;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.client.ChatClient;
@@ -81,6 +83,27 @@ class WebFetchToolTest {
 				new ToolContext(Collections.emptyMap()));
 		assertTrue(result.startsWith("Error:"));
 		assertTrue(result.contains("Invalid URL"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testCacheRespectsMaxCacheSize() throws Exception {
+		int maxCacheSize = 10;
+		ChatModel chatModel = mock(ChatModel.class);
+		ChatClient chatClient = ChatClient.builder(chatModel).build();
+		WebFetchTool tool = WebFetchTool.builder(chatClient).maxCacheSize(maxCacheSize).buildWebFetchTool();
+
+		Field cacheField = WebFetchTool.class.getDeclaredField("urlCache");
+		cacheField.setAccessible(true);
+		Cache<String, String> cache = (Cache<String, String>) cacheField.get(tool);
+
+		for (int i = 0; i < maxCacheSize * 10; i++) {
+			cache.put("https://example.com/" + i + "::prompt::0", "content-" + i);
+		}
+		cache.cleanUp();
+
+		assertTrue(cache.estimatedSize() <= maxCacheSize,
+				"cache size " + cache.estimatedSize() + " must not exceed maxCacheSize " + maxCacheSize);
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

`WebFetchTool`'s cache only removed **expired** entries when it exceeded `maxCacheSize`, then always inserted the new entry. So `maxCacheSize` was just a cleanup trigger, never a real cap: writing more than `maxCacheSize` distinct (url, prompt) entries within the 15-minute TTL evicts nothing and the cache grows without bound — a memory leak under high fetch rates.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Replace the hand-rolled `ConcurrentHashMap` + lock with a bounded Caffeine cache:

```java
Caffeine.newBuilder()
    .maximumSize(maxCacheSize)     // now actually enforced
    .expireAfterWrite(CACHE_TTL)   // same 15-min write-based TTL
    .build();
```

- No public API change; existing callers are unaffected.
- Caffeine is already used in the repo (studio) with a Spring Boot-managed version, so only a dependency entry was added to the module pom.

### Describe how to verify it

- Added WebFetchToolTest#testCacheRespectsMaxCacheSize (fails pre-fix, passes now).
- Existing WebFetchToolTest cases still pass (6/6).

### Special notes for reviews
