### PR TITLE
fix(graph): avoid duplicate state in compiled subgraphs

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -342,6 +342,18 @@ public class GraphRunnerContext {
 	}
 
 	/**
+	 * Replaces the current state data with an authoritative state snapshot while
+	 * preserving the configured key strategies and store.
+	 * @param state the complete state snapshot
+	 */
+	public void replaceCurrentState(Map<String, Object> state) {
+		Map<String, Object> filteredState = findTokenUsageInDeltaState(state);
+
+		this.overallState.reset();
+		this.overallState.updateStateWithKeyStrategies(filteredState, Map.of());
+	}
+
+	/**
 	 * FIXME, this method is a temporary fix to separate Usage from state updates.
 	 * works together with AgentLlmNode non-stream node.
 	 */

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -573,8 +573,6 @@ public class NodeExecutor extends BaseGraphExecutor {
 							&& !(e.getValue() instanceof ParallelGraphFlux))
 					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-			boolean isSubgraphError = data != null && data.isError();
-
 			Map<String, Object> updateState = new HashMap<>();
 			boolean hasStateResult = false;
 			if (nodeResultValue.isPresent()) {
@@ -592,24 +590,12 @@ public class NodeExecutor extends BaseGraphExecutor {
 				}
 			}
 
-			Map<String, Object> combinedUpdateState = new HashMap<>();
+			Map<String, Object> combinedUpdateState = new HashMap<>(partialStateWithoutFlux);
+			combinedUpdateState.putAll(updateState);
+			Optional<InterruptionMetadata> interruptAfterMetadata = interruptAfterForStreaming(context, combinedUpdateState);
 
