### PR TITLE
fix(admin): pin commons-io to 2.18.0 for POI/Tika document parsing

### DIFF
--- a/spring-ai-alibaba-admin/pom.xml
+++ b/spring-ai-alibaba-admin/pom.xml
@@ -60,6 +60,9 @@
         <logback.version>1.5.8</logback.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <commons-collections.version>3.2.2</commons-collections.version>
+        <!-- Align commons-io with the version required by POI/Tika (see #4453).
+             swagger-parser pulls in 2.15.1, which lacks BoundedInputStream.builder(). -->
+        <commons-io.version>2.18.0</commons-io.version>
 
         <!-- 搜索引擎 -->
         <elasticsearch.version>8.13.4</elasticsearch.version>
@@ -240,6 +243,14 @@
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
                 <version>${json-schema-validator.version}</version>
+            </dependency>
+
+            <!-- Force commons-io to the version POI/Tika need (#4453).
+                 Otherwise swagger-parser's 2.15.1 wins and lacks BoundedInputStream.builder(). -->
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
             </dependency>
 
             <!-- SpringDoc OpenAPI -->


### PR DESCRIPTION
### Describe what this PR does / why we need it

Uploading a `doc`/`docx` file to the knowledge base fails while parsing, with:

```
java.lang.NoSuchMethodError: 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
```

The `spring-ai-alibaba-admin` project uses `spring-ai-tika-document-reader`, which transitively brings in Tika 3.2.3 → POI 5.4.1. POI 5.4.1 requires `commons-io` 2.18.0, and `BoundedInputStream.builder()` was only introduced in commons-io **2.16.0**.

However `swagger-parser` declares `commons-io` **2.15.1** as a direct dependency, and Maven's nearest-wins resolution selects 2.15.1 over the higher versions POI/Tika request. So the newer builder API is missing at runtime and document parsing throws `NoSuchMethodError`.

### Does this pull request fix one issue?

Fixes #4453

### Describe how you did it

Explicitly manage `commons-io` to `2.18.0` (the version POI 5.4.1 declares) in the admin project's `dependencyManagement`, so every consumer resolves a compatible version instead of the 2.15.1 pulled in by swagger-parser.

### Describe how to verify it

Before — resolved version is 2.15.1 (missing the builder API):

```shell
./mvnw -f spring-ai-alibaba-admin/pom.xml -pl spring-ai-alibaba-admin-server-start -am \
  dependency:tree -Dincludes=commons-io:commons-io
# -> commons-io:commons-io:jar:2.15.1:compile
```

After this change:

```shell
./mvnw -f spring-ai-alibaba-admin/pom.xml -pl spring-ai-alibaba-admin-server-start -am \
  dependency:tree -Dincludes=commons-io:commons-io
# -> commons-io:commons-io:jar:2.18.0:compile
```

The admin project compiles successfully, and `BoundedInputStream.builder()` (introduced in commons-io 2.16.0) is now available at runtime, so POI/Tika can parse doc/docx uploads.

### Special notes for reviews

The value 2.18.0 matches what POI 5.4.1 itself declares, keeping the bump minimal and aligned with the parser stack rather than jumping to the newest commons-io release.