### PR TITLE
fix(agent): normalize null-content tool-calling AssistantMessage (#4561)

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/Builder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/Builder.java
@@ -100,6 +100,10 @@ public abstract class Builder {
 	protected boolean includeContents = true;
 	protected boolean returnReasoningContents;
 
+	// Register AssistantMessageSanitizerInterceptor by default to keep tool-calling
+	// AssistantMessages with null text compatible with strict DeepSeek-compatible backends.
+	protected boolean assistantMessageSanitizerEnabled = true;
+
 	protected String outputKey;
 
 	protected KeyStrategy outputKeyStrategy;
@@ -276,6 +280,23 @@ public abstract class Builder {
 
 	public Builder returnReasoningContents(boolean returnReasoningContents) {
 		this.returnReasoningContents = returnReasoningContents;
+		return this;
+	}
+
+	/**
+	 * Enables or disables the default {@code AssistantMessageSanitizerInterceptor}.
+	 * <p>
+	 * When enabled (the default), tool-calling {@code AssistantMessage}s whose text content
+	 * is {@code null} are rewritten with an empty-string content before being sent back to
+	 * the model. This keeps the serialized request compatible with strict
+	 * DeepSeek-compatible backends that reject assistant messages without a {@code content}
+	 * field. Disable this if you need the literal {@code "content": null} form once it is
+	 * supported upstream in Spring AI.
+	 * @param assistantMessageSanitizerEnabled true to register the sanitizer (default), false to disable it
+	 * @return this builder instance
+	 */
+	public Builder assistantMessageSanitizerEnabled(boolean assistantMessageSanitizerEnabled) {
+		this.assistantMessageSanitizerEnabled = assistantMessageSanitizerEnabled;
 		return this;
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.graph.agent;
 
+import com.alibaba.cloud.ai.graph.agent.extension.interceptor.AssistantMessageSanitizerInterceptor;
 import com.alibaba.cloud.ai.graph.agent.hook.Hook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.Interceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
@@ -118,7 +119,9 @@ public class DefaultBuilder extends Builder {
 		}
 		
 		separateInterceptorsByType();
-		
+
+		registerDefaultModelInterceptors();
+
 		List<ToolCallback> allTools = gatherLocalTools();
 		
 		// Set combined tools to LLM node
@@ -168,6 +171,30 @@ public class DefaultBuilder extends Builder {
 		return new ReactAgent(llmNode, toolNode, buildConfig(), this);
 	}
 	
+	/**
+	 * Register framework-provided model interceptors that are enabled by default.
+	 * <p>
+	 * The {@link AssistantMessageSanitizerInterceptor} is appended last so it sits innermost
+	 * in the interceptor chain (closest to the model call). This way it normalizes the message
+	 * list only after any user-configured interceptors have run, right before the request is
+	 * sent to the model. Registration is skipped when disabled via
+	 * {@link Builder#assistantMessageSanitizerEnabled(boolean)} or when an interceptor with the
+	 * same name is already present.
+	 */
+	protected void registerDefaultModelInterceptors() {
+		if (!this.assistantMessageSanitizerEnabled) {
+			return;
+		}
+		if (modelInterceptors == null) {
+			modelInterceptors = new ArrayList<>();
+		}
+		boolean alreadyPresent = modelInterceptors.stream()
+				.anyMatch(interceptor -> AssistantMessageSanitizerInterceptor.class.equals(interceptor.getClass()));
+		if (!alreadyPresent) {
+			modelInterceptors.add(AssistantMessageSanitizerInterceptor.builder().build());
+		}
+	}
+
 	/**
 	 * Separate unified interceptors by type into modelInterceptors and toolInterceptors.
 	 */

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/interceptor/AssistantMessageSanitizerInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/interceptor/AssistantMessageSanitizerInterceptor.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.extension.interceptor;
+
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Middleware that normalizes tool-calling {@link AssistantMessage}s whose text content
+ * is {@code null} before they are sent back to the model.
+ *
+ * <p>When a ReAct loop performs a tool call, the assistant message that carries the
+ * {@code tool_calls} typically has no textual content, so {@link AssistantMessage#getText()}
+ * is {@code null}. On the second {@code /chat/completions} call this message is sent back to
+ * the model together with the tool result. Spring AI's OpenAI/DeepSeek-compatible
+ * serialization layer drops the {@code content} field entirely when the text is {@code null},
+ * producing a payload such as:</p>
+ *
+ * <pre>{@code
+ * { "role": "assistant", "tool_calls": [ ... ] }
+ * }</pre>
+ *
+ * <p>instead of:</p>
+ *
+ * <pre>{@code
+ * { "role": "assistant", "content": null, "tool_calls": [ ... ] }
+ * }</pre>
+ *
+ * <p>Stricter DeepSeek-compatible backends reject the former with a validation error
+ * ({@code content} field required). This interceptor rebuilds such assistant messages with
+ * an empty-string content ({@code ""}) while preserving their {@code toolCalls}, metadata,
+ * and media, which is accepted by these backends.</p>
+ *
+ * <p>This is a compatibility shim: the ideal fix belongs in the upstream Spring AI serializer.
+ * It is registered as a default {@link ModelInterceptor} in the agent framework and can be
+ * disabled via {@code ReactAgent.builder().assistantMessageSanitizerEnabled(false)} for users
+ * who require a literal {@code "content": null} once upstream provides it.</p>
+ *
+ * @see <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4561">Issue #4561</a>
+ */
+public class AssistantMessageSanitizerInterceptor extends ModelInterceptor {
+
+	private static final Logger log = LoggerFactory.getLogger(AssistantMessageSanitizerInterceptor.class);
+
+	private static final String NAME = "AssistantMessageSanitizer";
+
+	private AssistantMessageSanitizerInterceptor(Builder builder) {
+		// Currently no configuration options, but builder pattern allows future extensibility
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public ModelResponse interceptModel(ModelRequest request, ModelCallHandler handler) {
+		List<Message> messages = request.getMessages();
+
+		if (messages == null || messages.isEmpty()) {
+			return handler.call(request);
+		}
+
+		List<Message> sanitized = sanitizeMessages(messages);
+
+		// Only rebuild the request when at least one message was rewritten.
+		if (sanitized != messages) {
+			ModelRequest sanitizedRequest = ModelRequest.builder(request)
+					.messages(sanitized)
+					.build();
+			return handler.call(sanitizedRequest);
+		}
+
+		return handler.call(request);
+	}
+
+	/**
+	 * Rewrite tool-calling {@link AssistantMessage}s with {@code null} text so their content
+	 * becomes an empty string, preserving tool calls, metadata, and media.
+	 *
+	 * @param messages the original message list
+	 * @return a new list with normalized messages, or the original list if nothing needed fixing
+	 */
+	private List<Message> sanitizeMessages(List<Message> messages) {
+		boolean needsFix = false;
+		for (Message msg : messages) {
+			if (needsSanitizing(msg)) {
+				needsFix = true;
+				break;
+			}
+		}
+
+		if (!needsFix) {
+			return messages;
+		}
+
+		List<Message> sanitized = new ArrayList<>(messages.size());
+		for (Message msg : messages) {
+			if (needsSanitizing(msg)) {
+				AssistantMessage assistantMsg = (AssistantMessage) msg;
+				// text == null -> use empty string; keep toolCalls, metadata and media intact.
+				AssistantMessage fixed = AssistantMessage.builder()
+						.content("")
+						.toolCalls(assistantMsg.getToolCalls())
+						.properties(assistantMsg.getMetadata())
+						.media(assistantMsg.getMedia())
+						.build();
+				if (log.isDebugEnabled()) {
+					log.debug("[{}] AssistantMessage text was null with tool calls; patched content to empty string", NAME);
+				}
+				sanitized.add(fixed);
+			} else {
+				sanitized.add(msg);
+			}
+		}
+
+		return sanitized;
+	}
+
+	private static boolean needsSanitizing(Message msg) {
+		return msg instanceof AssistantMessage assistantMsg
+				&& assistantMsg.getText() == null
+				&& assistantMsg.hasToolCalls();
+	}
+
+	/**
+	 * Builder for creating {@link AssistantMessageSanitizerInterceptor} instances.
+	 */
+	public static class Builder {
+
+		public Builder() {
+		}
+
+		/**
+		 * Build the {@link AssistantMessageSanitizerInterceptor} instance.
+		 * @return a new {@link AssistantMessageSanitizerInterceptor}
+		 */
+		public AssistantMessageSanitizerInterceptor build() {
+			return new AssistantMessageSanitizerInterceptor(this);
+		}
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilderSanitizerRegistrationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilderSanitizerRegistrationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.graph.agent.extension.interceptor.AssistantMessageSanitizerInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link DefaultBuilder} registers the {@link AssistantMessageSanitizerInterceptor}
+ * by default and honors the {@code assistantMessageSanitizerEnabled} opt-out (issue #4561).
+ * <p>
+ * The build path is exercised via {@link DefaultBuilder#registerDefaultModelInterceptors()}
+ * directly so the test does not require a real {@code ChatModel}. The method operates on the
+ * protected {@code modelInterceptors} list shared with the runtime build path.
+ */
+class DefaultBuilderSanitizerRegistrationTest {
+
+	private static long sanitizerCount(DefaultBuilder builder) {
+		if (builder.modelInterceptors == null) {
+			return 0;
+		}
+		return builder.modelInterceptors.stream()
+				.filter(i -> i instanceof AssistantMessageSanitizerInterceptor)
+				.count();
+	}
+
+	@Test
+	void registersSanitizerByDefault() {
+		DefaultBuilder builder = new DefaultBuilder();
+
+		builder.registerDefaultModelInterceptors();
+
+		assertEquals(1, sanitizerCount(builder), "sanitizer should be registered by default");
+		// Registered last so it is innermost (closest to the model call) in the chain.
+		ModelInterceptor last = builder.modelInterceptors.get(builder.modelInterceptors.size() - 1);
+		assertTrue(last instanceof AssistantMessageSanitizerInterceptor);
+	}
+
+	@Test
+	void optOutDisablesSanitizer() {
+		DefaultBuilder builder = new DefaultBuilder();
+		builder.assistantMessageSanitizerEnabled(false);
+
+		builder.registerDefaultModelInterceptors();
+
+		assertEquals(0, sanitizerCount(builder), "sanitizer should not be registered when disabled");
+	}
+
+	@Test
+	void doesNotRegisterDuplicateSanitizer() {
+		DefaultBuilder builder = new DefaultBuilder();
+		builder.interceptors(AssistantMessageSanitizerInterceptor.builder().build());
+		// Mirror the runtime ordering: user interceptors are separated by type first.
+		builder.separateInterceptorsByType();
+
+		builder.registerDefaultModelInterceptors();
+
+		assertEquals(1, sanitizerCount(builder), "an explicitly configured sanitizer must not be duplicated");
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/AssistantMessageSanitizerInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/AssistantMessageSanitizerInterceptorTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptors;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.alibaba.cloud.ai.graph.agent.extension.interceptor.AssistantMessageSanitizerInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link AssistantMessageSanitizerInterceptor}, covering issue #4561:
+ * tool-calling AssistantMessages with {@code null} text must be rewritten with an empty
+ * content so strict DeepSeek-compatible backends accept them.
+ */
+class AssistantMessageSanitizerInterceptorTest {
+
+	private final AssistantMessageSanitizerInterceptor interceptor = AssistantMessageSanitizerInterceptor.builder()
+			.build();
+
+	private static AssistantMessage.ToolCall sampleToolCall() {
+		return new AssistantMessage.ToolCall("call_1", "function", "search", "{\"query\": \"what is sy\"}");
+	}
+
+	/**
+	 * Capture the request that actually reaches the model and echo back a dummy response.
+	 */
+	private static ModelCallHandler capturingHandler(AtomicReference<ModelRequest> captured) {
+		return request -> {
+			captured.set(request);
+			return ModelResponse.of(new AssistantMessage("ok"));
+		};
+	}
+
+	@Test
+	void rewritesNullTextToolCallMessageToEmptyContent() {
+		AssistantMessage toolCallMessage = AssistantMessage.builder()
+				.content(null)
+				.toolCalls(List.of(sampleToolCall()))
+				.build();
+
+		ModelRequest request = ModelRequest.builder()
+				.messages(List.of(new UserMessage("search what is sy?"), toolCallMessage))
+				.build();
+
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+		interceptor.interceptModel(request, capturingHandler(captured));
+
+		ModelRequest forwarded = captured.get();
+		assertNotNull(forwarded);
+		Message rewritten = forwarded.getMessages().get(1);
+		assertInstanceOf(AssistantMessage.class, rewritten);
+		AssistantMessage rewrittenAssistant = (AssistantMessage) rewritten;
+		// null text -> empty string content, so the serialized request keeps the content field.
+		assertEquals("", rewrittenAssistant.getText());
+		assertTrue(rewrittenAssistant.hasToolCalls());
+		assertEquals(1, rewrittenAssistant.getToolCalls().size());
+		assertEquals("search", rewrittenAssistant.getToolCalls().get(0).name());
+	}
+
+	@Test
+	void preservesToolCallsMetadataAndMedia() {
+		Media media = Media.builder()
+				.mimeType(MimeTypeUtils.IMAGE_PNG)
+				.data(URI.create("http://example.com/image.png"))
+				.id("media-1")
+				.build();
+
+		AssistantMessage toolCallMessage = AssistantMessage.builder()
+				.content(null)
+				.toolCalls(List.of(sampleToolCall()))
+				.properties(Map.of("customKey", "customValue"))
+				.media(List.of(media))
+				.build();
+
+		ModelRequest request = ModelRequest.builder()
+				.messages(List.of(toolCallMessage))
+				.build();
+
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+		interceptor.interceptModel(request, capturingHandler(captured));
+
+		AssistantMessage rewritten = (AssistantMessage) captured.get().getMessages().get(0);
+		assertEquals("", rewritten.getText());
+		assertEquals(List.of(sampleToolCall()), rewritten.getToolCalls());
+		assertEquals("customValue", rewritten.getMetadata().get("customKey"));
+		assertEquals(1, rewritten.getMedia().size());
+		assertEquals("media-1", rewritten.getMedia().get(0).getId());
+	}
+
+	@Test
+	void leavesMessagesUntouchedWhenNoRewriteNeeded() {
+		AssistantMessage textWithToolCalls = AssistantMessage.builder()
+				.content("thinking...")
+				.toolCalls(List.of(sampleToolCall()))
+				.build();
+
+		List<Message> original = List.of(
+				new UserMessage("hi"),
+				new AssistantMessage("plain answer"),
+				textWithToolCalls,
+				ToolResponseMessage.builder()
+						.responses(List.of(new ToolResponseMessage.ToolResponse("call_1", "search", "result")))
+						.build());
+
+		ModelRequest request = ModelRequest.builder().messages(original).build();
+
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+		interceptor.interceptModel(request, capturingHandler(captured));
+
+		// No message needed fixing: the exact same request instance is forwarded.
+		assertSame(request, captured.get());
+		assertSame(original, captured.get().getMessages());
+	}
+
+	@Test
+	void handlesEmptyMessageListGracefully() {
+		ModelRequest request = ModelRequest.builder().messages(List.of()).build();
+
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+		interceptor.interceptModel(request, capturingHandler(captured));
+
+		assertSame(request, captured.get());
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #4561.

When a `ReactAgent` performs a tool call, the assistant message that carries the `tool_calls` has no text, so `AssistantMessage#getText()` is `null`. On the second `/chat/completions` call this message is sent back to the model together with the tool result, and Spring AI's OpenAI/DeepSeek-compatible serialization layer drops the `content` field entirely:

```json
{ "role": "assistant", "tool_calls": [ ... ] }
```

instead of:

```json
{ "role": "assistant", "content": null, "tool_calls": [ ... ] }
```

Strict DeepSeek-compatible backends reject the former with a pydantic validation error (`content` field required), returning HTTP 500.

## How it is fixed

- Add `AssistantMessageSanitizerInterceptor` (a `ModelInterceptor` under `extension/interceptor`) that rewrites assistant messages whose `text == null && hasToolCalls()` to an empty-string content (`""`), **preserving `toolCalls`, metadata, and media**. It short-circuits and forwards the original request unchanged when no message needs fixing.
- Register it as a **default** model interceptor in `DefaultBuilder`, appended **last** so it sits innermost in the chain (closest to the model call) and normalizes the message list only after any user-configured interceptors have run.
- Add an opt-out: `ReactAgent.builder().assistantMessageSanitizerEnabled(false)`, for users who will want a literal `"content": null` once it is supported upstream in Spring AI.

This follows the approach discussed in the issue thread. It is a compatibility shim — the ideal fix still belongs in the upstream Spring AI serializer.

## Tests

- `AssistantMessageSanitizerInterceptorTest`: rewrite of `text=null` + tool_calls → `content=""`; `toolCalls` / metadata / media preserved; short-circuit when no rewrite is needed; empty message list handled.
- `DefaultBuilderSanitizerRegistrationTest`: default registration; opt-out disables it; no duplicate registration when already configured.

All tests pass; `checkstyle:check` reports 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)