### PR TITLE
docs: add graph engineering repoops example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
 
 * **[Graph-based Workflow](https://java2ai.com/docs/frameworks/graph-core/quick-start)**: Graph based workflow runtime and api for conditional routing, nested graphs, parallel execution, and state management. Export workflows to PlantUML and Mermaid formats.
 
+* **[Graph Engineering](./docs/graph-engineering.md)**: Compose specialized agents or deterministic steps into explicit nodes, edges, shared state, verifier nodes, and distributed A2A handoffs when a single `ReactAgent` loop is no longer enough.
+
 * **[A2A Support](https://java2ai.com/docs/frameworks/agent-framework/advanced/a2a)**: Agent-to-Agent communication support with Nacos integration, enabling distributed agent coordination and collaboration across services.
 
 * **[Rich Model, Tool and MCP Support](https://java2ai.com/integration/chatmodels/dashScope)**: Leveraging core concepts of Spring AI, supports multiple LLM providers (DashScope, OpenAI, etc.), tool calling, and Model Context Protocol (MCP).
@@ -120,6 +122,9 @@ There's a ChatBot example provided by the community at [examples/chatbot](https:
 * [Quick Start](https://java2ai.com/docs/quick-start) - Get started with a simple agent
 * [Agent Framework Tutorials](https://java2ai.com/docs/frameworks/agent-framework/tutorials/agents) - Step by step tutorials
 * [Use Graph API to Build Complex Workflows](https://java2ai.com/docs/frameworks/agent-framework/advanced/context-engineering) - In-depth user guide for building multi-agent and workflows
+* [Graph Engineering with Spring AI Alibaba](./docs/graph-engineering.md) - Positioning guide for nodes, edges, shared state, verifier nodes, A2A, and external-agent orchestration
+* [Lightweight RepoOps Graph Engineering](./docs/graph-engineering-repoops-lightweight.md) - Single-application RepoOps lifecycle design using Spring AI Alibaba Graph, local agents, tools, and optional A2A
+* [Graph Engineering Examples](./examples/graphengineering) - Runnable RepoOps issue workflow using Spring AI Alibaba Graph with AgentScope Java nodes
 * [Spring AI Basics](https://java2ai.com/ecosystem/spring-ai/reference/concepts) - Ai Application basic concepts, including ChatModel, MCP, Tool, Messages, etc.
 * [Chat Memory](https://docs.spring.io/spring-ai/reference/api/chatclient.html#chat-memory) - Spring AI reference for chat memory repositories and usage
 
@@ -132,6 +137,7 @@ This project consists of several core components:
 * spring-ai-alibaba-admin: A one-stop Agent platform that supports visualized Agent development, observability, evaluation, and MCP management, etc.
 * spring-ai-alibaba-studio: The embedded ui for quickly debugging agent in a visualized way.
 * spring-boot-starters: Starters integrating Agent Framework with Nacos to provide A2A and dynamic config features.
+* examples/graphengineering: Runnable Graph Engineering examples. The current RepoOps issue workflow shows how Spring AI Alibaba Graph owns state and routing while AgentScope Java implements specialist nodes.
 
 ## Spring AI Alibaba Ecosystem
  Repository | Description | ⭐

--- a/docs/graph-engineering-repoops-lightweight.md
+++ b/docs/graph-engineering-repoops-lightweight.md
@@ -1,0 +1,516 @@
+# Lightweight RepoOps Graph Engineering
+
+This document is the lightweight version of the RepoOps Graph Engineering
+design. It keeps the same software-engineering lifecycle use case, but removes
+the managed worker/team control plane from the architecture.
+
+Use this version when the target deployment is a single Spring Boot application
+or a small set of Spring services, and when the team does not need a separate
+worker/team control plane.
+
+## Positioning
+
+The lightweight design uses Spring AI Alibaba as the full orchestration layer:
+
+- `StateGraph` owns workflow topology, routing, state, loop-back, and audit.
+- `ReactAgent` owns local agent reasoning loops.
+- `AgentScopeAgent` owns AgentScope Java implementations that should participate
+  in the same graph.
+- Deterministic `NodeAction` nodes own rule-based normalization, gating, and
+  evidence writing.
+- `ParallelAgent` or graph fan-out owns concurrent review and analysis branches.
+- `A2aRemoteAgent` is optional for remote service-owned agents.
+
+The rule is simple: start with local graph nodes and local agents. Add A2A only
+when a capability already belongs to another service. Do not introduce a worker
+control plane until worker lifecycle, room collaboration, permissions, and
+fleet-level governance become real requirements.
+
+This does not mean removing Worker, Team, or Capability definitions. In the
+lightweight design they are local application contracts, not runtime resources
+managed by a separate controller.
+
+## Responsibility Boundary
+
+| Layer | Owns | Example |
+| --- | --- | --- |
+| Spring AI Alibaba Graph | Lifecycle state machine, explicit routing, fan-out/fan-in, verifier loops, evidence bundle | Issue intake, route, review, verify, release guard, audit |
+| `ReactAgent` | Local specialist behavior inside one node | Triage agent, diagnosis agent, writer agent, reviewer agent |
+| `AgentScopeAgent` | AgentScope Java specialist behavior adapted as a graph node | AgentScope diagnosis worker, review worker, writer worker |
+| Deterministic node | Stable business rules and non-LLM checks | Required fields, severity mapping, branch policy, verification result merge |
+| Tool / MCP node | External system actions | GitHub/GitLab lookup, CI status, test command, issue comment draft |
+| A2A node, optional | Remote capability that is owned by another service | Release agent, security scanner, docs agent |
+| Local capability registry | Binding from graph node name to local bean, agent, tool, AgentScope agent, or A2A agent | `repoops.review_security_risk -> securityReviewAgent` |
+
+## Recommended Layout
+
+```text
+repoops-app/
+  graph/
+    graphs/
+      repoops-lifecycle.graph.yaml
+      pr-review.graph.yaml
+    workers/
+      triage-worker.yaml
+      implementation-worker.yaml
+      correctness-review-worker.yaml
+      security-review-worker.yaml
+      release-guardian-worker.yaml
+    teams/
+      repoops-review-team.yaml
+    capabilities/
+      repoops-capabilities.yaml
+    schemas/
+      lifecycle-context.schema.json
+      review-finding.schema.json
+      verification-result.schema.json
+
+  src/main/java/com/example/repoops/
+    RepoOpsGraphConfiguration.java
+    RepoOpsStateKeys.java
+    RepoOpsRoutes.java
+    RepoOpsCapabilityRegistry.java
+    nodes/
+      IntakeNode.java
+      TriageAgentNode.java
+      IssueRouterNode.java
+      BugDiagnosisAgentNode.java
+      FeaturePlannerAgentNode.java
+      QuestionAnswerAgentNode.java
+      ImplementationAgentNode.java
+      CorrectnessReviewAgentNode.java
+      TestReviewAgentNode.java
+      SecurityReviewAgentNode.java
+      PolicyReviewAgentNode.java
+      ReviewChairNode.java
+      VerificationGateNode.java
+      ReleaseGuardianNode.java
+      KnowledgeStewardNode.java
+      AuditorNode.java
+    tools/
+      RepositoryTools.java
+      CiTools.java
+      IssueTrackerTools.java
+      EvidenceTools.java
+```
+
+For a demo or documentation example, the same shape can live in one Java class.
+For production, split state keys, routes, node implementations, and tool
+adapters so the graph stays readable.
+
+## Local Worker and Team Definitions
+
+In this design, a worker definition describes a local executable capability. It
+does not create a worker process, open a team room, or manage runtime lifecycle.
+It is metadata that helps the graph remain declarative.
+
+Example local worker:
+
+```yaml
+kind: LocalWorker
+metadata:
+  name: repoops-security-review
+spec:
+  role: security-reviewer
+  provider: agentscope
+  bean: securityReviewAgentScopeAgent
+  input_schema: SecurityReviewRequest
+  output_schema: SecurityFinding
+  timeout: 2m
+```
+
+Example local team:
+
+```yaml
+kind: LocalTeam
+metadata:
+  name: repoops-review-team
+spec:
+  description: Local reviewers used by the RepoOps PR review pod
+  workers:
+    - repoops-correctness-review
+    - repoops-test-review
+    - repoops-security-review
+    - repoops-policy-review
+```
+
+The team definition is a logical grouping. The graph still owns the fan-out,
+fan-in, route policy, and verification loop.
+
+## Capability Registry
+
+The capability registry maps graph node names to concrete implementations. It
+supports Spring AI Alibaba agents, AgentScope Java agents, deterministic tools,
+and optional A2A remote agents.
+
+```yaml
+capabilities:
+  repoops.triage_issue:
+    provider: spring-ai-alibaba
+    target:
+      bean: triageReactAgent
+    input_schema: IssueEvent
+    output_schema: TriageResult
+    timeout: 2m
+
+  repoops.review_security_risk:
+    provider: agentscope
+    target:
+      bean: securityReviewAgentScopeAgent
+    input_schema: SecurityReviewRequest
+    output_schema: SecurityFinding
+    timeout: 2m
+
+  repoops.run_targeted_verification:
+    provider: spring-bean
+    target:
+      bean: ciTools
+      method: runTargetedTests
+    input_schema: VerificationRequest
+    output_schema: VerificationResult
+    timeout: 10m
+
+  repoops.release_guardian:
+    provider: a2a
+    target:
+      agent_name: release-guardian
+      registry: nacos
+    input_schema: ReleaseCandidate
+    output_schema: ReleaseDeployAudit
+    timeout: 5m
+```
+
+The important part is that `provider: agentscope` still runs inside the
+application through `AgentScopeAgent`. It is not a remote worker team.
+
+## Lightweight Runtime Flow
+
+```mermaid
+flowchart LR
+    event["Issue / PR / CI Event"]
+    graph["Spring AI Alibaba<br/>StateGraph"]
+    state["Graph State<br/>RepoOpsContext"]
+    agents["Local Workers<br/>ReactAgent + AgentScopeAgent"]
+    tools["Tools / MCP<br/>SCM, CI, Docs"]
+    remote["A2A Remote Agent<br/>optional"]
+    gate{"Verifier Gate"}
+    evidence["Evidence Bundle"]
+
+    event --> graph
+    graph --> state
+    graph --> agents
+    graph --> tools
+    graph -.-> remote
+    agents --> graph
+    tools --> graph
+    remote -.-> graph
+    graph --> gate
+    gate -->|revision required| graph
+    gate -->|pass| evidence
+
+    classDef primary fill:#7B68EE,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef business fill:#E99151,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef infra fill:#607D8B,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef warning fill:#F39C12,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef success fill:#4CA497,color:#FFFFFF,stroke:none,rx:10,ry:10
+
+    class graph,state primary
+    class event,agents business
+    class tools,remote infra
+    class gate warning
+    class evidence success
+
+    linkStyle default stroke-width:2px,stroke:#333333,opacity:0.8
+```
+
+## Lifecycle Graph
+
+The lightweight graph should still preserve the important business edges. The
+main simplification is that every node is a local Spring bean unless it is
+explicitly marked as A2A.
+
+```mermaid
+flowchart LR
+    intake["Intake<br/>normalize event"]
+    triage["Triage Agent<br/>classify, dedupe, priority"]
+    route{"Issue Router"}
+    bug["Bug Diagnosis<br/>ReactAgent or AgentScopeAgent"]
+    feature["Feature Planning<br/>requirement + design note"]
+    question["Question Answer<br/>support response"]
+    implement["Implementation Agent<br/>ReactAgent or AgentScopeAgent"]
+    review["Review Pod<br/>parallel local reviewers"]
+    verify{"Verification Gate"}
+    release["Release Guardian<br/>optional A2A"]
+    audit["Auditor<br/>evidence bundle"]
+
+    intake --> triage
+    triage --> route
+    route -->|bug| bug
+    route -->|feature| feature
+    route -->|question| question
+    bug --> implement
+    feature --> implement
+    implement --> review
+    review --> verify
+    verify -->|fail| implement
+    verify -->|pass| release
+    release --> audit
+    question --> audit
+
+    classDef business fill:#E99151,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef warning fill:#F39C12,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef success fill:#4CA497,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef external fill:#607D8B,color:#FFFFFF,stroke:none,rx:10,ry:10
+
+    class intake,triage,bug,feature,question,implement,review business
+    class route,verify warning
+    class release external
+    class audit success
+
+    linkStyle default stroke-width:2px,stroke:#333333,opacity:0.8
+```
+
+## Review Pod
+
+The review pod can be implemented with separate graph nodes or a
+`ParallelAgent`. Use separate nodes when each reviewer writes a distinct state
+key and the route must be audited. Use `ParallelAgent` when the branches are a
+common reusable pattern and the merge policy is simple.
+
+```mermaid
+flowchart LR
+    context["Review Context"]
+    correctness["Correctness Reviewer<br/>ReactAgent"]
+    tests["Test Reviewer<br/>ReactAgent"]
+    security["Security Reviewer<br/>ReactAgent"]
+    policy["Policy Reviewer<br/>ReactAgent"]
+    chair["Review Chair<br/>deterministic merge"]
+    verify{"Verification Gate"}
+
+    context --> correctness
+    context --> tests
+    context --> security
+    context --> policy
+    correctness --> chair
+    tests --> chair
+    security --> chair
+    policy --> chair
+    chair --> verify
+
+    classDef business fill:#E99151,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef warning fill:#F39C12,color:#FFFFFF,stroke:none,rx:10,ry:10
+
+    class context,correctness,tests,security,policy,chair business
+    class verify warning
+
+    linkStyle default stroke-width:2px,stroke:#333333,opacity:0.8
+```
+
+## State Contract
+
+Keep the state contract small and explicit:
+
+| State key | Strategy | Purpose |
+| --- | --- | --- |
+| `graph_id` | replace | Stable graph identity for trace correlation |
+| `run_id` | replace | Unique graph run identity |
+| `current_node` | replace | Last completed graph node |
+| `issue_event` | replace | Original issue, PR, CI, or release event |
+| `lifecycle_context` | replace | Normalized repository, branch, owner, priority, and risk context |
+| `triage_result` | replace | Classification and priority output |
+| `route_decision` | replace | `bug`, `feature`, or `question` selected from triage output by a router node |
+| `work_plan` | replace | Bug diagnosis or feature implementation plan |
+| `implementation_result` | replace | Patch suggestion, commands, or files changed |
+| `review_findings` | append | Findings from parallel reviewers |
+| `review_summary` | replace | Fan-in summary and blocking decision |
+| `review_gate_result` | replace | Pass/fail result and reason |
+| `release_deploy_audit` | replace | Release or deploy readiness result |
+| `knowledge_entry` | replace | FAQ, postmortem, or docs update candidate |
+| `node_trace` | append | Per-node execution metadata with node id, type, inputs, outputs, and timestamp |
+| `route_history` | append | Auditable route decisions and reasons |
+| `evidence_bundle` | append | Append-only operational audit evidence |
+
+Use `AppendStrategy` only for evidence-like data. Use `ReplaceStrategy` for
+current stage outputs so stale results do not accidentally drive a later route.
+
+## API Mapping
+
+| Requirement | Lightweight implementation |
+| --- | --- |
+| Lifecycle workflow | `StateGraph` |
+| Local specialist agent | `ReactAgent.asNode()` or `AsyncNodeAction` wrapping `ReactAgent.call(...)` |
+| AgentScope specialist agent | `AgentScopeAgent.fromBuilder(...).build()` and `agentScopeAgent.asNode()` |
+| Rule-based stage | `NodeAction` / `AsyncNodeAction` |
+| Auditable route decision | Deterministic router node plus `StateGraph.addConditionalEdges(...)` |
+| Parallel review | Multiple graph edges or `ParallelAgent` |
+| Fan-in review summary | Join node using `AppendStrategy` inputs |
+| Failed verification loop | Verifier agent plus deterministic gate node, then conditional edge back to `implementation` |
+| Optional distributed capability | `A2aRemoteAgent` |
+| Audit trail | State snapshots, checkpoint saver, `node_trace`, `route_history`, evidence bundle node |
+
+## Minimal Java Shape
+
+```java
+AgentScopeAgent securityReviewer = AgentScopeAgent.fromBuilder(scopeReActBuilder)
+        .name("repoops_security_review")
+        .instruction("Review security risk from the RepoOps review context.")
+        .outputKey("review_findings")
+        .build();
+
+StateGraph graph = new StateGraph(keyStrategyFactory)
+        .addNode("intake", intakeNode)
+        .addNode("triage", triageAgent.asNode())
+        .addNode("route_issue", routeIssueNode)
+        .addNode("bug_diagnosis", bugDiagnosisAgent.asNode())
+        .addNode("feature_planning", featurePlannerAgent.asNode())
+        .addNode("question_answer", questionAnswerAgent.asNode())
+        .addNode("implementation", implementationAgent.asNode())
+        .addNode("correctness_review", correctnessReviewer.asNode())
+        .addNode("test_review", testReviewer.asNode())
+        .addNode("security_review", securityReviewer.asNode())
+        .addNode("policy_review", policyReviewer.asNode())
+        .addNode("review_chair", reviewChairNode)
+        .addNode("verification_gate", verificationGateNode)
+        .addNode("release_guardian", releaseGuardianNode)
+        .addNode("auditor", auditorNode)
+        .addEdge(StateGraph.START, "intake")
+        .addEdge("intake", "triage")
+        .addEdge("triage", "route_issue")
+        .addConditionalEdges("route_issue", issueRoute,
+                Map.of("bug", "bug_diagnosis",
+                        "feature", "feature_planning",
+                        "question", "question_answer"))
+        .addEdge("bug_diagnosis", "implementation")
+        .addEdge("feature_planning", "implementation")
+        .addEdge("implementation", "correctness_review")
+        .addEdge("implementation", "test_review")
+        .addEdge("implementation", "security_review")
+        .addEdge("implementation", "policy_review")
+        .addEdge("correctness_review", "review_chair")
+        .addEdge("test_review", "review_chair")
+        .addEdge("security_review", "review_chair")
+        .addEdge("policy_review", "review_chair")
+        .addEdge("review_chair", "verification_gate")
+        .addConditionalEdges("verification_gate", verificationRoute,
+                Map.of("fail", "implementation", "pass", "release_guardian"))
+        .addEdge("release_guardian", "auditor")
+        .addEdge("question_answer", "auditor")
+        .addEdge("auditor", StateGraph.END);
+```
+
+## Runnable Issue Example
+
+The AgentScope issue example is the API-backed version of this lightweight
+design:
+
+- `examples/graphengineering/src/main/java/com/alibaba/cloud/ai/examples/graphengineering/AgentScopeRepoOpsIssueGraphExample.java`
+- `examples/graphengineering/src/main/resources/repoops-graph-topology.yaml`
+
+It reads a RepoOps issue JSON payload or a GitHub issue URL first, then routes
+the graph:
+
+```text
+initialize_run
+  -> read_issue
+read_issue
+  -> agentscope_triager
+  -> route_issue
+  -> bug: agentscope_bug_diagnoser -> agentscope_implementer -> agentscope_reviewer -> review_gate
+  -> feature: agentscope_feature_planner -> agentscope_implementer -> agentscope_reviewer -> review_gate
+  -> question: agentscope_question_responder -> record_question_evidence
+
+ review_gate
+   -> pass: agentscope_auditor
+   -> fail: agentscope_implementer
+
+ record_question_evidence
+   -> agentscope_auditor
+
+ agentscope_auditor
+  -> END
+```
+
+The implemented graph is:
+
+```mermaid
+flowchart LR
+    start["START"]
+    init["initialize_run<br/>graph_id + run_id"]
+    read["read_issue<br/>file or GitHub URL"]
+    triage["agentscope_triager<br/>classify and normalize"]
+    route["route_issue<br/>route_decision"]
+    bug["agentscope_bug_diagnoser"]
+    feature["agentscope_feature_planner"]
+    question["agentscope_question_responder"]
+    evidence["record_question_evidence"]
+    implement["agentscope_implementer"]
+    review["agentscope_reviewer<br/>review_decision"]
+    gate{"review_gate"}
+    audit["agentscope_auditor<br/>audit_report"]
+    end["END"]
+
+    start --> init
+    init --> read
+    read --> triage
+    triage --> route
+    route -->|bug| bug
+    route -->|feature| feature
+    route -->|question| question
+    bug --> implement
+    feature --> implement
+    question --> evidence
+    evidence --> audit
+    implement --> review
+    review --> gate
+    gate -->|PASS| audit
+    gate -->|FAIL| implement
+    audit --> end
+
+    classDef business fill:#E99151,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef gateway fill:#7B68EE,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef warning fill:#F39C12,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef success fill:#4CA497,color:#FFFFFF,stroke:none,rx:10,ry:10
+
+    class init,read,triage,bug,feature,question,evidence,implement,review business
+    class route,gate warning
+    class audit success
+    class start,end gateway
+
+    linkStyle default stroke-width:2px,stroke:#333333,opacity:0.8
+```
+
+The default local input is:
+
+```text
+classpath:issues/bug_issue.json
+```
+
+You can pass a different issue file or a public GitHub issue URL as the first
+argument:
+
+```text
+https://github.com/alibaba/spring-ai-alibaba/issues/4830
+```
+
+For GitHub URLs, the `read_issue` node fetches the issue through the public
+GitHub API and normalizes title, body, labels, repository, state, author, and
+timestamps into graph state. The issue payload is kept as `issue_payload`, and
+normalized fields such as `issue_type`, `issue_repository`, `requires_review`,
+and `requires_deploy` drive routing and audit. The runnable example also writes
+`node_trace`, `route_history`, and `evidence_bundle` so the runtime work graph is
+available as state, not only as logs.
+
+## When This Version Is Enough
+
+Use the lightweight version when:
+
+- One Spring Boot service can own the workflow.
+- Node implementations can be normal Spring beans.
+- Operators do not need to create, pause, scale, or govern workers separately.
+- Review, verification, and audit are more important than dynamic workforce
+  management.
+- A2A is enough for the few capabilities that are already remote.
+
+Move to a heavier architecture only when the system needs managed worker
+resources, team rooms, runtime selection, cross-agent collaboration surfaces,
+gateway-managed permissions, or fleet-level lifecycle management.

--- a/docs/graph-engineering.md
+++ b/docs/graph-engineering.md
@@ -1,0 +1,285 @@
+# Graph Engineering with Spring AI Alibaba
+
+Graph Engineering is the practice of composing specialized agents or deterministic
+steps into an explicit graph: nodes do the work, edges route the work, and shared
+state carries context between them. It is useful when one agent loop is no longer
+the right shape for the task.
+
+Spring AI Alibaba already treats this as a first-class application architecture:
+
+- `spring-ai-alibaba-graph-core` provides the stateful graph runtime.
+- `spring-ai-alibaba-agent-framework` turns agents into graph nodes and provides
+  higher-level multi-agent patterns.
+- A2A and Nacos integrations let a graph call agents owned by other services.
+- AgentScope integration shows that Spring AI Alibaba can orchestrate agents
+  implemented by other frameworks through `spring-ai-alibaba-starter-agentscope`,
+  not only Spring AI `ReactAgent`.
+
+The positioning is simple: use `ReactAgent` for a single well-scoped loop, use
+FlowAgent patterns for common multi-agent topologies, and use `StateGraph` when
+the handoffs, state, and routing must be explicit.
+
+## Concept Mapping
+
+| Graph Engineering concept | Spring AI Alibaba API | Where it fits |
+| --- | --- | --- |
+| Node | `StateGraph.addNode(...)`, `Node`, `NodeAction`, `AsyncNodeAction`, `agent.asNode()` | A unit of work: model call, tool call, deterministic function, local agent, remote A2A agent, or external-framework agent adapter. |
+| Edge | `StateGraph.addEdge(...)`, `StateGraph.addConditionalEdges(...)`, `AsyncEdgeAction.edge_async(...)` | Explicit routing between nodes, including straight-line, branch, and loop-back transitions. |
+| State | `OverAllState`, `KeyStrategyFactory`, `ReplaceStrategy`, `AppendStrategy`, `MergeStrategy` | Shared execution memory flowing across nodes, with per-key merge policies. |
+| Loop | `ReactAgent`, `LoopAgent`, conditional edge back to a previous node | Use a single loop for one job with a clear verifier; use graph loop-back when a different node should verify and route the work. |
+| Fan-out | Multiple edges from one node or from `START`; `ParallelAgent` | Run independent branches concurrently, such as several researchers using different tools or models. |
+| Fan-in | Multiple branches route into a join node; `ParallelAgent.MergeStrategy` | Merge branch outputs before synthesis, writing, or review. |
+| Verifier Node | Dedicated `ReactAgent`, deterministic `NodeAction`, hook, or reviewer node | Separates production from review so the writer does not grade its own work. |
+| A2A | `A2aRemoteAgent`, `AgentCardProvider`, Nacos A2A starter | Treat remote agents as graph nodes and route work across service boundaries. |
+
+## Why Spring AI Alibaba
+
+Graph Engineering is not just drawing boxes around agents. A production graph
+needs state, persistence, observability, routing, streaming, model/tool support,
+and a way to bring external agents into the same control plane. Spring AI Alibaba
+supports those layers together:
+
+1. **Graph Core as the runtime.** `StateGraph` defines nodes and edges, compiles
+   into `CompiledGraph`, and runs long-lived stateful workflows with checkpointing
+   and streaming.
+2. **Agent Framework as the agent layer.** `ReactAgent` handles the single-agent
+   loop. `SequentialAgent`, `ParallelAgent`, `RoutingAgent`, and `LoopAgent`
+   cover common graph shapes without forcing every user into low-level graph APIs.
+3. **Context Engineering as reliability policy.** Hooks and interceptors handle
+   context editing, summarization, human-in-the-loop, tool retry, model-call
+   limits, and dynamic tool selection inside graph nodes.
+4. **A2A and Nacos as distributed edges.** A graph can route to agents discovered
+   through a registry rather than only local Java beans.
+5. **External-agent orchestration.** `spring-ai-alibaba-starter-agentscope`
+   provides `AgentScopeAgent`, which adapts AgentScope `ReActAgent` into the
+   same Spring AI Alibaba graph node model, so Graph Engineering can coordinate
+   agents from multiple frameworks.
+
+## Use a Loop First
+
+The default should still be `ReactAgent`.
+
+Use a single agent loop when:
+
+- The task is one job with a clear finish line.
+- One toolset and one model are enough.
+- A retry or self-check is acceptable.
+- The routing does not need to be audited as a business workflow.
+
+Move to a graph only when the work forces it:
+
+- Distinct specialties need separate prompts, models, tools, or ownership.
+- Branches can run in parallel and then join.
+- A dedicated reviewer should check another node's output.
+- Routing must be explicit and inspectable.
+- One failed node should retry without corrupting downstream state.
+- The workflow must call local agents, remote A2A agents, or agents implemented
+  by another framework.
+
+## RepoOps Issue Graph
+
+The primary example is RepoOps: a graph-driven software engineering workflow
+around repository issues, PR/MR review, CI, release readiness, deployment
+signals, and audit evidence.
+
+The core graph reads an issue, normalizes it into state, lets the triage worker
+propose a route, records auditable route and verifier decisions, invokes
+specialized workers, and writes a final audit report:
+
+```mermaid
+flowchart LR
+    issue["Issue URL / JSON"]
+    init["Initialize Run<br/>graph_id + run_id"]
+    read["Read Issue<br/>normalize state"]
+    triage["Triage<br/>type, priority, owner"]
+    route["Route Issue<br/>route_decision"]
+    bug["Bug Diagnosis"]
+    feature["Feature Planning"]
+    question["Question Response"]
+    implement["Implementation Proposal"]
+    reviewer["Reviewer<br/>review_decision"]
+    gate{"Review Gate<br/>pass / fail"}
+    audit["Audit Report"]
+
+    issue --> init
+    init --> read
+    read --> triage
+    triage --> route
+    route -->|bug| bug
+    route -->|feature| feature
+    route -->|question| question
+    bug --> implement
+    feature --> implement
+    implement --> reviewer
+    reviewer --> gate
+    gate -->|fail| implement
+    gate -->|pass| audit
+    question --> audit
+
+    classDef business fill:#E99151,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef warning fill:#F39C12,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef success fill:#4CA497,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef input fill:#607D8B,color:#FFFFFF,stroke:none,rx:10,ry:10
+
+    class issue input
+    class init,read,triage,bug,feature,question,implement,reviewer business
+    class route,gate warning
+    class audit success
+
+    linkStyle default stroke-width:2px,stroke:#333333,opacity:0.8
+```
+
+This is the kind of workflow where the graph is justified: the route itself is
+part of the business record. A question should not enter the implementation
+path. A bug and a feature should produce different work plans. A failed review
+should loop back to implementation without corrupting the original issue state.
+The example stores `graph_id`, `run_id`, `node_trace`, `route_history`, and
+`evidence_bundle` so the runtime work graph is inspectable after execution.
+
+The runnable examples live in:
+
+- `examples/graphengineering`
+- `examples/graphengineering/src/main/java/com/alibaba/cloud/ai/examples/graphengineering/AgentScopeRepoOpsIssueGraphExample.java`
+
+`AgentScopeRepoOpsIssueGraphExample` can read a local issue JSON file or a
+public GitHub issue URL, then invoke AgentScope Java workers through
+`AgentScopeAgent` while Spring AI Alibaba Graph owns state and routing.
+
+The topology contract lives in
+`examples/graphengineering/src/main/resources/repoops-graph-topology.yaml`.
+It lists each node's type, mandate, inputs, outputs, and allowed outgoing
+routes, making the graph topology a versioned engineering artifact rather than
+only Java control flow.
+
+## Example Module
+
+The runnable code for this topic is collected under `examples/graphengineering`.
+That module is intentionally separate from `examples/agentscope/handoffs`:
+
+- `examples/agentscope/handoffs` demonstrates agent handoff mechanics.
+- `examples/graphengineering` demonstrates a business graph where Spring AI
+  Alibaba owns the workflow and AgentScope Java implements every specialist
+  business node.
+
+## RepoOps Lightweight Example
+
+Graph Engineering also fits software engineering lifecycle automation. The
+lightweight RepoOps example in this repository uses Spring AI Alibaba Graph as
+the lifecycle control plane for issue triage, role-specific handling, review
+loop-back, audit, and Evidence Bundle generation.
+
+- `examples/graphengineering` contains the runnable RepoOps startup class.
+- [Lightweight RepoOps Graph Engineering](./graph-engineering-repoops-lightweight.md)
+- `examples/graphengineering/src/main/java/com/alibaba/cloud/ai/examples/graphengineering/AgentScopeRepoOpsIssueGraphExample.java`
+
+In a real application each graph node can be implemented by:
+
+- a Spring AI Alibaba `ReactAgent` via `reactAgent.asNode()`;
+- a `ParallelAgent` for common fan-out/fan-in cases;
+- an `A2aRemoteAgent` for a remote team-owned agent;
+- an `AgentScopeAgent` for an AgentScope implementation.
+
+## AgentScope as an External Agent Example
+
+Spring AI Alibaba is not limited to orchestrating its own `ReactAgent`
+implementation. `spring-ai-alibaba-starter-agentscope` provides
+`AgentScopeAgent`, and the AgentScope handoff example shows the intended
+integration model:
+
+```java
+graph.addNode("sales_agent", salesAgent.asNode());
+graph.addNode("support_agent", supportAgent.asNode());
+```
+
+In that example:
+
+- `salesAgent` is a Spring AI Alibaba `ReactAgent`.
+- `supportAgent` is an AgentScope `ReActAgent` wrapped as `AgentScopeAgent`.
+- Both are normal graph nodes once adapted with `asNode()`.
+- Handoff tools update `active_agent` in shared state.
+- `addConditionalEdges(...)` routes to the next agent based on that state.
+
+This is the key positioning: Spring AI Alibaba Graph is the orchestration layer
+that can coordinate Spring AI agents, AgentScope agents, A2A remote agents, and
+plain deterministic nodes in one stateful graph.
+
+Reference example:
+
+- `examples/agentscope/handoffs`
+- `examples/graphengineering/src/main/java/com/alibaba/cloud/ai/examples/graphengineering/AgentScopeRepoOpsIssueGraphExample.java`
+
+The RepoOps issue example goes further than a single handoff: issue triage,
+planning, review, and audit are AgentScope Java nodes, while Spring AI Alibaba
+remains the graph engineering runtime around those nodes.
+
+## API Shape
+
+Low-level graph:
+
+```java
+StateGraph graph = new StateGraph(keyStrategyFactory)
+        .addNode("triage", triageNode)
+        .addNode("implementation", implementationNode)
+        .addNode("reviewer", reviewerNode)
+        .addNode("auditor", auditorNode)
+        .addEdge(StateGraph.START, "triage")
+        .addEdge("triage", "implementation")
+        .addEdge("implementation", "reviewer")
+        .addConditionalEdges("reviewer", reviewRoute,
+                Map.of("pass", "auditor", "fail", "implementation"))
+        .addEdge("auditor", StateGraph.END);
+```
+
+Agent as node:
+
+```java
+ReactAgent triageAgent = ReactAgent.builder()
+        .name("triage_agent")
+        .model(chatModel)
+        .systemPrompt("Classify and prioritize repository issues.")
+        .instruction("Use the normalized issue payload from state: {issue_payload}")
+        .outputKey("triage_result")
+        .build();
+
+graph.addNode("triage", triageAgent.asNode());
+```
+
+AgentScope as node:
+
+```java
+AgentScopeAgent reviewer = AgentScopeAgent.fromBuilder(scopeReActBuilder)
+        .name("repoops_reviewer")
+        .instruction("Review the RepoOps implementation proposal: {implementation_proposal}.")
+        .build();
+
+graph.addNode("reviewer", reviewer.asNode());
+```
+
+Remote A2A agent as node:
+
+```java
+A2aRemoteAgent remoteAgent = A2aRemoteAgent.builder()
+        .agentCardProvider(agentCardProvider)
+        .name("remote_release_guardian")
+        .instruction("Check release readiness for the current RepoOps issue.")
+        .build();
+
+graph.addNode("release_guardian", remoteAgent.asNode());
+```
+
+## Design Checklist
+
+Before turning a loop into a graph:
+
+1. Can one `ReactAgent` with a strong verifier finish the task? If yes, keep it a loop.
+2. Can every proposed node name a real specialty, toolset, model, or ownership boundary?
+3. Are the edges explicit enough to draw before coding?
+4. Is shared state intentionally designed, with `KeyStrategy` chosen per key?
+5. Is there a verifier node with authority to fail and route back?
+6. Can a failed node retry without damaging downstream state?
+7. Are external agents, such as AgentScope or A2A agents, adapted as nodes rather
+   than hidden inside one large prompt?
+
+Graph Engineering is valuable when the graph is doing work that a loop cannot
+hold cleanly. Spring AI Alibaba provides the runtime and integration surface for
+that escalation while keeping simple tasks simple.

--- a/examples/agentscope/handoffs/README.md
+++ b/examples/agentscope/handoffs/README.md
@@ -2,6 +2,12 @@
 
 This module implements the **multiple agent subgraphs handoffs** pattern (same logic as [handoffs-multiagent](../handoffs-multiagent)), with the support agent using **AgentScope** via `AgentScopeAgent`. Distinct sales and support agents exist as separate nodes in a StateGraph. Handoff tools navigate between agent nodes by updating `active_agent`, which the parent graph's conditional edges use for routing.
 
+Graph Engineering examples that use AgentScope Java have been moved to
+`../../graphengineering` so the handoff example stays focused on the handoff
+pattern. See `examples/graphengineering` for the RepoOps issue workflow where
+Spring AI Alibaba owns orchestration and AgentScope Java implements business
+nodes.
+
 ## Architecture
 
 - **Separate agents as graph nodes**  

--- a/examples/graphengineering/README.md
+++ b/examples/graphengineering/README.md
@@ -1,0 +1,199 @@
+# Graph Engineering Examples
+
+This module collects runnable Graph Engineering examples for Spring AI Alibaba.
+
+## Examples
+
+| Example | Main class | Requires API key | Purpose |
+| --- | --- | --- | --- |
+| AgentScope RepoOps issue | `AgentScopeRepoOpsIssueGraphExample` | Yes | Read a local issue JSON file or GitHub issue URL, then run RepoOps triage/planning/review/audit |
+
+## Startup Classes
+
+| Startup class | Input | Output |
+| --- | --- | --- |
+| `com.alibaba.cloud.ai.examples.graphengineering.AgentScopeRepoOpsIssueGraphExample` | Local issue JSON file or GitHub issue URL plus `AI_DASHSCOPE_API_KEY` | API-backed RepoOps issue triage, plan, review, and audit |
+
+## Which One To Run
+
+| Startup class | Use it when | What it proves | What it does not prove |
+| --- | --- | --- | --- |
+| `AgentScopeRepoOpsIssueGraphExample` | You want the closest practical RepoOps demo | Graph reads a local issue JSON file or GitHub issue URL, normalizes issue state, routes by issue type, and invokes AgentScope nodes for triage, planning, review, and audit | It does not post comments, create PRs, run CI, or mutate a repository |
+
+## Recommended Demo Order
+
+Run `AgentScopeRepoOpsIssueGraphExample` with a GitHub issue URL when presenting
+RepoOps. It is the practical demo because it starts from real issue intake and
+then executes real AgentScope model calls under Spring AI Alibaba Graph control.
+
+For offline explanation without an API key, use the diagrams and state contract
+in `docs/graph-engineering-repoops-lightweight.md` instead of maintaining a
+separate deterministic startup class.
+
+## Current Scope
+
+These examples intentionally stop at analysis and audit output. They do not make
+external write actions such as GitHub comments, branch creation, pull requests,
+CI reruns, releases, deployments, or rollbacks.
+
+Those write actions should be added as separate tool nodes behind explicit
+approval gates, for example:
+
+```text
+agentscope_reviewer
+  -> approval_gate
+  -> github_comment_tool
+  -> ci_rerun_tool
+  -> release_guardian
+  -> auditor
+```
+
+This keeps the example safe to run while still showing the Graph Engineering
+control plane: topology, issue intake, state normalization, route policy,
+specialized workers, verifier decisions, node trace, route history, and evidence
+output.
+
+## Graph Engineering Contract
+
+The executable graph has an explicit topology contract in
+`src/main/resources/repoops-graph-topology.yaml`. The Java code and this
+contract describe the same graph:
+
+| Node | Type | Graph Engineering role |
+| --- | --- | --- |
+| `initialize_run` | deterministic initializer | Creates `graph_id` and `run_id` before business work starts |
+| `read_issue` | deterministic intake | Normalizes classpath JSON, local JSON, or GitHub issue URL into graph state |
+| `agentscope_triager` | AgentScope agentic worker | Produces triage result from normalized issue state |
+| `route_issue` | deterministic router | Converts triager `route_candidate` into auditable `route_decision` and `route_history` |
+| `agentscope_bug_diagnoser` | AgentScope agentic worker | Produces bug diagnosis and regression-test plan |
+| `agentscope_feature_planner` | AgentScope agentic worker | Produces feature plan and acceptance criteria |
+| `agentscope_question_responder` | AgentScope agentic worker | Answers questions without entering implementation workflow |
+| `record_question_evidence` | deterministic evidence node | Records question bypass evidence and review outcome |
+| `agentscope_implementer` | AgentScope agentic worker | Produces reviewable implementation proposal |
+| `agentscope_reviewer` | AgentScope verifier agent | Reviews another node's proposal and writes `review_decision` |
+| `review_gate` | deterministic verifier/router | Converts reviewer output into `review_gate_result` and controls loop-back |
+| `agentscope_auditor` | AgentScope audit agent | Produces final lifecycle report from state and evidence |
+
+The state contract includes run identity and graph observability keys:
+
+| State key | Strategy | Purpose |
+| --- | --- | --- |
+| `graph_id` | replace | Stable graph identity for trace correlation |
+| `run_id` | replace | Unique workflow run identity |
+| `current_node` | replace | Last completed graph node |
+| `route_decision` | replace | Issue route selected from `triage_result`, with `issue_type` as fallback |
+| `review_gate_result` | replace | Pass/fail result selected by `review_gate` |
+| `node_trace` | append | Per-node execution metadata: node id, type, inputs, outputs, timestamp |
+| `route_history` | append | Auditable route decisions and reasons |
+| `evidence_bundle` | append | Operational evidence collected across nodes |
+
+## Implemented Graph Flow
+
+The current startup class implements this graph:
+
+```text
+START
+  -> initialize_run
+  -> read_issue
+  -> agentscope_triager
+  -> route_issue
+  -> bug: agentscope_bug_diagnoser -> agentscope_implementer -> agentscope_reviewer -> review_gate
+  -> feature: agentscope_feature_planner -> agentscope_implementer -> agentscope_reviewer -> review_gate
+  -> question: agentscope_question_responder -> record_question_evidence
+
+review_gate
+  -> PASS: agentscope_auditor
+  -> FAIL: agentscope_implementer
+
+record_question_evidence
+  -> agentscope_auditor
+
+agentscope_auditor
+  -> END
+```
+
+```mermaid
+flowchart LR
+    start["START"]
+    init["initialize_run<br/>graph_id + run_id"]
+    read["read_issue<br/>file or GitHub URL"]
+    triage["agentscope_triager<br/>classify and normalize"]
+    route["route_issue<br/>route_decision"]
+    bug["agentscope_bug_diagnoser"]
+    feature["agentscope_feature_planner"]
+    question["agentscope_question_responder"]
+    evidence["record_question_evidence"]
+    implement["agentscope_implementer"]
+    review["agentscope_reviewer<br/>review_decision"]
+    gate{"review_gate"}
+    audit["agentscope_auditor<br/>audit_report"]
+    end["END"]
+
+    start --> init
+    init --> read
+    read --> triage
+    triage --> route
+    route -->|bug| bug
+    route -->|feature| feature
+    route -->|question| question
+    bug --> implement
+    feature --> implement
+    question --> evidence
+    evidence --> audit
+    implement --> review
+    review --> gate
+    gate -->|PASS| audit
+    gate -->|FAIL| implement
+    audit --> end
+
+    classDef business fill:#E99151,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef gateway fill:#7B68EE,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef warning fill:#F39C12,color:#FFFFFF,stroke:none,rx:10,ry:10
+    classDef success fill:#4CA497,color:#FFFFFF,stroke:none,rx:10,ry:10
+
+    class init,read,triage,bug,feature,question,evidence,implement,review business
+    class route,gate warning
+    class audit success
+    class start,end gateway
+
+    linkStyle default stroke-width:2px,stroke:#333333,opacity:0.8
+```
+
+## Build
+
+```bash
+cd examples/graphengineering
+../../mvnw -DskipTests compile
+```
+
+## Validate Topology Contract
+
+```bash
+../../mvnw -DskipTests \
+  -Dexec.mainClass=com.alibaba.cloud.ai.examples.graphengineering.AgentScopeRepoOpsIssueGraphExample \
+  -Dexec.args=--validate-topology \
+  org.codehaus.mojo:exec-maven-plugin:3.5.0:java
+```
+
+## Run With DashScope API Key
+
+```bash
+export AI_DASHSCOPE_API_KEY=your-api-key
+
+../../mvnw -DskipTests \
+  -Dexec.mainClass=com.alibaba.cloud.ai.examples.graphengineering.AgentScopeRepoOpsIssueGraphExample \
+  -Dexec.args=https://github.com/alibaba/spring-ai-alibaba/issues/4830 \
+  org.codehaus.mojo:exec-maven-plugin:3.5.0:java
+```
+
+`AgentScopeRepoOpsIssueGraphExample` also accepts a local issue JSON file:
+
+```bash
+../../mvnw -DskipTests \
+  -Dexec.mainClass=com.alibaba.cloud.ai.examples.graphengineering.AgentScopeRepoOpsIssueGraphExample \
+  -Dexec.args=src/main/resources/issues/bug_issue.json \
+  org.codehaus.mojo:exec-maven-plugin:3.5.0:java
+```
+
+When no argument is provided, the example uses the bundled
+`classpath:issues/bug_issue.json` sample.

--- a/examples/graphengineering/pom.xml
+++ b/examples/graphengineering/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>4.1.0</version>
+		<relativePath/>
+	</parent>
+
+	<groupId>com.alibaba.cloud.ai</groupId>
+	<artifactId>graphengineering</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Examples::Graph Engineering</name>
+	<description>Graph Engineering examples for Spring AI Alibaba.</description>
+
+	<properties>
+		<java.version>17</java.version>
+		<spring-ai.version>2.0.0</spring-ai.version>
+		<spring-ai-alibaba.version>2.0.0.0-RC1</spring-ai-alibaba.version>
+		<spring-ai-alibaba-extensions.version>2.0.0.0-RC1</spring-ai-alibaba-extensions.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.alibaba.cloud.ai</groupId>
+				<artifactId>spring-ai-alibaba-extensions-bom</artifactId>
+				<version>${spring-ai-alibaba-extensions.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.alibaba.cloud.ai</groupId>
+				<artifactId>spring-ai-alibaba-bom</artifactId>
+				<version>${spring-ai-alibaba.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-agent-framework</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-starter-agentscope</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-starter-dashscope</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.5.0</version>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+			<id>snapshots</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+			<id>sonatype-snapshots</id>
+			<name>Sonatype Snapshot Repository</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</repository>
+	</repositories>
+</project>

--- a/examples/graphengineering/src/main/java/com/alibaba/cloud/ai/examples/graphengineering/AgentScopeRepoOpsIssueGraphExample.java
+++ b/examples/graphengineering/src/main/java/com/alibaba/cloud/ai/examples/graphengineering/AgentScopeRepoOpsIssueGraphExample.java
@@ -1,0 +1,823 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.graphengineering;
+
+import com.alibaba.cloud.ai.agent.agentscope.AgentScopeAgent;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.KeyStrategyFactory;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
+import com.alibaba.cloud.ai.graph.exception.GraphStateException;
+import com.alibaba.cloud.ai.graph.internal.node.ParallelNode;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.agentscope.core.ReActAgent;
+import io.agentscope.core.memory.InMemoryMemory;
+import io.agentscope.core.model.DashScopeChatModel;
+import io.agentscope.core.model.Model;
+import org.springframework.util.StringUtils;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncEdgeAction.edge_async;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+
+/**
+ * RepoOps issue-driven Graph Engineering example with real AgentScope Java nodes.
+ *
+ * <p>
+ * The graph reads an issue JSON payload, routes by issue type, and then invokes
+ * AgentScope agents for triage, planning/diagnosis, implementation proposal,
+ * review, and audit. Spring AI Alibaba Graph owns state, routing, fan-out/fan-in,
+ * verifier loop-back, and final evidence.
+ */
+public class AgentScopeRepoOpsIssueGraphExample {
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private static final String CLASSPATH_PREFIX = "classpath:";
+
+	private static final String DEFAULT_ISSUE_REF = CLASSPATH_PREFIX + "issues/bug_issue.json";
+
+	private static final String TOPOLOGY_RESOURCE = "repoops-graph-topology.yaml";
+
+	private static final String GRAPH_ID_VALUE = "repoops-issue-lifecycle";
+
+	private static final Pattern GITHUB_ISSUE_URL = Pattern
+			.compile("^https://github\\.com/([^/]+)/([^/]+)/issues/(\\d+)(?:[/?#].*)?$");
+
+	private static final Pattern ROUTE_CANDIDATE = Pattern
+			.compile("(?im)^\\s*[-*]?\\s*(?:route_candidate|route|type)\\s*[:=]\\s*`?\\s*(bug|feature|question)\\b");
+
+	private static final String ISSUE_FILE = "issue_file";
+
+	private static final String GRAPH_ID = "graph_id";
+
+	private static final String RUN_ID = "run_id";
+
+	private static final String CURRENT_NODE = "current_node";
+
+	private static final String ISSUE_URL = "issue_url";
+
+	private static final String ISSUE_PAYLOAD = "issue_payload";
+
+	private static final String ISSUE_TITLE = "issue_title";
+
+	private static final String ISSUE_TYPE = "issue_type";
+
+	private static final String ISSUE_SOURCE = "issue_source";
+
+	private static final String ISSUE_REPOSITORY = "issue_repository";
+
+	private static final String ISSUE_SUMMARY = "issue_summary";
+
+	private static final String REQUIRES_REVIEW = "requires_review";
+
+	private static final String REQUIRES_DEPLOY = "requires_deploy";
+
+	private static final String TRIAGE_RESULT = "triage_result";
+
+	private static final String ROUTE_DECISION = "route_decision";
+
+	private static final String WORK_PLAN = "work_plan";
+
+	private static final String IMPLEMENTATION_PROPOSAL = "implementation_proposal";
+
+	private static final String REVIEW_DECISION = "review_decision";
+
+	private static final String REVIEW_GATE_RESULT = "review_gate_result";
+
+	private static final String AUDIT_REPORT = "audit_report";
+
+	private static final String EVIDENCE_BUNDLE = "evidence_bundle";
+
+	private static final String NODE_TRACE = "node_trace";
+
+	private static final String ROUTE_HISTORY = "route_history";
+
+	private static final List<String> GRAPH_NODE_IDS = List.of(
+			"initialize_run",
+			"read_issue",
+			"agentscope_triager",
+			"route_issue",
+			"agentscope_bug_diagnoser",
+			"agentscope_feature_planner",
+			"agentscope_question_responder",
+			"record_question_evidence",
+			"agentscope_implementer",
+			"agentscope_reviewer",
+			"review_gate",
+			"agentscope_auditor");
+
+	private static final List<String> GRAPH_STATE_KEYS = List.of(
+			GRAPH_ID,
+			RUN_ID,
+			CURRENT_NODE,
+			ISSUE_FILE,
+			ISSUE_URL,
+			ISSUE_PAYLOAD,
+			ISSUE_TITLE,
+			ISSUE_TYPE,
+			ISSUE_SOURCE,
+			ISSUE_REPOSITORY,
+			ISSUE_SUMMARY,
+			REQUIRES_REVIEW,
+			REQUIRES_DEPLOY,
+			TRIAGE_RESULT,
+			ROUTE_DECISION,
+			WORK_PLAN,
+			IMPLEMENTATION_PROPOSAL,
+			REVIEW_DECISION,
+			REVIEW_GATE_RESULT,
+			AUDIT_REPORT,
+			NODE_TRACE,
+			ROUTE_HISTORY,
+			EVIDENCE_BUNDLE);
+
+	public static CompiledGraph createGraph(String dashScopeApiKey) throws GraphStateException {
+		validateTopologyContract();
+
+		Model model = createModel(dashScopeApiKey);
+		AgentScopeAgent triager = createAgentScopeNode(model, "repoops_agentscope_triager",
+				"RepoOps issue triage worker",
+				"""
+				You are the RepoOps intake and triage worker. Use only the supplied issue payload.
+				Classify the issue, identify repository impact, priority, owner hint, required
+				review gates, and missing context. Preserve source and repository fields.
+				""",
+				"""
+				Issue payload:
+				{issue_payload}
+
+				Return a concise triage result. The first line must be exactly:
+				route_candidate: bug|feature|question
+
+				Then include:
+				- type
+				- priority
+				- repository
+				- source
+				- owner_hint
+				- required_review
+				- required_deploy
+				- missing_context
+				""",
+				TRIAGE_RESULT);
+		AgentScopeAgent bugDiagnoser = createAgentScopeNode(model, "repoops_agentscope_bug_diagnoser",
+				"RepoOps bug diagnosis worker",
+				"""
+				You are a RepoOps bug diagnosis worker. Use only the issue payload and triage
+				result. Produce a realistic reproduction and diagnosis plan. Do not claim that
+				tests or code were changed.
+				""",
+				"""
+				Issue payload:
+				{issue_payload}
+
+				Triage:
+				{triage_result}
+
+				Return:
+				1. reproduction plan
+				2. likely fault boundary
+				3. target files or modules to inspect
+				4. regression test proposal
+				5. unresolved evidence gaps
+				""",
+				WORK_PLAN);
+		AgentScopeAgent featurePlanner = createAgentScopeNode(model, "repoops_agentscope_feature_planner",
+				"RepoOps feature planning worker",
+				"""
+				You are a RepoOps feature planning worker. Use only the issue payload and triage
+				result. Produce a design and implementation plan that can be reviewed.
+				""",
+				"""
+				Issue payload:
+				{issue_payload}
+
+				Triage:
+				{triage_result}
+
+				Return:
+				1. user story
+				2. non-goals
+				3. design sketch
+				4. acceptance criteria
+				5. review and deploy gates
+				""",
+				WORK_PLAN);
+		AgentScopeAgent questionResponder = createAgentScopeNode(model, "repoops_agentscope_question_responder",
+				"RepoOps question response worker",
+				"""
+				You are a RepoOps support response worker. Use only the issue payload and triage
+				result. Answer the question and identify whether docs or runbooks should be
+				updated.
+				""",
+				"""
+				Issue payload:
+				{issue_payload}
+
+				Triage:
+				{triage_result}
+
+				Return:
+				1. direct answer
+				2. supporting rationale
+				3. doc/runbook update candidate
+				4. whether implementation is required
+				""",
+				WORK_PLAN);
+		AgentScopeAgent implementer = createAgentScopeNode(model, "repoops_agentscope_implementer",
+				"RepoOps implementation proposal worker",
+				"""
+				You are a RepoOps implementation worker. Produce a reviewable patch proposal from
+				the issue payload and work plan. Do not invent actual diffs. Describe files,
+				tests, commands, and rollout risk.
+				""",
+				"""
+				Issue payload:
+				{issue_payload}
+
+				Work plan:
+				{work_plan}
+
+				Return:
+				1. proposed changes
+				2. tests to add or run
+				3. commands to verify
+				4. release/deploy impact
+				5. risks
+				""",
+				IMPLEMENTATION_PROPOSAL);
+		AgentScopeAgent reviewer = createAgentScopeNode(model, "repoops_agentscope_reviewer",
+				"RepoOps reviewer worker",
+				"""
+				You are the independent RepoOps reviewer. Check whether the implementation proposal
+				is supported by the issue and work plan. Start your answer with PASS when the
+				proposal is reviewable and audit-ready. Start with FAIL only for concrete blocking
+				gaps.
+				""",
+				"""
+				Issue payload:
+				{issue_payload}
+
+				Triage:
+				{triage_result}
+
+				Work plan:
+				{work_plan}
+
+				Implementation proposal:
+				{implementation_proposal}
+
+				Return PASS or FAIL first, then:
+				1. blocking findings
+				2. required tests
+				3. release/deploy notes
+				4. audit evidence required
+				""",
+				REVIEW_DECISION);
+		AgentScopeAgent auditor = createAgentScopeNode(model, "repoops_agentscope_auditor",
+				"RepoOps evidence auditor worker",
+				"""
+				You are the RepoOps evidence auditor. Produce a final lifecycle report using only
+				the issue payload and graph state. Preserve repository, source, issue type, review
+				decision, and deploy requirement.
+				""",
+				"""
+				Issue file:
+				{issue_file}
+
+				Issue payload:
+				{issue_payload}
+
+				Triage:
+				{triage_result}
+
+				Work plan:
+				{work_plan}
+
+				Implementation proposal:
+				{implementation_proposal}
+
+				Review decision:
+				{review_decision}
+
+				Return:
+				1. lifecycle route
+				2. repository/source summary
+				3. review decision
+				4. deploy readiness
+				5. evidence appendix
+				""",
+				AUDIT_REPORT);
+
+		StateGraph graph = new StateGraph("agentscope_repoops_issue", keyStrategyFactory())
+				.addNode("initialize_run", node_async(state -> initializeRun()))
+				.addNode("read_issue", node_async(state -> normalizeIssue(state.value(ISSUE_FILE, String.class)
+						.orElse(DEFAULT_ISSUE_REF), state)))
+				.addNode("agentscope_triager", agentScopeAction("agentscope_triager", "agentic_worker", triager,
+						TRIAGE_RESULT))
+				.addNode("route_issue", node_async(AgentScopeRepoOpsIssueGraphExample::routeIssue))
+				.addNode("agentscope_bug_diagnoser", agentScopeAction("agentscope_bug_diagnoser", "agentic_worker",
+						bugDiagnoser, WORK_PLAN))
+				.addNode("agentscope_feature_planner", agentScopeAction("agentscope_feature_planner", "agentic_worker",
+						featurePlanner, WORK_PLAN))
+				.addNode("agentscope_question_responder", agentScopeAction("agentscope_question_responder",
+						"agentic_worker", questionResponder, WORK_PLAN))
+				.addNode("agentscope_implementer", agentScopeAction("agentscope_implementer", "agentic_worker",
+						implementer, IMPLEMENTATION_PROPOSAL))
+				.addNode("agentscope_reviewer", agentScopeAction("agentscope_reviewer", "verifier_agent", reviewer,
+						REVIEW_DECISION))
+				.addNode("review_gate", node_async(AgentScopeRepoOpsIssueGraphExample::reviewGate))
+				.addNode("agentscope_auditor", agentScopeAction("agentscope_auditor", "audit_agent", auditor,
+						AUDIT_REPORT))
+				.addNode("record_question_evidence", node_async(state -> Map.of(
+						CURRENT_NODE, "record_question_evidence",
+						IMPLEMENTATION_PROPOSAL, "Not required: question issue was answered without implementation workflow.",
+						REVIEW_DECISION, "PASS: question issue does not require implementation review.",
+						REVIEW_GATE_RESULT, "pass",
+						NODE_TRACE, List.of(nodeTrace(state, "record_question_evidence", "deterministic_evidence",
+								List.of(WORK_PLAN), List.of(IMPLEMENTATION_PROPOSAL, REVIEW_DECISION))),
+						EVIDENCE_BUNDLE, List.of(evidence(state, "record_question_evidence",
+								"question issue answered without implementation workflow")))))
+				.addEdge(START, "initialize_run")
+				.addEdge("initialize_run", "read_issue")
+				.addEdge("read_issue", "agentscope_triager")
+				.addEdge("agentscope_triager", "route_issue")
+				.addConditionalEdges("route_issue", edge_async(state -> state.value(ROUTE_DECISION, String.class)
+						.orElse("question")), Map.of(
+								"bug", "agentscope_bug_diagnoser",
+								"feature", "agentscope_feature_planner",
+								"question", "agentscope_question_responder"))
+				.addEdge("agentscope_bug_diagnoser", "agentscope_implementer")
+				.addEdge("agentscope_feature_planner", "agentscope_implementer")
+				.addEdge("agentscope_question_responder", "record_question_evidence")
+				.addEdge("agentscope_implementer", "agentscope_reviewer")
+				.addEdge("agentscope_reviewer", "review_gate")
+				.addConditionalEdges("review_gate", edge_async(state -> state.value(REVIEW_GATE_RESULT, String.class)
+								.orElse("fail")),
+						Map.of("pass", "agentscope_auditor", "fail", "agentscope_implementer"))
+				.addEdge("record_question_evidence", "agentscope_auditor")
+				.addEdge("agentscope_auditor", END);
+
+		return graph.compile();
+	}
+
+	public static void main(String[] args) throws Exception {
+		if (args.length > 0 && "--validate-topology".equals(args[0])) {
+			validateTopologyContract();
+			System.out.println("Topology contract is aligned with the Java graph constants.");
+			return;
+		}
+
+		String apiKey = System.getenv("AI_DASHSCOPE_API_KEY");
+		if (!StringUtils.hasText(apiKey)) {
+			throw new IllegalArgumentException("Set AI_DASHSCOPE_API_KEY before running this example.");
+		}
+
+		String issueRef = args.length > 0 ? args[0] : DEFAULT_ISSUE_REF;
+		try {
+			CompiledGraph graph = createGraph(apiKey);
+			graph.stream(Map.of(ISSUE_FILE, issueRef))
+					.doOnNext(System.out::println)
+					.blockLast();
+		}
+		finally {
+			ParallelNode.shutdownDefaultExecutor();
+			Schedulers.shutdownNow();
+		}
+	}
+
+	private static Model createModel(String dashScopeApiKey) {
+		return DashScopeChatModel.builder()
+				.apiKey(dashScopeApiKey)
+				.modelName("qwen-plus")
+				.build();
+	}
+
+	private static AgentScopeAgent createAgentScopeNode(Model model, String name, String description,
+			String systemPrompt, String instruction, String outputKey) {
+		ReActAgent.Builder builder = ReActAgent.builder()
+				.name(name)
+				.description(description)
+				.sysPrompt(systemPrompt)
+				.model(model)
+				.memory(new InMemoryMemory());
+
+		return AgentScopeAgent.fromBuilder(builder)
+				.name(name)
+				.description(description)
+				.instruction(instruction)
+				.outputKey(outputKey)
+				.includeContents(false)
+				.returnReasoningContents(false)
+				.build();
+	}
+
+	private static AsyncNodeActionWithConfig agentScopeAction(String nodeId, String nodeType, AgentScopeAgent agent,
+			String outputKey) {
+		return AsyncNodeActionWithConfig.node_async((state, config) ->
+				Map.of(
+						CURRENT_NODE, nodeId,
+						outputKey, Objects.requireNonNull(agent.call(state.data()).getText()),
+						NODE_TRACE, List.of(nodeTrace(state, nodeId, nodeType, agentInputKeys(outputKey),
+								List.of(outputKey))),
+						EVIDENCE_BUNDLE, List.of(evidence(state, nodeId, "produced " + outputKey))));
+	}
+
+	private static Map<String, Object> initializeRun() {
+		String runId = UUID.randomUUID().toString();
+		return Map.of(
+				GRAPH_ID, GRAPH_ID_VALUE,
+				RUN_ID, runId,
+				CURRENT_NODE, "initialize_run",
+				NODE_TRACE, List.of(Map.of(
+						"graph_id", GRAPH_ID_VALUE,
+						"run_id", runId,
+						"node_id", "initialize_run",
+						"node_type", "deterministic_initializer",
+						"output_keys", List.of(GRAPH_ID, RUN_ID),
+						"timestamp", Instant.now().toString())),
+				EVIDENCE_BUNDLE, List.of(Map.of(
+						"graph_id", GRAPH_ID_VALUE,
+						"run_id", runId,
+						"node_id", "initialize_run",
+						"summary", "created graph run identity")));
+	}
+
+	private static Map<String, Object> routeIssue(OverAllState state) {
+		String fallbackRoute = sanitizeRoute(state.value(ISSUE_TYPE, String.class).orElse("question"));
+		String triageResult = state.value(TRIAGE_RESULT, String.class).orElse("");
+		String route = routeFromTriage(triageResult);
+		String reason;
+		if (route == null) {
+			route = fallbackRoute;
+			reason = "fallback issue_type=" + fallbackRoute;
+		}
+		else {
+			reason = "triage_result route_candidate=" + route;
+		}
+		return Map.of(
+				CURRENT_NODE, "route_issue",
+				ROUTE_DECISION, route,
+				ROUTE_HISTORY, List.of(routeEntry(state, "route_issue", route, reason)),
+				NODE_TRACE, List.of(nodeTrace(state, "route_issue", "deterministic_router",
+						List.of(TRIAGE_RESULT, ISSUE_TYPE), List.of(ROUTE_DECISION))),
+				EVIDENCE_BUNDLE, List.of(evidence(state, "route_issue", "routed issue to " + route)));
+	}
+
+	private static String routeFromTriage(String triageResult) {
+		Matcher matcher = ROUTE_CANDIDATE.matcher(triageResult);
+		if (matcher.find()) {
+			return sanitizeRoute(matcher.group(1));
+		}
+		return null;
+	}
+
+	private static String sanitizeRoute(String route) {
+		route = route.toLowerCase();
+		if (!List.of("bug", "feature", "question").contains(route)) {
+			return "question";
+		}
+		return route;
+	}
+
+	private static Map<String, Object> reviewGate(OverAllState state) {
+		String result = reviewRoute(state);
+		return Map.of(
+				CURRENT_NODE, "review_gate",
+				REVIEW_GATE_RESULT, result,
+				ROUTE_HISTORY, List.of(routeEntry(state, "review_gate", result,
+						"review_decision starts with PASS=" + "pass".equals(result))),
+				NODE_TRACE, List.of(nodeTrace(state, "review_gate", "deterministic_verifier_router",
+						List.of(REVIEW_DECISION), List.of(REVIEW_GATE_RESULT))),
+				EVIDENCE_BUNDLE, List.of(evidence(state, "review_gate", "review gate result " + result)));
+	}
+
+	private static Map<String, Object> normalizeIssue(String issueRef, OverAllState state)
+			throws IOException, InterruptedException {
+		if (issueRef.startsWith("https://github.com/")) {
+			return normalizeGitHubIssue(issueRef, state);
+		}
+		if (issueRef.startsWith(CLASSPATH_PREFIX)) {
+			return normalizeIssueResource(issueRef, state);
+		}
+		return normalizeIssueFile(Path.of(issueRef), state);
+	}
+
+	private static Map<String, Object> normalizeIssueFile(Path issueFile, OverAllState state) throws IOException {
+		Map<String, Object> issue = OBJECT_MAPPER.readValue(Files.readString(issueFile),
+				new TypeReference<>() {
+				});
+		return normalizeLocalIssue(issueFile.toString(), issue, state);
+	}
+
+	private static Map<String, Object> normalizeIssueResource(String issueRef, OverAllState state) throws IOException {
+		String resourceName = issueRef.substring(CLASSPATH_PREFIX.length());
+		try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
+			if (inputStream == null) {
+				throw new FileNotFoundException("Classpath issue resource not found: " + resourceName);
+			}
+			Map<String, Object> issue = OBJECT_MAPPER.readValue(inputStream, new TypeReference<>() {
+			});
+			return normalizeLocalIssue(issueRef, issue, state);
+		}
+	}
+
+	private static Map<String, Object> normalizeLocalIssue(String issueRef, Map<String, Object> issue, OverAllState state)
+			throws IOException {
+		String type = String.valueOf(issue.getOrDefault("type", "question")).toLowerCase();
+		if (!List.of("bug", "feature", "question").contains(type)) {
+			type = "question";
+		}
+		Map<String, Object> normalized = new HashMap<>();
+		normalized.put(CURRENT_NODE, "read_issue");
+		normalized.put(ISSUE_FILE, issueRef);
+		normalized.put(ISSUE_PAYLOAD, OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(issue));
+		normalized.put(ISSUE_TITLE, String.valueOf(issue.getOrDefault("title", "")));
+		normalized.put(ISSUE_TYPE, type);
+		normalized.put(ISSUE_SOURCE, String.valueOf(issue.getOrDefault("source", "")));
+		normalized.put(ISSUE_REPOSITORY, String.valueOf(issue.getOrDefault("repository", "")));
+		normalized.put(ISSUE_SUMMARY, String.valueOf(issue.getOrDefault("summary", "")));
+		normalized.put(REQUIRES_REVIEW,
+				Boolean.parseBoolean(String.valueOf(issue.getOrDefault("requires_review", "false"))));
+		normalized.put(REQUIRES_DEPLOY,
+				Boolean.parseBoolean(String.valueOf(issue.getOrDefault("requires_deploy", "false"))));
+		normalized.put(NODE_TRACE, List.of(nodeTrace(state, "read_issue", "deterministic_intake",
+				List.of(ISSUE_FILE), List.of(ISSUE_PAYLOAD, ISSUE_TYPE, ISSUE_REPOSITORY))));
+		normalized.put(EVIDENCE_BUNDLE, List.of(evidence(state, "read_issue", "loaded " + issueRef)));
+		return normalized;
+	}
+
+	private static Map<String, Object> normalizeGitHubIssue(String issueUrl, OverAllState graphState)
+			throws IOException, InterruptedException {
+		Matcher matcher = GITHUB_ISSUE_URL.matcher(issueUrl);
+		if (!matcher.matches()) {
+			throw new IllegalArgumentException("Only GitHub issue URLs are supported: " + issueUrl);
+		}
+
+		String owner = matcher.group(1);
+		String repo = matcher.group(2);
+		String number = matcher.group(3);
+		String apiUrl = "https://api.github.com/repos/" + owner + "/" + repo + "/issues/" + number;
+		HttpResponse<String> response = sendGitHubIssueRequest(apiUrl);
+		if (response.statusCode() < 200 || response.statusCode() >= 300) {
+			throw new IOException("GitHub issue request failed: status=" + response.statusCode());
+		}
+
+		Map<String, Object> githubIssue = OBJECT_MAPPER.readValue(response.body(), new TypeReference<>() {
+		});
+		if (githubIssue.containsKey("pull_request")) {
+			throw new IllegalArgumentException("Expected an issue URL, but this URL points to a pull request: " + issueUrl);
+		}
+
+		String title = String.valueOf(githubIssue.getOrDefault("title", ""));
+		String body = String.valueOf(githubIssue.getOrDefault("body", ""));
+		List<String> labels = extractLabelNames(githubIssue.get("labels"));
+		String type = classifyIssue(title, labels);
+		Map<String, Object> normalized = new HashMap<>();
+		normalized.put("title", title);
+		normalized.put("type", type);
+		normalized.put("source", "github");
+		normalized.put("repository", owner + "/" + repo);
+		normalized.put("summary", firstNonBlank(body, title));
+		normalized.put("requires_review", !"question".equals(type));
+		normalized.put("requires_deploy", false);
+		normalized.put("url", issueUrl);
+		normalized.put("number", githubIssue.get("number"));
+		normalized.put("state", githubIssue.get("state"));
+		normalized.put("author", login(githubIssue.get("user")));
+		normalized.put("created_at", githubIssue.get("created_at"));
+		normalized.put("updated_at", githubIssue.get("updated_at"));
+		normalized.put("labels", labels);
+		normalized.put("body", body);
+
+		Map<String, Object> output = new HashMap<>();
+		output.put(CURRENT_NODE, "read_issue");
+		output.put(ISSUE_FILE, issueUrl);
+		output.put(ISSUE_URL, issueUrl);
+		output.put(ISSUE_PAYLOAD, OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(normalized));
+		output.put(ISSUE_TITLE, title);
+		output.put(ISSUE_TYPE, type);
+		output.put(ISSUE_SOURCE, "github");
+		output.put(ISSUE_REPOSITORY, owner + "/" + repo);
+		output.put(ISSUE_SUMMARY, firstNonBlank(body, title));
+		output.put(REQUIRES_REVIEW, !"question".equals(type));
+		output.put(REQUIRES_DEPLOY, false);
+		output.put(NODE_TRACE, List.of(nodeTrace(graphState, "read_issue", "deterministic_intake",
+				List.of(ISSUE_FILE), List.of(ISSUE_PAYLOAD, ISSUE_TYPE, ISSUE_REPOSITORY))));
+		output.put(EVIDENCE_BUNDLE, List.of(evidence(graphState, "read_issue", "fetched " + issueUrl)));
+		return output;
+	}
+
+	private static HttpResponse<String> sendGitHubIssueRequest(String apiUrl) throws IOException, InterruptedException {
+		HttpClient client = HttpClient.newBuilder()
+				.connectTimeout(Duration.ofSeconds(20))
+				.version(HttpClient.Version.HTTP_1_1)
+				.build();
+		HttpRequest request = HttpRequest.newBuilder(URI.create(apiUrl))
+				.timeout(Duration.ofSeconds(20))
+				.header("Accept", "application/vnd.github+json")
+				.header("User-Agent", "spring-ai-alibaba-graphengineering-example")
+				.header("X-GitHub-Api-Version", "2022-11-28")
+				.GET()
+				.build();
+		try {
+			return client.send(request, HttpResponse.BodyHandlers.ofString());
+		}
+		catch (IOException ex) {
+			return client.send(request, HttpResponse.BodyHandlers.ofString());
+		}
+	}
+
+	private static List<String> extractLabelNames(Object labelsValue) {
+		if (!(labelsValue instanceof List<?> labels)) {
+			return List.of();
+		}
+		List<String> names = new ArrayList<>();
+		for (Object label : labels) {
+			if (label instanceof Map<?, ?> labelMap && labelMap.get("name") != null) {
+				names.add(String.valueOf(labelMap.get("name")));
+			}
+		}
+		return names;
+	}
+
+	private static String classifyIssue(String title, List<String> labels) {
+		String text = (title + " " + String.join(" ", labels)).toLowerCase();
+		if (text.contains("bug") || text.contains("regression") || text.contains("fix")) {
+			return "bug";
+		}
+		if (text.contains("feature") || text.contains("enhancement")) {
+			return "feature";
+		}
+		return "question";
+	}
+
+	private static String firstNonBlank(String first, String fallback) {
+		return StringUtils.hasText(first) ? first : fallback;
+	}
+
+	private static String login(Object userValue) {
+		if (userValue instanceof Map<?, ?> user && user.get("login") != null) {
+			return String.valueOf(user.get("login"));
+		}
+		return "";
+	}
+
+	private static KeyStrategyFactory keyStrategyFactory() {
+		return () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put(GRAPH_ID, new ReplaceStrategy());
+			strategies.put(RUN_ID, new ReplaceStrategy());
+			strategies.put(CURRENT_NODE, new ReplaceStrategy());
+			strategies.put(ISSUE_FILE, new ReplaceStrategy());
+			strategies.put(ISSUE_URL, new ReplaceStrategy());
+			strategies.put(ISSUE_PAYLOAD, new ReplaceStrategy());
+			strategies.put(ISSUE_TITLE, new ReplaceStrategy());
+			strategies.put(ISSUE_TYPE, new ReplaceStrategy());
+			strategies.put(ISSUE_SOURCE, new ReplaceStrategy());
+			strategies.put(ISSUE_REPOSITORY, new ReplaceStrategy());
+			strategies.put(ISSUE_SUMMARY, new ReplaceStrategy());
+			strategies.put(REQUIRES_REVIEW, new ReplaceStrategy());
+			strategies.put(REQUIRES_DEPLOY, new ReplaceStrategy());
+			strategies.put(TRIAGE_RESULT, new ReplaceStrategy());
+			strategies.put(ROUTE_DECISION, new ReplaceStrategy());
+			strategies.put(WORK_PLAN, new ReplaceStrategy());
+			strategies.put(IMPLEMENTATION_PROPOSAL, new ReplaceStrategy());
+			strategies.put(REVIEW_DECISION, new ReplaceStrategy());
+			strategies.put(REVIEW_GATE_RESULT, new ReplaceStrategy());
+			strategies.put(AUDIT_REPORT, new ReplaceStrategy());
+			strategies.put(EVIDENCE_BUNDLE, new AppendStrategy(false));
+			strategies.put(NODE_TRACE, new AppendStrategy(false));
+			strategies.put(ROUTE_HISTORY, new AppendStrategy(false));
+			strategies.put("messages", new AppendStrategy(false));
+			return strategies;
+		};
+	}
+
+	private static void validateTopologyContract() {
+		String topology = readClasspathText(TOPOLOGY_RESOURCE);
+		requireContractContains(topology, "id: " + GRAPH_ID_VALUE, "graph id");
+		for (String nodeId : GRAPH_NODE_IDS) {
+			requireContractContains(topology, "id: " + nodeId, "node " + nodeId);
+		}
+		for (String stateKey : GRAPH_STATE_KEYS) {
+			requireContractContains(topology, "- " + stateKey, "state key " + stateKey);
+		}
+	}
+
+	private static String readClasspathText(String resourceName) {
+		try (InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
+			if (inputStream == null) {
+				throw new IllegalStateException("Classpath resource not found: " + resourceName);
+			}
+			return new String(inputStream.readAllBytes());
+		}
+		catch (IOException ex) {
+			throw new IllegalStateException("Failed to read classpath resource: " + resourceName, ex);
+		}
+	}
+
+	private static void requireContractContains(String topology, String expected, String description) {
+		if (!topology.contains(expected)) {
+			throw new IllegalStateException("Topology contract missing " + description + ": " + expected);
+		}
+	}
+
+	private static List<String> agentInputKeys(String outputKey) {
+		if (TRIAGE_RESULT.equals(outputKey)) {
+			return List.of(ISSUE_PAYLOAD);
+		}
+		if (WORK_PLAN.equals(outputKey)) {
+			return List.of(ISSUE_PAYLOAD, TRIAGE_RESULT);
+		}
+		if (IMPLEMENTATION_PROPOSAL.equals(outputKey)) {
+			return List.of(ISSUE_PAYLOAD, WORK_PLAN);
+		}
+		if (REVIEW_DECISION.equals(outputKey)) {
+			return List.of(ISSUE_PAYLOAD, TRIAGE_RESULT, WORK_PLAN, IMPLEMENTATION_PROPOSAL);
+		}
+		if (AUDIT_REPORT.equals(outputKey)) {
+			return List.of(ISSUE_PAYLOAD, TRIAGE_RESULT, WORK_PLAN, IMPLEMENTATION_PROPOSAL, REVIEW_DECISION,
+					REVIEW_GATE_RESULT, ROUTE_HISTORY);
+		}
+		return List.of(ISSUE_PAYLOAD);
+	}
+
+	private static Map<String, Object> nodeTrace(OverAllState state, String nodeId, String nodeType,
+			List<String> inputKeys, List<String> outputKeys) {
+		return Map.of(
+				"graph_id", state.value(GRAPH_ID, String.class).orElse(GRAPH_ID_VALUE),
+				"run_id", state.value(RUN_ID, String.class).orElse("unknown"),
+				"node_id", nodeId,
+				"node_type", nodeType,
+				"input_keys", inputKeys,
+				"output_keys", outputKeys,
+				"timestamp", Instant.now().toString());
+	}
+
+	private static Map<String, Object> routeEntry(OverAllState state, String nodeId, String route, String reason) {
+		return Map.of(
+				"graph_id", state.value(GRAPH_ID, String.class).orElse(GRAPH_ID_VALUE),
+				"run_id", state.value(RUN_ID, String.class).orElse("unknown"),
+				"node_id", nodeId,
+				"route", route,
+				"reason", reason,
+				"timestamp", Instant.now().toString());
+	}
+
+	private static Map<String, Object> evidence(OverAllState state, String nodeId, String summary) {
+		return Map.of(
+				"graph_id", state.value(GRAPH_ID, String.class).orElse(GRAPH_ID_VALUE),
+				"run_id", state.value(RUN_ID, String.class).orElse("unknown"),
+				"node_id", nodeId,
+				"summary", summary,
+				"timestamp", Instant.now().toString());
+	}
+
+	private static String reviewRoute(OverAllState state) {
+		String decision = state.value(REVIEW_DECISION, String.class).orElse("FAIL");
+		return decision.toUpperCase().startsWith("PASS") ? "pass" : "fail";
+	}
+
+}

--- a/examples/graphengineering/src/main/resources/issues/bug_issue.json
+++ b/examples/graphengineering/src/main/resources/issues/bug_issue.json
@@ -1,0 +1,9 @@
+{
+  "title": "Regression: CI fails after dependency bump",
+  "type": "bug",
+  "source": "github",
+  "repository": "example/api",
+  "summary": "CI log indicates a deterministic unit test regression.",
+  "requires_review": true,
+  "requires_deploy": false
+}

--- a/examples/graphengineering/src/main/resources/repoops-graph-topology.yaml
+++ b/examples/graphengineering/src/main/resources/repoops-graph-topology.yaml
@@ -1,0 +1,131 @@
+graph:
+  id: repoops-issue-lifecycle
+  runtime: Spring AI Alibaba StateGraph
+  purpose: >
+    Issue-driven RepoOps lifecycle graph. Spring AI Alibaba owns topology,
+    state, routing, verifier loop-back, and evidence. AgentScope Java owns
+    specialist agent execution inside business nodes.
+
+state:
+  replace:
+    - graph_id
+    - run_id
+    - current_node
+    - issue_file
+    - issue_url
+    - issue_payload
+    - issue_title
+    - issue_type
+    - issue_source
+    - issue_repository
+    - issue_summary
+    - requires_review
+    - requires_deploy
+    - triage_result
+    - route_decision
+    - work_plan
+    - implementation_proposal
+    - review_decision
+    - review_gate_result
+    - audit_report
+  append:
+    - node_trace
+    - route_history
+    - evidence_bundle
+
+nodes:
+  - id: initialize_run
+    type: deterministic_initializer
+    mandate: Create graph_id and run_id before business work starts.
+    inputs: []
+    outputs: [graph_id, run_id, current_node, node_trace, evidence_bundle]
+    outgoing: [read_issue]
+
+  - id: read_issue
+    type: deterministic_intake
+    mandate: Read classpath JSON, local JSON, or GitHub issue URL and normalize issue state.
+    inputs: [issue_file]
+    outputs: [issue_payload, issue_type, issue_repository, issue_summary, node_trace, evidence_bundle]
+    outgoing: [agentscope_triager]
+
+  - id: agentscope_triager
+    type: agentic_worker
+    provider: AgentScopeAgent
+    mandate: Classify issue impact, priority, owner hint, and missing context.
+    inputs: [issue_payload]
+    outputs: [triage_result, node_trace, evidence_bundle]
+    outgoing: [route_issue]
+
+  - id: route_issue
+    type: deterministic_router
+    mandate: Turn triage route_candidate into an auditable route_decision, falling back to issue_type when needed.
+    inputs: [triage_result, issue_type]
+    outputs: [route_decision, route_history, node_trace, evidence_bundle]
+    outgoing:
+      bug: agentscope_bug_diagnoser
+      feature: agentscope_feature_planner
+      question: agentscope_question_responder
+
+  - id: agentscope_bug_diagnoser
+    type: agentic_worker
+    provider: AgentScopeAgent
+    mandate: Produce a reproduction, diagnosis, and regression-test plan.
+    inputs: [issue_payload, triage_result]
+    outputs: [work_plan, node_trace, evidence_bundle]
+    outgoing: [agentscope_implementer]
+
+  - id: agentscope_feature_planner
+    type: agentic_worker
+    provider: AgentScopeAgent
+    mandate: Produce a feature design and acceptance criteria.
+    inputs: [issue_payload, triage_result]
+    outputs: [work_plan, node_trace, evidence_bundle]
+    outgoing: [agentscope_implementer]
+
+  - id: agentscope_question_responder
+    type: agentic_worker
+    provider: AgentScopeAgent
+    mandate: Answer support questions without entering implementation workflow.
+    inputs: [issue_payload, triage_result]
+    outputs: [work_plan, node_trace, evidence_bundle]
+    outgoing: [record_question_evidence]
+
+  - id: record_question_evidence
+    type: deterministic_evidence
+    mandate: Record that question issues bypass implementation and review.
+    inputs: [work_plan]
+    outputs: [implementation_proposal, review_decision, review_gate_result, node_trace, evidence_bundle]
+    outgoing: [agentscope_auditor]
+
+  - id: agentscope_implementer
+    type: agentic_worker
+    provider: AgentScopeAgent
+    mandate: Produce a reviewable implementation proposal, not an actual patch.
+    inputs: [issue_payload, work_plan]
+    outputs: [implementation_proposal, node_trace, evidence_bundle]
+    outgoing: [agentscope_reviewer]
+
+  - id: agentscope_reviewer
+    type: verifier_agent
+    provider: AgentScopeAgent
+    mandate: Independently review the implementation proposal.
+    inputs: [issue_payload, triage_result, work_plan, implementation_proposal]
+    outputs: [review_decision, node_trace, evidence_bundle]
+    outgoing: [review_gate]
+
+  - id: review_gate
+    type: deterministic_verifier_router
+    mandate: Convert reviewer text into pass/fail route and preserve the decision.
+    inputs: [review_decision]
+    outputs: [review_gate_result, route_history, node_trace, evidence_bundle]
+    outgoing:
+      pass: agentscope_auditor
+      fail: agentscope_implementer
+
+  - id: agentscope_auditor
+    type: audit_agent
+    provider: AgentScopeAgent
+    mandate: Produce final route, repository/source, review, deploy, and evidence summary.
+    inputs: [issue_payload, triage_result, work_plan, implementation_proposal, review_decision, review_gate_result]
+    outputs: [audit_report, node_trace, evidence_bundle]
+    outgoing: [END]


### PR DESCRIPTION
## Summary
- add Graph Engineering positioning docs for Spring AI Alibaba
- add a lightweight RepoOps Graph Engineering design without AgentTeams
- add runnable examples/graphengineering module with AgentScope Java nodes, explicit topology contract, route/gate nodes, node trace, route history, and evidence bundle

## Validation
- cd examples/graphengineering && ../../mvnw -DskipTests compile
- cd examples/graphengineering && ../../mvnw -DskipTests -Dexec.mainClass=com.alibaba.cloud.ai.examples.graphengineering.AgentScopeRepoOpsIssueGraphExample -Dexec.args=--validate-topology org.codehaus.mojo:exec-maven-plugin:3.5.0:java