### PR TITLE
fix(agent): preserve Gemini thought signatures

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
@@ -52,7 +52,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,6 +68,10 @@ import static com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver.THREAD_I
 public class AgentLlmNode implements NodeActionWithConfig {
 	private static final Logger logger = LoggerFactory.getLogger(AgentLlmNode.class);
 	public static final String MODEL_ITERATION_KEY = "_MODEL_ITERATION_";
+
+	private static final String THOUGHT_SIGNATURES_METADATA_KEY = "thoughtSignatures";
+
+	private static final String BINARY_METADATA_DATA_FIELD = "data";
 
 	private String agentName;
 
@@ -172,6 +178,7 @@ public class AgentLlmNode implements NodeActionWithConfig {
 			messages = (List<Message>) state.value("messages").get();
 		}
 
+		messages = restoreThoughtSignatures(messages);
 		augmentUserMessage(messages, outputSchema);
 		renderTemplatedUserMessage(messages, state.data(), config.metadata());
 
@@ -537,7 +544,92 @@ public class AgentLlmNode implements NodeActionWithConfig {
 			}
         }
 
-        return promptSpec;
+		return promptSpec;
+	}
+
+	private List<Message> restoreThoughtSignatures(List<Message> messages) {
+		if (messages == null || messages.isEmpty()) {
+			return messages;
+		}
+
+		List<Message> restoredMessages = new ArrayList<>(messages.size());
+		boolean changed = false;
+		for (Message message : messages) {
+			Message restoredMessage = restoreAssistantThoughtSignatures(message);
+			restoredMessages.add(restoredMessage);
+			changed = changed || restoredMessage != message;
+		}
+		return changed ? restoredMessages : messages;
+	}
+
+	private Message restoreAssistantThoughtSignatures(Message message) {
+		if (!(message instanceof AssistantMessage assistantMessage)) {
+			return message;
+		}
+		if (message.getClass() != AssistantMessage.class) {
+			return message;
+		}
+		Map<String, Object> metadata = assistantMessage.getMetadata();
+		if (metadata == null || metadata.isEmpty()) {
+			return message;
+		}
+
+		Object thoughtSignatures = metadata.get(THOUGHT_SIGNATURES_METADATA_KEY);
+		Object restoredThoughtSignatures = restoreThoughtSignatureList(thoughtSignatures);
+		if (restoredThoughtSignatures == thoughtSignatures) {
+			return message;
+		}
+
+		Map<String, Object> restoredMetadata = new LinkedHashMap<>(metadata);
+		restoredMetadata.put(THOUGHT_SIGNATURES_METADATA_KEY, restoredThoughtSignatures);
+		return AssistantMessage.builder()
+			.content(assistantMessage.getText())
+			.properties(restoredMetadata)
+			.toolCalls(assistantMessage.getToolCalls())
+			.media(assistantMessage.getMedia())
+			.build();
+	}
+
+	private Object restoreThoughtSignatureList(Object value) {
+		if (!(value instanceof List<?> signatures)) {
+			return value;
+		}
+
+		List<Object> restoredSignatures = new ArrayList<>(signatures.size());
+		boolean changed = false;
+		for (Object signature : signatures) {
+			Object restoredSignature = restoreThoughtSignature(signature);
+			restoredSignatures.add(restoredSignature);
+			changed = changed || restoredSignature != signature;
+		}
+		return changed ? restoredSignatures : value;
+	}
+
+	private Object restoreThoughtSignature(Object value) {
+		if (value instanceof byte[]) {
+			return value;
+		}
+		if (value instanceof Map<?, ?> map) {
+			byte[] bytes = byteArrayFromNumbers(map.get(BINARY_METADATA_DATA_FIELD));
+			return bytes != null ? bytes : value;
+		}
+		byte[] bytes = byteArrayFromNumbers(value);
+		return bytes != null ? bytes : value;
+	}
+
+	private byte[] byteArrayFromNumbers(Object value) {
+		if (!(value instanceof Collection<?> numbers)) {
+			return null;
+		}
+		byte[] bytes = new byte[numbers.size()];
+		int index = 0;
+		for (Object item : numbers) {
+			if (!(item instanceof Number number)) {
+				return null;
+			}
+			bytes[index++] = number.byteValue();
+		}
+		return bytes;
 	}
 
 	public String getName() {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentThoughtSignatureStateTransferTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/ReactAgentThoughtSignatureStateTransferTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.deepseek.DeepSeekAssistantMessage;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReactAgentThoughtSignatureStateTransferTest {
+
+	private static final String THOUGHT_SIGNATURES_KEY = "thoughtSignatures";
+
+	@ParameterizedTest
+	@ValueSource(booleans = { false, true })
+	void shouldPreserveThoughtSignaturesAcrossToolRoundWithMemorySaver(boolean parallelToolExecution) throws Exception {
+		List<byte[]> signatures = List.of(new byte[] { 21, 22, 23, 24 }, new byte[] { 31, 32, 33, 34 });
+		SignatureAwareChatModel chatModel = new SignatureAwareChatModel(signatures);
+		RunnableConfig config = RunnableConfig.builder()
+			.threadId("thought-signature-thread-" + parallelToolExecution)
+			.build();
+		ReactAgent agent = ReactAgent.builder()
+			.name("thought_signature_agent")
+			.model(chatModel)
+			.tools(tool("read_skill", "skill-content"), tool("search_skill", "search-content"))
+			.parallelToolExecution(parallelToolExecution)
+			.saver(new MemorySaver())
+			.build();
+
+		AssistantMessage firstResult = agent.call("Read the skill before answering.", config);
+		AssistantMessage secondResult = agent.call("Continue with the saved context.", config);
+
+		assertEquals("done", firstResult.getText());
+		assertEquals("continued", secondResult.getText());
+		assertEquals(3, chatModel.callCount());
+		assertTrue(chatModel.toolRoundPromptValidated(),
+				"The prompt after tool execution should include the preserved assistant thought signature");
+		assertTrue(chatModel.resumedPromptValidated(),
+				"The resumed model prompt should include the preserved assistant thought signature");
+	}
+
+	@Test
+	void shouldNotDowngradeAssistantMessageSubclassesWhenRestoringThoughtSignatures() throws Exception {
+		SubclassAwareChatModel chatModel = new SubclassAwareChatModel();
+		DeepSeekAssistantMessage assistantMessage = new DeepSeekAssistantMessage.Builder()
+			.content("Need reasoning")
+			.reasoningContent("reasoning-content")
+			.properties(Map.of(THOUGHT_SIGNATURES_KEY, List.of(Map.of("data", List.of(1, 2, 3)))))
+			.build();
+		ReactAgent agent = ReactAgent.builder().name("thought_signature_subclass_agent").model(chatModel).build();
+
+		AssistantMessage result = agent.call(
+				List.of(new UserMessage("Start"), assistantMessage, new UserMessage("Continue")));
+
+		assertEquals("ok", result.getText());
+		assertTrue(chatModel.promptValidated(),
+				"The prompt should keep provider-specific assistant message subclasses untouched");
+	}
+
+	private static ToolCallback tool(String name, String result) {
+		return new ToolCallback() {
+			@Override
+			public ToolDefinition getToolDefinition() {
+				return ToolDefinition.builder()
+					.name(name)
+					.description("Test tool")
+					.inputSchema("{}")
+					.build();
+			}
+
+			@Override
+			public String call(String toolInput, ToolContext toolContext) {
+				return result;
+			}
+
+			@Override
+			public String call(String toolInput) {
+				return call(toolInput, new ToolContext(Map.of()));
+			}
+		};
+	}
+
+	private static final class SignatureAwareChatModel implements ChatModel {
+
+		private final List<byte[]> expectedSignatures;
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		private final AtomicBoolean toolRoundPromptValidated = new AtomicBoolean();
+
+		private final AtomicBoolean resumedPromptValidated = new AtomicBoolean();
+
+		private SignatureAwareChatModel(List<byte[]> expectedSignatures) {
+			this.expectedSignatures = expectedSignatures;
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int currentCall = callCount.incrementAndGet();
+			if (currentCall == 1) {
+				return response(toolCallMessage());
+			}
+			if (currentCall == 2) {
+				assertThoughtSignaturePreserved(prompt);
+				toolRoundPromptValidated.set(true);
+				return response(new AssistantMessage("done"));
+			}
+			if (currentCall == 3) {
+				assertThoughtSignaturePreserved(prompt);
+				resumedPromptValidated.set(true);
+				return response(new AssistantMessage("continued"));
+			}
+			throw new AssertionError("Unexpected model call count: " + currentCall);
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		private int callCount() {
+			return callCount.get();
+		}
+
+		private boolean toolRoundPromptValidated() {
+			return toolRoundPromptValidated.get();
+		}
+
+		private boolean resumedPromptValidated() {
+			return resumedPromptValidated.get();
+		}
+
+		private AssistantMessage toolCallMessage() {
+			AssistantMessage.ToolCall readSkillCall = new AssistantMessage.ToolCall("call-1", "function", "read_skill",
+					"{\"input\":\"x\"}");
+			AssistantMessage.ToolCall searchSkillCall = new AssistantMessage.ToolCall("call-2", "function",
+					"search_skill",
+					"{\"input\":\"x\"}");
+			return AssistantMessage.builder()
+				.content("")
+				.toolCalls(List.of(readSkillCall, searchSkillCall))
+				.properties(Map.of(THOUGHT_SIGNATURES_KEY, expectedSignatures))
+				.build();
+		}
+
+		private void assertThoughtSignaturePreserved(Prompt prompt) {
+			List<Message> instructions = prompt.getInstructions();
+			AssistantMessage assistantMessage = instructions.stream()
+				.filter(AssistantMessage.class::isInstance)
+				.map(AssistantMessage.class::cast)
+				.filter(AssistantMessage::hasToolCalls)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Tool-calling assistant message was not found"));
+			assertTrue(instructions.stream().anyMatch(ToolResponseMessage.class::isInstance),
+					"Tool response should be present before the second model call");
+			ToolResponseMessage toolResponseMessage = instructions.stream()
+				.filter(ToolResponseMessage.class::isInstance)
+				.map(ToolResponseMessage.class::cast)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("Tool response message was not found"));
+			assertEquals(2, toolResponseMessage.getResponses().size());
+
+			Object signaturesValue = assistantMessage.getMetadata().get(THOUGHT_SIGNATURES_KEY);
+			List<?> signatures = assertInstanceOf(List.class, signaturesValue);
+			assertEquals(expectedSignatures.size(), signatures.size());
+			for (int i = 0; i < expectedSignatures.size(); i++) {
+				byte[] signature = assertInstanceOf(byte[].class, signatures.get(i));
+				assertArrayEquals(expectedSignatures.get(i), signature);
+			}
+		}
+
+		private ChatResponse response(AssistantMessage message) {
+			return new ChatResponse(List.of(new Generation(message)));
+		}
+
+	}
+
+	private static final class SubclassAwareChatModel implements ChatModel {
+
+		private final AtomicBoolean promptValidated = new AtomicBoolean();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			DeepSeekAssistantMessage assistantMessage = prompt.getInstructions()
+				.stream()
+				.filter(DeepSeekAssistantMessage.class::isInstance)
+				.map(DeepSeekAssistantMessage.class::cast)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("DeepSeek assistant message was not found"));
+
+			assertEquals("reasoning-content", assistantMessage.getReasoningContent());
+			Object signaturesValue = assistantMessage.getMetadata().get(THOUGHT_SIGNATURES_KEY);
+			List<?> signatures = assertInstanceOf(List.class, signaturesValue);
+			assertInstanceOf(Map.class, signatures.get(0));
+			promptValidated.set(true);
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("ok"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		private boolean promptValidated() {
+			return promptValidated.get();
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/SerializationHelper.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/SerializationHelper.java
@@ -16,6 +16,9 @@
 package com.alibaba.cloud.ai.graph.serializer.plain_text.jackson;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -27,6 +30,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 class SerializationHelper {
 
 	static final String METADATA_FIELD = "metadata";
+
+	private static final String THOUGHT_SIGNATURES_METADATA_KEY = "thoughtSignatures";
 
 	static Map<String, Object> deserializeMetadata(ObjectMapper mapper, JsonNode parentNode)
 			throws JsonProcessingException {
@@ -42,12 +47,113 @@ class SerializationHelper {
 		if (!node.isObject()) {
 			throw new IllegalStateException("Metadata must be an object");
 		}
-		return mapper.treeToValue(node, new TypeReference<>() {
+		Map<String, Object> metadata = mapper.treeToValue(node, new TypeReference<>() {
 		});
+		return restoreThoughtSignatures(metadata);
 	}
 
 	static void serializeMetadata(JsonGenerator gen, Map<String, Object> metadata) throws IOException {
-		gen.writeObjectField(METADATA_FIELD, metadata);
+		gen.writeObjectField(METADATA_FIELD, normalizeThoughtSignatures(metadata));
+	}
+
+	private static Map<String, Object> normalizeThoughtSignatures(Map<String, Object> metadata) {
+		if (metadata == null || metadata.isEmpty()) {
+			return metadata;
+		}
+		Object thoughtSignatures = metadata.get(THOUGHT_SIGNATURES_METADATA_KEY);
+		Object normalizedThoughtSignatures = normalizeThoughtSignatureList(thoughtSignatures);
+		if (normalizedThoughtSignatures == thoughtSignatures) {
+			return metadata;
+		}
+		Map<String, Object> normalized = new LinkedHashMap<>(metadata);
+		normalized.put(THOUGHT_SIGNATURES_METADATA_KEY, normalizedThoughtSignatures);
+		return normalized;
+	}
+
+	private static Object normalizeThoughtSignatureList(Object value) {
+		if (!(value instanceof List<?> signatures)) {
+			return value;
+		}
+
+		List<Object> normalized = new ArrayList<>(signatures.size());
+		boolean changed = false;
+		for (Object signature : signatures) {
+			Object normalizedSignature = normalizeThoughtSignature(signature);
+			normalized.add(normalizedSignature);
+			changed = changed || normalizedSignature != signature;
+		}
+		return changed ? normalized : value;
+	}
+
+	private static Object normalizeThoughtSignature(Object value) {
+		return (value instanceof byte[] bytes) ? new BinaryMetadata(bytes) : value;
+	}
+
+	private static Map<String, Object> restoreThoughtSignatures(Map<String, Object> metadata) {
+		if (metadata == null || metadata.isEmpty()) {
+			return metadata;
+		}
+		Object thoughtSignatures = metadata.get(THOUGHT_SIGNATURES_METADATA_KEY);
+		Object restoredThoughtSignatures = restoreThoughtSignatureList(thoughtSignatures);
+		if (restoredThoughtSignatures == thoughtSignatures) {
+			return metadata;
+		}
+		Map<String, Object> restored = new LinkedHashMap<>(metadata);
+		restored.put(THOUGHT_SIGNATURES_METADATA_KEY, restoredThoughtSignatures);
+		return restored;
+	}
+
+	private static Object restoreThoughtSignatureList(Object value) {
+		if (!(value instanceof List<?> signatures)) {
+			return value;
+		}
+
+		List<Object> restored = new ArrayList<>(signatures.size());
+		boolean changed = false;
+		for (Object signature : signatures) {
+			Object restoredSignature = restoreThoughtSignature(signature);
+			restored.add(restoredSignature);
+			changed = changed || restoredSignature != signature;
+		}
+		return changed ? restored : value;
+	}
+
+	private static Object restoreThoughtSignature(Object value) {
+		return (value instanceof BinaryMetadata binaryMetadata) ? binaryMetadata.toByteArray() : value;
+	}
+
+	public static class BinaryMetadata {
+
+		private List<Integer> data;
+
+		@SuppressWarnings("unused")
+		public BinaryMetadata() {
+		}
+
+		BinaryMetadata(byte[] bytes) {
+			this.data = new ArrayList<>(bytes.length);
+			for (byte item : bytes) {
+				this.data.add((int) item);
+			}
+		}
+
+		public List<Integer> getData() {
+			return data;
+		}
+
+		@SuppressWarnings("unused")
+		public void setData(List<Integer> data) {
+			this.data = data;
+		}
+
+		private byte[] toByteArray() {
+			byte[] bytes = new byte[data.size()];
+			for (int i = 0; i < data.size(); i++) {
+				bytes[i] = data.get(i).byteValue();
+			}
+			return bytes;
+		}
+
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/SpringAIJacksonStateSerializerTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/SpringAIJacksonStateSerializerTest.java
@@ -16,6 +16,8 @@
 package com.alibaba.cloud.ai.graph.plain_text;
 
 import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
+import com.alibaba.cloud.ai.graph.serializer.check_point.CheckPointSerializer;
 import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
 import com.alibaba.cloud.ai.graph.state.AgentStateFactory;
 
@@ -38,6 +40,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -128,6 +131,72 @@ class SpringAIJacksonStateSerializerTest {
 		assertEquals(original.getText(), deserialized.getText());
 		assertEquals(original.getMetadata(), deserialized.getMetadata());
 		assertEquals(MessageType.ASSISTANT, deserialized.getMessageType());
+	}
+
+	@Test
+	void shouldPreserveAssistantMessageBinaryListMetadata() throws Exception {
+		byte[] signature = new byte[] { 1, -2, 127, -128 };
+		AssistantMessage original = AssistantMessage.builder()
+			.content("Use tool")
+			.properties(Map.of("thoughtSignatures", List.of(signature)))
+			.build();
+
+		AssistantMessage deserialized = serializeAndDeserialize(original);
+
+		assertNotNull(deserialized);
+		@SuppressWarnings("unchecked")
+		List<byte[]> signatures = (List<byte[]>) deserialized.getMetadata().get("thoughtSignatures");
+		assertEquals(1, signatures.size());
+		assertArrayEquals(signature, signatures.get(0));
+	}
+
+	@Test
+	void shouldPreserveAssistantMessageBinaryListMetadataWhenCloningState() throws Exception {
+		byte[] signature = new byte[] { 5, 6, 7, 8 };
+		AssistantMessage original = AssistantMessage.builder()
+			.content("Call tool")
+			.properties(Map.of("thoughtSignatures", List.of(signature)))
+			.build();
+
+		OverAllState cloned = serializer.cloneObject(Map.of("messages", List.of(original)));
+
+		@SuppressWarnings("unchecked")
+		List<AssistantMessage> messages = (List<AssistantMessage>) cloned.data().get("messages");
+		@SuppressWarnings("unchecked")
+		List<byte[]> signatures = (List<byte[]>) messages.get(0).getMetadata().get("thoughtSignatures");
+		assertEquals(1, signatures.size());
+		assertArrayEquals(signature, signatures.get(0));
+	}
+
+	@Test
+	void shouldPreserveAssistantMessageBinaryListMetadataInCheckpoint() throws Exception {
+		byte[] signature = new byte[] { 13, 14, 15, 16 };
+		AssistantMessage original = AssistantMessage.builder()
+			.content("Call tool")
+			.properties(Map.of("thoughtSignatures", List.of(signature)))
+			.build();
+		Checkpoint checkpoint = Checkpoint.builder()
+			.id("checkpoint-1")
+			.nodeId("model")
+			.nextNodeId("tool")
+			.state(Map.of("messages", List.of(original)))
+			.build();
+		CheckPointSerializer checkpointSerializer = new CheckPointSerializer(serializer);
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream out = new ObjectOutputStream(baos);
+		checkpointSerializer.write(checkpoint, out);
+		out.flush();
+
+		ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+		Checkpoint deserialized = checkpointSerializer.read(in);
+
+		@SuppressWarnings("unchecked")
+		List<AssistantMessage> messages = (List<AssistantMessage>) deserialized.getState().get("messages");
+		@SuppressWarnings("unchecked")
+		List<byte[]> signatures = (List<byte[]>) messages.get(0).getMetadata().get("thoughtSignatures");
+		assertEquals(1, signatures.size());
+		assertArrayEquals(signature, signatures.get(0));
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

Gemini thought signatures are stored by Spring AI Google GenAI as `AssistantMessage.metadata[thoughtSignatures]` with `List<byte[]>` values.

During graph state clone / checkpoint round trips, those binary signature values can be degraded into generic map/list structures. After a tool round, the next model call may then receive an assistant tool-call message without real `byte[]` thought signatures, which breaks the Google GenAI adapter contract and can lead to Gemini 3.x `missing thought_signature` errors.

This PR keeps the fix intentionally narrow to Gemini thought signatures.

### Does this pull request fix one issue?

Fixes #4742

### Describe how you did it

- Normalize only `metadata[thoughtSignatures]` during Spring AI message metadata serialization.
- Restore those signatures back to `byte[]` during metadata deserialization.
- Add a model-call boundary restore in `AgentLlmNode` for plain `AssistantMessage` instances, so ReactAgent tool rounds recover signatures before the next model call.
- Avoid rebuilding provider-specific assistant subclasses such as `DeepSeekAssistantMessage`, so reasoning-specific fields are not lost.
- Do not introduce a general-purpose metadata codec or broader Map/Collection type-preservation behavior.

### Describe how to verify it

Ran locally:

- `./mvnw -pl spring-ai-alibaba-agent-framework -am -Dtest=ReactAgentThoughtSignatureStateTransferTest -DfailIfNoTests=false test`
  - Covers MemorySaver, sequential tool execution, parallel tool execution, resumed prompt, and subclass preservation.
- `./mvnw -pl spring-ai-alibaba-graph-core -Dtest=com.alibaba.cloud.ai.graph.plain_text.SpringAIJacksonStateSerializerTest#shouldPreserveAssistantMessageBinaryListMetadata+shouldPreserveAssistantMessageBinaryListMetadataWhenCloningState+shouldPreserveAssistantMessageBinaryListMetadataInCheckpoint,com.alibaba.cloud.ai.graph.plain_text.JacksonContainerTypeRecognitionTest,com.alibaba.cloud.ai.graph.plain_text.DeepSeekAssistantMessageSerializationTest test`
- `./mvnw -pl spring-ai-alibaba-graph-core,spring-ai-alibaba-agent-framework checkstyle:check spotless:check`
- `git diff --check`