### PR TITLE
fix(graph): rollback from incomplete checkpoint messages

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -30,6 +30,7 @@ import com.alibaba.cloud.ai.graph.internal.node.Node;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduleConfig;
 import com.alibaba.cloud.ai.graph.scheduling.ScheduledAgentTask;
 import com.alibaba.cloud.ai.graph.state.StateSnapshot;
+import com.alibaba.cloud.ai.graph.utils.MessageSequenceValidator;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -462,9 +463,20 @@ public class CompiledGraph {
 	public Map<String, Object> getInitialState(Map<String, Object> inputs, RunnableConfig config) {
 
 		return compileConfig.checkpointSaver()
-				.flatMap(saver -> saver.get(config))
+				.flatMap(saver -> latestConsistentCheckpoint(saver, config))
 				.map(cp -> OverAllState.updateState(cp.getState(), inputs, keyStrategyMap))
 				.orElseGet(() -> OverAllState.updateState(new HashMap<>(), inputs, keyStrategyMap));
+	}
+
+	private Optional<Checkpoint> latestConsistentCheckpoint(BaseCheckpointSaver saver, RunnableConfig config) {
+		if (config.checkPointId().isPresent()) {
+			return saver.get(config).filter(checkpoint -> MessageSequenceValidator
+				.isCheckpointReadyForNewInput(checkpoint.getState()));
+		}
+		// Saver histories are latest-first; this is also the order used by
+		// lastStateOf().
+		return saver.list(config).stream().filter(checkpoint -> MessageSequenceValidator
+			.isCheckpointReadyForNewInput(checkpoint.getState())).findFirst();
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/MessageSequenceValidator.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/MessageSequenceValidator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.utils;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class MessageSequenceValidator {
+
+	private MessageSequenceValidator() {
+	}
+
+	public static boolean isCheckpointReadyForNewInput(Map<String, Object> state) {
+		Object messages = state.get("messages");
+		if (!(messages instanceof List<?> messageList)) {
+			return true;
+		}
+		return isReadyForNewInput(messageList);
+	}
+
+	private static boolean isReadyForNewInput(List<?> messages) {
+		Set<String> pendingToolCallIds = new HashSet<>();
+		boolean waitingForAssistantAfterTool = false;
+		for (Object item : messages) {
+			if (!(item instanceof Message message)) {
+				continue;
+			}
+			if (message instanceof AssistantMessage assistantMessage) {
+				if (!pendingToolCallIds.isEmpty()) {
+					return false;
+				}
+				waitingForAssistantAfterTool = false;
+				if (assistantMessage.hasToolCalls()) {
+					for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
+						pendingToolCallIds.add(toolCall.id());
+					}
+				}
+			}
+			else if (message instanceof ToolResponseMessage toolResponseMessage) {
+				if (pendingToolCallIds.isEmpty()) {
+					return false;
+				}
+				for (ToolResponseMessage.ToolResponse response : toolResponseMessage.getResponses()) {
+					if (!pendingToolCallIds.remove(response.id())) {
+						return false;
+					}
+				}
+				waitingForAssistantAfterTool = pendingToolCallIds.isEmpty();
+			}
+			else if (!pendingToolCallIds.isEmpty() || waitingForAssistantAfterTool) {
+				return false;
+			}
+		}
+		return pendingToolCallIds.isEmpty() && !waitingForAssistantAfterTool;
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CheckpointRollbackConsistencyTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CheckpointRollbackConsistencyTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CheckpointRollbackConsistencyTest {
+
+	@Test
+	void newUserInputShouldRollbackToLatestSafeCheckpointWhenLatestEndsWithToolResponse() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph graph = buildContinuationGraph(saver, new AtomicBoolean(false),
+				List.of("user", "assistant", "user"));
+		RunnableConfig config = RunnableConfig.builder().threadId("rollback-safe-checkpoint-thread").build();
+
+		saver.put(config, Checkpoint.builder().nodeId("stable").nextNodeId(END).state(stableState()).build());
+		saver.put(config, Checkpoint.builder()
+			.nodeId("tool_node")
+			.nextNodeId("streaming_model")
+			.state(incompleteToolResponseState())
+			.build());
+
+		@SuppressWarnings("unchecked")
+		List<Message> nextTurnMessages = (List<Message>) graph
+			.getInitialState(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+			.get("messages");
+
+		assertEquals(List.of("user", "assistant", "user"),
+				toOpenAiMessages(nextTurnMessages).stream().map(message -> (String) message.get("role")).toList());
+		assertFalse(nextTurnMessages.stream().anyMatch(ToolResponseMessage.class::isInstance),
+				"next user input must not be appended after an incomplete tool response checkpoint");
+		assertEquals("please continue", nextTurnMessages.get(nextTurnMessages.size() - 1).getText());
+	}
+
+	@Test
+	void nextTurnAfterToolCancellationShouldInvokeModelWithOpenAiCompatibleMessages() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph cancelledGraph = buildToolThenModelGraph(saver, Flux.just(chatResponse("done")));
+		RunnableConfig config = RunnableConfig.builder().threadId("rollback-after-tool-cancel-thread").build();
+
+		List<NodeOutput> observed = cancelledGraph.stream(initialMessages(), config)
+			.takeUntil(output -> "tool_node".equals(output.node()))
+			.collectList()
+			.block(Duration.ofSeconds(5));
+
+		assertNotNull(observed, "stream should emit the tool node before cancellation");
+		assertTrue(observed.stream().anyMatch(output -> "tool_node".equals(output.node())),
+				"test should cancel after the tool response checkpoint is written");
+
+		AtomicBoolean openAiPayloadVerified = new AtomicBoolean(false);
+		CompiledGraph continuationGraph = buildContinuationGraph(saver, openAiPayloadVerified, List.of("user"));
+
+		List<NodeOutput> outputs = continuationGraph
+			.stream(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+
+		assertNotNull(outputs);
+		assertTrue(openAiPayloadVerified.get(), "next model call should receive OpenAI-compatible messages");
+		List<?> checkpointMessages = checkpointMessages(continuationGraph, config);
+		Object lastMessage = checkpointMessages.get(checkpointMessages.size() - 1);
+		assertInstanceOf(AssistantMessage.class, lastMessage);
+		assertEquals("continued", ((AssistantMessage) lastMessage).getText());
+	}
+
+	@Test
+	void nextTurnAfterStreamTimeoutShouldInvokeModelWithOpenAiCompatibleMessages() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		CompiledGraph timeoutGraph = buildToolThenModelGraph(saver,
+				Flux.concat(Flux.just(chatResponse("partial")), Flux.just(chatResponse(" done"))
+					.delayElements(Duration.ofMillis(200))));
+		RunnableConfig config = RunnableConfig.builder().threadId("rollback-after-stream-timeout-thread").build();
+
+		RuntimeException error = assertThrows(RuntimeException.class,
+				() -> timeoutAfterStreamingModelStarts(timeoutGraph.stream(initialMessages(), config))
+					.collectList()
+					.block(Duration.ofSeconds(5)));
+		assertTrue(hasCause(error, TimeoutException.class), "test should first reproduce timeout cancellation");
+
+		AtomicBoolean openAiPayloadVerified = new AtomicBoolean(false);
+		CompiledGraph continuationGraph = buildContinuationGraph(saver, openAiPayloadVerified, List.of("user"));
+
+		List<NodeOutput> outputs = continuationGraph
+			.stream(Map.of("messages", List.of(new UserMessage("please continue"))), config)
+			.collectList()
+			.block(Duration.ofSeconds(5));
+
+		assertNotNull(outputs);
+		assertTrue(openAiPayloadVerified.get(), "next model call after timeout should receive OpenAI-compatible messages");
+	}
+
+	private static CompiledGraph buildToolThenModelGraph(MemorySaver saver, Flux<ChatResponse> modelStream)
+			throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("tool_node", node_async(state -> Map.of("messages", toolResponse())))
+			.addNode("streaming_model",
+					node_async(state -> Map.of("messages", modelStream)))
+			.addEdge(START, "tool_node")
+			.addEdge("tool_node", "streaming_model")
+			.addEdge("streaming_model", END);
+
+		return stateGraph.compile(CompileConfig.builder()
+			.saverConfig(SaverConfig.builder().register(saver).build())
+			.build());
+	}
+
+	private static CompiledGraph buildContinuationGraph(MemorySaver saver, AtomicBoolean openAiPayloadVerified,
+			List<String> expectedRoles) throws Exception {
+		StateGraph stateGraph = new StateGraph(() -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("messages", new AppendStrategy());
+			return strategies;
+		}).addNode("streaming_model", node_async(state -> {
+			@SuppressWarnings("unchecked")
+			List<Message> messages = (List<Message>) state.value("messages").orElseThrow();
+			ChatModel chatModel = verifyingOpenAiPayloadChatModel(openAiPayloadVerified, expectedRoles);
+			return Map.of("messages", chatModel.stream(new Prompt(messages)));
+		})).addEdge(START, "streaming_model").addEdge("streaming_model", END);
+
+		return stateGraph.compile(CompileConfig.builder()
+			.saverConfig(SaverConfig.builder().register(saver).build())
+			.build());
+	}
+
+	private static ChatModel verifyingOpenAiPayloadChatModel(AtomicBoolean verified, List<String> expectedRoles) {
+		return new ChatModel() {
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				return new ChatResponse(List.of(new Generation(new AssistantMessage("continued"))));
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				List<Map<String, Object>> openAiMessages = toOpenAiMessages(prompt.getInstructions());
+				assertOpenAiToolMessageOrder(openAiMessages);
+				assertEquals(expectedRoles, openAiMessages.stream()
+					.map(message -> (String) message.get("role"))
+					.toList());
+				assertEquals("please continue", openAiMessages.get(openAiMessages.size() - 1).get("content"));
+				verified.set(true);
+				return Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("continued")))));
+			}
+		};
+	}
+
+	private static Map<String, Object> initialMessages() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		List<Message> messages = List.of(
+				new UserMessage("search first"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build());
+		return Map.of(OverAllState.DEFAULT_INPUT_KEY, "search first", "messages", messages);
+	}
+
+	private static Map<String, Object> stableState() {
+		return Map.of("messages", List.of(new UserMessage("hello"), new AssistantMessage("previous answer")));
+	}
+
+	private static Map<String, Object> incompleteToolResponseState() {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		return Map.of("messages", List.of(
+				new UserMessage("hello"),
+				new AssistantMessage("previous answer"),
+				new UserMessage("search"),
+				AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build(),
+				toolResponse()));
+	}
+
+	private static ToolResponseMessage toolResponse() {
+		return ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", "ok")))
+			.build();
+	}
+
+	private static ChatResponse chatResponse(String text) {
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(text))));
+	}
+
+	private static List<?> checkpointMessages(CompiledGraph compiledGraph, RunnableConfig config) {
+		return compiledGraph.stateOf(config)
+			.flatMap(state -> state.state().value("messages"))
+			.filter(List.class::isInstance)
+			.map(List.class::cast)
+			.orElse(List.of());
+	}
+
+	private static List<Map<String, Object>> toOpenAiMessages(List<Message> messages) {
+		List<Map<String, Object>> openAiMessages = new ArrayList<>();
+		for (Message message : messages) {
+			if (message instanceof UserMessage userMessage) {
+				openAiMessages.add(Map.of("role", "user", "content", userMessage.getText()));
+			}
+			else if (message instanceof AssistantMessage assistantMessage) {
+				Map<String, Object> openAiMessage = new HashMap<>();
+				openAiMessage.put("role", "assistant");
+				openAiMessage.put("content", assistantMessage.getText());
+				if (assistantMessage.hasToolCalls()) {
+					openAiMessage.put("tool_calls", assistantMessage.getToolCalls()
+						.stream()
+						.map(toolCall -> Map.of("id", toolCall.id(), "type", toolCall.type(), "function",
+								Map.of("name", toolCall.name(), "arguments", toolCall.arguments())))
+						.toList());
+				}
+				openAiMessages.add(openAiMessage);
+			}
+			else if (message instanceof ToolResponseMessage toolResponseMessage) {
+				for (ToolResponseMessage.ToolResponse response : toolResponseMessage.getResponses()) {
+					openAiMessages.add(Map.of("role", "tool", "tool_call_id", response.id(), "content",
+							response.responseData()));
+				}
+			}
+		}
+		return openAiMessages;
+	}
+
+	private static Flux<NodeOutput> timeoutAfterStreamingModelStarts(Flux<NodeOutput> stream) {
+		return stream.timeout(Mono.delay(Duration.ofSeconds(1)), output -> "streaming_model".equals(output.node())
+				? Mono.delay(Duration.ofMillis(25)) : Mono.delay(Duration.ofSeconds(1)));
+	}
+
+	private static boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
+		Throwable current = throwable;
+		while (current != null) {
+			if (causeType.isInstance(current)) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void assertOpenAiToolMessageOrder(List<Map<String, Object>> messages) {
+		Set<String> pendingToolCallIds = new HashSet<>();
+		boolean waitingForAssistantAfterTool = false;
+		for (Map<String, Object> message : messages) {
+			String role = (String) message.get("role");
+			if ("assistant".equals(role)) {
+				assertTrue(pendingToolCallIds.isEmpty(), "assistant cannot appear before all tool calls are answered");
+				waitingForAssistantAfterTool = false;
+				Object toolCalls = message.get("tool_calls");
+				if (toolCalls instanceof List<?> calls) {
+					for (Object call : calls) {
+						pendingToolCallIds.add((String) ((Map<String, Object>) call).get("id"));
+					}
+				}
+			}
+			else if ("tool".equals(role)) {
+				assertFalse(pendingToolCallIds.isEmpty(), "tool message must follow assistant tool calls");
+				assertTrue(pendingToolCallIds.remove(message.get("tool_call_id")),
+						"tool message must reference a pending assistant tool call");
+				waitingForAssistantAfterTool = pendingToolCallIds.isEmpty();
+			}
+			else {
+				assertTrue(pendingToolCallIds.isEmpty() && !waitingForAssistantAfterTool,
+						role + " message cannot follow an unfinished tool response sequence");
+			}
+		}
+		assertTrue(pendingToolCallIds.isEmpty(), "all assistant tool calls must have tool responses");
+		assertFalse(waitingForAssistantAfterTool, "tool response must be followed by assistant before new user input");
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/utils/MessageSequenceValidatorTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/utils/MessageSequenceValidatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.graph.utils;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessageSequenceValidatorTest {
+
+	@Test
+	void shouldAcceptHistoryClosedByFinalAssistantMessage() {
+		assertTrue(MessageSequenceValidator.isCheckpointReadyForNewInput(state(List.of(
+				new UserMessage("search"),
+				assistantToolCall("call_1"),
+				toolResponse("call_1"),
+				new AssistantMessage("answer")))));
+	}
+
+	@Test
+	void shouldRejectAssistantToolCallWithoutToolResponse() {
+		assertFalse(MessageSequenceValidator.isCheckpointReadyForNewInput(state(List.of(
+				new UserMessage("search"),
+				assistantToolCall("call_1")))));
+	}
+
+	@Test
+	void shouldRejectToolResponseWithoutFinalAssistantMessage() {
+		assertFalse(MessageSequenceValidator.isCheckpointReadyForNewInput(state(List.of(
+				new UserMessage("search"),
+				assistantToolCall("call_1"),
+				toolResponse("call_1")))));
+	}
+
+	@Test
+	void shouldRejectPartialToolResponsesForMultipleToolCalls() {
+		AssistantMessage.ToolCall first = new AssistantMessage.ToolCall("call_1", "function", "search", "{}");
+		AssistantMessage.ToolCall second = new AssistantMessage.ToolCall("call_2", "function", "lookup", "{}");
+
+		assertFalse(MessageSequenceValidator.isCheckpointReadyForNewInput(state(List.of(
+				new UserMessage("search"),
+				AssistantMessage.builder().content("").toolCalls(List.of(first, second)).build(),
+				toolResponse("call_1")))));
+	}
+
+	private static Map<String, Object> state(List<Message> messages) {
+		return Map.of("messages", messages);
+	}
+
+	private static AssistantMessage assistantToolCall(String id) {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall(id, "function", "search", "{}");
+		return AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build();
+	}
+
+	private static ToolResponseMessage toolResponse(String id) {
+		return ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse(id, "search", "ok")))
+			.build();
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes #4789.

When a graph stream is cancelled or times out after a tool node has already persisted `ToolResponseMessage`, the following streaming model node may never persist the final `AssistantMessage`. The next user turn can then load an incomplete checkpoint and build an invalid message sequence such as:

```text
assistant(tool_calls) -> tool -> user
```

That sequence is not accepted by OpenAI/DashScope-compatible chat APIs and can make the next model request fail.

This PR replaces #4790 with a smaller rollback-oriented fix. The previous background-continuation approach tried to keep the cancelled run alive internally, but that introduced extra concurrency risks between an old background run and a newer turn on the same thread. This PR keeps normal Reactor cancellation semantics and instead makes the next turn recover from the latest safe checkpoint.

### Does this pull request fix one issue?

Fixes #4789

### Describe how you did it

This PR adds a checkpoint message-sequence validator and uses it when `CompiledGraph.getInitialState(...)` loads checkpoint state for a new user input.

If the latest checkpoint contains an incomplete tool-call sequence, the graph skips it and rolls back to the nearest earlier checkpoint whose `messages` history can safely accept another user message.

The validator rejects persisted histories such as:

- assistant tool calls without matching tool responses;
- partial tool responses for multiple tool calls;
- tool responses not followed by a final assistant message;
- `tool -> user` continuation.

It accepts histories where the tool-call chain has been closed by a final assistant message.

This PR does not rewrite checkpoint records, delete checkpoint records, fabricate a placeholder assistant message, or keep cancelled graph executions running in the background. It only changes which checkpoint is selected as the base state for the next user input.

### Why rollback instead of background continuation

A background-continuation approach can preserve the cancelled turn's final assistant output when it eventually completes, but it also creates a race: the old cancelled run may keep appending checkpoints while the user immediately sends the next message on the same thread. That requires additional lineage guards around checkpoint writes and `releaseThread(true)`, and still leaves backend-level CAS/distributed-locking concerns for multi-instance deployments.

The rollback approach is more conservative for this issue:

- downstream timeout/cancellation still aborts the current run;
- incomplete checkpoints can remain in storage for history/debugging;
- the next user turn never resumes from an unsafe tool-response checkpoint;
- no detached subscription or background writer is introduced.

### Describe how to verify it

I verified this PR with:

```bash
mvn -pl spring-ai-alibaba-graph-core -Dtest=CheckpointRollbackConsistencyTest,MessageSequenceValidatorTest,GraphRunnerContextResumeMessageOrderTest,StreamFunctionCallTest test
mvn -pl spring-ai-alibaba-graph-core checkstyle:check
mvn -pl spring-ai-alibaba-graph-core spotless:check
git diff --check
```

Latest local result:

```text
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
You have 0 Checkstyle violations.
spotless:check: 0 needs changes
git diff --check: no whitespace errors
```

Regression coverage includes:

- latest checkpoint ending with `ToolResponseMessage` rolls back to the previous safe checkpoint;
- cancellation after a tool node writes its checkpoint, followed by the next user turn;
- timeout after the streaming model node starts, followed by the next user turn;
- next model call receives OpenAI-compatible message ordering;
- validator rejects unclosed assistant tool calls, partial tool responses, and `tool` histories without a final assistant;
- validator accepts a fully closed `assistant(tool_calls) -> tool -> assistant` chain;
- existing resume message ordering still passes;
- existing streaming tool-call merge behavior still passes.
