### PR TITLE
fix(agent): honor returnDirect routing

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -36,11 +36,12 @@ import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
 import com.alibaba.cloud.ai.graph.agent.hook.InstructionAgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.InterruptionHook;
 import com.alibaba.cloud.ai.graph.agent.hook.JumpTo;
-import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesAgentHook;
-import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesModelHook;
 import com.alibaba.cloud.ai.graph.agent.hook.ModelHook;
 import com.alibaba.cloud.ai.graph.agent.hook.ToolInjection;
 import com.alibaba.cloud.ai.graph.agent.hook.hip.HumanInTheLoopHook;
+import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesAgentHook;
+import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesModelHook;
+import com.alibaba.cloud.ai.graph.agent.hook.returndirect.ReturnDirectModelHook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.StreamingModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
@@ -317,6 +318,9 @@ public class ReactAgent extends BaseAgent {
 		// Always inject default InstructionAgentHook so instruction is handled in beforeAgent
 		List<Hook> effectiveHooks = new ArrayList<>();
 		effectiveHooks.add(InstructionAgentHook.create());
+		if (hasTools && shouldAddReturnDirectModelHook(hooks)) {
+			effectiveHooks.add(new ReturnDirectModelHook());
+		}
 		effectiveHooks.addAll(hooks);
 
 		// Validate hook uniqueness
@@ -680,15 +684,7 @@ public class ReactAgent extends BaseAgent {
 
 		if (canJumpTo != null && !canJumpTo.isEmpty()) {
 			EdgeAction router = state -> {
-				Object jumpToValue = state.value("jump_to").orElse(null);
-				JumpTo jumpTo = null;
-				if (jumpToValue != null) {
-					if (jumpToValue instanceof JumpTo) {
-						jumpTo = (JumpTo) jumpToValue;
-					} else if (jumpToValue instanceof String) {
-						jumpTo = JumpTo.fromStringOrNull((String) jumpToValue);
-					}
-				}
+				JumpTo jumpTo = consumeJumpTo(state);
 				return resolveJump(jumpTo, modelDestination, endDestination, defaultDestination);
 			};
 
@@ -722,7 +718,7 @@ public class ReactAgent extends BaseAgent {
 		graph.addConditionalEdges(loopExitNode, edge_async(agentInstance.makeModelToTools(loopEntryNode, exitNode)), Map.of(AGENT_TOOL_NAME, AGENT_TOOL_NAME, exitNode, exitNode, loopEntryNode, loopEntryNode));
 
 		// Tools to model routing
-		graph.addConditionalEdges(AGENT_TOOL_NAME, edge_async(agentInstance.makeToolsToModelEdge(loopEntryNode, exitNode)), Map.of(loopEntryNode, loopEntryNode, exitNode, exitNode));
+		graph.addConditionalEdges(AGENT_TOOL_NAME, edge_async(agentInstance.makeToolsToModelEdge(loopEntryNode)), Map.of(loopEntryNode, loopEntryNode));
 	}
 
 	private static String resolveJump(JumpTo jumpTo, String modelDestination, String endDestination, String defaultDestination) {
@@ -763,23 +759,13 @@ public class ReactAgent extends BaseAgent {
 		return state -> {
 			// Priority 1: Check for jump_to instruction from hooks
 			// This allows afterModel hooks to control workflow execution
-			Object jumpToValue = state.value("jump_to").orElse(null);
-			if (jumpToValue != null) {
-				JumpTo jumpTo = null;
-				if (jumpToValue instanceof JumpTo) {
-					jumpTo = (JumpTo) jumpToValue;
-				} else if (jumpToValue instanceof String) {
-					jumpTo = JumpTo.fromStringOrNull((String) jumpToValue);
-				}
-				
-				// If a valid jump_to instruction exists, execute it immediately
-				if (jumpTo != null) {
-					return switch (jumpTo) {
-						case model -> modelDestination;
-						case end -> endDestination;
-						case tool -> AGENT_TOOL_NAME;
-					};
-				}
+			JumpTo jumpTo = consumeJumpTo(state);
+			if (jumpTo != null) {
+				return switch (jumpTo) {
+					case model -> modelDestination;
+					case end -> endDestination;
+					case tool -> AGENT_TOOL_NAME;
+				};
 			}
 			
 			// Priority 2: Check message content for tool calls
@@ -832,41 +818,23 @@ public class ReactAgent extends BaseAgent {
 		};
 	}
 
-	private EdgeAction makeToolsToModelEdge(String modelDestination, String endDestination) {
-		return state -> {
-			// 1. Extract last AI message and corresponding tool messages
-			ToolResponseMessage toolResponseMessage = fetchLastToolResponseMessage(state);
-			// 2. Exit condition: All executed tools have return_direct=True
-			if (toolResponseMessage != null && !toolResponseMessage.getResponses().isEmpty()) {
-				boolean allReturnDirect = toolResponseMessage.getResponses().stream().allMatch(toolResponse -> {
-					String toolName = toolResponse.name();
-					return false; // FIXME
-				});
-				if (allReturnDirect) {
-					return endDestination;
-				}
-			}
-
-			// 3. Default: Continue the loop
-			//    Tool execution completed successfully, route back to the model
-			//    so it can process the tool results and decide the next action.
-			return modelDestination;
-		};
+	private EdgeAction makeToolsToModelEdge(String modelDestination) {
+		return state -> modelDestination;
 	}
 
-	private ToolResponseMessage fetchLastToolResponseMessage(OverAllState state) {
-		List<Message> messages = (List<Message>) state.value("messages").orElse(List.of());
-
-		ToolResponseMessage toolResponseMessage = null;
-
-		for (int i = messages.size() - 1; i >= 0; i--) {
-			if (messages.get(i) instanceof ToolResponseMessage) {
-				toolResponseMessage = (ToolResponseMessage) messages.get(i);
-				break;
-			}
+	private static JumpTo consumeJumpTo(OverAllState state) {
+		Object jumpToValue = state.value("jump_to").orElse(null);
+		if (jumpToValue == null) {
+			return null;
 		}
-
-		return toolResponseMessage;
+		state.updateState(Map.of("jump_to", OverAllState.MARK_FOR_REMOVAL));
+		if (jumpToValue instanceof JumpTo jumpTo) {
+			return jumpTo;
+		}
+		if (jumpToValue instanceof String jumpToText) {
+			return JumpTo.fromStringOrNull(jumpToText);
+		}
+		return null;
 	}
 
 	/**
@@ -951,6 +919,12 @@ public class ReactAgent extends BaseAgent {
 		}
 
 		return result.isEmpty() ? null : result;
+	}
+
+	private static boolean shouldAddReturnDirectModelHook(List<? extends Hook> hooks) {
+		return hooks.stream()
+				.noneMatch(hook -> hook instanceof ReturnDirectModelHook
+						|| ReturnDirectModelHook.NAME.equals(hook.getName()));
 	}
 
 	public String instruction() {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -41,6 +41,7 @@ import com.alibaba.cloud.ai.graph.agent.hook.ToolInjection;
 import com.alibaba.cloud.ai.graph.agent.hook.hip.HumanInTheLoopHook;
 import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesAgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.messages.MessagesModelHook;
+import com.alibaba.cloud.ai.graph.agent.hook.returndirect.ReturnDirectModelHook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.StreamingModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
@@ -317,6 +318,9 @@ public class ReactAgent extends BaseAgent {
 		// Always inject default InstructionAgentHook so instruction is handled in beforeAgent
 		List<Hook> effectiveHooks = new ArrayList<>();
 		effectiveHooks.add(InstructionAgentHook.create());
+		if (hasTools && shouldAddReturnDirectModelHook(hooks)) {
+			effectiveHooks.add(new ReturnDirectModelHook());
+		}
 		effectiveHooks.addAll(hooks);
 
 		// Validate hook uniqueness
@@ -680,15 +684,7 @@ public class ReactAgent extends BaseAgent {
 
 		if (canJumpTo != null && !canJumpTo.isEmpty()) {
 			EdgeAction router = state -> {
-				Object jumpToValue = state.value("jump_to").orElse(null);
-				JumpTo jumpTo = null;
-				if (jumpToValue != null) {
-					if (jumpToValue instanceof JumpTo) {
-						jumpTo = (JumpTo) jumpToValue;
-					} else if (jumpToValue instanceof String) {
-						jumpTo = JumpTo.fromStringOrNull((String) jumpToValue);
-					}
-				}
+				JumpTo jumpTo = consumeJumpTo(state);
 				return resolveJump(jumpTo, modelDestination, endDestination, defaultDestination);
 			};
 
@@ -722,7 +718,7 @@ public class ReactAgent extends BaseAgent {
 		graph.addConditionalEdges(loopExitNode, edge_async(agentInstance.makeModelToTools(loopEntryNode, exitNode)), Map.of(AGENT_TOOL_NAME, AGENT_TOOL_NAME, exitNode, exitNode, loopEntryNode, loopEntryNode));
 
 		// Tools to model routing
-		graph.addConditionalEdges(AGENT_TOOL_NAME, edge_async(agentInstance.makeToolsToModelEdge(loopEntryNode, exitNode)), Map.of(loopEntryNode, loopEntryNode, exitNode, exitNode));
+		graph.addConditionalEdges(AGENT_TOOL_NAME, edge_async(agentInstance.makeToolsToModelEdge(loopEntryNode)), Map.of(loopEntryNode, loopEntryNode));
 	}
 
 	private static String resolveJump(JumpTo jumpTo, String modelDestination, String endDestination, String defaultDestination) {
@@ -763,23 +759,13 @@ public class ReactAgent extends BaseAgent {
 		return state -> {
 			// Priority 1: Check for jump_to instruction from hooks
 			// This allows afterModel hooks to control workflow execution
-			Object jumpToValue = state.value("jump_to").orElse(null);
-			if (jumpToValue != null) {
-				JumpTo jumpTo = null;
-				if (jumpToValue instanceof JumpTo) {
-					jumpTo = (JumpTo) jumpToValue;
-				} else if (jumpToValue instanceof String) {
-					jumpTo = JumpTo.fromStringOrNull((String) jumpToValue);
-				}
-				
-				// If a valid jump_to instruction exists, execute it immediately
-				if (jumpTo != null) {
-					return switch (jumpTo) {
-						case model -> modelDestination;
-						case end -> endDestination;
-						case tool -> AGENT_TOOL_NAME;
-					};
-				}
+			JumpTo jumpTo = consumeJumpTo(state);
+			if (jumpTo != null) {
+				return switch (jumpTo) {
+					case model -> modelDestination;
+					case end -> endDestination;
+					case tool -> AGENT_TOOL_NAME;
+				};
 			}
 			
 			// Priority 2: Check message content for tool calls
@@ -832,41 +818,23 @@ public class ReactAgent extends BaseAgent {
 		};
 	}
 
-	private EdgeAction makeToolsToModelEdge(String modelDestination, String endDestination) {
-		return state -> {
-			// 1. Extract last AI message and corresponding tool messages
-			ToolResponseMessage toolResponseMessage = fetchLastToolResponseMessage(state);
-			// 2. Exit condition: All executed tools have return_direct=True
-			if (toolResponseMessage != null && !toolResponseMessage.getResponses().isEmpty()) {
-				boolean allReturnDirect = toolResponseMessage.getResponses().stream().allMatch(toolResponse -> {
-					String toolName = toolResponse.name();
-					return false; // FIXME
-				});
-				if (allReturnDirect) {
-					return endDestination;
-				}
-			}
-
-			// 3. Default: Continue the loop
-			//    Tool execution completed successfully, route back to the model
-			//    so it can process the tool results and decide the next action.
-			return modelDestination;
-		};
+	private EdgeAction makeToolsToModelEdge(String modelDestination) {
+		return state -> modelDestination;
 	}
 
-	private ToolResponseMessage fetchLastToolResponseMessage(OverAllState state) {
-		List<Message> messages = (List<Message>) state.value("messages").orElse(List.of());
-
-		ToolResponseMessage toolResponseMessage = null;
-
-		for (int i = messages.size() - 1; i >= 0; i--) {
-			if (messages.get(i) instanceof ToolResponseMessage) {
-				toolResponseMessage = (ToolResponseMessage) messages.get(i);
-				break;
-			}
+	private static JumpTo consumeJumpTo(OverAllState state) {
+		Object jumpToValue = state.value("jump_to").orElse(null);
+		if (jumpToValue == null) {
+			return null;
 		}
-
-		return toolResponseMessage;
+		state.updateState(Map.of("jump_to", OverAllState.MARK_FOR_REMOVAL));
+		if (jumpToValue instanceof JumpTo jumpTo) {
+			return jumpTo;
+		}
+		if (jumpToValue instanceof String jumpToText) {
+			return JumpTo.fromStringOrNull(jumpToText);
+		}
+		return null;
 	}
 
 	/**
@@ -951,6 +919,12 @@ public class ReactAgent extends BaseAgent {
 		}
 
 		return result.isEmpty() ? null : result;
+	}
+
+	private static boolean shouldAddReturnDirectModelHook(List<? extends Hook> hooks) {
+		return hooks.stream()
+				.noneMatch(hook -> hook instanceof ReturnDirectModelHook
+						|| ReturnDirectModelHook.NAME.equals(hook.getName()));
 	}
 
 	public String instruction() {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/messages/MessagesModelHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/messages/MessagesModelHook.java
@@ -20,8 +20,10 @@ import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.hook.Hook;
+import com.alibaba.cloud.ai.graph.agent.hook.JumpTo;
 import com.alibaba.cloud.ai.graph.state.ReplaceAllWith;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 
 import java.util.HashMap;
@@ -110,6 +112,20 @@ public abstract class MessagesModelHook implements Hook {
 			}
 			if (command.getJumpTo() != null) {
 				result.put("jump_to", command.getJumpTo().name());
+			}
+			// A before-model hook can terminate without another AgentLlmNode run, so keep a
+			// configured output key aligned with the final assistant message.
+			if (JumpTo.end == command.getJumpTo()) {
+				ReactAgent agent = messagesModelHook.getAgent();
+				List<Message> updatedMessages = command.getMessages();
+				String outputKey = agent == null ? null : agent.getOutputKey();
+				if (outputKey != null && !outputKey.isEmpty()
+						&& updatedMessages != null && !updatedMessages.isEmpty()) {
+					Message finalMessage = updatedMessages.get(updatedMessages.size() - 1);
+					if (finalMessage instanceof AssistantMessage) {
+						result.put(outputKey, finalMessage);
+					}
+				}
 			}
 
 			return CompletableFuture.completedFuture(result);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/returndirect/ReturnDirectModelHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/returndirect/ReturnDirectModelHook.java
@@ -42,9 +42,11 @@ import static org.springframework.ai.model.tool.ToolExecutionResult.FINISH_REASO
 @HookPositions({HookPosition.BEFORE_MODEL})
 public class ReturnDirectModelHook extends MessagesModelHook {
 
+	public static final String NAME = "finish_reason_check_messages_model_hook";
+
 	@Override
 	public String getName() {
-		return "finish_reason_check_messages_model_hook";
+		return NAME;
 	}
 
 	@Override

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentReturnDirectRoutingTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentReturnDirectRoutingTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.annotation.Tool;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReactAgentReturnDirectRoutingTest {
+
+	@Test
+	void returnDirectToolDoesNotShortCircuitLaterTurns() throws Exception {
+		ToolCallingModel model = new ToolCallingModel("directAnswer", "second turn reached the model");
+		DirectTools tools = new DirectTools();
+		RunnableConfig config = RunnableConfig.builder().threadId("return-direct-thread").build();
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("return_direct_agent")
+				.model(model)
+				.tools(ToolCallbacks.from(tools))
+				.saver(new MemorySaver())
+				.build();
+
+		AssistantMessage firstResponse = agent.call("call the direct tool", config);
+
+		assertTrue(firstResponse.getText().contains("direct response"));
+		assertEquals(1, model.callCount());
+		assertEquals(1, tools.callCount());
+
+		AssistantMessage secondResponse = agent.call("start a new turn", config);
+
+		assertEquals("second turn reached the model", secondResponse.getText());
+		assertEquals(2, model.callCount());
+		assertEquals(1, tools.callCount());
+	}
+
+	@Test
+	void normalToolStillReturnsToModel() throws Exception {
+		ToolCallingModel model = new ToolCallingModel("normalAnswer", "model processed tool response");
+		NormalTools tools = new NormalTools();
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("normal_tool_agent")
+				.model(model)
+				.tools(ToolCallbacks.from(tools))
+				.saver(new MemorySaver())
+				.build();
+
+		AssistantMessage response = agent.call("call the normal tool");
+
+		assertEquals("model processed tool response", response.getText());
+		assertEquals(2, model.callCount());
+		assertEquals(1, tools.callCount());
+	}
+
+	private static final class ToolCallingModel implements ChatModel {
+
+		private final String toolName;
+
+		private final String secondResponse;
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		private ToolCallingModel(String toolName, String secondResponse) {
+			this.toolName = toolName;
+			this.secondResponse = secondResponse;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int currentCall = callCount.incrementAndGet();
+			AssistantMessage message = currentCall == 1 ? toolCallMessage(toolName) : new AssistantMessage(secondResponse);
+			return new ChatResponse(List.of(new Generation(message)));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		private int callCount() {
+			return callCount.get();
+		}
+
+		private static AssistantMessage toolCallMessage(String toolName) {
+			return AssistantMessage.builder()
+					.content("")
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", toolName, "{}")))
+					.build();
+		}
+	}
+
+	private static final class DirectTools {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Tool(name = "directAnswer", description = "Return a direct answer", returnDirect = true)
+		public String directAnswer() {
+			callCount.incrementAndGet();
+			return "direct response";
+		}
+
+		private int callCount() {
+			return callCount.get();
+		}
+	}
+
+	private static final class NormalTools {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Tool(name = "normalAnswer", description = "Return a normal answer", returnDirect = false)
+		public String normalAnswer() {
+			callCount.incrementAndGet();
+			return "normal response";
+		}
+
+		private int callCount() {
+			return callCount.get();
+		}
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentReturnDirectRoutingTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentReturnDirectRoutingTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.annotation.Tool;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReactAgentReturnDirectRoutingTest {
+
+	@Test
+	void returnDirectToolDoesNotShortCircuitLaterTurns() throws Exception {
+		ToolCallingModel model = new ToolCallingModel("directAnswer", "second turn reached the model");
+		DirectTools tools = new DirectTools();
+		RunnableConfig config = RunnableConfig.builder().threadId("return-direct-thread").build();
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("return_direct_agent")
+				.model(model)
+				.tools(ToolCallbacks.from(tools))
+				.saver(new MemorySaver())
+				.build();
+
+		AssistantMessage firstResponse = agent.call("call the direct tool", config);
+
+		assertTrue(firstResponse.getText().contains("direct response"));
+		assertEquals(1, model.callCount());
+		assertEquals(1, tools.callCount());
+
+		AssistantMessage secondResponse = agent.call("start a new turn", config);
+
+		assertEquals("second turn reached the model", secondResponse.getText());
+		assertEquals(2, model.callCount());
+		assertEquals(1, tools.callCount());
+	}
+
+	@Test
+	void normalToolStillReturnsToModel() throws Exception {
+		ToolCallingModel model = new ToolCallingModel("normalAnswer", "model processed tool response");
+		NormalTools tools = new NormalTools();
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("normal_tool_agent")
+				.model(model)
+				.tools(ToolCallbacks.from(tools))
+				.saver(new MemorySaver())
+				.build();
+
+		AssistantMessage response = agent.call("call the normal tool");
+
+		assertEquals("model processed tool response", response.getText());
+		assertEquals(2, model.callCount());
+		assertEquals(1, tools.callCount());
+	}
+
+	@Test
+	void returnDirectToolUpdatesConfiguredOutputKey() throws Exception {
+		ToolCallingModel model = new ToolCallingModel("directAnswer", "model should not be called again");
+		DirectTools tools = new DirectTools();
+
+		ReactAgent agent = ReactAgent.builder()
+				.name("return_direct_output_key_agent")
+				.model(model)
+				.tools(ToolCallbacks.from(tools))
+				.outputKey("result")
+				.saver(new MemorySaver())
+				.build();
+
+		AssistantMessage response = agent.call("call the direct tool");
+
+		assertTrue(response.getText().contains("direct response"));
+		assertEquals(1, model.callCount());
+		assertEquals(1, tools.callCount());
+	}
+
+	private static final class ToolCallingModel implements ChatModel {
+
+		private final String toolName;
+
+		private final String secondResponse;
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		private ToolCallingModel(String toolName, String secondResponse) {
+			this.toolName = toolName;
+			this.secondResponse = secondResponse;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int currentCall = callCount.incrementAndGet();
+			AssistantMessage message = currentCall == 1 ? toolCallMessage(toolName) : new AssistantMessage(secondResponse);
+			return new ChatResponse(List.of(new Generation(message)));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		private int callCount() {
+			return callCount.get();
+		}
+
+		private static AssistantMessage toolCallMessage(String toolName) {
+			return AssistantMessage.builder()
+					.content("")
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", toolName, "{}")))
+					.build();
+		}
+	}
+
+	private static final class DirectTools {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Tool(name = "directAnswer", description = "Return a direct answer", returnDirect = true)
+		public String directAnswer() {
+			callCount.incrementAndGet();
+			return "direct response";
+		}
+
+		private int callCount() {
+			return callCount.get();
+		}
+	}
+
+	private static final class NormalTools {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Tool(name = "normalAnswer", description = "Return a normal answer", returnDirect = false)
+		public String normalAnswer() {
+			callCount.incrementAndGet();
+			return "normal response";
+		}
+
+		private int callCount() {
+			return callCount.get();
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes the ReactAgent `returnDirect` routing behavior reported in #4427.

`jump_to` is a transient hook routing command, but it was stored in graph state. After a returnDirect tool set `jump_to=end`, the checkpoint for that turn could carry the stale command into a later invocation on the same thread and short-circuit before the model ran. ReactAgent also did not install the existing return-direct model hook by default, so `@Tool(returnDirect = true)` was not honored unless users wired the hook manually.

This change:

- registers `ReturnDirectModelHook` automatically for tool-enabled ReactAgent instances unless an equivalent hook is already present
- consumes and removes `jump_to` when routing so one-shot hook decisions do not leak through checkpoints or later turns
- routes tool-node output back through the before-model hook chain, letting `ReturnDirectModelHook` end direct tool responses while normal tools still return to the model
- adds a mock `ChatModel` regression test covering direct tools, same-thread follow-up turns, and normal tool routing

Fixes #4427

## Tests

- `./mvnw -pl :spring-ai-alibaba-agent-framework -am -Dtest=ReactAgentReturnDirectRoutingTest test`