### PR TITLE
fix(agent): parse YAML list tools in agent specs

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoader.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoader.java
@@ -168,7 +168,7 @@ public final class AgentSpecLoader {
 			return null;
 		}
 
-		List<String> toolNames = parseToolNames(getString(frontMatter, "tools"));
+		List<String> toolNames = parseToolNames(frontMatter.get("tools"));
 		String model = getString(frontMatter, "model");
 
 		return new AgentSpec(name, description, content, toolNames, model);
@@ -179,7 +179,19 @@ public final class AgentSpecLoader {
 		return v != null ? v.toString().trim() : null;
 	}
 
-	private static List<String> parseToolNames(String toolsStr) {
+	private static List<String> parseToolNames(Object tools) {
+		if (tools instanceof Iterable<?> iterable) {
+			List<String> toolNames = new ArrayList<>();
+			for (Object tool : iterable) {
+				String toolName = tool != null ? tool.toString().trim() : null;
+				if (StringUtils.hasText(toolName)) {
+					toolNames.add(toolName);
+				}
+			}
+			return toolNames;
+		}
+
+		String toolsStr = tools != null ? tools.toString().trim() : null;
 		if (!StringUtils.hasText(toolsStr)) {
 			return List.of();
 		}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoaderTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecLoaderTest.java
@@ -53,6 +53,28 @@ class AgentSpecLoaderTest {
 	}
 
 	@Test
+	@DisplayName("Should parse tool names from YAML list")
+	void shouldParseToolNamesFromYamlList() {
+		String markdown = """
+				---
+				name: Explore
+				description: Fast agent for exploring codebases
+				tools:
+				  - Read
+				  - Grep
+				  - Glob
+				---
+
+				You are a file search specialist.
+				""";
+
+		AgentSpec spec = AgentSpecLoader.parse(markdown);
+
+		assertThat(spec).isNotNull();
+		assertThat(spec.toolNames()).containsExactly("Read", "Grep", "Glob");
+	}
+
+	@Test
 	@DisplayName("Should return null for content without front matter")
 	void shouldReturnNullForContentWithoutFrontMatter() {
 		AgentSpec spec = AgentSpecLoader.parse("Just plain content");


### PR DESCRIPTION


  ## Summary
  - Fix `AgentSpecLoader` so `tools` in YAML front matter can be parsed from standard YAML list syntax.
  - Keep existing comma-separated `tools: Read, Grep, Glob` syntax supported.
  
  ## Problem
  `AgentSpecLoader` previously converted the `tools` front matter value with `toString()` before splitting by comma. When `tools` is written as a YAML list, SnakeYAML returns a list, which becomes a 
  string like `[Read, Grep, Glob]`. This causes parsed tool names to include brackets, such as `[Read` and `Glob]`.

  ## Test plan
  - Added regression coverage for YAML list-form `tools`.
  - Ran:
    - `./mvnw -q -pl :spring-ai-alibaba-agent-framework -Dtest=AgentSpecLoaderTest test`
  - Result: currently blocked by unrelated existing compilation errors in skills-related classes, e.g. missing `SkillRegistry#getByPath(...)` and `SkillMetadata#getAllowedTools()`.




