### PR TITLE
fix(build): bump spring boot bom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <!-- Spring version -->
         <spring-ai.version>1.1.2</spring-ai.version>
         <spring-ai-alibaba-extensions.version>1.1.2.2</spring-ai-alibaba-extensions.version>
-        <spring-boot.version>3.5.8</spring-boot.version>
+        <spring-boot.version>3.5.16</spring-boot.version>
         <springdoc-openapi.version>2.8.8</springdoc-openapi.version>
 
         <!-- DashScope SDK Version -->


### PR DESCRIPTION
## Summary

Fixes #4793.

The repository still pointed Spring Boot BOM resolution at `3.5.8`, but that import POM is no longer resolvable. Bumping the shared Spring Boot version property restores dependency resolution for the build.

## Changes

- update the root `spring-boot.version` property to a resolvable release

## Checklist

- [x] kept the change scoped to the root build property
- [x] verified the repository validate task locally
- [x] confirmed no extra files are included

## Release Impact

The build now resolves Spring Boot dependencies from a valid BOM version again.

## Validation

- `./mvnw -q -DskipTests validate`
- `git diff --check`