-			if (!isSubgraphError) {
-				combinedUpdateState.putAll(partialStateWithoutFlux);
-				combinedUpdateState.putAll(updateState);
-			}
-
-			Optional<InterruptionMetadata> interruptAfterMetadata = isSubgraphError
-					? Optional.empty()
-					: interruptAfterForStreaming(context, combinedUpdateState);
-
-			if (isSubgraphError) {
-				if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("Skip applying subgraph state updates after error from '{}'", context.getCurrentNodeId());
-				}
-			}
-			else if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction && hasStateResult
-					&& !updateState.isEmpty()) {
+			if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction
+					&& hasStateResult && !data.isError()) {
 				context.replaceCurrentState(updateState);
 			}
 			else {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -594,7 +594,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 			combinedUpdateState.putAll(updateState);
 			Optional<InterruptionMetadata> interruptAfterMetadata = interruptAfterForStreaming(context, combinedUpdateState);
 
-			if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction && hasStateResult) {
+			if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction && hasStateResult
+					&& !updateState.isEmpty()) {
 				context.replaceCurrentState(updateState);
 			}
 			else {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -565,10 +565,12 @@ public class NodeExecutor extends BaseGraphExecutor {
 					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
 			Map<String, Object> updateState = new HashMap<>();
+			boolean hasStateResult = false;
 			if (nodeResultValue.isPresent()) {
 				Object value = nodeResultValue.get();
 				if (value instanceof Map<?, ?>) {
 					updateState = (Map<String, Object>) value;
+					hasStateResult = true;
 				}
 				else {
 					throw new IllegalArgumentException("Node stream must return Map result using Data.done(),");
@@ -579,7 +581,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 			combinedUpdateState.putAll(updateState);
 			Optional<InterruptionMetadata> interruptAfterMetadata = interruptAfterForStreaming(context, combinedUpdateState);
 
-			if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction) {
+			if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction && hasStateResult) {
 				context.replaceCurrentState(updateState);
 			}
 			else {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -26,6 +26,7 @@ import com.alibaba.cloud.ai.graph.action.Command;
 import com.alibaba.cloud.ai.graph.action.InterruptableAction;
 import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
 import com.alibaba.cloud.ai.graph.exception.RunnableErrors;
+import com.alibaba.cloud.ai.graph.internal.node.SubCompiledGraphNodeAction;
 import com.alibaba.cloud.ai.graph.streaming.GraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.ParallelGraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
@@ -578,8 +579,13 @@ public class NodeExecutor extends BaseGraphExecutor {
 			combinedUpdateState.putAll(updateState);
 			Optional<InterruptionMetadata> interruptAfterMetadata = interruptAfterForStreaming(context, combinedUpdateState);
 
-			context.mergeIntoCurrentState(partialStateWithoutFlux);
-			context.mergeIntoCurrentState(updateState);
+			if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction) {
+				context.replaceCurrentState(updateState);
+			}
+			else {
+				context.mergeIntoCurrentState(partialStateWithoutFlux);
+				context.mergeIntoCurrentState(updateState);
+			}
 
 			try {
 				Command nextCommand = context.nextNodeId(context.getCurrentNodeId(), context.getCurrentStateData());

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -573,6 +573,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 							&& !(e.getValue() instanceof ParallelGraphFlux))
 					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+			boolean isSubgraphError = data != null && data.isError();
+
 			Map<String, Object> updateState = new HashMap<>();
 			boolean hasStateResult = false;
 			if (nodeResultValue.isPresent()) {
@@ -590,11 +592,23 @@ public class NodeExecutor extends BaseGraphExecutor {
 				}
 			}
 
-			Map<String, Object> combinedUpdateState = new HashMap<>(partialStateWithoutFlux);
-			combinedUpdateState.putAll(updateState);
-			Optional<InterruptionMetadata> interruptAfterMetadata = interruptAfterForStreaming(context, combinedUpdateState);
+			Map<String, Object> combinedUpdateState = new HashMap<>();
 
-			if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction && hasStateResult
+			if (!isSubgraphError) {
+				combinedUpdateState.putAll(partialStateWithoutFlux);
+				combinedUpdateState.putAll(updateState);
+			}
+
+			Optional<InterruptionMetadata> interruptAfterMetadata = isSubgraphError
+					? Optional.empty()
+					: interruptAfterForStreaming(context, combinedUpdateState);
+
+			if (isSubgraphError) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("Skip applying subgraph state updates after error from '{}'", context.getCurrentNodeId());
+				}
+			}
+			else if (context.getNodeAction(context.getCurrentNodeId()) instanceof SubCompiledGraphNodeAction && hasStateResult
 					&& !updateState.isEmpty()) {
 				context.replaceCurrentState(updateState);
 			}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SubGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SubGraphTest.java
@@ -642,6 +642,43 @@ public class SubGraphTest {
 				.block();
 	}
 
+	@Test
+	void compiledSubgraphsShouldNotReappendInheritedState() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> Map.of("output", new AppendStrategy());
+
+		CompiledGraph subGraphA = new StateGraph(keyStrategyFactory)
+			.addNode("a", node_async(state -> Map.of("output", "a")))
+			.addNode("b", node_async(state -> Map.of("output", "b")))
+			.addEdge(START, "a")
+			.addEdge("a", "b")
+			.addEdge("b", END)
+			.compile();
+
+		CompiledGraph subGraphB = new StateGraph(keyStrategyFactory)
+			.addNode("c", node_async(state -> Map.of("output", "c")))
+			.addNode("d", node_async(state -> Map.of("output", "d")))
+			.addEdge(START, "c")
+			.addEdge("c", "d")
+			.addEdge("d", END)
+			.compile();
+
+		OverAllState state = new StateGraph(keyStrategyFactory)
+			.addNode("a", node_async(currentState -> Map.of("output", "a")))
+			.addNode("subGraphA", subGraphA)
+			.addNode("c", node_async(currentState -> Map.of("output", "c")))
+			.addNode("subGraphB", subGraphB)
+			.addEdge(START, "a")
+			.addEdge("a", "subGraphA")
+			.addEdge("subGraphA", "c")
+			.addEdge("c", "subGraphB")
+			.addEdge("subGraphB", END)
+			.compile()
+			.invoke(Map.of())
+			.orElseThrow();
+
+		assertEquals(List.of("a", "a", "b", "c", "c", "d"), state.value("output").orElseThrow());
+	}
+
     @Test
     public void testMultiSubgraphKeyStrategyMerge() throws Exception {
         // Subgraph A: provides the strategy for aKey

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SubGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SubGraphTest.java
@@ -679,6 +679,38 @@ public class SubGraphTest {
 		assertEquals(List.of("a", "a", "b", "c", "c", "d"), state.value("output").orElseThrow());
 	}
 
+	@Test
+	void compiledSubgraphErrorShouldPreserveParentState() throws Exception {
+		KeyStrategyFactory keyStrategyFactory = () -> Map.of("output", new AppendStrategy());
+
+		CompiledGraph failingSubGraph = new StateGraph(keyStrategyFactory)
+			.addNode("failure", node_async(state -> {
+				throw new IllegalStateException("subgraph failure");
+			}))
+			.addEdge(START, "failure")
+			.addEdge("failure", END)
+			.compile();
+
+		CompiledGraph parentGraph = new StateGraph(keyStrategyFactory)
+			.addNode("parent", node_async(state -> Map.of("output", "parent")))
+			.addNode("subGraph", failingSubGraph)
+			.addEdge(START, "parent")
+			.addEdge("parent", "subGraph")
+			.addEdge("subGraph", END)
+			.compile();
+
+		List<GraphResponse<NodeOutput>> responses = parentGraph
+			.graphResponseStream(Map.of(), RunnableConfig.builder().build())
+			.collectList()
+			.block();
+
+		assertNotNull(responses);
+		assertTrue(responses.stream().anyMatch(GraphResponse::isError));
+		Map<?, ?> finalState = assertInstanceOf(Map.class,
+				responses.get(responses.size() - 1).resultValue().orElseThrow());
+		assertEquals(List.of("parent"), finalState.get("output"));
+	}
+
     @Test
     public void testMultiSubgraphKeyStrategyMerge() throws Exception {
         // Subgraph A: provides the strategy for aKey

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SubGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/SubGraphTest.java
@@ -694,9 +694,16 @@ public class SubGraphTest {
 		CompiledGraph parentGraph = new StateGraph(keyStrategyFactory)
 			.addNode("parent", node_async(state -> Map.of("output", "parent")))
 			.addNode("subGraph", failingSubGraph)
+			.addNode("recovered", node_async(state -> Map.of("output", "recovered")))
+			.addNode("lostState", node_async(state -> Map.of("output", "lost-state")))
 			.addEdge(START, "parent")
 			.addEdge("parent", "subGraph")
-			.addEdge("subGraph", END)
+			.addConditionalEdges("subGraph",
+					edge_async(state -> List.of("parent").equals(state.value("output").orElse(null))
+							? "recovered" : "lostState"),
+					Map.of("recovered", "recovered", "lostState", "lostState"))
+			.addEdge("recovered", END)
+			.addEdge("lostState", END)
 			.compile();
 
 		List<GraphResponse<NodeOutput>> responses = parentGraph
@@ -708,7 +715,7 @@ public class SubGraphTest {
 		assertTrue(responses.stream().anyMatch(GraphResponse::isError));
 		Map<?, ?> finalState = assertInstanceOf(Map.class,
 				responses.get(responses.size() - 1).resultValue().orElseThrow());
-		assertEquals(List.of("parent"), finalState.get("output"));
+		assertEquals(List.of("parent", "recovered"), finalState.get("output"));
 	}
 
     @Test


### PR DESCRIPTION
## Summary

- treat a compiled subgraph's final state as an authoritative snapshot instead of applying parent key strategies to it again
- only replace the parent snapshot after a compiled subgraph returns a state map, preserving parent state on subgraph errors
- preserve the parent state's configured key strategies and store when replacing its data
- add regression tests for consecutive compiled subgraphs with an `APPEND` key and for subgraph error handling

## Root cause

A compiled subgraph starts with the parent's full state and returns its full final state. The parent executor then merged that result as a delta, so `APPEND` re-added all inherited values after every subgraph completion.

The snapshot replacement must only run after a successful final map result. Error responses do not contain a state result and must leave the existing parent state unchanged.

## Impact

Nested compiled subgraphs no longer duplicate inherited list entries, and subgraph errors no longer clear the parent state. Ordinary embedded Flux nodes keep their existing incremental merge behavior.

## Validation

- `./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=SubGraphTest,CompiledSubGraphTest,StateGraphTest test` (53 tests, 0 failures/errors, 1 skipped)
- `./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=*,!DatabaseStorePostgreSqlIntegrationTest test` (399 tests, 0 failures/errors, 71 environment-dependent skips)
- Checkstyle: 0 violations

The excluded PostgreSQL integration test requires a running Docker environment.

Fixes #4305