### PR TITLE
fix(agent): isolate model request messages

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/ModelRequest.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/ModelRequest.java
@@ -46,7 +46,7 @@ public class ModelRequest {
 			List<String> tools, List<ToolCallback> dynamicToolCallbacks, Map<String, String> toolDescriptions,
 			Map<String, Object> context) {
 		this.systemMessage = systemMessage;
-		this.messages = messages;
+		this.messages = messages == null ? null : new ArrayList<>(messages);
 		this.options = options;
 		this.tools = tools;
 		this.dynamicToolCallbacks = dynamicToolCallbacks;

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRequestTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ModelRequestTest.java
@@ -17,9 +17,11 @@ package com.alibaba.cloud.ai.graph.agent.interceptors;
 
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,30 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests the new toolDescriptions field added to support enhanced tool selection.
  */
 class ModelRequestTest {
+
+	@Test
+	void testModelRequestMessagesAreIsolatedFromSourceList() {
+		List<Message> stateMessages = new ArrayList<>(List.of(new UserMessage("Hello")));
+		ModelRequest request = ModelRequest.builder().messages(stateMessages).build();
+
+		request.getMessages().clear();
+
+		assertEquals(1, stateMessages.size(),
+				"Mutating an interceptor request must not mutate the graph state message list");
+	}
+
+	@Test
+	void testModelRequestCopyHasIndependentMessages() {
+		ModelRequest original = ModelRequest.builder()
+			.messages(List.of(new UserMessage("Hello")))
+			.build();
+		ModelRequest copy = ModelRequest.builder(original).build();
+
+		copy.getMessages().clear();
+
+		assertEquals(1, original.getMessages().size(),
+				"An interceptor-built request must not mutate the previous request");
+	}
 
 	@Test
 	void testModelRequestWithToolDescriptions() {


### PR DESCRIPTION
## What changed

- Copy the message list when constructing a `ModelRequest`.
- Keep the request-local list mutable for interceptor compatibility while preventing mutations from leaking into graph state or an earlier request.
- Add regression coverage for both the source state list and `ModelRequest.builder(existingRequest)`.

## Why

`AgentLlmNode` builds a `ModelRequest` from the graph state's message list. `ModelRequest` previously retained that list by reference, so an interceptor such as `request.getMessages().clear()` also cleared the persisted conversation history. The defensive copy limits the mutation to the current model request.

Fixes #4499.

## Validation

```text
.\mvnw.cmd -pl :spring-ai-alibaba-agent-framework -am -Dtest=ModelRequestTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: 9 tests passed; graph-core and agent-framework compiled successfully.