### PR TITLE
fix(graph): replace recursive step chaining with iterative expansion to prevent StackOverflowError

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphResponse.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphResponse.java
@@ -17,11 +17,14 @@ package com.alibaba.cloud.ai.graph;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import reactor.core.publisher.Flux;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -38,6 +41,17 @@ public class GraphResponse<E> implements Serializable {
 	Object resultValue;
 
 	Map<String, Object> metadata;
+
+	/**
+	 * Lazy continuation of the graph execution. Executors emit a marker response
+	 * carrying the next execution step instead of recursively nesting it with
+	 * {@code concatWith(Flux.defer(...))}; {@link com.alibaba.cloud.ai.graph.GraphRunner}
+	 * expands these markers iteratively so the reactive operator depth stays constant
+	 * regardless of how many nodes execute (see issue #4594). Markers are internal and
+	 * never emitted to downstream consumers.
+	 */
+	@JsonIgnore
+	transient Supplier<Flux<GraphResponse<E>>> continuation;
 
 	public GraphResponse(){}
 
@@ -91,6 +105,21 @@ public class GraphResponse<E> implements Serializable {
 		return GraphResponse.of(future, metadata);
 	}
 
+	/**
+	 * Creates an internal marker response carrying the next execution step. The supplier
+	 * is invoked lazily by the runner-level driver once all elements preceding the marker
+	 * have been emitted, preserving the ordering semantics of the previous recursive
+	 * {@code concatWith(Flux.defer(...))} chaining without growing the operator chain.
+	 * @param continuation supplier of the next execution step
+	 * @param <E> the type of the data element
+	 * @return a continuation marker response
+	 */
+	public static <E> GraphResponse<E> continueWith(Supplier<Flux<GraphResponse<E>>> continuation) {
+		GraphResponse<E> response = new GraphResponse<>(null, null);
+		response.continuation = continuation;
+		return response;
+	}
+
 	public CompletableFuture<E> getOutput() {
 		return output;
 	}
@@ -102,6 +131,16 @@ public class GraphResponse<E> implements Serializable {
 	@JsonIgnore
 	public boolean isDone() {
 		return output == null;
+	}
+
+	@JsonIgnore
+	public Supplier<Flux<GraphResponse<E>>> getContinuation() {
+		return continuation;
+	}
+
+	@JsonIgnore
+	public boolean hasContinuation() {
+		return continuation != null;
 	}
 
 	@JsonIgnore

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunner.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunner.java
@@ -49,8 +49,17 @@ public class GraphRunner {
 		return Flux.defer(() -> {
 			try {
 				GraphRunnerContext context = new GraphRunnerContext(initialState, config, compiledGraph);
-				// Delegate to the main execution handler - demonstrates polymorphism
-				return mainGraphExecutor.execute(context, resultValue);
+				// Delegate to the main execution handler, then expand step continuations
+				// iteratively (depth-first). Executors emit a continuation marker as the
+				// last element of each step instead of recursively nesting the next step
+				// with concatWith(Flux.defer(...)), which grew the reactive operator chain
+				// by one layer per executed node and blew the stack on long-running loops
+				// (issue #4594). expandDeep drains continuations through a single operator,
+				// keeping the subscriber depth constant while preserving emission order.
+				return mainGraphExecutor.execute(context, resultValue)
+					.expandDeep(response -> response.hasContinuation()
+							? Flux.defer(() -> response.getContinuation().get()) : Flux.empty())
+					.filter(response -> !response.hasContinuation());
 			}
 			catch (Exception e) {
 				return Flux.error(e);

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/MainGraphExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/MainGraphExecutor.java
@@ -130,9 +130,9 @@ public class MainGraphExecutor extends BaseGraphExecutor {
 			NodeOutput output = context.buildOutput(START, cp);
 
 			context.setCurrentNodeId(context.getNextNodeId());
-			// Recursively call the main execution handler
-			return Flux.just(GraphResponse.of(output))
-				.concatWith(Flux.defer(() -> execute(context, new AtomicReference<>())));
+			// Continue with the main execution handler (expanded iteratively by GraphRunner)
+			return Flux.just(GraphResponse.of(output),
+					GraphResponse.continueWith(() -> execute(context, new AtomicReference<>())));
 		}
 		catch (Exception e) {
 			return Flux.just(GraphResponse.error(e));
@@ -150,8 +150,8 @@ public class MainGraphExecutor extends BaseGraphExecutor {
 		try {
 			context.doListeners(END, null);
 			NodeOutput output = context.buildNodeOutput(END);
-			return Flux.just(GraphResponse.of(output))
-				.concatWith(Flux.defer(() -> handleCompletion(context, resultValue)));
+			return Flux.just(GraphResponse.of(output),
+					GraphResponse.continueWith(() -> handleCompletion(context, resultValue)));
 		}
 		catch (Exception e) {
 			return Flux.just(GraphResponse.error(e));

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -206,9 +206,9 @@ public class NodeExecutor extends BaseGraphExecutor {
 			NodeOutput output = context.buildNodeOutputAndAddCheckpoint(updateState);
 
 			context.doListeners(NODE_AFTER, null);
-			// Recursively call the main execution handler
-			return Flux.just(GraphResponse.of(output))
-				.concatWith(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue)));
+			// Continue with the main execution handler (expanded iteratively by GraphRunner)
+			return Flux.just(GraphResponse.of(output),
+					GraphResponse.continueWith(() -> mainGraphExecutor.execute(context, resultValue)));
 		}
 		catch (Exception e) {
 			return Flux.just(GraphResponse.error(e));
@@ -609,7 +609,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 		});
 
 		return processedFlux
-			.concatWith(updateContextMono.thenMany(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue))));
+			.concatWith(updateContextMono.thenMany(Flux
+				.just(GraphResponse.continueWith(() -> mainGraphExecutor.execute(context, resultValue)))));
 	}
 
 	/**
@@ -777,7 +778,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 		});
 
 		return processedFlux
-				.concatWith(updateContextMono.thenMany(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue))));
+				.concatWith(updateContextMono.thenMany(Flux
+					.just(GraphResponse.continueWith(() -> mainGraphExecutor.execute(context, resultValue)))));
 	}
 
 	private Map<String, Object> graphFluxResultState(GraphFlux<?> graphFlux, Object lastData) {
@@ -929,7 +931,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 		});
 
 		return mergedFlux
-				.concatWith(updateContextMono.thenMany(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue))));
+				.concatWith(updateContextMono.thenMany(Flux
+					.just(GraphResponse.continueWith(() -> mainGraphExecutor.execute(context, resultValue)))));
 	}
 
 	/**
@@ -952,8 +955,8 @@ public class NodeExecutor extends BaseGraphExecutor {
 		}
 
 		NodeOutput output = context.buildNodeOutputAndAddCheckpoint(partialState);
-		// Recursively call the main execution handler
-		return Flux.just(GraphResponse.of(output))
-				.concatWith(Flux.defer(() -> mainGraphExecutor.execute(context, resultValue)));
+		// Continue with the main execution handler (expanded iteratively by GraphRunner)
+		return Flux.just(GraphResponse.of(output),
+				GraphResponse.continueWith(() -> mainGraphExecutor.execute(context, resultValue)));
 	}
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/DeepLoopStackDepthTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/DeepLoopStackDepthTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph;
+
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncEdgeAction.edge_async;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces issue #4594: graph execution advances nodes by recursively
+ * appending {@code concatWith(Flux.defer(...))}, so the reactive operator
+ * chain grows linearly with the number of executed nodes and long-running
+ * loops (e.g. many-turn conversations) blow the stack.
+ *
+ * @see <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4594">Issue #4594</a>
+ */
+public class DeepLoopStackDepthTest {
+
+	private static final int ITERATIONS = 3000;
+
+	@Test
+	public void longSelfLoopShouldCompleteWithoutStackOverflow() throws Exception {
+		StateGraph graph = new StateGraph(() -> {
+			Map<String, com.alibaba.cloud.ai.graph.KeyStrategy> strategies = new HashMap<>();
+			strategies.put("count", new ReplaceStrategy());
+			return strategies;
+		}).addNode("worker", node_async(state -> {
+			int count = (int) state.value("count").orElse(0);
+			return Map.of("count", count + 1);
+		}))
+			.addEdge(START, "worker")
+			.addConditionalEdges("worker",
+					edge_async(state -> (int) state.value("count").orElse(0) < ITERATIONS ? "loop" : "done"),
+					Map.of("loop", "worker", "done", END));
+
+		CompiledGraph app = graph.compile();
+		app.setMaxIterations(ITERATIONS + 10);
+
+		// Before the fix the StackOverflowError was swallowed by Reactor (onErrorDropped)
+		// and the stream never terminated, so guard with a timeout instead of blocking forever.
+		OverAllState finalState = app.stream(Map.of("count", 0))
+			.map(NodeOutput::state)
+			.blockLast(java.time.Duration.ofSeconds(90));
+
+		assertEquals(ITERATIONS, finalState.value("count").get());
+	}
+
+}


### PR DESCRIPTION
Fixes #4594

## Root cause

Graph execution advances nodes by recursively appending `concatWith(Flux.defer(() -> mainGraphExecutor.execute(...)))` at every step (7 sites in `MainGraphExecutor` / `NodeExecutor`). Each executed node adds one more operator layer to the reactive chain, so `request()` / completion signals must traverse the whole accumulated chain. On long-running loops or many-turn conversations this blows the stack — the overflow trace is the repeating triple:

```
at reactor.core.publisher.FluxConcatArray$ConcatArraySubscriber.request(FluxConcatArray.java:256)
at reactor.core.publisher.MonoFlatMapMany$FlatMapManyMain.request(MonoFlatMapMany.java:112)
at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.request(Operators.java:2330)
... (one group per executed node)
```

It is actually worse than a crash: the `StackOverflowError` is swallowed by Reactor (`onErrorDropped`) and the stream never terminates, so callers block forever with no error signal — a silent hang in production.

Reproduced with a 3000-iteration self-loop graph (`DeepLoopStackDepthTest`, included): before the fix the test hangs until timeout with the dropped `StackOverflowError` visible via `Hooks.onErrorDropped`; after the fix it completes in ~0.4s.

## Fix

Executors now emit a lazy continuation marker (`GraphResponse.continueWith(supplier)`) as the **last element** of each step instead of nesting the next step recursively. `GraphRunner.run` drains these markers through a single `expandDeep` operator:

- **Ordering preserved**: depth-first expansion emits the continuation's elements immediately after the marker, exactly matching the previous `concat` semantics (including the `updateContextMono.thenMany(...)` sites — the side-effecting Mono still completes before the marker is emitted).
- **Constant stack depth**: `expandDeep` maintains its own internal structure, so subscriber depth no longer grows with node count.
- **No API change**: markers are internal and filtered out inside `GraphRunner.run`, so `graphResponseStream` / `stream` consumers see exactly the same elements as before. Backpressure and cancellation propagate through the single `expandDeep` operator as usual.

## Verification

- New `DeepLoopStackDepthTest`: 3000-iteration conditional self-loop completes without stack overflow (guarded by a timeout so a regression fails instead of hanging).
- `spring-ai-alibaba-graph-core`: 405 tests, 0 failures (the only error is the pre-existing Docker-dependent `DatabaseStorePostgreSqlIntegrationTest` environment failure, unrelated).
- `spring-ai-alibaba-agent-framework`: 590 tests, 0 failures.
- `checkstyle:check` passes.

## Note

While touching `MainGraphExecutor.handleStartNode` I kept its existing behavior of passing a fresh `AtomicReference` to the continuation, but it looks like a latent bug: the top-level `resultValue` reference is discarded right after START, so `GraphRunner#resultValue()` can never observe values set later in the run. Happy to fix that here or in a follow-up if maintainers confirm.
