### PR TITLE
test(agent): cover dynamic skill tools in AgentTool subagents

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolConfigPropagationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolConfigPropagationTest.java
@@ -20,8 +20,11 @@ import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPositions;
 import com.alibaba.cloud.ai.graph.agent.hook.ModelHook;
+import com.alibaba.cloud.ai.graph.agent.hook.skills.SkillsAgentHook;
 import com.alibaba.cloud.ai.graph.agent.tools.ToolContextConstants;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.skills.registry.SkillRegistry;
+import com.alibaba.cloud.ai.graph.skills.registry.filesystem.FileSystemSkillRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -30,11 +33,15 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import reactor.core.publisher.Flux;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -103,6 +110,45 @@ class AgentToolConfigPropagationTest {
 		assertTrue(exception.getMessage().contains("input=hello"));
 	}
 
+	@Test
+	@DisplayName("AgentTool sub-agent should execute tools activated by read_skill")
+	void shouldExecuteDynamicSkillToolInSubAgent() throws Exception {
+		AtomicReference<String> recordedValue = new AtomicReference<>();
+		ToolCallback recordResultTool = FunctionToolCallback
+				.builder("record_result",
+						(RecordResultRequest request, ToolContext context) -> {
+							recordedValue.set(request.value);
+							return "recorded";
+						})
+				.description("Records a result value")
+				.inputType(RecordResultRequest.class)
+				.build();
+		SkillRegistry registry = FileSystemSkillRegistry.builder()
+				.projectSkillsDirectory(Path.of("src/test/resources/skills").toAbsolutePath().toString())
+				.build();
+		SkillsAgentHook skillsHook = SkillsAgentHook.builder()
+				.skillRegistry(registry)
+				.groupedTools(Map.of("grouped-tools-test", List.of(recordResultTool)))
+				.build();
+		ReactAgent subAgent = ReactAgent.builder()
+				.name("skill_child_agent")
+				.description("Executes tasks using dynamically activated skill tools")
+				.model(new SkillToolCallingChatModel())
+				.hooks(List.of(skillsHook))
+				.build();
+		ReactAgent parentAgent = ReactAgent.builder()
+				.name("streaming_parent_agent")
+				.model(new ParentToolCallingChatModel())
+				.tools(AgentTool.create(subAgent))
+				.build();
+
+		RunnableConfig parentConfig = RunnableConfig.builder().threadId("parent-thread").build();
+		assertNotNull(parentAgent.stream("delegate this task", parentConfig).blockLast());
+
+		assertEquals("nested-value", recordedValue.get(),
+				"Tool activated by read_skill should remain available to the sub-agent tool node");
+	}
+
 	private static class FixedResponseChatModel implements ChatModel {
 
 		private final String responseText;
@@ -120,6 +166,65 @@ class AgentToolConfigPropagationTest {
 		public Flux<ChatResponse> stream(Prompt prompt) {
 			return Flux.just(call(prompt));
 		}
+	}
+
+	private static class SkillToolCallingChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			AssistantMessage response = switch (callCount.getAndIncrement()) {
+				case 0 -> AssistantMessage.builder()
+						.content("")
+						.toolCalls(List.of(new AssistantMessage.ToolCall("read-skill", "function", "read_skill",
+								"{\"skill_name\":\"grouped-tools-test\"}")))
+						.build();
+				case 1 -> AssistantMessage.builder()
+						.content("")
+						.toolCalls(List.of(new AssistantMessage.ToolCall("record-result", "function", "record_result",
+								"{\"value\":\"nested-value\"}")))
+						.build();
+				default -> new AssistantMessage("done");
+			};
+			return new ChatResponse(List.of(new Generation(response)));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+	}
+
+	private static class ParentToolCallingChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			return response();
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(response());
+		}
+
+		private ChatResponse response() {
+			AssistantMessage response = callCount.getAndIncrement() == 0
+					? AssistantMessage.builder()
+							.content("")
+							.toolCalls(List.of(new AssistantMessage.ToolCall("delegate", "function",
+									"skill_child_agent", "{\"input\":\"record nested-value\"}")))
+							.build()
+					: new AssistantMessage("parent done");
+			return new ChatResponse(List.of(new Generation(response)));
+		}
+	}
+
+	private static class RecordResultRequest {
+
+		public String value;
 	}
 
 	@HookPositions(HookPosition.BEFORE_MODEL)

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolConfigPropagationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolConfigPropagationTest.java
@@ -130,11 +130,12 @@ class AgentToolConfigPropagationTest {
 				.skillRegistry(registry)
 				.groupedTools(Map.of("grouped-tools-test", List.of(recordResultTool)))
 				.build();
+		ConfigCaptureHook captureHook = new ConfigCaptureHook();
 		ReactAgent subAgent = ReactAgent.builder()
 				.name("skill_child_agent")
 				.description("Executes tasks using dynamically activated skill tools")
 				.model(new SkillToolCallingChatModel())
-				.hooks(List.of(skillsHook))
+				.hooks(List.of(skillsHook, captureHook))
 				.build();
 		ReactAgent parentAgent = ReactAgent.builder()
 				.name("streaming_parent_agent")
@@ -142,11 +143,20 @@ class AgentToolConfigPropagationTest {
 				.tools(AgentTool.create(subAgent))
 				.build();
 
-		RunnableConfig parentConfig = RunnableConfig.builder().threadId("parent-thread").build();
+		RunnableConfig parentConfig = RunnableConfig.builder()
+				.threadId("parent-thread")
+				.addMetadata("business_key", "streaming-parent-value")
+				.build();
 		assertNotNull(parentAgent.stream("delegate this task", parentConfig).blockLast());
 
 		assertEquals("nested-value", recordedValue.get(),
 				"Tool activated by read_skill should remain available to the sub-agent tool node");
+		RunnableConfig childConfig = captureHook.capturedConfig();
+		assertNotNull(childConfig, "Streaming AgentTool should pass a runnable config to the child");
+		assertEquals("parent-thread_skill_child_agent", childConfig.threadId().orElse(null),
+				"Child thread id should be derived from the streaming parent config");
+		assertEquals("streaming-parent-value", childConfig.metadata("business_key").orElse(null),
+				"Child should preserve business metadata from the streaming parent config");
 	}
 
 	private static class FixedResponseChatModel implements ChatModel {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adds deterministic regression coverage for the multi-agent scenario reported in #4656. The test exercises a streaming parent agent that invokes an AgentTool sub-agent; the sub-agent reads a skill, receives a grouped dynamic ToolCallback, and executes that callback successfully.

The reported failure does not reproduce on the current `main` branch. The missing piece is automated coverage for this exact configuration boundary, so this PR protects the working RunnableConfig propagation behavior from regressions without changing production code.

### Does this pull request fix one issue?

Fixes #4656

### Describe how you did it

- Added scripted parent and child ChatModel fixtures so the test is deterministic and does not require an external model or MCP server.
- Streamed the parent ReactAgent and delegated through `AgentTool.create(subAgent)`.
- Configured the child with `SkillsAgentHook.groupedTools`.
- Made the child call `read_skill`, then call the dynamically activated `record_result` ToolCallback.
- Asserted that the grouped tool executes with the expected value.

User impact: maintainers now have a focused regression test for dynamic skill-tool propagation across streaming AgentTool boundaries. Runtime behavior and public APIs are unchanged.

### Describe how to verify it

Run:

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -pl spring-ai-alibaba-agent-framework -Dtest=AgentToolConfigPropagationTest test
```

Result: BUILD SUCCESS; 3 tests run, 0 failures, 0 errors, 0 skipped. Checkstyle and Spotless also passed as part of the command.

### Special notes for reviews

This is intentionally test-only because the exact reporter-provided path works on current `main`. The test uses the existing `grouped-tools-test` fixture and a generic ToolCallback, matching the issue details. Compatibility risk is limited to test execution; there is no production or API change.