### PR TITLE
fix(agent): parse front matter delimiters by line

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoader.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoader.java
@@ -23,6 +23,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -56,6 +58,8 @@ public final class AgentSpecLoader {
 	private static final Logger logger = LoggerFactory.getLogger(AgentSpecLoader.class);
 
 	private static final Yaml YAML = new Yaml();
+
+	private static final Pattern FRONT_MATTER_DELIMITER = Pattern.compile("^---[ \\t]*(?:\\r?\\n|$)", Pattern.MULTILINE);
 
 	private AgentSpecLoader() {
 	}
@@ -127,19 +131,20 @@ public final class AgentSpecLoader {
 		if (!StringUtils.hasText(markdown)) {
 			return null;
 		}
-		if (!markdown.startsWith("---")) {
+		Matcher delimiterMatcher = FRONT_MATTER_DELIMITER.matcher(markdown);
+		if (!delimiterMatcher.find() || delimiterMatcher.start() != 0) {
 			logger.warn("Agent spec must start with YAML front matter (---)");
 			return null;
 		}
 
-		int endIndex = markdown.indexOf("---", 3);
-		if (endIndex == -1) {
+		int frontMatterStart = delimiterMatcher.end();
+		if (!delimiterMatcher.find()) {
 			logger.warn("Agent spec front matter not properly closed with ---");
 			return null;
 		}
 
-		String frontMatterStr = markdown.substring(3, endIndex).trim();
-		String content = markdown.substring(endIndex + 3).trim();
+		String frontMatterStr = markdown.substring(frontMatterStart, delimiterMatcher.start()).trim();
+		String content = markdown.substring(delimiterMatcher.end()).trim();
 
 		Map<String, Object> frontMatter;
 		try {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoaderTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoaderTest.java
@@ -53,6 +53,25 @@ class AgentSpecLoaderTest {
 	}
 
 	@Test
+	@DisplayName("Should ignore delimiter text inside front matter values")
+	void shouldIgnoreDelimiterTextInsideFrontMatterValues() {
+		String markdown = """
+				---
+				name: Explore
+				description: Fast---and safe codebase exploration
+				---
+
+				You are a file search specialist.
+				""";
+
+		AgentSpec spec = AgentSpecLoader.parse(markdown);
+
+		assertThat(spec).isNotNull();
+		assertThat(spec.description()).isEqualTo("Fast---and safe codebase exploration");
+		assertThat(spec.systemPrompt()).isEqualTo("You are a file search specialist.");
+	}
+
+	@Test
 	@DisplayName("Should return null for content without front matter")
 	void shouldReturnNullForContentWithoutFrontMatter() {
 		AgentSpec spec = AgentSpecLoader.parse("Just plain content");


### PR DESCRIPTION
### Describe what this PR does / why we need it

AgentSpecLoader treats any occurrence of three hyphens as the end of YAML front matter. A valid description such as Fast---and safe is truncated and causes the agent spec to fail parsing.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Recognize front matter delimiters only when they appear on their own line, with support for LF, CRLF, trailing whitespace, and an end-of-file delimiter. Add a regression test containing three hyphens inside a YAML value.

### Describe how to verify it

Run: ./mvnw -B -pl :spring-ai-alibaba-agent-framework -am -Dtest=AgentSpecLoaderTest -Dsurefire.failIfNoSpecifiedTests=false test

### Special notes for reviews

NONE