### PR TITLE
feat(agent): support batched array loops

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategy.java
@@ -38,12 +38,26 @@ public class ArrayLoopStrategy implements LoopStrategy {
 
     private final Converter<List<Message>, List<?>> converter;
 
+    private final int batchSize;
+
     public ArrayLoopStrategy(Converter<List<Message>, List<?>> converter) {
+        this(converter, 1);
+    }
+
+    public ArrayLoopStrategy(Converter<List<Message>, List<?>> converter, int batchSize) {
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than zero");
+        }
         this.converter = converter;
+        this.batchSize = batchSize;
+    }
+
+    public ArrayLoopStrategy(int batchSize) {
+        this(DEFAULT_MESSAGE_CONVERTER, batchSize);
     }
 
     public ArrayLoopStrategy() {
-        this(DEFAULT_MESSAGE_CONVERTER);
+        this(1);
     }
 
     @Override
@@ -63,8 +77,12 @@ public class ArrayLoopStrategy implements LoopStrategy {
         List<?> list = state.value(loopListKey(), List.class).orElse(List.of());
         int index = state.value(loopCountKey(), maxLoopCount());
         if(index < list.size()) {
-            UserMessage message = new UserMessage(list.get(index).toString());
-            return Map.of(loopCountKey(), index + 1, loopFlagKey(), true,
+            int nextIndex = Math.min(index + batchSize, list.size());
+            String messageText = batchSize == 1
+                    ? list.get(index).toString()
+                    : JsonParser.toJson(list.subList(index, nextIndex));
+            UserMessage message = new UserMessage(messageText);
+            return Map.of(loopCountKey(), nextIndex, loopFlagKey(), true,
                     LoopStrategy.MESSAGE_KEY, message);
         } else {
             return Map.of(loopFlagKey(), false);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategy.java
@@ -40,16 +40,23 @@ public class ArrayLoopStrategy implements LoopStrategy {
 
     private final int batchSize;
 
+    private final boolean batchFraming;
+
     public ArrayLoopStrategy(Converter<List<Message>, List<?>> converter) {
-        this(converter, 1);
+        this(converter, 1, false);
     }
 
     public ArrayLoopStrategy(Converter<List<Message>, List<?>> converter, int batchSize) {
+        this(converter, batchSize, true);
+    }
+
+    private ArrayLoopStrategy(Converter<List<Message>, List<?>> converter, int batchSize, boolean batchFraming) {
         if (batchSize <= 0) {
             throw new IllegalArgumentException("batchSize must be greater than zero");
         }
         this.converter = converter;
         this.batchSize = batchSize;
+        this.batchFraming = batchFraming;
     }
 
     public ArrayLoopStrategy(int batchSize) {
@@ -57,7 +64,7 @@ public class ArrayLoopStrategy implements LoopStrategy {
     }
 
     public ArrayLoopStrategy() {
-        this(1);
+        this(DEFAULT_MESSAGE_CONVERTER, 1, false);
     }
 
     @Override
@@ -78,9 +85,9 @@ public class ArrayLoopStrategy implements LoopStrategy {
         int index = state.value(loopCountKey(), maxLoopCount());
         if(index < list.size()) {
             int nextIndex = Math.min(index + batchSize, list.size());
-            String messageText = batchSize == 1
-                    ? list.get(index).toString()
-                    : JsonParser.toJson(list.subList(index, nextIndex));
+            String messageText = batchFraming
+                    ? JsonParser.toJson(list.subList(index, nextIndex))
+                    : list.get(index).toString();
             UserMessage message = new UserMessage(messageText);
             return Map.of(loopCountKey(), nextIndex, loopFlagKey(), true,
                     LoopStrategy.MESSAGE_KEY, message);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/LoopMode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/LoopMode.java
@@ -45,6 +45,26 @@ public final class LoopMode {
         return new ArrayLoopStrategy(converter);
     }
 
+    /**
+     * Creates an array loop that sends up to {@code batchSize} elements as a JSON array
+     * on each iteration.
+     * @param batchSize maximum number of elements in each iteration
+     * @return the configured array loop strategy
+     */
+    public static ArrayLoopStrategy array(int batchSize) {
+        return new ArrayLoopStrategy(batchSize);
+    }
+
+    /**
+     * Creates an array loop with a custom source converter and batched dispatch.
+     * @param batchSize maximum number of elements in each iteration
+     * @param converter converter used to obtain the source elements
+     * @return the configured array loop strategy
+     */
+    public static ArrayLoopStrategy array(int batchSize, Converter<List<Message>, List<?>> converter) {
+        return new ArrayLoopStrategy(converter, batchSize);
+    }
+
     public static ConditionLoopStrategy condition(Predicate<List<Message>> messagePredicate) {
         return new ConditionLoopStrategy(messagePredicate);
     }

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategyTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategyTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.flow.agent.loop;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArrayLoopStrategyTest {
+
+	@Test
+	void shouldDispatchArrayElementsInBatches() {
+		ArrayLoopStrategy strategy = LoopMode.array(2, messages -> List.of("one", "two", "three", "four", "five"));
+		Map<String, Object> state = new HashMap<>(strategy.loopInit(stateWithMessage("ignored")));
+
+		Map<String, Object> first = strategy.loopDispatch(new OverAllState(state));
+		assertDispatch(first, strategy, 2, "[\"one\",\"two\"]");
+		state.putAll(first);
+
+		Map<String, Object> second = strategy.loopDispatch(new OverAllState(state));
+		assertDispatch(second, strategy, 4, "[\"three\",\"four\"]");
+		state.putAll(second);
+
+		Map<String, Object> last = strategy.loopDispatch(new OverAllState(state));
+		assertDispatch(last, strategy, 5, "[\"five\"]");
+		state.putAll(last);
+
+		Map<String, Object> completed = strategy.loopDispatch(new OverAllState(state));
+		assertFalse((Boolean) completed.get(strategy.loopFlagKey()));
+	}
+
+	@Test
+	void defaultArrayModeShouldKeepSingleElementMessages() {
+		ArrayLoopStrategy strategy = LoopMode.array(messages -> List.of("one", "two"));
+		Map<String, Object> state = new HashMap<>(strategy.loopInit(stateWithMessage("ignored")));
+
+		Map<String, Object> first = strategy.loopDispatch(new OverAllState(state));
+
+		assertDispatch(first, strategy, 1, "one");
+	}
+
+	@Test
+	void shouldRejectNonPositiveBatchSize() {
+		assertThrows(IllegalArgumentException.class, () -> LoopMode.array(0));
+		assertThrows(IllegalArgumentException.class, () -> LoopMode.array(-1, messages -> List.of()));
+	}
+
+	private static OverAllState stateWithMessage(String text) {
+		return new OverAllState(Map.of(LoopStrategy.MESSAGE_KEY, List.of(new UserMessage(text))));
+	}
+
+	private static void assertDispatch(Map<String, Object> update, ArrayLoopStrategy strategy, int expectedIndex,
+			String expectedMessage) {
+		assertTrue((Boolean) update.get(strategy.loopFlagKey()));
+		assertEquals(expectedIndex, update.get(strategy.loopCountKey()));
+		Message message = (Message) update.get(LoopStrategy.MESSAGE_KEY);
+		assertEquals(expectedMessage, message.getText());
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategyTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/agent/loop/ArrayLoopStrategyTest.java
@@ -63,6 +63,23 @@ class ArrayLoopStrategyTest {
 	}
 
 	@Test
+	void explicitSingleElementBatchShouldKeepJsonArrayFraming() {
+		ArrayLoopStrategy customConverterStrategy = LoopMode.array(1, messages -> List.of("one", "two"));
+		Map<String, Object> customState =
+				new HashMap<>(customConverterStrategy.loopInit(stateWithMessage("ignored")));
+
+		assertDispatch(customConverterStrategy.loopDispatch(new OverAllState(customState)),
+				customConverterStrategy, 1, "[\"one\"]");
+
+		ArrayLoopStrategy defaultConverterStrategy = LoopMode.array(1);
+		Map<String, Object> defaultState =
+				new HashMap<>(defaultConverterStrategy.loopInit(stateWithMessage("[\"one\",\"two\"]")));
+
+		assertDispatch(defaultConverterStrategy.loopDispatch(new OverAllState(defaultState)),
+				defaultConverterStrategy, 1, "[\"one\"]");
+	}
+
+	@Test
 	void shouldRejectNonPositiveBatchSize() {
 		assertThrows(IllegalArgumentException.class, () -> LoopMode.array(0));
 		assertThrows(IllegalArgumentException.class, () -> LoopMode.array(-1, messages -> List.of()));


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adds opt-in batched dispatch to LoopAgent array loops. Callers can now use `LoopMode.array(batchSize)` when a sub-agent should process several input elements per iteration, such as processing 20 images in groups of 5.

The root cause of the limitation was that `ArrayLoopStrategy.loopDispatch` always selected exactly one list element and incremented its cursor by one. There was no API for controlling the number of elements sent to each iteration.

### Does this pull request fix one issue?

Fixes #4664

### Describe how you did it

- Added `LoopMode.array(int batchSize)` and `LoopMode.array(int batchSize, Converter<...>)` overloads.
- Added validated batch-size configuration to `ArrayLoopStrategy`.
- Dispatches each opt-in batch as a valid JSON array and advances the cursor by the actual number of consumed elements.
- Preserves the existing `array()` and `array(converter)` single-element message behavior.
- Added deterministic unit tests for full batches, a short final batch, backward-compatible single-element dispatch, completion, and invalid batch sizes.

User impact: LoopAgent users can express bounded batch processing without wrapping or subclassing agents. Existing users see no behavior change unless they select a batched overload.

### Describe how to verify it

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -pl spring-ai-alibaba-agent-framework test
```

Result: BUILD SUCCESS; 593 tests run, 0 failures, 0 errors, 167 environment-dependent tests skipped. Checkstyle and Spotless passed in the same build.

### Special notes for reviews

The API change is additive and source compatible. Batched message serialization is only enabled when `batchSize` is explicitly provided; the final batch may contain fewer elements. Non-positive sizes fail fast with `IllegalArgumentException`.