### PR TITLE
fix(graph): preserve checkpoint consistency after stream cancellation

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -30,6 +30,7 @@ import com.alibaba.cloud.ai.graph.internal.node.Node;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduleConfig;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduledAgentTask;
 import com.alibaba.cloud.ai.graph.state.StateSnapshot;
+import com.alibaba.cloud.ai.graph.utils.MessageSequenceValidator;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -48,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
 import static java.lang.String.format;
@@ -462,9 +464,20 @@ public class CompiledGraph {
 	public Map<String, Object> getInitialState(Map<String, Object> inputs, RunnableConfig config) {
 
 		return compileConfig.checkpointSaver()
-				.flatMap(saver -> saver.get(config))
+				.flatMap(saver -> latestConsistentCheckpoint(saver, config))
 				.map(cp -> OverAllState.updateState(cp.getState(), inputs, keyStrategyMap))
 				.orElseGet(() -> OverAllState.updateState(new HashMap<>(), inputs, keyStrategyMap));
+	}
+
+	private Optional<Checkpoint> latestConsistentCheckpoint(BaseCheckpointSaver saver, RunnableConfig config) {
+		if (config.checkPointId().isPresent()) {
+			return saver.get(config).filter(checkpoint -> MessageSequenceValidator
+				.isCheckpointReadyForNewInput(checkpoint.getState()));
+		}
+		// Saver histories are latest-first; this is also the order used by
+		// lastStateOf().
+		return saver.list(config).stream().filter(checkpoint -> MessageSequenceValidator
+			.isCheckpointReadyForNewInput(checkpoint.getState())).findFirst();
 	}
 
 	/**
@@ -554,10 +567,33 @@ public class CompiledGraph {
 		Objects.requireNonNull(config, "config cannot be null");
 		try {
 			GraphRunner runner = new GraphRunner(this, config);
-			return runner.run(state);
+			return keepExecutingAfterDownstreamCancel(runner.run(state));
 		} catch (Exception e) {
 			return Flux.error(e);
 		}
+	}
+
+	private Flux<GraphResponse<NodeOutput>> keepExecutingAfterDownstreamCancel(
+			Flux<GraphResponse<NodeOutput>> executionFlux) {
+		if (compileConfig.checkpointSaver().isEmpty()) {
+			return executionFlux;
+		}
+		return Flux.create(sink -> Schedulers.boundedElastic().schedule(() -> executionFlux.subscribe(data -> {
+			if (!sink.isCancelled()) {
+				sink.next(data);
+			}
+		}, error -> {
+			if (!sink.isCancelled()) {
+				sink.error(error);
+			}
+			else {
+				log.warn("Background graph execution failed after downstream cancellation.", error);
+			}
+		}, () -> {
+			if (!sink.isCancelled()) {
+				sink.complete();
+			}
+		})));
 	}
 
 	/**
@@ -583,7 +619,7 @@ public class CompiledGraph {
 		Objects.requireNonNull(config, "config cannot be null");
 		try {
 			GraphRunner runner = new GraphRunner(this, config);
-			return flattenGraphResponsesPreservingOrder(runner.run(overAllState));
+			return flattenGraphResponsesPreservingOrder(keepExecutingAfterDownstreamCancel(runner.run(overAllState)));
 		} catch (Exception e) {
 			return Flux.error(e);
 		}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -99,6 +99,7 @@ public class GraphRunnerContext {
 
 		var saver = compiledGraph.compileConfig.checkpointSaver()
 				.orElseThrow(() -> new IllegalStateException("Resume request without a configured checkpoint saver!"));
+		initializeCheckpointLineage(config);
 		var checkpoint = saver.get(config)
 				.orElseThrow(() -> new IllegalStateException("Resume request without a valid checkpoint!"));
 
@@ -258,16 +259,11 @@ public class GraphRunnerContext {
 	public Optional<Checkpoint> addCheckpoint(String nodeId, String nextNodeId) throws Exception {
 		if (compiledGraph.compileConfig.checkpointSaver().isPresent()) {
 			var saver = compiledGraph.compileConfig.checkpointSaver().get();
-			if (checkpointLineageGuardActive) {
-				RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
-				Optional<Checkpoint> latestCheckpoint = saver.get(latestConfig);
-				String latestCheckpointId = latestCheckpoint.map(Checkpoint::getId).orElse(null);
-				if (!Objects.equals(latestCheckpointId, checkpointLineageHeadId)) {
-					log.debug(
-							"Skip checkpoint for node '{}' because a newer checkpoint has already been persisted for this thread.",
-							nodeId);
-					return Optional.empty();
-				}
+			if (!isCheckpointLineageCurrent()) {
+				log.debug(
+						"Skip checkpoint for node '{}' because a newer checkpoint has already been persisted for this thread.",
+						nodeId);
+				return Optional.empty();
 			}
 			var cp = Checkpoint.builder().nodeId(nodeId).state(cloneState(overallState.data())).nextNodeId(nextNodeId)
 					.build();
@@ -280,6 +276,18 @@ public class GraphRunnerContext {
 			return Optional.of(cp);
 		}
 		return Optional.empty();
+	}
+
+	public boolean isCheckpointLineageCurrent() {
+		if (!checkpointLineageGuardActive) {
+			return true;
+		}
+		return compiledGraph.compileConfig.checkpointSaver().map(saver -> {
+			RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
+			Optional<Checkpoint> latestCheckpoint = saver.get(latestConfig);
+			String latestCheckpointId = latestCheckpoint.map(Checkpoint::getId).orElse(null);
+			return Objects.equals(latestCheckpointId, checkpointLineageHeadId);
+		}).orElse(true);
 	}
 
 	// ================================================================================================================

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -17,9 +17,10 @@ package com.alibaba.cloud.ai.graph;
 
 import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
 import com.alibaba.cloud.ai.graph.action.Command;
-import com.alibaba.cloud.ai.graph.internal.edge.EdgeValue;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
 import com.alibaba.cloud.ai.graph.exception.RunnableErrors;
+import com.alibaba.cloud.ai.graph.internal.edge.EdgeValue;
 import com.alibaba.cloud.ai.graph.internal.node.ParallelNode;
 import com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction;
 import com.alibaba.cloud.ai.graph.state.StateSnapshot;
@@ -99,9 +100,12 @@ public class GraphRunnerContext {
 
 		var saver = compiledGraph.compileConfig.checkpointSaver()
 				.orElseThrow(() -> new IllegalStateException("Resume request without a configured checkpoint saver!"));
-		initializeCheckpointLineage(config);
-		var checkpoint = saver.get(config)
-				.orElseThrow(() -> new IllegalStateException("Resume request without a valid checkpoint!"));
+		Checkpoint checkpoint;
+		synchronized (saver) {
+			initializeCheckpointLineage(saver, config);
+			checkpoint = saver.get(config)
+					.orElseThrow(() -> new IllegalStateException("Resume request without a valid checkpoint!"));
+		}
 
 		var startCheckpointNextNodeAction = compiledGraph.getNodeAction(checkpoint.getNextNodeId());
 		if (startCheckpointNextNodeAction instanceof ResumableSubGraphAction resumableAction) {
@@ -135,19 +139,25 @@ public class GraphRunnerContext {
 			log.debug("Initializing with inputs: {}", inputs.keySet());
 		}
 
-		initializeCheckpointLineage(config);
 		// Use CompiledGraph's getInitialState method
-		this.overallState = stateCreate(compiledGraph.getInitialState(inputs, config), initialState);
+		var saver = compiledGraph.compileConfig.checkpointSaver();
+		if (saver.isPresent()) {
+			synchronized (saver.get()) {
+				initializeCheckpointLineage(saver.get(), config);
+				this.overallState = stateCreate(compiledGraph.getInitialState(inputs, config), initialState);
+			}
+		}
+		else {
+			this.overallState = stateCreate(compiledGraph.getInitialState(inputs, config), initialState);
+		}
 		this.currentNodeId = START;
 		this.nextNodeId = null;
 	}
 
-	private void initializeCheckpointLineage(RunnableConfig config) {
-		compiledGraph.compileConfig.checkpointSaver().ifPresent(saver -> {
-			RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
-			this.checkpointLineageHeadId = saver.get(latestConfig).map(Checkpoint::getId).orElse(null);
-			this.checkpointLineageGuardActive = true;
-		});
+	private void initializeCheckpointLineage(BaseCheckpointSaver saver, RunnableConfig config) {
+		RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
+		this.checkpointLineageHeadId = saver.get(latestConfig).map(Checkpoint::getId).orElse(null);
+		this.checkpointLineageGuardActive = true;
 	}
 
 	// FIXME, duplicated method with CompiledGraph.stateCreate, need to have a
@@ -259,35 +269,60 @@ public class GraphRunnerContext {
 	public Optional<Checkpoint> addCheckpoint(String nodeId, String nextNodeId) throws Exception {
 		if (compiledGraph.compileConfig.checkpointSaver().isPresent()) {
 			var saver = compiledGraph.compileConfig.checkpointSaver().get();
-			if (!isCheckpointLineageCurrent()) {
-				log.debug(
-						"Skip checkpoint for node '{}' because a newer checkpoint has already been persisted for this thread.",
-						nodeId);
-				return Optional.empty();
-			}
-			var cp = Checkpoint.builder().nodeId(nodeId).state(cloneState(overallState.data())).nextNodeId(nextNodeId)
+			synchronized (saver) {
+				if (!isCheckpointLineageCurrent(saver)) {
+					log.debug(
+							"Skip checkpoint for node '{}' because a newer checkpoint has already been persisted for this thread.",
+							nodeId);
+					return Optional.empty();
+				}
+				var cp = Checkpoint.builder()
+					.nodeId(nodeId)
+					.state(cloneState(overallState.data()))
+					.nextNodeId(nextNodeId)
 					.build();
-			// Force checkPointId to null to ensure we append a new checkpoint instead of
-			// replacing the current one
-			RunnableConfig appendConfig = RunnableConfig.builder(config).checkPointId(null).build();
-			this.config = saver.put(appendConfig, cp);
-			this.checkpointLineageHeadId = cp.getId();
-			this.checkpointLineageGuardActive = true;
-			return Optional.of(cp);
+				// Force checkPointId to null to ensure we append a new checkpoint instead of
+				// replacing the current one
+				RunnableConfig appendConfig = RunnableConfig.builder(config).checkPointId(null).build();
+				this.config = saver.put(appendConfig, cp);
+				this.checkpointLineageHeadId = cp.getId();
+				this.checkpointLineageGuardActive = true;
+				return Optional.of(cp);
+			}
 		}
 		return Optional.empty();
 	}
 
 	public boolean isCheckpointLineageCurrent() {
+		return compiledGraph.compileConfig.checkpointSaver().map(saver -> {
+			synchronized (saver) {
+				return isCheckpointLineageCurrent(saver);
+			}
+		}).orElse(true);
+	}
+
+	private boolean isCheckpointLineageCurrent(BaseCheckpointSaver saver) {
 		if (!checkpointLineageGuardActive) {
 			return true;
 		}
-		return compiledGraph.compileConfig.checkpointSaver().map(saver -> {
-			RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
-			Optional<Checkpoint> latestCheckpoint = saver.get(latestConfig);
-			String latestCheckpointId = latestCheckpoint.map(Checkpoint::getId).orElse(null);
-			return Objects.equals(latestCheckpointId, checkpointLineageHeadId);
-		}).orElse(true);
+		RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
+		Optional<Checkpoint> latestCheckpoint = saver.get(latestConfig);
+		String latestCheckpointId = latestCheckpoint.map(Checkpoint::getId).orElse(null);
+		return Objects.equals(latestCheckpointId, checkpointLineageHeadId);
+	}
+
+	public Optional<BaseCheckpointSaver.Tag> releaseCheckpointThread() throws Exception {
+		if (compiledGraph.compileConfig.checkpointSaver().isEmpty()) {
+			return Optional.empty();
+		}
+		var saver = compiledGraph.compileConfig.checkpointSaver().get();
+		synchronized (saver) {
+			if (!isCheckpointLineageCurrent(saver)) {
+				log.debug("Skip thread release because a newer checkpoint has already been persisted for this thread.");
+				return Optional.empty();
+			}
+			return Optional.of(saver.release(config));
+		}
 	}
 
 	// ================================================================================================================

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -78,6 +78,8 @@ public class GraphRunnerContext {
 
 	ReturnFromEmbed returnFromEmbed;
 
+	String checkpointLineageHeadId;
+
 	public GraphRunnerContext(OverAllState initialState, RunnableConfig config, CompiledGraph compiledGraph)
 			throws Exception {
 		this.compiledGraph = compiledGraph;
@@ -244,12 +246,25 @@ public class GraphRunnerContext {
 
 	public Optional<Checkpoint> addCheckpoint(String nodeId, String nextNodeId) throws Exception {
 		if (compiledGraph.compileConfig.checkpointSaver().isPresent()) {
+			var saver = compiledGraph.compileConfig.checkpointSaver().get();
+			if (checkpointLineageHeadId != null) {
+				RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
+				Optional<Checkpoint> latestCheckpoint = saver.get(latestConfig);
+				if (latestCheckpoint.isEmpty()
+						|| !Objects.equals(latestCheckpoint.get().getId(), checkpointLineageHeadId)) {
+					log.debug(
+							"Skip checkpoint for node '{}' because a newer checkpoint has already been persisted for this thread.",
+							nodeId);
+					return Optional.empty();
+				}
+			}
 			var cp = Checkpoint.builder().nodeId(nodeId).state(cloneState(overallState.data())).nextNodeId(nextNodeId)
 					.build();
 			// Force checkPointId to null to ensure we append a new checkpoint instead of
 			// replacing the current one
 			RunnableConfig appendConfig = RunnableConfig.builder(config).checkPointId(null).build();
-			this.config = compiledGraph.compileConfig.checkpointSaver().get().put(appendConfig, cp);
+			this.config = saver.put(appendConfig, cp);
+			this.checkpointLineageHeadId = cp.getId();
 			return Optional.of(cp);
 		}
 		return Optional.empty();

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -80,6 +80,8 @@ public class GraphRunnerContext {
 
 	String checkpointLineageHeadId;
 
+	boolean checkpointLineageGuardActive;
+
 	public GraphRunnerContext(OverAllState initialState, RunnableConfig config, CompiledGraph compiledGraph)
 			throws Exception {
 		this.compiledGraph = compiledGraph;
@@ -132,10 +134,19 @@ public class GraphRunnerContext {
 			log.debug("Initializing with inputs: {}", inputs.keySet());
 		}
 
+		initializeCheckpointLineage(config);
 		// Use CompiledGraph's getInitialState method
 		this.overallState = stateCreate(compiledGraph.getInitialState(inputs, config), initialState);
 		this.currentNodeId = START;
 		this.nextNodeId = null;
+	}
+
+	private void initializeCheckpointLineage(RunnableConfig config) {
+		compiledGraph.compileConfig.checkpointSaver().ifPresent(saver -> {
+			RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
+			this.checkpointLineageHeadId = saver.get(latestConfig).map(Checkpoint::getId).orElse(null);
+			this.checkpointLineageGuardActive = true;
+		});
 	}
 
 	// FIXME, duplicated method with CompiledGraph.stateCreate, need to have a
@@ -247,11 +258,11 @@ public class GraphRunnerContext {
 	public Optional<Checkpoint> addCheckpoint(String nodeId, String nextNodeId) throws Exception {
 		if (compiledGraph.compileConfig.checkpointSaver().isPresent()) {
 			var saver = compiledGraph.compileConfig.checkpointSaver().get();
-			if (checkpointLineageHeadId != null) {
+			if (checkpointLineageGuardActive) {
 				RunnableConfig latestConfig = RunnableConfig.builder(config).checkPointId(null).build();
 				Optional<Checkpoint> latestCheckpoint = saver.get(latestConfig);
-				if (latestCheckpoint.isEmpty()
-						|| !Objects.equals(latestCheckpoint.get().getId(), checkpointLineageHeadId)) {
+				String latestCheckpointId = latestCheckpoint.map(Checkpoint::getId).orElse(null);
+				if (!Objects.equals(latestCheckpointId, checkpointLineageHeadId)) {
 					log.debug(
 							"Skip checkpoint for node '{}' because a newer checkpoint has already been persisted for this thread.",
 							nodeId);
@@ -265,6 +276,7 @@ public class GraphRunnerContext {
 			RunnableConfig appendConfig = RunnableConfig.builder(config).checkPointId(null).build();
 			this.config = saver.put(appendConfig, cp);
 			this.checkpointLineageHeadId = cp.getId();
+			this.checkpointLineageGuardActive = true;
 			return Optional.of(cp);
 		}
 		return Optional.empty();

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
@@ -54,7 +54,8 @@ public abstract class BaseGraphExecutor {
 		return Flux.defer(() -> {
 			try {
 				if (context.getCompiledGraph().compileConfig.releaseThread()
-						&& context.getCompiledGraph().compileConfig.checkpointSaver().isPresent()) {
+						&& context.getCompiledGraph().compileConfig.checkpointSaver().isPresent()
+						&& context.isCheckpointLineageCurrent()) {
 					BaseCheckpointSaver.Tag tag = context
 						.getCompiledGraph().compileConfig.checkpointSaver()
 						.get()

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/BaseGraphExecutor.java
@@ -18,8 +18,6 @@ package com.alibaba.cloud.ai.graph.executor;
 import com.alibaba.cloud.ai.graph.GraphRunnerContext;
 import com.alibaba.cloud.ai.graph.GraphResponse;
 import com.alibaba.cloud.ai.graph.NodeOutput;
-import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
-
 import reactor.core.publisher.Flux;
 
 import java.util.HashMap;
@@ -54,13 +52,14 @@ public abstract class BaseGraphExecutor {
 		return Flux.defer(() -> {
 			try {
 				if (context.getCompiledGraph().compileConfig.releaseThread()
-						&& context.getCompiledGraph().compileConfig.checkpointSaver().isPresent()
-						&& context.isCheckpointLineageCurrent()) {
-					BaseCheckpointSaver.Tag tag = context
-						.getCompiledGraph().compileConfig.checkpointSaver()
-						.get()
-						.release(context.getConfig());
-					resultValue.set(tag);
+						&& context.getCompiledGraph().compileConfig.checkpointSaver().isPresent()) {
+					var tag = context.releaseCheckpointThread();
+					if (tag.isPresent()) {
+						resultValue.set(tag.get());
+					}
+					else {
+						resultValue.set(new HashMap<>(context.getOverallState().data()));
+					}
 				} else {
 					resultValue.set(new HashMap<>(context.getOverallState().data()));
 				}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/MessageSequenceValidator.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/MessageSequenceValidator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.utils;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Validates whether a persisted message history can be safely used as the base
+ * for a new user input.
+ */
+public final class MessageSequenceValidator {
+
+	private MessageSequenceValidator() {
+	}
+
+	public static boolean isCheckpointReadyForNewInput(Map<String, Object> state) {
+		Object messages = state.get("messages");
+		if (!(messages instanceof List<?> messageList) || messageList.isEmpty()) {
+			return true;
+		}
+
+		Set<String> pendingToolCallIds = new LinkedHashSet<>();
+		boolean waitingForAssistantAfterToolResponse = false;
+
+		for (Object item : messageList) {
+			if (!(item instanceof Message)) {
+				continue;
+			}
+			if (item instanceof AssistantMessage assistantMessage) {
+				if (!pendingToolCallIds.isEmpty()) {
+					return false;
+				}
+				waitingForAssistantAfterToolResponse = false;
+				if (assistantMessage.hasToolCalls()) {
+					pendingToolCallIds = toolCallIds(assistantMessage);
+					if (pendingToolCallIds.size() != assistantMessage.getToolCalls().size()) {
+						return false;
+					}
+				}
+			}
+			else if (item instanceof ToolResponseMessage toolResponseMessage) {
+				if (pendingToolCallIds.isEmpty() || waitingForAssistantAfterToolResponse) {
+					return false;
+				}
+				if (!removeToolResponseIds(pendingToolCallIds, toolResponseMessage)) {
+					return false;
+				}
+				waitingForAssistantAfterToolResponse = pendingToolCallIds.isEmpty();
+			}
+			else if (!pendingToolCallIds.isEmpty() || waitingForAssistantAfterToolResponse) {
+				return false;
+			}
+		}
+
+		return pendingToolCallIds.isEmpty() && !waitingForAssistantAfterToolResponse;
+	}
+
+	private static Set<String> toolCallIds(AssistantMessage assistantMessage) {
+		Set<String> ids = new LinkedHashSet<>();
+		for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
+			if (StringUtils.hasText(toolCall.id())) {
+				ids.add(toolCall.id());
+			}
+		}
+		return ids;
+	}
+
+	private static boolean removeToolResponseIds(Set<String> pendingToolCallIds,
+			ToolResponseMessage toolResponseMessage) {
+		for (ToolResponseMessage.ToolResponse response : toolResponseMessage.getResponses()) {
+			if (!StringUtils.hasText(response.id()) || !pendingToolCallIds.remove(response.id())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CheckpointMessageConsistencyTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CheckpointMessageConsistencyTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+class CheckpointMessageConsistencyTest {
+
+	private static final String THREAD_ID = "checkpoint-message-consistency-thread";
+
+	@Test
+	void newUserInputShouldLoadLastConsistentCheckpointWhenLatestEndsWithToolResponse() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph compiledGraph = buildGraph(saver);
+		RunnableConfig config = RunnableConfig.builder().threadId(THREAD_ID).build();
+
+		saver.put(config, checkpoint("stable", END, stableState()));
+		saver.put(config, checkpoint("tool_node", "streaming_model", inconsistentStateEndingWithToolResponse()));
+
+		@SuppressWarnings("unchecked")
+		List<Message> messages = (List<Message>) compiledGraph
+			.getInitialState(Map.of("messages", List.of(new UserMessage("continue"))), config)
+			.get("messages");
+
+		assertFalse(messages.stream().anyMatch(ToolResponseMessage.class::isInstance),
+				"new user input must not be appended after an incomplete tool response checkpoint");
+		assertInstanceOf(UserMessage.class, messages.get(messages.size() - 1));
+		assertIterableEquals(List.of("hello", "previous answer", "continue"),
+				messages.stream().map(Message::getText).toList());
+	}
+
+	@Test
+	void newUserInputShouldLoadLastConsistentCheckpointWhenLatestHasPartialToolResponses() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph compiledGraph = buildGraph(saver);
+		RunnableConfig config = RunnableConfig.builder().threadId(THREAD_ID).build();
+
+		saver.put(config, checkpoint("stable", END, stableState()));
+		saver.put(config, checkpoint("tool_node", "model_node", inconsistentStateWithPartialToolResponses()));
+
+		@SuppressWarnings("unchecked")
+		List<Message> messages = (List<Message>) compiledGraph
+			.getInitialState(Map.of("messages", List.of(new UserMessage("continue"))), config)
+			.get("messages");
+
+		assertFalse(messages.stream().anyMatch(ToolResponseMessage.class::isInstance),
+				"new user input must not be appended after a partial tool response checkpoint");
+		assertInstanceOf(UserMessage.class, messages.get(messages.size() - 1));
+		assertIterableEquals(List.of("hello", "previous answer", "continue"),
+				messages.stream().map(Message::getText).toList());
+	}
+
+	@Test
+	void newUserInputShouldLoadLastConsistentCheckpointWhenLatestEndsWithAssistantToolCall() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph compiledGraph = buildGraph(saver);
+		RunnableConfig config = RunnableConfig.builder().threadId(THREAD_ID).build();
+
+		saver.put(config, checkpoint("stable", END, stableState()));
+		saver.put(config, checkpoint("model_node", "tool_node", inconsistentStateEndingWithAssistantToolCall()));
+
+		@SuppressWarnings("unchecked")
+		List<Message> messages = (List<Message>) compiledGraph
+			.getInitialState(Map.of("messages", List.of(new UserMessage("continue"))), config)
+			.get("messages");
+
+		assertFalse(messages.stream()
+			.filter(AssistantMessage.class::isInstance)
+			.map(AssistantMessage.class::cast)
+			.anyMatch(AssistantMessage::hasToolCalls),
+				"new user input must not be appended after an incomplete assistant tool call checkpoint");
+		assertInstanceOf(UserMessage.class, messages.get(messages.size() - 1));
+		assertIterableEquals(List.of("hello", "previous answer", "continue"),
+				messages.stream().map(Message::getText).toList());
+	}
+
+	@Test
+	void newUserInputShouldKeepLatestCheckpointWhenToolCallIsClosedByAssistantMessage() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph compiledGraph = buildGraph(saver);
+		RunnableConfig config = RunnableConfig.builder().threadId(THREAD_ID).build();
+
+		saver.put(config, checkpoint("stable", END, stableState()));
+		saver.put(config, checkpoint("final_model", END, consistentToolCallState()));
+
+		@SuppressWarnings("unchecked")
+		List<Message> messages = (List<Message>) compiledGraph
+			.getInitialState(Map.of("messages", List.of(new UserMessage("continue"))), config)
+			.get("messages");
+
+		assertInstanceOf(ToolResponseMessage.class, messages.get(4));
+		assertInstanceOf(AssistantMessage.class, messages.get(5));
+		assertInstanceOf(UserMessage.class, messages.get(6));
+		assertIterableEquals(List.of("hello", "previous answer", "search", "", "", "final answer", "continue"),
+				messages.stream().map(Message::getText).toList());
+	}
+
+	private static CompiledGraph buildGraph(MemorySaver saver) throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("echo", node_async(state -> Map.of("messages", new AssistantMessage("ok"))))
+			.addEdge(START, "echo")
+			.addEdge("echo", END);
+
+		return stateGraph.compile(CompileConfig.builder()
+			.saverConfig(SaverConfig.builder().register(saver).build())
+			.build());
+	}
+
+	private static Checkpoint checkpoint(String nodeId, String nextNodeId, Map<String, Object> state) {
+		return Checkpoint.builder().nodeId(nodeId).nextNodeId(nextNodeId).state(state).build();
+	}
+
+	private static Map<String, Object> stableState() {
+		return Map.of("messages", List.of(new UserMessage("hello"), new AssistantMessage("previous answer")));
+	}
+
+	private static Map<String, Object> inconsistentStateEndingWithToolResponse() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		return Map.of("messages", List.of(
+				new UserMessage("hello"),
+				new AssistantMessage("previous answer"),
+				new UserMessage("search"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", "result")))
+					.build()));
+	}
+
+	private static Map<String, Object> inconsistentStateWithPartialToolResponses() {
+		AssistantMessage.ToolCall toolCall1 = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		AssistantMessage.ToolCall toolCall2 = new AssistantMessage.ToolCall("call_2", "function", "lookup", "{}");
+		return Map.of("messages", List.of(
+				new UserMessage("hello"),
+				new AssistantMessage("previous answer"),
+				new UserMessage("search"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall1, toolCall2)).build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", "result")))
+					.build()));
+	}
+
+	private static Map<String, Object> inconsistentStateEndingWithAssistantToolCall() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		return Map.of("messages", List.of(
+				new UserMessage("hello"),
+				new AssistantMessage("previous answer"),
+				new UserMessage("search"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build()));
+	}
+
+	private static Map<String, Object> consistentToolCallState() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		return Map.of("messages", List.of(
+				new UserMessage("hello"),
+				new AssistantMessage("previous answer"),
+				new UserMessage("search"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build(),
+				ToolResponseMessage.builder()
+					.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", "result")))
+					.build(),
+				new AssistantMessage("final answer")));
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
@@ -47,6 +47,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
@@ -184,6 +187,50 @@ class StreamCheckpointCancellationTest {
 	}
 
 	@Test
+	void staleBackgroundCheckpointBeforeFirstWriteShouldNotOverrideNextTurnCheckpoint() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CountDownLatch oldRunAtStart = new CountDownLatch(1);
+		CountDownLatch releaseOldRun = new CountDownLatch(1);
+		RunnableConfig config = RunnableConfig.builder().threadId("stale-background-first-write-thread").build();
+		CompiledGraph oldGraph = buildAnswerGraph(saver, "old background", new GraphLifecycleListener() {
+			@Override
+			public void onStart(String nodeId, Map<String, Object> state, RunnableConfig config) {
+				oldRunAtStart.countDown();
+				try {
+					if (!releaseOldRun.await(3, TimeUnit.SECONDS)) {
+						throw new IllegalStateException("old run was not released");
+					}
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(ex);
+				}
+			}
+		});
+
+		CompletableFuture<List<NodeOutput>> oldRun = CompletableFuture.supplyAsync(() -> oldGraph
+			.stream(Map.of("messages", List.of(new UserMessage("old request"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5)));
+		assertTrue(oldRunAtStart.await(2, TimeUnit.SECONDS), "old run should stop before its START checkpoint");
+
+		CompiledGraph nextGraph = buildAnswerGraph(saver, "continued", null);
+		List<NodeOutput> outputs = nextGraph
+			.stream(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+		assertNotNull(outputs);
+
+		releaseOldRun.countDown();
+		oldRun.get(5, TimeUnit.SECONDS);
+		Object lastMessage = awaitLastCheckpointMessage(nextGraph, config);
+
+		assertInstanceOf(AssistantMessage.class, lastMessage);
+		assertEquals("continued", ((AssistantMessage) lastMessage).getText(),
+				"old background run must not write its first checkpoint after a newer turn has advanced the thread");
+	}
+
+	@Test
 	void streamCancellationAfterToolBeforeModelShouldStillPersistFinalAssistantMessage() throws Exception {
 		MemorySaver saver = MemorySaver.builder().build();
 		StreamGraphFixture fixture = buildStreamGraphFixture(saver);
@@ -310,6 +357,25 @@ class StreamCheckpointCancellationTest {
 		return stateGraph.compile(CompileConfig.builder()
 			.saverConfig(SaverConfig.builder().register(saver).build())
 			.build());
+	}
+
+	private static CompiledGraph buildAnswerGraph(MemorySaver saver, String answer, GraphLifecycleListener listener)
+			throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("streaming_model",
+				node_async(state -> Map.of("messages", Flux.just(chatResponse(answer)))))
+			.addEdge(START, "streaming_model")
+			.addEdge("streaming_model", END);
+
+		CompileConfig.Builder builder = CompileConfig.builder()
+			.saverConfig(SaverConfig.builder().register(saver).build());
+		if (listener != null) {
+			builder.withLifecycleListener(listener);
+		}
+		return stateGraph.compile(builder.build());
 	}
 
 	private static CompiledGraph buildContinuationGraph(MemorySaver saver, AtomicBoolean openAiPayloadVerified,

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
@@ -24,6 +24,7 @@ import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.OverAllState;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
@@ -42,10 +43,13 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -228,6 +232,74 @@ class StreamCheckpointCancellationTest {
 		assertInstanceOf(AssistantMessage.class, lastMessage);
 		assertEquals("continued", ((AssistantMessage) lastMessage).getText(),
 				"old background run must not write its first checkpoint after a newer turn has advanced the thread");
+	}
+
+	@Test
+	void checkpointLineageCheckAndAppendShouldBeAtomic() throws Exception {
+		BlockingSaver saver = new BlockingSaver(true, false);
+		RunnableConfig config = RunnableConfig.builder().threadId("checkpoint-lineage-atomic-thread").build();
+		CompiledGraph oldGraph = buildAnswerGraph(saver, "old background", false, null);
+
+		CompletableFuture<List<NodeOutput>> oldRun = CompletableFuture.supplyAsync(() -> oldGraph
+			.stream(Map.of("messages", List.of(new UserMessage("old request"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5)));
+		assertTrue(saver.awaitFirstAppendReached(), "old run should pause after passing the lineage check");
+
+		CompiledGraph nextGraph = buildAnswerGraph(saver, "continued", false, null);
+		CountDownLatch nextRunCompleted = new CountDownLatch(1);
+		CompletableFuture<List<NodeOutput>> nextRun = CompletableFuture.supplyAsync(() -> {
+			try {
+				return nextGraph.stream(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+					.collectList()
+					.block(Duration.ofSeconds(5));
+			}
+			finally {
+				nextRunCompleted.countDown();
+			}
+		});
+		assertFalse(nextRunCompleted.await(200, TimeUnit.MILLISECONDS),
+				"another run on the same saver must not complete while the first append is inside its critical section");
+
+		saver.releaseFirstAppend();
+		assertNotNull(oldRun.get(5, TimeUnit.SECONDS));
+		assertNotNull(nextRun.get(5, TimeUnit.SECONDS));
+	}
+
+	@Test
+	void checkpointLineageCheckAndReleaseShouldBeAtomic() throws Exception {
+		BlockingSaver saver = new BlockingSaver(false, true);
+		RunnableConfig config = RunnableConfig.builder().threadId("checkpoint-release-atomic-thread").build();
+		CompiledGraph oldGraph = buildAnswerGraph(saver, "old background", true, null);
+
+		CompletableFuture<List<NodeOutput>> oldRun = CompletableFuture.supplyAsync(() -> oldGraph
+			.stream(Map.of("messages", List.of(new UserMessage("old request"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5)));
+		assertTrue(saver.awaitFirstReleaseReached(), "old run should pause inside release after passing the lineage check");
+
+		CompiledGraph nextGraph = buildAnswerGraph(saver, "continued", false, null);
+		CountDownLatch nextRunCompleted = new CountDownLatch(1);
+		CompletableFuture<List<NodeOutput>> nextRun = CompletableFuture.supplyAsync(() -> {
+			try {
+				return nextGraph.stream(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+					.collectList()
+					.block(Duration.ofSeconds(5));
+			}
+			finally {
+				nextRunCompleted.countDown();
+			}
+		});
+		assertFalse(nextRunCompleted.await(200, TimeUnit.MILLISECONDS),
+				"another run on the same saver must not complete while release is inside its critical section");
+
+		saver.releaseFirstRelease();
+		assertNotNull(oldRun.get(5, TimeUnit.SECONDS));
+		assertNotNull(nextRun.get(5, TimeUnit.SECONDS));
+
+		Object lastMessage = awaitLastCheckpointMessage(nextGraph, config);
+		assertInstanceOf(AssistantMessage.class, lastMessage);
+		assertEquals("continued", ((AssistantMessage) lastMessage).getText());
 	}
 
 	@Test
@@ -459,12 +531,12 @@ class StreamCheckpointCancellationTest {
 			.build());
 	}
 
-	private static CompiledGraph buildAnswerGraph(MemorySaver saver, String answer, GraphLifecycleListener listener)
+	private static CompiledGraph buildAnswerGraph(BaseCheckpointSaver saver, String answer, GraphLifecycleListener listener)
 			throws Exception {
 		return buildAnswerGraph(saver, answer, false, listener);
 	}
 
-	private static CompiledGraph buildAnswerGraph(MemorySaver saver, String answer, boolean releaseThread,
+	private static CompiledGraph buildAnswerGraph(BaseCheckpointSaver saver, String answer, boolean releaseThread,
 			GraphLifecycleListener listener) throws Exception {
 		StateGraph stateGraph = new StateGraph(() -> {
 			Map<String, KeyStrategy> strategies = new HashMap<>();
@@ -482,6 +554,110 @@ class StreamCheckpointCancellationTest {
 			builder.withLifecycleListener(listener);
 		}
 		return stateGraph.compile(builder.build());
+	}
+
+	private static final class BlockingSaver implements BaseCheckpointSaver {
+
+		private final LinkedList<Checkpoint> checkpoints = new LinkedList<>();
+
+		private final boolean blockFirstAppend;
+
+		private final boolean blockFirstRelease;
+
+		private final CountDownLatch firstAppendReached = new CountDownLatch(1);
+
+		private final CountDownLatch releaseFirstAppend = new CountDownLatch(1);
+
+		private final CountDownLatch firstReleaseReached = new CountDownLatch(1);
+
+		private final CountDownLatch releaseFirstRelease = new CountDownLatch(1);
+
+		private final AtomicBoolean shouldBlockFirstAppend = new AtomicBoolean(true);
+
+		private final AtomicBoolean shouldBlockFirstRelease = new AtomicBoolean(true);
+
+		BlockingSaver(boolean blockFirstAppend, boolean blockFirstRelease) {
+			this.blockFirstAppend = blockFirstAppend;
+			this.blockFirstRelease = blockFirstRelease;
+		}
+
+		@Override
+		public synchronized Collection<Checkpoint> list(RunnableConfig config) {
+			return List.copyOf(checkpoints);
+		}
+
+		@Override
+		public synchronized Optional<Checkpoint> get(RunnableConfig config) {
+			if (config.checkPointId().isPresent()) {
+				return checkpoints.stream()
+					.filter(checkpoint -> checkpoint.getId().equals(config.checkPointId().get()))
+					.findFirst();
+			}
+			return checkpoints.isEmpty() ? Optional.empty() : Optional.of(checkpoints.peek());
+		}
+
+		@Override
+		public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+			if (config.checkPointId().isPresent()) {
+				return replace(config, checkpoint);
+			}
+			if (blockFirstAppend && shouldBlockFirstAppend.compareAndSet(true, false)) {
+				firstAppendReached.countDown();
+				if (!releaseFirstAppend.await(3, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("first append was not released");
+				}
+			}
+			synchronized (this) {
+				checkpoints.push(checkpoint);
+			}
+			return RunnableConfig.builder(config).checkPointId(checkpoint.getId()).build();
+		}
+
+		private synchronized RunnableConfig replace(RunnableConfig config, Checkpoint checkpoint) {
+			String checkpointId = config.checkPointId().orElseThrow();
+			for (int i = 0; i < checkpoints.size(); i++) {
+				if (checkpointId.equals(checkpoints.get(i).getId())) {
+					checkpoints.set(i, checkpoint);
+					return config;
+				}
+			}
+			throw new IllegalArgumentException("Checkpoint with id " + checkpointId + " not found");
+		}
+
+		@Override
+		public Tag release(RunnableConfig config) throws Exception {
+			if (blockFirstRelease && shouldBlockFirstRelease.compareAndSet(true, false)) {
+				firstReleaseReached.countDown();
+				if (!releaseFirstRelease.await(3, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("first release was not released");
+				}
+			}
+			return doRelease(config);
+		}
+
+		private synchronized Tag doRelease(RunnableConfig config) {
+			String threadId = config.threadId().orElse(THREAD_ID_DEFAULT);
+			List<Checkpoint> released = List.copyOf(checkpoints);
+			checkpoints.clear();
+			return new Tag(threadId, released);
+		}
+
+		boolean awaitFirstAppendReached() throws InterruptedException {
+			return firstAppendReached.await(2, TimeUnit.SECONDS);
+		}
+
+		void releaseFirstAppend() {
+			releaseFirstAppend.countDown();
+		}
+
+		boolean awaitFirstReleaseReached() throws InterruptedException {
+			return firstReleaseReached.await(2, TimeUnit.SECONDS);
+		}
+
+		void releaseFirstRelease() {
+			releaseFirstRelease.countDown();
+		}
+
 	}
 
 	private static CompiledGraph buildContinuationGraph(MemorySaver saver, AtomicBoolean openAiPayloadVerified,

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
@@ -231,6 +231,106 @@ class StreamCheckpointCancellationTest {
 	}
 
 	@Test
+	void staleResumedCheckpointBeforeFirstWriteShouldNotOverrideNextTurnCheckpoint() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		RunnableConfig config = RunnableConfig.builder().threadId("stale-resume-first-write-thread").build();
+		Checkpoint resumeCheckpoint = Checkpoint.builder()
+			.nodeId(START)
+			.nextNodeId("streaming_model")
+			.state(stableState())
+			.build();
+		saver.put(config, resumeCheckpoint);
+
+		CountDownLatch oldRunBeforeNode = new CountDownLatch(1);
+		CountDownLatch releaseOldRun = new CountDownLatch(1);
+		CompiledGraph oldGraph = buildAnswerGraph(saver, "old resumed", false, new GraphLifecycleListener() {
+			@Override
+			public void before(String nodeId, Map<String, Object> state, RunnableConfig config, Long curTime) {
+				oldRunBeforeNode.countDown();
+				try {
+					if (!releaseOldRun.await(3, TimeUnit.SECONDS)) {
+						throw new IllegalStateException("old resumed run was not released");
+					}
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(ex);
+				}
+			}
+		});
+		RunnableConfig resumeConfig = RunnableConfig.builder(config)
+			.checkPointId(resumeCheckpoint.getId())
+			.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, "continue")
+			.build();
+
+		CompletableFuture<List<NodeOutput>> oldRun = CompletableFuture.supplyAsync(() -> oldGraph
+			.stream(Map.of("messages", List.of(new UserMessage("old resume"))), resumeConfig)
+			.collectList()
+			.block(Duration.ofSeconds(5)));
+		assertTrue(oldRunBeforeNode.await(2, TimeUnit.SECONDS), "old resumed run should stop before its first checkpoint");
+
+		CompiledGraph nextGraph = buildAnswerGraph(saver, "continued", false, null);
+		List<NodeOutput> outputs = nextGraph
+			.stream(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+		assertNotNull(outputs);
+
+		releaseOldRun.countDown();
+		oldRun.get(5, TimeUnit.SECONDS);
+		Object lastMessage = awaitLastCheckpointMessage(nextGraph, config);
+
+		assertInstanceOf(AssistantMessage.class, lastMessage);
+		assertEquals("continued", ((AssistantMessage) lastMessage).getText(),
+				"old resumed run must not write its first checkpoint after a newer turn has advanced the thread");
+	}
+
+	@Test
+	void staleBackgroundCompletionShouldNotReleaseNewerTurnCheckpoints() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CountDownLatch oldRunAtStart = new CountDownLatch(1);
+		CountDownLatch releaseOldRun = new CountDownLatch(1);
+		RunnableConfig config = RunnableConfig.builder().threadId("stale-background-release-thread").build();
+		CompiledGraph oldGraph = buildAnswerGraph(saver, "old background", true, new GraphLifecycleListener() {
+			@Override
+			public void onStart(String nodeId, Map<String, Object> state, RunnableConfig config) {
+				oldRunAtStart.countDown();
+				try {
+					if (!releaseOldRun.await(3, TimeUnit.SECONDS)) {
+						throw new IllegalStateException("old run was not released");
+					}
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(ex);
+				}
+			}
+		});
+
+		CompletableFuture<List<NodeOutput>> oldRun = CompletableFuture.supplyAsync(() -> oldGraph
+			.stream(Map.of("messages", List.of(new UserMessage("old request"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5)));
+		assertTrue(oldRunAtStart.await(2, TimeUnit.SECONDS), "old run should stop before its START checkpoint");
+
+		CompiledGraph nextGraph = buildAnswerGraph(saver, "continued", false, null);
+		List<NodeOutput> outputs = nextGraph
+			.stream(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+		assertNotNull(outputs);
+
+		releaseOldRun.countDown();
+		oldRun.get(5, TimeUnit.SECONDS);
+		List<?> checkpointMessages = checkpointMessages(nextGraph, config);
+
+		assertFalse(checkpointMessages.isEmpty(), "newer turn checkpoints must not be released by an older run");
+		Object lastMessage = checkpointMessages.get(checkpointMessages.size() - 1);
+		assertInstanceOf(AssistantMessage.class, lastMessage);
+		assertEquals("continued", ((AssistantMessage) lastMessage).getText());
+	}
+
+	@Test
 	void streamCancellationAfterToolBeforeModelShouldStillPersistFinalAssistantMessage() throws Exception {
 		MemorySaver saver = MemorySaver.builder().build();
 		StreamGraphFixture fixture = buildStreamGraphFixture(saver);
@@ -361,6 +461,11 @@ class StreamCheckpointCancellationTest {
 
 	private static CompiledGraph buildAnswerGraph(MemorySaver saver, String answer, GraphLifecycleListener listener)
 			throws Exception {
+		return buildAnswerGraph(saver, answer, false, listener);
+	}
+
+	private static CompiledGraph buildAnswerGraph(MemorySaver saver, String answer, boolean releaseThread,
+			GraphLifecycleListener listener) throws Exception {
 		StateGraph stateGraph = new StateGraph(() -> {
 			Map<String, KeyStrategy> strategies = new HashMap<>();
 			strategies.put("messages", new AppendStrategy());
@@ -371,7 +476,8 @@ class StreamCheckpointCancellationTest {
 			.addEdge("streaming_model", END);
 
 		CompileConfig.Builder builder = CompileConfig.builder()
-			.saverConfig(SaverConfig.builder().register(saver).build());
+			.saverConfig(SaverConfig.builder().register(saver).build())
+			.releaseThread(releaseThread);
 		if (listener != null) {
 			builder.withLifecycleListener(listener);
 		}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
@@ -150,6 +151,39 @@ class StreamCheckpointCancellationTest {
 	}
 
 	@Test
+	void staleBackgroundCheckpointShouldNotOverrideNextTurnCheckpoint() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		StreamGraphFixture timeoutFixture = buildStreamGraphFixture(saver, Duration.ofMillis(300));
+		RunnableConfig firstTurnConfig = RunnableConfig.builder().threadId("stale-background-checkpoint-thread").build();
+
+		RuntimeException error = assertThrows(RuntimeException.class,
+				() -> timeoutAfterStreamingModelStarts(timeoutFixture.compiledGraph().stream(initialMessages(),
+						firstTurnConfig))
+					.collectList()
+					.block(Duration.ofSeconds(5)));
+		assertTrue(hasCause(error, TimeoutException.class), "test should first reproduce timeout cancellation");
+
+		AtomicBoolean openAiPayloadVerified = new AtomicBoolean(false);
+		CompiledGraph continuationGraph = buildContinuationGraph(saver, openAiPayloadVerified, List.of("user"));
+		RunnableConfig nextTurnConfig = RunnableConfig.builder().threadId("stale-background-checkpoint-thread").build();
+
+		List<NodeOutput> outputs = continuationGraph
+			.stream(Map.of("messages", List.of(new UserMessage("\u8bf7\u7ee7\u7eed"))), nextTurnConfig)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+		assertNotNull(outputs);
+		assertTrue(openAiPayloadVerified.get(), "next turn should run before the old background stream completes");
+
+		assertTrue(awaitUntil(timeoutFixture.modelStreamCompleted()::get),
+				"old background stream should complete after the next turn");
+		Object lastMessage = awaitLastCheckpointMessage(continuationGraph, nextTurnConfig);
+
+		assertInstanceOf(AssistantMessage.class, lastMessage);
+		assertEquals("continued", ((AssistantMessage) lastMessage).getText(),
+				"stale background checkpoint must not become the latest checkpoint after a newer turn");
+	}
+
+	@Test
 	void streamCancellationAfterToolBeforeModelShouldStillPersistFinalAssistantMessage() throws Exception {
 		MemorySaver saver = MemorySaver.builder().build();
 		StreamGraphFixture fixture = buildStreamGraphFixture(saver);
@@ -222,6 +256,11 @@ class StreamCheckpointCancellationTest {
 	}
 
 	private static StreamGraphFixture buildStreamGraphFixture(MemorySaver saver) throws Exception {
+		return buildStreamGraphFixture(saver, Duration.ofMillis(50));
+	}
+
+	private static StreamGraphFixture buildStreamGraphFixture(MemorySaver saver, Duration finalChunkDelay)
+			throws Exception {
 		AtomicBoolean modelStreamSubscribed = new AtomicBoolean(false);
 		AtomicBoolean modelStreamCancelled = new AtomicBoolean(false);
 		AtomicBoolean modelStreamCompleted = new AtomicBoolean(false);
@@ -235,7 +274,7 @@ class StreamCheckpointCancellationTest {
 			.addNode("streaming_model",
 					node_async(state -> Map.of("messages",
 							streamingAssistantResponse(modelStreamSubscribed, modelStreamCancelled,
-									modelStreamCompleted))))
+									modelStreamCompleted, finalChunkDelay))))
 			.addEdge(START, "tool_node")
 			.addEdge("tool_node", "streaming_model")
 			.addEdge("streaming_model", END);
@@ -341,10 +380,10 @@ class StreamCheckpointCancellationTest {
 	}
 
 	private static Flux<ChatResponse> streamingAssistantResponse(AtomicBoolean subscribed, AtomicBoolean cancelled,
-			AtomicBoolean completed) {
+			AtomicBoolean completed, Duration finalChunkDelay) {
 		return Flux.concat(
 				Flux.just(chatResponse("tool result")),
-				Flux.just(chatResponse(" received")).delayElements(Duration.ofMillis(50)))
+				Flux.just(chatResponse(" received")).delayElements(finalChunkDelay))
 			.doOnSubscribe(subscription -> subscribed.set(true))
 			.doOnCancel(() -> cancelled.set(true))
 			.doOnComplete(() -> completed.set(true));
@@ -380,6 +419,16 @@ class StreamCheckpointCancellationTest {
 			throws InterruptedException {
 		List<?> checkpointMessages = awaitCheckpointMessages(compiledGraph, config);
 		return checkpointMessages.get(checkpointMessages.size() - 1);
+	}
+
+	private static boolean awaitUntil(BooleanSupplier condition) throws InterruptedException {
+		for (int attempt = 0; attempt < 20; attempt++) {
+			if (condition.getAsBoolean()) {
+				return true;
+			}
+			Thread.sleep(50);
+		}
+		return false;
 	}
 
 	private static Flux<NodeOutput> timeoutAfterStreamingModelStarts(Flux<NodeOutput> stream) {

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/executor/StreamCheckpointCancellationTest.java
@@ -1,0 +1,475 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.executor;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.GraphLifecycleListener;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for external stream cancellation while a checkpoint saver is
+ * enabled. A cancelled SSE/client subscription must not leave the persisted message
+ * history ending with a tool response.
+ */
+class StreamCheckpointCancellationTest {
+
+	private static final String THREAD_ID = "stream-cancel-checkpoint-thread";
+
+	@Test
+	void streamCancellationShouldStillPersistFinalAssistantMessage() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		StreamGraphFixture fixture = buildStreamGraphFixture(saver);
+		CompiledGraph compiledGraph = fixture.compiledGraph();
+		RunnableConfig config = RunnableConfig.builder().threadId(THREAD_ID).build();
+
+		List<NodeOutput> observed = compiledGraph.stream(initialMessages(), config)
+			.takeUntil(output -> "streaming_model".equals(output.node()))
+			.collectList()
+			.block(Duration.ofSeconds(5));
+
+		assertNotNull(observed, "stream should emit before cancellation");
+		assertTrue(observed.stream().anyMatch(output -> "streaming_model".equals(output.node())),
+				"test should cancel after the first streaming chunk");
+
+		Object lastMessage = awaitLastCheckpointMessage(compiledGraph, config);
+
+		fixture.assertModelStreamCompletedWithoutCancellation("downstream cancellation");
+		assertTrue(fixture.streamingNodeAfterCalled().get(),
+				"streaming node after-listener should run after stream completion");
+		assertInstanceOf(AssistantMessage.class, lastMessage,
+				"checkpoint history must not end with ToolResponseMessage after stream cancellation");
+		assertEquals("tool result received", ((AssistantMessage) lastMessage).getText());
+	}
+
+	@Test
+	void streamTimeoutShouldStillPersistFinalAssistantMessage() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		StreamGraphFixture fixture = buildStreamGraphFixture(saver);
+		CompiledGraph compiledGraph = fixture.compiledGraph();
+		RunnableConfig config = RunnableConfig.builder().threadId("stream-timeout-checkpoint-thread").build();
+		List<NodeOutput> observed = new ArrayList<>();
+
+		RuntimeException error = assertThrows(RuntimeException.class,
+				() -> timeoutAfterStreamingModelStarts(compiledGraph.stream(initialMessages(), config)
+					.doOnNext(observed::add))
+					.collectList()
+					.block(Duration.ofSeconds(5)));
+
+		assertTrue(hasCause(error, TimeoutException.class), "test should fail through Flux timeout");
+		assertTrue(observed.stream().anyMatch(output -> "streaming_model".equals(output.node())),
+				"test should time out after the streaming model starts");
+
+		Object lastMessage = awaitLastCheckpointMessage(compiledGraph, config);
+
+		fixture.assertModelStreamCompletedWithoutCancellation("timeout cancellation");
+		assertTrue(fixture.streamingNodeAfterCalled().get(), "streaming node after-listener should run after timeout");
+		assertInstanceOf(AssistantMessage.class, lastMessage,
+				"checkpoint history must not end with ToolResponseMessage after stream timeout");
+		assertEquals("tool result received", ((AssistantMessage) lastMessage).getText());
+	}
+
+	@Test
+	void nextTurnAfterStreamTimeoutShouldInvokeModelWithOpenAiCompatibleMessages() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph timeoutGraph = buildStreamGraphFixture(saver).compiledGraph();
+		RunnableConfig config = RunnableConfig.builder().threadId("timeout-next-turn-openai-payload-thread").build();
+
+		RuntimeException error = assertThrows(RuntimeException.class,
+				() -> timeoutAfterStreamingModelStarts(timeoutGraph.stream(initialMessages(), config))
+					.collectList()
+					.block(Duration.ofSeconds(5)));
+		assertTrue(hasCause(error, TimeoutException.class), "test should first reproduce timeout cancellation");
+		assertTrue(awaitLastCheckpointMessage(timeoutGraph, config) instanceof AssistantMessage,
+				"timeout cancellation should still persist the final assistant message");
+
+		AtomicBoolean openAiPayloadVerified = new AtomicBoolean(false);
+		CompiledGraph continuationGraph = buildContinuationGraph(saver, openAiPayloadVerified,
+				List.of("user", "assistant", "tool", "assistant", "user"));
+
+		List<NodeOutput> outputs = continuationGraph
+			.stream(Map.of("messages", List.of(new UserMessage("\u8bf7\u7ee7\u7eed"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+
+		assertNotNull(outputs);
+		assertTrue(openAiPayloadVerified.get(), "next turn after timeout should send OpenAI-compatible messages");
+	}
+
+	@Test
+	void streamCancellationAfterToolBeforeModelShouldStillPersistFinalAssistantMessage() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		StreamGraphFixture fixture = buildStreamGraphFixture(saver);
+		CompiledGraph compiledGraph = fixture.compiledGraph();
+		RunnableConfig config = RunnableConfig.builder().threadId("stream-cancel-after-tool-thread").build();
+		saver.put(config, Checkpoint.builder().nodeId("stable").nextNodeId(END).state(stableState()).build());
+
+		List<NodeOutput> observed = compiledGraph.stream(initialMessages(), config)
+			.takeUntil(output -> "tool_node".equals(output.node()))
+			.collectList()
+			.block(Duration.ofSeconds(5));
+
+		assertNotNull(observed, "stream should emit the tool node output before cancellation");
+		assertTrue(observed.stream().anyMatch(output -> "tool_node".equals(output.node())),
+				"test should cancel before the streaming model node is subscribed");
+
+		Object lastMessage = awaitLastCheckpointMessage(compiledGraph, config);
+
+		fixture.assertModelStreamCompletedWithoutCancellation("downstream cancellation");
+		assertInstanceOf(AssistantMessage.class, lastMessage,
+				"background execution should keep tool response and final assistant paired");
+		assertEquals("tool result received", ((AssistantMessage) lastMessage).getText());
+	}
+
+	@Test
+	void streamFailureBeforeAssistantChunkShouldNotBeLoadedAsNextTurnHistory() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph compiledGraph = buildFailingGraph(saver);
+		RunnableConfig config = RunnableConfig.builder().threadId("stream-failure-checkpoint-thread").build();
+
+		assertThrows(IllegalStateException.class,
+				() -> compiledGraph.stream(initialMessages(), config).collectList().block(Duration.ofSeconds(5)));
+
+		List<?> latestCheckpointMessages = checkpointMessages(compiledGraph, config);
+		assertInstanceOf(ToolResponseMessage.class, latestCheckpointMessages.get(latestCheckpointMessages.size() - 1),
+				"the latest raw checkpoint reproduces the incomplete tool response state");
+
+		@SuppressWarnings("unchecked")
+		List<Message> nextTurnMessages = (List<Message>) compiledGraph
+			.getInitialState(Map.of("messages", List.of(new UserMessage("continue"))), config)
+			.get("messages");
+
+		assertFalse(nextTurnMessages.stream().anyMatch(ToolResponseMessage.class::isInstance),
+				"next user input must not be appended after an incomplete tool response checkpoint");
+		assertInstanceOf(UserMessage.class, nextTurnMessages.get(nextTurnMessages.size() - 1));
+	}
+
+	@Test
+	void nextTurnShouldInvokeModelWithOpenAiCompatibleMessagesAfterIncompleteCheckpoint() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		AtomicBoolean openAiPayloadVerified = new AtomicBoolean(false);
+		CompiledGraph compiledGraph = buildContinuationGraph(saver, openAiPayloadVerified,
+				List.of("user", "assistant", "user"));
+		RunnableConfig config = RunnableConfig.builder().threadId("next-turn-openai-payload-thread").build();
+
+		saver.put(config, Checkpoint.builder().nodeId("stable").nextNodeId(END).state(stableState()).build());
+		saver.put(config, Checkpoint.builder()
+			.nodeId("tool_node")
+			.nextNodeId("streaming_model")
+			.state(incompleteToolResponseState())
+			.build());
+
+		List<NodeOutput> outputs = compiledGraph
+			.stream(Map.of("messages", List.of(new UserMessage("\u8bf7\u7ee7\u7eed"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+
+		assertNotNull(outputs);
+		assertTrue(openAiPayloadVerified.get(), "the next model call should receive an OpenAI-compatible payload");
+	}
+
+	private static StreamGraphFixture buildStreamGraphFixture(MemorySaver saver) throws Exception {
+		AtomicBoolean modelStreamSubscribed = new AtomicBoolean(false);
+		AtomicBoolean modelStreamCancelled = new AtomicBoolean(false);
+		AtomicBoolean modelStreamCompleted = new AtomicBoolean(false);
+		AtomicBoolean streamingNodeAfterCalled = new AtomicBoolean(false);
+
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("tool_node", node_async(state -> Map.of("messages", toolResponse())))
+			.addNode("streaming_model",
+					node_async(state -> Map.of("messages",
+							streamingAssistantResponse(modelStreamSubscribed, modelStreamCancelled,
+									modelStreamCompleted))))
+			.addEdge(START, "tool_node")
+			.addEdge("tool_node", "streaming_model")
+			.addEdge("streaming_model", END);
+
+		CompiledGraph compiledGraph = stateGraph.compile(CompileConfig.builder()
+			.saverConfig(SaverConfig.builder().register(saver).build())
+			.withLifecycleListener(new GraphLifecycleListener() {
+				@Override
+				public void after(String nodeId, Map<String, Object> state, RunnableConfig config, Long curTime) {
+					if ("streaming_model".equals(nodeId)) {
+						streamingNodeAfterCalled.set(true);
+					}
+				}
+			})
+			.build());
+		return new StreamGraphFixture(compiledGraph, modelStreamSubscribed, modelStreamCancelled, modelStreamCompleted,
+				streamingNodeAfterCalled);
+	}
+
+	private static CompiledGraph buildFailingGraph(MemorySaver saver) throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("tool_node", node_async(state -> Map.of("messages", toolResponse())))
+			.addNode("streaming_model",
+					node_async(state -> Map.of("messages",
+							Flux.<ChatResponse>error(new IllegalStateException("model stream failed")))))
+			.addEdge(START, "tool_node")
+			.addEdge("tool_node", "streaming_model")
+			.addEdge("streaming_model", END);
+
+		return stateGraph.compile(CompileConfig.builder()
+			.saverConfig(SaverConfig.builder().register(saver).build())
+			.build());
+	}
+
+	private static CompiledGraph buildContinuationGraph(MemorySaver saver, AtomicBoolean openAiPayloadVerified,
+			List<String> expectedRoles) throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("streaming_model", node_async(state -> {
+			@SuppressWarnings("unchecked")
+			List<Message> messages = (List<Message>) state.value("messages").orElseThrow();
+			ChatModel chatModel = verifyingOpenAiPayloadChatModel(openAiPayloadVerified, expectedRoles);
+			return Map.of("messages", chatModel.stream(new Prompt(messages)));
+		})).addEdge(START, "streaming_model").addEdge("streaming_model", END);
+
+		return stateGraph.compile(CompileConfig.builder()
+			.saverConfig(SaverConfig.builder().register(saver).build())
+			.build());
+	}
+
+	private static ChatModel verifyingOpenAiPayloadChatModel(AtomicBoolean verified, List<String> expectedRoles) {
+		return new ChatModel() {
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				return new ChatResponse(List.of(new Generation(new AssistantMessage("continued"))));
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				List<Map<String, Object>> openAiMessages = toOpenAiMessages(prompt.getInstructions());
+				assertOpenAiToolMessageOrder(openAiMessages);
+				assertEquals(expectedRoles, openAiMessages.stream()
+					.map(message -> (String) message.get("role"))
+					.toList());
+				assertEquals("\u8bf7\u7ee7\u7eed", openAiMessages.get(openAiMessages.size() - 1).get("content"));
+				verified.set(true);
+				return Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("continued")))));
+			}
+		};
+	}
+
+	private static Map<String, Object> initialMessages() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		List<Message> messages = List.of(
+				new UserMessage("search first"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build());
+		return Map.of(OverAllState.DEFAULT_INPUT_KEY, "search first", "messages", messages);
+	}
+
+	private static Map<String, Object> stableState() {
+		return Map.of("messages", List.of(new UserMessage("hello"), new AssistantMessage("previous answer")));
+	}
+
+	private static Map<String, Object> incompleteToolResponseState() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		return Map.of("messages", List.of(
+				new UserMessage("hello"),
+				new AssistantMessage("previous answer"),
+				new UserMessage("search"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build(),
+				toolResponse()));
+	}
+
+	private static ToolResponseMessage toolResponse() {
+		return ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", "ok")))
+			.build();
+	}
+
+	private static Flux<ChatResponse> streamingAssistantResponse(AtomicBoolean subscribed, AtomicBoolean cancelled,
+			AtomicBoolean completed) {
+		return Flux.concat(
+				Flux.just(chatResponse("tool result")),
+				Flux.just(chatResponse(" received")).delayElements(Duration.ofMillis(50)))
+			.doOnSubscribe(subscription -> subscribed.set(true))
+			.doOnCancel(() -> cancelled.set(true))
+			.doOnComplete(() -> completed.set(true));
+	}
+
+	private static ChatResponse chatResponse(String text) {
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+	}
+
+	private static List<?> awaitCheckpointMessages(CompiledGraph compiledGraph, RunnableConfig config)
+			throws InterruptedException {
+		List<?> lastMessages = List.of();
+		for (int attempt = 0; attempt < 20; attempt++) {
+			lastMessages = checkpointMessages(compiledGraph, config);
+			if (!lastMessages.isEmpty()
+					&& lastMessages.get(lastMessages.size() - 1) instanceof AssistantMessage) {
+				return lastMessages;
+			}
+			Thread.sleep(50);
+		}
+		return lastMessages;
+	}
+
+	private static List<?> checkpointMessages(CompiledGraph compiledGraph, RunnableConfig config) {
+		return compiledGraph.stateOf(config)
+			.flatMap(state -> state.state().value("messages"))
+			.filter(List.class::isInstance)
+			.map(List.class::cast)
+			.orElse(List.of());
+	}
+
+	private static Object awaitLastCheckpointMessage(CompiledGraph compiledGraph, RunnableConfig config)
+			throws InterruptedException {
+		List<?> checkpointMessages = awaitCheckpointMessages(compiledGraph, config);
+		return checkpointMessages.get(checkpointMessages.size() - 1);
+	}
+
+	private static Flux<NodeOutput> timeoutAfterStreamingModelStarts(Flux<NodeOutput> stream) {
+		return stream.timeout(Mono.delay(Duration.ofSeconds(1)), output -> "streaming_model".equals(output.node())
+				? Mono.delay(Duration.ofMillis(25)) : Mono.delay(Duration.ofSeconds(1)));
+	}
+
+	private static boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
+		Throwable current = throwable;
+		while (current != null) {
+			if (causeType.isInstance(current)) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
+	}
+
+	private static List<Map<String, Object>> toOpenAiMessages(List<Message> messages) {
+		List<Map<String, Object>> openAiMessages = new ArrayList<>();
+		for (Message message : messages) {
+			if (message instanceof UserMessage userMessage) {
+				openAiMessages.add(Map.of("role", "user", "content", userMessage.getText()));
+			}
+			else if (message instanceof AssistantMessage assistantMessage) {
+				Map<String, Object> openAiMessage = new HashMap<>();
+				openAiMessage.put("role", "assistant");
+				openAiMessage.put("content", assistantMessage.getText());
+				if (assistantMessage.hasToolCalls()) {
+					openAiMessage.put("tool_calls", assistantMessage.getToolCalls()
+						.stream()
+						.map(toolCall -> Map.of("id", toolCall.id(), "type", toolCall.type(), "function",
+								Map.of("name", toolCall.name(), "arguments", toolCall.arguments())))
+						.toList());
+				}
+				openAiMessages.add(openAiMessage);
+			}
+			else if (message instanceof ToolResponseMessage toolResponseMessage) {
+				for (ToolResponseMessage.ToolResponse response : toolResponseMessage.getResponses()) {
+					openAiMessages.add(Map.of("role", "tool", "tool_call_id", response.id(), "content",
+							response.responseData()));
+				}
+			}
+		}
+		return openAiMessages;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void assertOpenAiToolMessageOrder(List<Map<String, Object>> messages) {
+		Set<String> pendingToolCallIds = new HashSet<>();
+		boolean waitingForAssistantAfterTool = false;
+		for (Map<String, Object> message : messages) {
+			String role = (String) message.get("role");
+			if ("assistant".equals(role)) {
+				assertTrue(pendingToolCallIds.isEmpty(), "assistant cannot appear before all tool calls are answered");
+				waitingForAssistantAfterTool = false;
+				Object toolCalls = message.get("tool_calls");
+				if (toolCalls instanceof List<?> calls) {
+					for (Object call : calls) {
+						pendingToolCallIds.add((String) ((Map<String, Object>) call).get("id"));
+					}
+				}
+			}
+			else if ("tool".equals(role)) {
+				assertFalse(pendingToolCallIds.isEmpty(), "tool message must follow assistant tool calls");
+				assertTrue(pendingToolCallIds.remove(message.get("tool_call_id")),
+						"tool message must reference a pending assistant tool call");
+				waitingForAssistantAfterTool = pendingToolCallIds.isEmpty();
+			}
+			else {
+				assertTrue(pendingToolCallIds.isEmpty() && !waitingForAssistantAfterTool,
+						role + " message cannot follow an unfinished tool response sequence");
+			}
+		}
+		assertTrue(pendingToolCallIds.isEmpty(), "all assistant tool calls must have tool responses");
+		assertFalse(waitingForAssistantAfterTool, "tool response must be followed by assistant before new user input");
+	}
+
+	private record StreamGraphFixture(
+			CompiledGraph compiledGraph,
+			AtomicBoolean modelStreamSubscribed,
+			AtomicBoolean modelStreamCancelled,
+			AtomicBoolean modelStreamCompleted,
+			AtomicBoolean streamingNodeAfterCalled) {
+
+		void assertModelStreamCompletedWithoutCancellation(String cancellationType) {
+			assertTrue(modelStreamSubscribed.get(), "model stream should be subscribed");
+			assertFalse(modelStreamCancelled.get(), "model stream should not be cancelled by " + cancellationType);
+			assertTrue(modelStreamCompleted.get(), "model stream should keep running after " + cancellationType);
+		}
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes #4789.

When a graph stream is used with `CheckpointSaver`, downstream cancellation can currently leave the persisted message history in an invalid intermediate state.

A typical sequence is:

1. an assistant message emits tool calls;
2. the tool node completes and persists `ToolResponseMessage` immediately;
3. the following streaming LLM node is cancelled by a downstream timeout/SSE disconnect before its stream tail runs;
4. the final `AssistantMessage` is not persisted;
5. the next user input is appended after the tool response, producing an invalid `assistant(tool_calls) -> tool -> user` message sequence.

This breaks OpenAI/DashScope-compatible message ordering and can cause the next model request to be rejected.

### Does this pull request fix one issue?

Fixes #4789

### Describe how you did it

This PR adds three safeguards.

1. Keep graph execution running after downstream cancellation when checkpoint persistence is enabled.

   With a configured `CheckpointSaver`, `CompiledGraph` now internally consumes the graph execution stream on a background scheduler. Downstream cancellation still stops client-side emission, but it no longer directly cancels the internal graph execution that is responsible for finishing state merge and checkpoint persistence.

   This treats Reactor downstream cancellation as client-side stream consumption cancellation, for example frontend SSE disconnects or timeout-triggered cancellation. It does not introduce a semantic user-requested abort API.

   When no `CheckpointSaver` is configured, the previous stream behavior is preserved.

2. Prevent stale background checkpoints and releases from becoming latest after a newer turn has progressed.

   Each graph run records the checkpoint that was latest for the thread when the run starts, before loading the initial state. The same lineage baseline is now initialized for normal start runs and resumed/HITL runs using `HUMAN_FEEDBACK_METADATA_KEY` or an explicit `checkPointId`.

   Before appending any checkpoint, including the initial `START` checkpoint and the first checkpoint after resume, the run verifies that the thread latest is still the checkpoint it is based on. After a successful write, the run advances its own lineage head to the newly written checkpoint.

   If another request has already advanced the same thread, the older background run skips its checkpoint write instead of pushing stale state back to the latest position. `releaseThread(true)` uses the same lineage check before calling `checkpointSaver.release(...)`, so a stale background completion cannot release checkpoints written by a newer turn.

   This keeps the benefit of completing a cancelled/timeout turn when no newer turn has arrived, while preventing an old background run from overriding or deleting the next turn's checkpoint lineage.

3. Avoid resuming from an unsafe checkpoint.

   When loading initial state for a new user input, the graph now selects the latest checkpoint whose message history can safely accept another user message. This prevents histories ending with incomplete tool-call sequences from being used as the base for the next turn.

   The validator rejects histories such as:

   - assistant tool calls without matching tool responses;
   - partial tool responses for multiple tool calls;
   - tool responses not followed by a final assistant message;
   - invalid `tool -> user` continuation.

   It does not rewrite existing checkpoints or fabricate an empty assistant message. If the original streaming LLM completes after downstream cancellation, the persisted assistant message is the real aggregated model output. If the LLM stream itself fails before producing a valid assistant completion, the next turn falls back to the latest safe checkpoint.

### Describe how to verify it

I verified this PR with:

```bash
mvn -pl spring-ai-alibaba-graph-core -Dtest=CheckpointMessageConsistencyTest,StreamCheckpointCancellationTest,StreamingTokenUsageTest,GraphNodeStreamFinishedTest,StreamFunctionCallTest,GraphRunnerContextResumeMessageOrderTest test
mvn -pl spring-ai-alibaba-graph-core checkstyle:check
mvn -pl spring-ai-alibaba-graph-core spotless:check
git diff --check
```

The regression coverage includes:

- downstream cancellation while the streaming model node is already emitting;
- timeout-triggered cancellation while the streaming model node is already emitting;
- downstream cancellation after the tool node and before the model node is subscribed;
- timeout followed by the next user turn, verifying the model receives OpenAI-compatible messages in the order `user -> assistant(tool_calls) -> tool -> assistant -> user`;
- timeout followed immediately by a newer turn on the same thread, verifying the old background run cannot become the latest checkpoint after the newer turn has saved state;
- old background run blocked before its first `START` checkpoint, verifying it cannot write its first checkpoint after a newer turn has advanced the thread;
- old resumed/HITL run blocked before its first checkpoint, verifying it cannot write stale resumed state after a newer turn has advanced the thread;
- stale background completion with `releaseThread(true)`, verifying it cannot release checkpoints written by a newer turn;
- streaming model failure before a valid assistant completion, verifying the next turn does not resume from the incomplete `ToolResponseMessage` checkpoint;
- checkpoint fallback for histories ending with `ToolResponseMessage`;
- checkpoint fallback for assistant tool calls without tool responses;
- checkpoint fallback for partial tool responses with multiple tool calls;
- preserving the latest checkpoint when the tool-call chain is fully closed by a final assistant message.

Latest local result:

```text
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
You have 0 Checkstyle violations.
spotless:check: 0 needs changes
git diff --check: no whitespace errors
```

### Special notes for reviews

This PR only changes cancellation handling when a graph has a configured `CheckpointSaver`. The reported failure happens when an incomplete message sequence is persisted and then loaded as the base state of the next turn. Without a checkpoint saver, Graph Core does not persist that intermediate checkpoint and does not later restore it through `CompiledGraph.getInitialState(...)`, so this PR keeps the existing non-checkpoint stream cancellation behavior unchanged.

The fallback validator is only used when choosing a checkpoint for the next user input. It checks whether the persisted message history is safe to append a new user message to. It does not rewrite checkpoint records, remove messages from storage, or create a placeholder assistant message. If the latest checkpoint is incomplete, the next turn uses the nearest earlier safe checkpoint instead.