### PR TITLE
fix(autoconf): correct Nacos partner agents data ID

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosPartnerAgentsInjector.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/main/java/com/alibaba/cloud/ai/agent/nacos/NacosPartnerAgentsInjector.java
@@ -29,15 +29,17 @@ public class NacosPartnerAgentsInjector {
 
 	private static final Logger logger = LoggerFactory.getLogger(NacosPartnerAgentsInjector.class);
 
+	private static final String PARTNER_AGENTS_DATA_ID = "partner-agents.json";
+
 	public static void registry(AgentLlmNode llmNode, AgentToolNode toolNode, NacosOptions nacosOptions, String agentName) {
 
 		try {
 			nacosOptions.getNacosConfigService()
-					.addListener("parterner-agents.json", "ai-agent-" + agentName, new AbstractListener() {
+					.addListener(PARTNER_AGENTS_DATA_ID, "ai-agent-" + agentName, new AbstractListener() {
 						@Override
 						public void receiveConfigInfo(String configInfo) {
 							PartnerAgentsVO partnerAgentsVO = JSON.parseObject(configInfo, PartnerAgentsVO.class);
-							System.out.println(partnerAgentsVO);
+							logger.debug("Received partner agents config: {}", partnerAgentsVO);
 						}
 					});
 		}
@@ -50,7 +52,7 @@ public class NacosPartnerAgentsInjector {
 	public static PartnerAgentsVO getPartnerVO(NacosOptions nacosOptions, String agentName) {
 		try {
 			String config = nacosOptions.getNacosConfigService()
-					.getConfig("parterner-agents.json", "ai-agent-" + agentName, 3000L);
+					.getConfig(PARTNER_AGENTS_DATA_ID, "ai-agent-" + agentName, 3000L);
 			return JSON.parseObject(config, PartnerAgentsVO.class);
 		}
 		catch (NacosException e) {

--- a/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/NacosPartnerAgentsInjectorTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-config-nacos/src/test/java/com/alibaba/cloud/ai/agent/nacos/NacosPartnerAgentsInjectorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.agent.nacos;
+
+import com.alibaba.cloud.ai.agent.nacos.vo.PartnerAgentsVO;
+import com.alibaba.nacos.api.config.listener.Listener;
+import com.alibaba.nacos.client.config.NacosConfigService;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NacosPartnerAgentsInjectorTest {
+
+	@Test
+	void registryShouldListenToPartnerAgentsDataId() throws Exception {
+		NacosConfigService configService = mock(NacosConfigService.class);
+		NacosOptions nacosOptions = mock(NacosOptions.class);
+		when(nacosOptions.getNacosConfigService()).thenReturn(configService);
+
+		NacosPartnerAgentsInjector.registry(null, null, nacosOptions, "demo");
+
+		verify(configService).addListener(eq("partner-agents.json"), eq("ai-agent-demo"), any(Listener.class));
+	}
+
+	@Test
+	void getPartnerVOShouldReadPartnerAgentsDataId() throws Exception {
+		NacosConfigService configService = mock(NacosConfigService.class);
+		NacosOptions nacosOptions = mock(NacosOptions.class);
+		when(nacosOptions.getNacosConfigService()).thenReturn(configService);
+		when(configService.getConfig("partner-agents.json", "ai-agent-demo", 3000L))
+			.thenReturn("{\"agents\":[{\"agentName\":\"partner\"}]}");
+
+		PartnerAgentsVO partnerAgentsVO = NacosPartnerAgentsInjector.getPartnerVO(nacosOptions, "demo");
+
+		assertThat(partnerAgentsVO.getAgents()).hasSize(1);
+		assertThat(partnerAgentsVO.getAgents().get(0).getAgentName()).isEqualTo("partner");
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

The Nacos partner-agent injector subscribed to parterner-agents.json, while the published configuration uses partner-agents.json. This typo prevents partner agent updates from being received. It also replaces direct console output with debug logging.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Use the correct partner-agents.json data ID and verify the subscription and listener behavior with a mocked Nacos ConfigService.

### Describe how to verify it

Run: ./mvnw -B -pl :spring-ai-alibaba-starter-config-nacos -Dtest=NacosPartnerAgentsInjectorTest test

### Special notes for reviews

NONE