### PR TITLE
fix(graph): deep copy primitive arrays without ClassCastException

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/utils/SerializationUtils.java
@@ -128,10 +128,21 @@ public class SerializationUtils {
 
 		// Handle arrays
 		if (value.getClass().isArray()) {
-			Object[] originalArray = (Object[]) value;
-			Object[] copyArray = new Object[originalArray.length];
-			for (int i = 0; i < originalArray.length; i++) {
-				copyArray[i] = deepCopyValue(originalArray[i]);
+			Class<?> componentType = value.getClass().getComponentType();
+			int length = java.lang.reflect.Array.getLength(value);
+			// Primitive arrays (int[], float[], byte[], ...) are not instances of
+			// Object[], so casting them would throw a ClassCastException. Their
+			// elements are immutable, so a shallow element copy is sufficient.
+			if (componentType.isPrimitive()) {
+				Object copyArray = java.lang.reflect.Array.newInstance(componentType, length);
+				System.arraycopy(value, 0, copyArray, 0, length);
+				return copyArray;
+			}
+			// Object arrays: preserve the original component type instead of forcing
+			// Object[], and deep copy each element.
+			Object copyArray = java.lang.reflect.Array.newInstance(componentType, length);
+			for (int i = 0; i < length; i++) {
+				java.lang.reflect.Array.set(copyArray, i, deepCopyValue(java.lang.reflect.Array.get(value, i)));
 			}
 			return copyArray;
 		}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SerializationUtilsArrayTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SerializationUtilsArrayTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.utils.SerializationUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@link SerializationUtils#deepCopyValue(Object)} to verify that array values,
+ * including primitive arrays, are deep copied without throwing a {@link ClassCastException}.
+ * <p>
+ * This is a regression test for issue #4812 where primitive arrays (e.g. {@code float[]}
+ * embeddings or {@code byte[]} audio) passed as graph input caused a
+ * {@code ClassCastException} because every array was cast to {@code Object[]}.
+ * </p>
+ *
+ * @author Spring AI Alibaba
+ * @see <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4812">Issue #4812</a>
+ */
+public class SerializationUtilsArrayTest {
+
+	@Test
+	public void testDeepCopyFloatArray() {
+		float[] original = { 1.0f, 2.5f, -3.75f };
+
+		Object copied = SerializationUtils.deepCopyValue(original);
+
+		assertInstanceOf(float[].class, copied, "float[] should stay a float[] after deep copy");
+		assertNotSame(original, copied, "float[] should be copied, not reused");
+		assertArrayEquals(original, (float[]) copied);
+	}
+
+	@Test
+	public void testDeepCopyByteArray() {
+		byte[] original = { 0, 1, 2, (byte) 0xFF };
+
+		Object copied = SerializationUtils.deepCopyValue(original);
+
+		assertInstanceOf(byte[].class, copied);
+		assertNotSame(original, copied);
+		assertArrayEquals(original, (byte[]) copied);
+	}
+
+	@Test
+	public void testDeepCopyIntArray() {
+		int[] original = { 10, 20, 30 };
+
+		Object copied = SerializationUtils.deepCopyValue(original);
+
+		assertInstanceOf(int[].class, copied);
+		assertNotSame(original, copied);
+		assertArrayEquals(original, (int[]) copied);
+	}
+
+	@Test
+	public void testDeepCopyObjectArrayPreservesComponentType() {
+		Integer[] original = { 1, 2, 3 };
+
+		Object copied = SerializationUtils.deepCopyValue(original);
+
+		assertInstanceOf(Integer[].class, copied, "Component type should be preserved instead of widened to Object[]");
+		assertNotSame(original, copied);
+		assertArrayEquals(original, (Integer[]) copied);
+	}
+
+	@Test
+	public void testDeepCopyMapWithPrimitiveArrayValue() {
+		Map<String, Object> original = new HashMap<>();
+		original.put("embedding", new float[] { 0.1f, 0.2f, 0.3f });
+
+		Map<String, Object> copied = SerializationUtils.deepCopyMap(original);
+
+		Object copiedEmbedding = copied.get("embedding");
+		assertInstanceOf(float[].class, copiedEmbedding);
+		assertArrayEquals(new float[] { 0.1f, 0.2f, 0.3f }, (float[]) copiedEmbedding);
+	}
+
+	@Test
+	public void testGraphInvokeWithPrimitiveArrayInput() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("embedding", (o, n) -> n);
+			strategies.put("result", (o, n) -> n);
+			return strategies;
+		};
+
+		CompiledGraph graph = new StateGraph(keyStrategyFactory)
+			.addNode("echo", node_async(state -> Map.of("result", "ok")))
+			.addEdge(START, "echo")
+			.addEdge("echo", END)
+			.compile();
+
+		Map<String, Object> inputs = new HashMap<>();
+		inputs.put("embedding", new float[] { 1.0f, 2.0f, 3.0f });
+
+		OverAllState finalState = graph.invoke(inputs)
+			.orElseThrow(() -> new AssertionError("Graph should produce a final state"));
+
+		assertEquals("ok", finalState.value("result").orElse(null));
+		Object embedding = finalState.value("embedding").orElse(null);
+		assertInstanceOf(float[].class, embedding);
+		assertArrayEquals(new float[] { 1.0f, 2.0f, 3.0f }, (float[]) embedding);
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

`SerializationUtils.deepCopyValue(Object)` casts every array to `Object[]`. Primitive arrays (`int[]`, `float[]`, `double[]`, `byte[]`, `long[]`, `short[]`, `char[]`, `boolean[]`) are **not** subtypes of `Object[]`, so the cast throws a `ClassCastException`. This code path is not wrapped by the surrounding `try/catch`, so the exception escapes the public API `CompiledGraph.invoke(...)` and crashes the graph during initial state creation, before any node runs.

This is easy to hit because several public APIs return primitive arrays — e.g. `EmbeddingModel.embed(...)` returns a `float[]` and multimodal TTS output is a `byte[]`. Passing either as graph input fails immediately.

### Does this pull request fix one issue?

Fixes #4812

### Describe how you did it

Handle arrays via `java.lang.reflect.Array` in `deepCopyValue`:

- **Primitive arrays**: allocate an array of the same component type and `System.arraycopy` the elements (primitive elements are immutable, so a shallow element copy is a correct deep copy).
- **Object arrays**: allocate an array of the *original* component type (instead of widening to `Object[]`) and recursively `deepCopyValue` each element, preserving the declared array type.

### Describe how to verify it

Added `SerializationUtilsArrayTest` covering:

- `deepCopyValue` on `float[]`, `byte[]`, `int[]` — no exception, values equal, new instance returned
- object arrays preserve their component type (`Integer[]` stays `Integer[]`, not `Object[]`)
- `deepCopyMap` with a primitive-array value
- `CompiledGraph.invoke(...)` with a `float[]` graph input runs end to end and preserves the array in the final state

```shell
./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=SerializationUtilsArrayTest test
```

All 6 new tests pass, and the existing `SerializationUtilsCustomMapTypeTest` still passes.

### Special notes for reviews

The object-array branch now preserves the concrete component type, which is a small behavior improvement over the previous always-`Object[]` result.