### PR TITLE
fix(a2a): handle missing preferred transport

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/registry/nacos/discovery/NacosAgentCardWrapper.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/main/java/com/alibaba/cloud/ai/a2a/registry/nacos/discovery/NacosAgentCardWrapper.java
@@ -19,6 +19,7 @@ package com.alibaba.cloud.ai.a2a.registry.nacos.discovery;
 import com.alibaba.cloud.ai.graph.agent.a2a.AgentCardWrapper;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -53,7 +54,11 @@ public class NacosAgentCardWrapper extends AgentCardWrapper {
 		if (CollectionUtils.isEmpty(getAgentCard().additionalInterfaces())) {
 			return super.url();
 		}
-		List<AgentInterface> agentInterfaces = getAgentCard().additionalInterfaces().stream().filter(agentInterface -> getAgentCard().preferredTransport().equals(agentInterface.transport())).toList();
+		List<AgentInterface> agentInterfaces = getAgentCard().additionalInterfaces()
+			.stream()
+			.filter(agentInterface -> agentInterface != null
+					&& Objects.equals(getAgentCard().preferredTransport(), agentInterface.transport()))
+			.toList();
 		if (CollectionUtils.isEmpty(agentInterfaces)) {
 			return super.url();
 		}

--- a/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/test/java/com/alibaba/cloud/ai/a2a/registry/nacos/discovery/NacosAgentCardWrapperTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-a2a-nacos/src/test/java/com/alibaba/cloud/ai/a2a/registry/nacos/discovery/NacosAgentCardWrapperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.a2a.registry.nacos.discovery;
+
+import java.util.List;
+
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+import io.a2a.spec.AgentInterface;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class NacosAgentCardWrapperTest {
+
+	@Test
+	void urlShouldFallbackToAgentCardUrlWhenPreferredTransportIsMissing() {
+		AgentCard agentCard = createAgentCard(null,
+				List.of(new AgentInterface("JSONRPC", "http://localhost:8081")));
+		NacosAgentCardWrapper wrapper = new NacosAgentCardWrapper(agentCard);
+
+		assertThatNoException().isThrownBy(wrapper::url);
+		assertThat(wrapper.url()).isEqualTo("http://localhost:8080");
+	}
+
+	@Test
+	void urlShouldUseAdditionalInterfaceWithPreferredTransport() {
+		AgentCard agentCard = createAgentCard("JSONRPC",
+				List.of(new AgentInterface("JSONRPC", "http://localhost:8081")));
+		NacosAgentCardWrapper wrapper = new NacosAgentCardWrapper(agentCard);
+
+		assertThat(wrapper.url()).isEqualTo("http://localhost:8081");
+	}
+
+	private AgentCard createAgentCard(String preferredTransport, List<AgentInterface> additionalInterfaces) {
+		return new AgentCard.Builder().name("test-agent")
+			.description("Test Agent")
+			.url("http://localhost:8080")
+			.version("1.0.0")
+			.protocolVersion("0.3.0")
+			.preferredTransport(preferredTransport)
+			.defaultInputModes(List.of("text/plain"))
+			.defaultOutputModes(List.of("text/plain"))
+			.skills(List.of())
+			.capabilities(new AgentCapabilities.Builder().streaming(false).build())
+			.additionalInterfaces(additionalInterfaces)
+			.build();
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

NacosAgentCardWrapper throws a NullPointerException when an agent card omits preferredTransport. Agent cards without a preferred transport should still be able to use their declared additional interfaces.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Use null-safe transport comparison and ignore null additional interface entries while preserving round-robin selection.

### Describe how to verify it

Run: ./mvnw -B -pl :spring-ai-alibaba-starter-a2a-nacos -Dtest=NacosAgentCardWrapperTest test

### Special notes for reviews

NONE