### PR TITLE
fix(graph): support primitive arrays in deep copy to prevent ClassCastException

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
@@ -126,13 +126,18 @@ public class SerializationUtils {
 			return copySet;
 		}
 
-		// Handle arrays
-		if (value.getClass().isArray()) {
-			Object[] originalArray = (Object[]) value;
-			Object[] copyArray = new Object[originalArray.length];
-			for (int i = 0; i < originalArray.length; i++) {
-				copyArray[i] = deepCopyValue(originalArray[i]);
-			}
+        // Handle arrays (both object arrays like String[] and primitive arrays like
+        // int[], float[], double[], byte[], ...). Using java.lang.reflect.Array preserves
+        // the original component type and avoids casting a primitive array to Object[],
+        // which throws ClassCastException (e.g. [F cannot be cast to [Ljava.lang.Object;).
+        // Primitive elements are immutable and returned as-is by the recursive call, so a
+        // single element-wise loop is a correct deep copy for both array kinds.
+        if (value.getClass().isArray()) {
+            int length = java.lang.reflect.Array.getLength(value);
+            Object copyArray = java.lang.reflect.Array.newInstance(value.getClass().getComponentType(), length);
+            for (int i = 0; i < length; i++) {
+                java.lang.reflect.Array.set(copyArray, i, deepCopyValue(java.lang.reflect.Array.get(value, i)));
+            }
 			return copyArray;
 		}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SerializationUtilsPrimitiveArrayTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SerializationUtilsPrimitiveArrayTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.utils.SerializationUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/**
+ * Regression test for {@link SerializationUtils#deepCopyValue(Object)} to verify that
+ * primitive arrays are deep copied correctly.
+ * <p>
+ * Previously the array branch cast every array to {@code Object[]}, which threw
+ * {@code ClassCastException} for primitive arrays (e.g. {@code float[]} embeddings or
+ * {@code byte[]} multimodal data) passed as graph inputs to
+ * {@code CompiledGraph.invoke(...)}. It also silently narrowed reference arrays such as
+ * {@code String[]} into {@code Object[]}. Both cases are covered below.
+ * </p>
+ *
+ */
+public class SerializationUtilsPrimitiveArrayTest {
+
+    @Test
+    void deepCopyIntArray() {
+        int[] original = { 1, 2, 3 };
+        Object copied = SerializationUtils.deepCopyValue(original);
+        assertInstanceOf(int[].class, copied);
+        assertArrayEquals(original, (int[]) copied);
+        assertNotSame(original, copied);
+    }
+
+    @Test
+    void deepCopyFloatArray() {
+        float[] original = { 0.1f, 0.2f, 0.3f };
+        Object copied = SerializationUtils.deepCopyValue(original);
+        assertInstanceOf(float[].class, copied);
+        assertArrayEquals(original, (float[]) copied, 1e-9f);
+        assertNotSame(original, copied);
+    }
+
+    @Test
+    void deepCopyDoubleArray() {
+        double[] original = { 1.5, 2.5, 3.5 };
+        Object copied = SerializationUtils.deepCopyValue(original);
+        assertInstanceOf(double[].class, copied);
+        assertArrayEquals(original, (double[]) copied, 1e-9);
+    }
+
+    @Test
+    void deepCopyByteArray() {
+        byte[] original = { 1, 2, 3, 4 };
+        Object copied = SerializationUtils.deepCopyValue(original);
+        assertInstanceOf(byte[].class, copied);
+        assertArrayEquals(original, (byte[]) copied);
+    }
+
+    @Test
+    void deepCopyLongAndShortAndCharAndBooleanArrays() {
+        assertArrayEquals(new long[] { 1L, 2L }, (long[]) SerializationUtils.deepCopyValue(new long[] { 1L, 2L }));
+        assertArrayEquals(new short[] { 1, 2 }, (short[]) SerializationUtils.deepCopyValue(new short[] { 1, 2 }));
+        assertArrayEquals(new char[] { 'a', 'b' }, (char[]) SerializationUtils.deepCopyValue(new char[] { 'a', 'b' }));
+        assertArrayEquals(new boolean[] { true, false },
+                (boolean[]) SerializationUtils.deepCopyValue(new boolean[] { true, false }));
+    }
+
+    @Test
+    void deepCopyEmptyPrimitiveArray() {
+        int[] original = {};
+        Object copied = SerializationUtils.deepCopyValue(original);
+        assertInstanceOf(int[].class, copied);
+        assertEquals(0, ((int[]) copied).length);
+    }
+
+    @Test
+    void mutatingCopyDoesNotAffectOriginal() {
+        int[] original = { 1, 2, 3 };
+        int[] copied = (int[]) SerializationUtils.deepCopyValue(original);
+        copied[0] = 999;
+        assertEquals(1, original[0]);
+    }
+
+    @Test
+    void objectArrayPreservesRuntimeComponentType() {
+        String[] original = { "a", "b" };
+        Object copied = SerializationUtils.deepCopyValue(original);
+        // Must stay String[], not be narrowed to Object[].
+        assertInstanceOf(String[].class, copied);
+        assertArrayEquals(original, (String[]) copied);
+    }
+
+    @Test
+    void objectArrayElementsAreDeepCopied() {
+        Map<String, Object> element = new HashMap<>();
+        element.put("k", "v");
+        Map<String, Object>[] original = new Map[] { element };
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object>[] copied = (Map<String, Object>[]) SerializationUtils.deepCopyValue(original);
+
+        assertNotSame(original[0], copied[0]);
+        copied[0].put("k", "changed");
+        assertEquals("v", original[0].get("k"));
+    }
+
+    @Test
+    void deepCopyMapContainingPrimitiveArrayValue() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("embedding", new float[] { 0.1f, 0.2f, 0.3f });
+
+        Map<String, Object> copied = SerializationUtils.deepCopyMap(data);
+
+        assertInstanceOf(float[].class, copied.get("embedding"));
+        assertArrayEquals(new float[] { 0.1f, 0.2f, 0.3f }, (float[]) copied.get("embedding"), 1e-9f);
+    }
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it
`SerializationUtils.deepCopyValue(Object)` casts every array to `Object[]`, which throws a `ClassCastException` for primitive arrays (`int[]`, `float[]`, `double[]`, `byte[]`, etc.). The array-handling branch is not guarded by the surrounding `try/catch`, so the exception propagates through the public API:

```text
CompiledGraph.invoke(inputs)
    -> OverAllStateBuilder.withData(inputs)
        -> SerializationUtils.deepCopyMap(inputs)
            -> SerializationUtils.deepCopyValue(value)
```

As a result, the graph crashes during initial state creation before any node is executed.

This is a real and reachable scenario. For example:

- `EmbeddingModel.embed(...)` returns a `float[]`.
- Multimodal TTS output is a `byte[]`.

Passing either value as graph input triggers the crash.

Additionally, the previous implementation silently narrowed reference arrays (e.g. `String[]`) to `Object[]`, losing their runtime component type.


### Does this pull request fix one issue?

Fixes #4812

### Describe how you did it
Use `java.lang.reflect.Array` to copy arrays while preserving their runtime component type. Primitive arrays (e.g. `int[]`, `float[]`) are copied as their original types, while reference-array elements continue to be deep copied recursively.

```java
if (value.getClass().isArray()) {
    int length = java.lang.reflect.Array.getLength(value);
    Object copyArray = java.lang.reflect.Array.newInstance(value.getClass().getComponentType(), length);
    for (int i = 0; i < length; i++) {
        java.lang.reflect.Array.set(copyArray, i, deepCopyValue(java.lang.reflect.Array.get(value, i)));
    }

    return copyArray;
}
```


### Describe how to verify it
Added `SerializationUtilsPrimitiveArrayTest` (10 tests) covering:

- All primitive array types.
- Empty arrays.
- Deep-copy independence (modifying the copy does not affect the original).
- Runtime component-type preservation (`String[]` remains `String[]`, not `Object[]`).
- Recursive deep copy of reference-array elements.
- The `deepCopyMap` path with a `float[]` value.

Run:

```bash
./mvnw -pl :spring-ai-alibaba-graph-core \
    -Dtest=SerializationUtilsPrimitiveArrayTest test
```

Also verified against the published `1.1.2.2` artifact:

- **Before the fix:** `CompiledGraph.invoke(Map.of("embedding", new float[]{...}))` throws `ClassCastException`.
- **After the fix:** the graph executes successfully and the `float[]` is preserved.

Checkstyle also passes with **0 violations**.

### Special notes for reviews