### PR TITLE
fix: honor RetryConfig enable in HttpNode

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/HttpNode.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/HttpNode.java
@@ -143,8 +143,12 @@ public class HttpNode implements NodeAction {
 			initBody(body, requestSpec, state);
 
 			Mono<ResponseEntity<byte[]>> responseMono = requestSpec
-				.exchangeToMono((ClientResponse resp) -> resp.toEntity(byte[].class))
-				.retryWhen(Retry.backoff(retryConfig.maxRetries, Duration.ofMillis(retryConfig.maxRetryInterval)));
+				.exchangeToMono((ClientResponse resp) -> resp.toEntity(byte[].class));
+			if (retryConfig.isEnable()) {
+				responseMono = responseMono.retryWhen(
+						Retry.backoff(retryConfig.maxRetries,Duration.ofMillis(retryConfig.maxRetryInterval)));
+			}
+
 			ResponseEntity<byte[]> responseEntity = responseMono.block();
 			Map<String, Object> httpResponse = processResponse(responseEntity, state);
 

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/HttpNodeTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/HttpNodeTest.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HttpNodeTest {
 
@@ -279,6 +280,24 @@ public class HttpNodeTest {
 		assertEquals(HttpStatus.OK.value(), messages.get("status"));
 
 		assertEquals(3, mockWebServer.getRequestCount());
+	}
+
+	@Test
+	void testShouldNotRetryWhenRetryDisabled() {
+		mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+		mockWebServer.enqueue(new MockResponse().setBody("OK").setHeader(HttpHeaders.CONTENT_TYPE, "text/plain"));
+
+		String url = mockWebServer.url("/retry-disabled").toString();
+		HttpNode node = HttpNode.builder()
+				.webClient(webClient)
+				.method(HttpMethod.POST)
+				.url(url)
+				.retryConfig(new RetryConfig(3, 100, false))
+				.build();
+
+		assertThrows(Exception.class, () -> node.apply(new OverAllState()));
+
+		assertEquals(1, mockWebServer.getRequestCount());
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it


This PR fixes `HttpNode` retry behavior.

Before this change, `HttpNode` would still retry failed HTTP requests when `RetryConfig.enable` was set to `false`. This could be unexpected, especially for POST/PUT/PATCH requests.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #4797 

### Describe how you did it

I changed `HttpNode` to only apply `retryWhen(....)`  when  `retryConfig.isEnable()` is true'.

I also added a test to make sure retry-disabled requests are only sent once.

### Describe how to verify it
Run it:

```bash
./mvnw.cmd -pl spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes -Dtest=HttpNodeTest test
```

### Special notes for reviews
None.