### PR TITLE
fix(agent): emit observations for tool executions

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
@@ -71,10 +71,17 @@ public class DefaultBuilder extends Builder {
 				? getChatClientDefaultOptions(chatClient)
 				: getChatModelDefaultOptions(model);
 		ChatOptions effectiveOptions = mergeSourceOptionsWithAgentOptions(sourceOptions, this.chatOptions);
+		ObservationRegistry effectiveObservationRegistry = this.observationRegistry;
+		if (effectiveObservationRegistry == null && this.compileConfig != null) {
+			effectiveObservationRegistry = this.compileConfig.observationRegistry();
+		}
+		if (effectiveObservationRegistry == null) {
+			effectiveObservationRegistry = ObservationRegistry.NOOP;
+		}
 
 		if (chatClient == null) {
 			ChatClient.Builder clientBuilder = ChatClient.builder(model,
-					this.observationRegistry == null ? ObservationRegistry.NOOP : this.observationRegistry,
+					effectiveObservationRegistry,
 					this.customObservationConvention, this.advisorObservationConvention);
 			if (effectiveOptions != null) {
 				clientBuilder.defaultOptions(effectiveOptions);
@@ -136,6 +143,7 @@ public class DefaultBuilder extends Builder {
 		AgentToolNode toolNode;
 		AgentToolNode.Builder toolBuilder = AgentToolNode.builder()
 				.agentName(this.name)
+				.observationRegistry(effectiveObservationRegistry)
 				.parallelToolExecution(this.parallelToolExecution)
 				.maxParallelTools(this.maxParallelTools)
 				.toolExecutionTimeout(this.toolExecutionTimeout)

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -34,6 +34,7 @@ import com.alibaba.cloud.ai.graph.agent.tool.StateAwareToolCallback;
 import com.alibaba.cloud.ai.graph.agent.tool.ToolCancelledException;
 import com.alibaba.cloud.ai.graph.agent.tool.ToolStateCollector;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -46,7 +47,12 @@ import org.springframework.ai.tool.execution.ToolExecutionException;
 import org.springframework.ai.tool.execution.ToolExecutionExceptionProcessor;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.ai.tool.method.MethodToolCallback;
+import org.springframework.ai.tool.observation.DefaultToolCallingObservationConvention;
+import org.springframework.ai.tool.observation.ToolCallingObservationContext;
+import org.springframework.ai.tool.observation.ToolCallingObservationConvention;
+import org.springframework.ai.tool.observation.ToolCallingObservationDocumentation;
 import org.springframework.ai.tool.resolution.ToolCallbackResolver;
+import org.springframework.util.StringUtils;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -65,6 +71,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -99,6 +106,9 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 	private static final Logger logger = LoggerFactory.getLogger(AgentToolNode.class);
 
+	private static final ToolCallingObservationConvention DEFAULT_OBSERVATION_CONVENTION =
+			new DefaultToolCallingObservationConvention();
+
 	private final String agentName;
 
 	private final boolean enableActingLog;
@@ -110,6 +120,8 @@ public class AgentToolNode implements NodeActionWithConfig {
 	private final Duration toolExecutionTimeout;
 
 	private final boolean wrapSyncToolsAsAsync;
+
+	private final ObservationRegistry observationRegistry;
 
 	private List<ToolCallback> toolCallbacks;
 
@@ -132,6 +144,7 @@ public class AgentToolNode implements NodeActionWithConfig {
 		this.maxParallelTools = builder.maxParallelTools;
 		this.toolExecutionTimeout = builder.toolExecutionTimeout;
 		this.wrapSyncToolsAsAsync = builder.wrapSyncToolsAsAsync;
+		this.observationRegistry = builder.observationRegistry;
 	}
 
 	public void setToolCallbacks(List<ToolCallback> toolCallbacks) {
@@ -572,8 +585,9 @@ public class AgentToolNode implements NodeActionWithConfig {
 			}
 
 			// Route to async or sync execution based on callback type
-			return executeToolByType(toolCallback, req, toolContextMap, config, extraStateFromToolCall,
-					inParallelExecution, cancellationTokens, toolIndex);
+			return observeToolCall(toolCallback, req,
+					() -> executeToolByType(toolCallback, req, toolContextMap, config, extraStateFromToolCall,
+							inParallelExecution, cancellationTokens, toolIndex));
 		};
 
 		// Chain interceptors if any
@@ -581,6 +595,24 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 		// Execute the chained handler
 		return chainedHandler.call(request);
+	}
+
+	private ToolCallResponse observeToolCall(ToolCallback toolCallback, ToolCallRequest request,
+			Supplier<ToolCallResponse> execution) {
+		String arguments = StringUtils.hasText(request.getArguments()) ? request.getArguments() : "{}";
+		ToolCallingObservationContext observationContext = ToolCallingObservationContext.builder()
+				.toolDefinition(toolCallback.getToolDefinition())
+				.toolMetadata(toolCallback.getToolMetadata())
+				.toolCallArguments(arguments)
+				.build();
+
+		return ToolCallingObservationDocumentation.TOOL_CALL
+				.observation(null, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, observationRegistry)
+				.observe(() -> {
+					ToolCallResponse response = execution.get();
+					observationContext.setToolCallResult(response.getResult());
+					return response;
+				});
 	}
 
 	/**
@@ -888,6 +920,8 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 		private boolean wrapSyncToolsAsAsync = false;
 
+		private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+
 		private List<ToolCallback> toolCallbacks = new ArrayList<>();
 
 		private Map<String, Object> toolContext = new HashMap<>();
@@ -906,6 +940,12 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 		public Builder enableActingLog(boolean enableActingLog) {
 			this.enableActingLog = enableActingLog;
+			return this;
+		}
+
+		public Builder observationRegistry(ObservationRegistry observationRegistry) {
+			this.observationRegistry = Objects.requireNonNull(observationRegistry,
+					"observationRegistry must not be null");
 			return this;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -34,6 +34,7 @@ import com.alibaba.cloud.ai.graph.agent.tool.StateAwareToolCallback;
 import com.alibaba.cloud.ai.graph.agent.tool.ToolCancelledException;
 import com.alibaba.cloud.ai.graph.agent.tool.ToolStateCollector;
 
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -606,13 +607,16 @@ public class AgentToolNode implements NodeActionWithConfig {
 				.toolCallArguments(arguments)
 				.build();
 
-		return ToolCallingObservationDocumentation.TOOL_CALL
-				.observation(null, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, observationRegistry)
-				.observe(() -> {
-					ToolCallResponse response = execution.get();
-					observationContext.setToolCallResult(response.getResult());
-					return response;
-				});
+		Observation observation = ToolCallingObservationDocumentation.TOOL_CALL
+			.observation(null, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, observationRegistry);
+		return observation.observe(() -> {
+			ToolCallResponse response = execution.get();
+			observationContext.setToolCallResult(response.getResult());
+			if (response.isError()) {
+				observation.error(new IllegalStateException(response.getResult()));
+			}
+			return response;
+		});
 	}
 
 	/**
@@ -786,8 +790,7 @@ public class AgentToolNode implements NodeActionWithConfig {
 			else if (cause instanceof ToolExecutionException toolExecutionException) {
 				logger.error("Async tool {} execution failed, handling with processor: {}", request.getToolName(),
 						toolExecutionExceptionProcessor.getClass().getName(), toolExecutionException);
-				String result = toolExecutionExceptionProcessor.process(toolExecutionException);
-				return ToolCallResponse.of(request.getToolCallId(), request.getToolName(), result);
+				return handledToolFailure(request, toolExecutionException);
 			}
 			else {
 				logger.error("Async tool {} execution failed: {}", request.getToolName(), cause.getMessage(), cause);
@@ -828,13 +831,23 @@ public class AgentToolNode implements NodeActionWithConfig {
 		catch (ToolExecutionException e) {
 			logger.error("Tool {} execution failed, handling with processor: {}", request.getToolName(),
 					toolExecutionExceptionProcessor.getClass().getName(), e);
-			String result = toolExecutionExceptionProcessor.process(e);
-			return ToolCallResponse.of(request.getToolCallId(), request.getToolName(), result);
+			return handledToolFailure(request, e);
 		}
 		catch (Exception e) {
 			logger.error("Tool {} execution failed: {}", request.getToolName(), e.getMessage(), e);
 			return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), e);
 		}
+	}
+
+	private ToolCallResponse handledToolFailure(ToolCallRequest request, ToolExecutionException exception) {
+		String result = toolExecutionExceptionProcessor.process(exception);
+		return ToolCallResponse.builder()
+			.content(result)
+			.toolName(request.getToolName())
+			.toolCallId(request.getToolCallId())
+			.status("error")
+			.metadata(Map.of("error", true, "errorMessage", extractErrorMessage(exception)))
+			.build();
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -71,6 +71,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -313,6 +315,7 @@ public class AgentToolNode implements NodeActionWithConfig {
 		}
 
 		Executor executor = getToolExecutor(config);
+		Observation parentObservation = observationRegistry.getCurrentObservation();
 
 		// Create state snapshot for thread safety
 		// Note: snapShot() is a shallow copy, shared mutable objects (like messages List)
@@ -336,16 +339,23 @@ public class AgentToolNode implements NodeActionWithConfig {
 		List<CompletableFuture<Void>> futures = IntStream.range(0, toolCalls.size()).mapToObj(index -> {
 			AssistantMessage.ToolCall toolCall = toolCalls.get(index);
 			Map<String, Object> toolSpecificUpdate = stateCollector.createToolUpdateMap(index);
+			ToolObservationTracker observationTracker = new ToolObservationTracker();
 
 			return CompletableFuture.runAsync(() -> {
-				try {
+				try (Observation.Scope parentScope =
+						parentObservation != null ? parentObservation.openScope() : null) {
 					// Acquire permit to limit concurrent executions
 					semaphore.acquire();
 					try {
+						if (orderedResponses.get(index) != null) {
+							return;
+						}
 						ToolCallResponse response = executeToolCallWithInterceptors(toolCall, stateSnapshot, config,
-								toolSpecificUpdate, true, cancellationTokens, index);
+								toolSpecificUpdate, true, cancellationTokens, index, observationTracker);
 						// CAS: only set if still null (not already timed out)
-						orderedResponses.compareAndSet(index, null, response);
+						if (orderedResponses.compareAndSet(index, null, response)) {
+							observationTracker.complete();
+						}
 					}
 					finally {
 						semaphore.release();
@@ -355,8 +365,10 @@ public class AgentToolNode implements NodeActionWithConfig {
 					Thread.currentThread().interrupt();
 					failures.add(e);
 					// CAS: only set error if still null
-					orderedResponses.compareAndSet(index, null,
-							ToolCallResponse.error(toolCall.id(), toolCall.name(), "Tool execution was interrupted"));
+					if (orderedResponses.compareAndSet(index, null,
+							ToolCallResponse.error(toolCall.id(), toolCall.name(), "Tool execution was interrupted"))) {
+						observationTracker.errorAndComplete(e);
+					}
 				}
 			}, executor)
 				.orTimeout(toolExecutionTimeout.toMillis(), TimeUnit.MILLISECONDS)
@@ -366,6 +378,7 @@ public class AgentToolNode implements NodeActionWithConfig {
 					ToolCallResponse errorResponse = ToolCallResponse.error(toolCall.id(), toolCall.name(),
 							extractErrorMessage(cause));
 					if (orderedResponses.compareAndSet(index, null, errorResponse)) {
+						observationTracker.errorAndComplete(cause);
 						if (cause instanceof TimeoutException) {
 							stateCollector.discardToolUpdateMap(index);
 							// Cancel the tool's cancellation token to notify it to stop gracefully
@@ -523,7 +536,7 @@ public class AgentToolNode implements NodeActionWithConfig {
 	private ToolCallResponse executeToolCallWithInterceptors(AssistantMessage.ToolCall toolCall, OverAllState state,
 			RunnableConfig config, Map<String, Object> extraStateFromToolCall, boolean inParallelExecution) {
 		return executeToolCallWithInterceptors(toolCall, state, config, extraStateFromToolCall, inParallelExecution,
-				null, -1);
+				null, -1, null);
 	}
 
 	/**
@@ -539,11 +552,14 @@ public class AgentToolNode implements NodeActionWithConfig {
 	 * execution (may be null)
 	 * @param toolIndex the index of this tool in the parallel execution (used as key in
 	 * cancellationTokens)
+	 * @param observationTracker optional tracker that lets the parallel timeout path
+	 * complete the observation
 	 * @return the tool call response
 	 */
 	private ToolCallResponse executeToolCallWithInterceptors(AssistantMessage.ToolCall toolCall, OverAllState state,
 			RunnableConfig config, Map<String, Object> extraStateFromToolCall, boolean inParallelExecution,
-			Map<Integer, DefaultCancellationToken> cancellationTokens, int toolIndex) {
+			Map<Integer, DefaultCancellationToken> cancellationTokens, int toolIndex,
+			ToolObservationTracker observationTracker) {
 
 		// Create ToolCallRequest
 		ToolCallRequest request = ToolCallRequest.builder()
@@ -588,7 +604,8 @@ public class AgentToolNode implements NodeActionWithConfig {
 			// Route to async or sync execution based on callback type
 			return observeToolCall(toolCallback, req,
 					() -> executeToolByType(toolCallback, req, toolContextMap, config, extraStateFromToolCall,
-							inParallelExecution, cancellationTokens, toolIndex));
+							inParallelExecution, cancellationTokens, toolIndex),
+					observationTracker);
 		};
 
 		// Chain interceptors if any
@@ -599,7 +616,7 @@ public class AgentToolNode implements NodeActionWithConfig {
 	}
 
 	private ToolCallResponse observeToolCall(ToolCallback toolCallback, ToolCallRequest request,
-			Supplier<ToolCallResponse> execution) {
+			Supplier<ToolCallResponse> execution, ToolObservationTracker observationTracker) {
 		String arguments = StringUtils.hasText(request.getArguments()) ? request.getArguments() : "{}";
 		ToolCallingObservationContext observationContext = ToolCallingObservationContext.builder()
 				.toolDefinition(toolCallback.getToolDefinition())
@@ -609,14 +626,74 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 		Observation observation = ToolCallingObservationDocumentation.TOOL_CALL
 			.observation(null, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, observationRegistry);
-		return observation.observe(() -> {
-			ToolCallResponse response = execution.get();
-			observationContext.setToolCallResult(response.getResult());
-			if (response.isError()) {
-				observation.error(new IllegalStateException(response.getResult()));
+		if (observationTracker != null) {
+			observation.start();
+			observationTracker.register(observation);
+			try (Observation.Scope scope = observation.openScope()) {
+				return executeObservedToolCall(execution, observationContext, observation);
 			}
-			return response;
+			catch (RuntimeException | Error ex) {
+				observationTracker.errorAndComplete(ex);
+				throw ex;
+			}
+		}
+		return observation.observe(() -> {
+			return executeObservedToolCall(execution, observationContext, observation);
 		});
+	}
+
+	private ToolCallResponse executeObservedToolCall(Supplier<ToolCallResponse> execution,
+			ToolCallingObservationContext observationContext, Observation observation) {
+		ToolCallResponse response = execution.get();
+		observationContext.setToolCallResult(response.getResult());
+		if (response.isError()) {
+			observation.error(new IllegalStateException(response.getResult()));
+		}
+		return response;
+	}
+
+	private static final class ToolObservationTracker {
+
+		private final AtomicReference<Observation> observation = new AtomicReference<>();
+
+		private final AtomicReference<Throwable> terminalError = new AtomicReference<>();
+
+		private final AtomicBoolean terminalRequested = new AtomicBoolean();
+
+		private final AtomicBoolean completed = new AtomicBoolean();
+
+		private void register(Observation observation) {
+			this.observation.set(observation);
+			completeIfReady();
+		}
+
+		private void complete() {
+			complete(null);
+		}
+
+		private void errorAndComplete(Throwable error) {
+			complete(error);
+		}
+
+		private void complete(Throwable error) {
+			if (error != null) {
+				this.terminalError.compareAndSet(null, error);
+			}
+			this.terminalRequested.set(true);
+			completeIfReady();
+		}
+
+		private void completeIfReady() {
+			Observation current = this.observation.get();
+			if (this.terminalRequested.get() && current != null && this.completed.compareAndSet(false, true)) {
+				Throwable error = this.terminalError.get();
+				if (error != null) {
+					current.error(error);
+				}
+				current.stop();
+			}
+		}
+
 	}
 
 	/**

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecReactAgentFactory.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/task/AgentSpecReactAgentFactory.java
@@ -92,6 +92,7 @@ public final class AgentSpecReactAgentFactory {
 				.description(spec.description())
 				.systemPrompt(StringUtils.hasText(spec.systemPrompt()) ? spec.systemPrompt() : "")
 				.chatClient(client)
+				.observationRegistry(this.observationRegistry)
 				.tools(tools);
 
 		ReactAgent agent = agentBuilder.build();

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolObservationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolObservationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent;
+
+import com.alibaba.cloud.ai.graph.CompileConfig;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.ai.tool.observation.ToolCallingObservationContext;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AgentToolObservationTest {
+
+	@Test
+	void shouldCreateSpringAiObservationForToolExecution() throws Exception {
+		assertToolObservation(false);
+	}
+
+	@Test
+	void shouldUseObservationRegistryFromCompileConfig() throws Exception {
+		assertToolObservation(true);
+	}
+
+	private static void assertToolObservation(boolean useCompileConfigRegistry) throws Exception {
+		ObservationRegistry observationRegistry = ObservationRegistry.create();
+		List<ToolCallingObservationContext> stoppedToolObservations = new CopyOnWriteArrayList<>();
+		observationRegistry.observationConfig()
+				.observationHandler(new ObservationHandler<ToolCallingObservationContext>() {
+					@Override
+					public void onStop(ToolCallingObservationContext context) {
+						stoppedToolObservations.add(context);
+					}
+
+					@Override
+					public boolean supportsContext(Observation.Context context) {
+						return context instanceof ToolCallingObservationContext;
+					}
+				});
+		ToolCallback observedTool = FunctionToolCallback.builder("observed_tool",
+				(ObservedRequest request) -> "observed:" + request.value)
+			.description("Returns an observed value")
+			.inputType(ObservedRequest.class)
+			.build();
+		Builder agentBuilder = ReactAgent.builder()
+			.name("observed_agent")
+			.model(new ToolCallingChatModel())
+			.tools(observedTool);
+		if (useCompileConfigRegistry) {
+			agentBuilder.compileConfig(CompileConfig.builder().observationRegistry(observationRegistry).build());
+		}
+		else {
+			agentBuilder.observationRegistry(observationRegistry);
+		}
+		ReactAgent agent = agentBuilder.build();
+
+		agent.call("invoke the observed tool");
+
+		assertEquals(1, stoppedToolObservations.size());
+		ToolCallingObservationContext context = stoppedToolObservations.get(0);
+		assertEquals("spring.ai.tool", context.getName());
+		assertEquals("tool_call", context.getLowCardinalityKeyValue("spring.ai.kind").getValue());
+		assertEquals("observed_tool", context.getToolDefinition().name());
+		assertEquals("{\"value\":\"hello\"}", context.getToolCallArguments());
+		assertEquals("\"observed:hello\"", context.getToolCallResult());
+	}
+
+	private static class ToolCallingChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			AssistantMessage response = callCount.getAndIncrement() == 0
+					? AssistantMessage.builder()
+						.content("")
+						.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "observed_tool",
+								"{\"value\":\"hello\"}")))
+						.build()
+					: new AssistantMessage("done");
+			return new ChatResponse(List.of(new Generation(response)));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+	}
+
+	private static class ObservedRequest {
+
+		public String value;
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolObservationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolObservationTest.java
@@ -16,10 +16,13 @@
 package com.alibaba.cloud.ai.graph.agent;
 
 import com.alibaba.cloud.ai.graph.CompileConfig;
+import com.alibaba.cloud.ai.graph.agent.tools.task.AgentSpec;
+import com.alibaba.cloud.ai.graph.agent.tools.task.AgentSpecReactAgentFactory;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -48,26 +51,58 @@ class AgentToolObservationTest {
 		assertToolObservation(true);
 	}
 
+	@Test
+	void shouldMarkHandledToolFailureOnObservation() throws Exception {
+		ObservationRegistry observationRegistry = ObservationRegistry.create();
+		List<ToolCallingObservationContext> stoppedToolObservations = new CopyOnWriteArrayList<>();
+		AtomicInteger observedErrors = new AtomicInteger();
+		observationRegistry.observationConfig()
+			.observationHandler(new ToolObservationCollector(stoppedToolObservations, observedErrors));
+		ToolCallback failingTool = FunctionToolCallback.builder("failing_tool", (ObservedRequest request) -> {
+			throw new IllegalStateException("tool failed");
+		})
+			.description("Always fails")
+			.inputType(ObservedRequest.class)
+			.build();
+		ReactAgent agent = ReactAgent.builder()
+			.name("failing_tool_agent")
+			.model(new ToolCallingChatModel("failing_tool"))
+			.tools(failingTool)
+			.observationRegistry(observationRegistry)
+			.build();
+
+		agent.call("invoke the failing tool");
+
+		assertEquals(1, stoppedToolObservations.size());
+		assertEquals(1, observedErrors.get());
+	}
+
+	@Test
+	void shouldForwardObservationRegistryFromAgentSpecFactory() throws Exception {
+		ObservationRegistry observationRegistry = ObservationRegistry.create();
+		List<ToolCallingObservationContext> stoppedToolObservations = new CopyOnWriteArrayList<>();
+		observationRegistry.observationConfig()
+			.observationHandler(new ToolObservationCollector(stoppedToolObservations));
+		ToolCallback observedTool = observedTool();
+		ChatClient chatClient = ChatClient.builder(new ToolCallingChatModel(), observationRegistry, null, null).build();
+		AgentSpecReactAgentFactory factory = AgentSpecReactAgentFactory.builder()
+			.chatClient(chatClient)
+			.defaultTools(observedTool)
+			.observationRegistry(observationRegistry)
+			.build();
+
+		ReactAgent agent = factory.create(AgentSpec.of("spec_agent", "test agent", "use the tool"));
+		agent.call("invoke the observed tool");
+
+		assertEquals(1, stoppedToolObservations.size());
+	}
+
 	private static void assertToolObservation(boolean useCompileConfigRegistry) throws Exception {
 		ObservationRegistry observationRegistry = ObservationRegistry.create();
 		List<ToolCallingObservationContext> stoppedToolObservations = new CopyOnWriteArrayList<>();
 		observationRegistry.observationConfig()
-				.observationHandler(new ObservationHandler<ToolCallingObservationContext>() {
-					@Override
-					public void onStop(ToolCallingObservationContext context) {
-						stoppedToolObservations.add(context);
-					}
-
-					@Override
-					public boolean supportsContext(Observation.Context context) {
-						return context instanceof ToolCallingObservationContext;
-					}
-				});
-		ToolCallback observedTool = FunctionToolCallback.builder("observed_tool",
-				(ObservedRequest request) -> "observed:" + request.value)
-			.description("Returns an observed value")
-			.inputType(ObservedRequest.class)
-			.build();
+			.observationHandler(new ToolObservationCollector(stoppedToolObservations));
+		ToolCallback observedTool = observedTool();
 		Builder agentBuilder = ReactAgent.builder()
 			.name("observed_agent")
 			.model(new ToolCallingChatModel())
@@ -91,16 +126,34 @@ class AgentToolObservationTest {
 		assertEquals("\"observed:hello\"", context.getToolCallResult());
 	}
 
+	private static ToolCallback observedTool() {
+		return FunctionToolCallback.builder("observed_tool",
+				(ObservedRequest request) -> "observed:" + request.value)
+			.description("Returns an observed value")
+			.inputType(ObservedRequest.class)
+			.build();
+	}
+
 	private static class ToolCallingChatModel implements ChatModel {
 
 		private final AtomicInteger callCount = new AtomicInteger();
+
+		private final String toolName;
+
+		private ToolCallingChatModel() {
+			this("observed_tool");
+		}
+
+		private ToolCallingChatModel(String toolName) {
+			this.toolName = toolName;
+		}
 
 		@Override
 		public ChatResponse call(Prompt prompt) {
 			AssistantMessage response = callCount.getAndIncrement() == 0
 					? AssistantMessage.builder()
 						.content("")
-						.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "observed_tool",
+						.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", this.toolName,
 								"{\"value\":\"hello\"}")))
 						.build()
 					: new AssistantMessage("done");
@@ -111,6 +164,30 @@ class AgentToolObservationTest {
 		public Flux<ChatResponse> stream(Prompt prompt) {
 			return Flux.just(call(prompt));
 		}
+	}
+
+	private record ToolObservationCollector(List<ToolCallingObservationContext> observations, AtomicInteger errors)
+			implements ObservationHandler<ToolCallingObservationContext> {
+
+		private ToolObservationCollector(List<ToolCallingObservationContext> observations) {
+			this(observations, new AtomicInteger());
+		}
+
+		@Override
+		public void onError(ToolCallingObservationContext context) {
+			this.errors.incrementAndGet();
+		}
+
+		@Override
+		public void onStop(ToolCallingObservationContext context) {
+			this.observations.add(context);
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return context instanceof ToolCallingObservationContext;
+		}
+
 	}
 
 	private static class ObservedRequest {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolObservationTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/AgentToolObservationTest.java
@@ -33,11 +33,16 @@ import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.ai.tool.observation.ToolCallingObservationContext;
 import reactor.core.publisher.Flux;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AgentToolObservationTest {
 
@@ -97,6 +102,73 @@ class AgentToolObservationTest {
 		assertEquals(1, stoppedToolObservations.size());
 	}
 
+	@Test
+	void shouldPropagateParentObservationIntoParallelToolWorkers() throws Exception {
+		ObservationRegistry observationRegistry = ObservationRegistry.create();
+		List<ToolCallingObservationContext> stoppedToolObservations = new CopyOnWriteArrayList<>();
+		observationRegistry.observationConfig()
+			.observationHandler(new ToolObservationCollector(stoppedToolObservations));
+		ReactAgent agent = ReactAgent.builder()
+			.name("parallel_observed_agent")
+			.model(new MultiToolCallingChatModel("first_tool", "second_tool"))
+			.tools(observedTool("first_tool"), observedTool("second_tool"))
+			.parallelToolExecution(true)
+			.observationRegistry(observationRegistry)
+			.build();
+		Observation parent = Observation.start("parent", observationRegistry);
+
+		try (Observation.Scope scope = parent.openScope()) {
+			agent.call("invoke both tools");
+		}
+		finally {
+			parent.stop();
+		}
+
+		assertEquals(2, stoppedToolObservations.size());
+		stoppedToolObservations.forEach(context -> assertSame(parent, context.getParentObservation()));
+	}
+
+	@Test
+	void shouldCompleteParallelToolObservationWhenOuterTimeoutWins() throws Exception {
+		ObservationRegistry observationRegistry = ObservationRegistry.create();
+		List<ToolCallingObservationContext> stoppedToolObservations = new CopyOnWriteArrayList<>();
+		AtomicInteger observedErrors = new AtomicInteger();
+		observationRegistry.observationConfig()
+			.observationHandler(new ToolObservationCollector(stoppedToolObservations, observedErrors));
+		CountDownLatch releaseSlowTool = new CountDownLatch(1);
+		ToolCallback slowTool = FunctionToolCallback.builder("slow_tool", (ObservedRequest request) -> {
+			try {
+				releaseSlowTool.await(2, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+			}
+			return "slow";
+		})
+			.description("Waits until released")
+			.inputType(ObservedRequest.class)
+			.build();
+		ReactAgent agent = ReactAgent.builder()
+			.name("parallel_timeout_agent")
+			.model(new MultiToolCallingChatModel("slow_tool", "fast_tool"))
+			.tools(slowTool, observedTool("fast_tool"))
+			.parallelToolExecution(true)
+			.toolExecutionTimeout(Duration.ofMillis(50))
+			.observationRegistry(observationRegistry)
+			.build();
+
+		try {
+			agent.call("invoke both tools");
+			assertEquals(2, stoppedToolObservations.size());
+			assertEquals(1, observedErrors.get());
+			assertTrue(stoppedToolObservations.stream()
+				.anyMatch(context -> context.getToolDefinition().name().equals("slow_tool")));
+		}
+		finally {
+			releaseSlowTool.countDown();
+		}
+	}
+
 	private static void assertToolObservation(boolean useCompileConfigRegistry) throws Exception {
 		ObservationRegistry observationRegistry = ObservationRegistry.create();
 		List<ToolCallingObservationContext> stoppedToolObservations = new CopyOnWriteArrayList<>();
@@ -127,11 +199,46 @@ class AgentToolObservationTest {
 	}
 
 	private static ToolCallback observedTool() {
-		return FunctionToolCallback.builder("observed_tool",
+		return observedTool("observed_tool");
+	}
+
+	private static ToolCallback observedTool(String name) {
+		return FunctionToolCallback.builder(name,
 				(ObservedRequest request) -> "observed:" + request.value)
 			.description("Returns an observed value")
 			.inputType(ObservedRequest.class)
 			.build();
+	}
+
+	private static class MultiToolCallingChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		private final List<String> toolNames;
+
+		private MultiToolCallingChatModel(String... toolNames) {
+			this.toolNames = List.of(toolNames);
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			AssistantMessage response = this.callCount.getAndIncrement() == 0
+					? AssistantMessage.builder()
+						.content("")
+						.toolCalls(this.toolNames.stream()
+							.map(name -> new AssistantMessage.ToolCall("call-" + name, "function", name,
+									"{\"value\":\"hello\"}"))
+							.toList())
+						.build()
+					: new AssistantMessage("done");
+			return new ChatResponse(List.of(new Generation(response)));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
 	}
 
 	private static class ToolCallingChatModel implements ChatModel {


### PR DESCRIPTION
## Root cause

`ReactAgent` intentionally disables Spring AI's internal tool execution because `AgentToolNode` owns the execution lifecycle. As a result, tool callbacks bypassed Spring AI's `DefaultToolCallingManager` and no standard `spring.ai.tool` observation was emitted, so tracing backends could not report tool inputs and outputs.

## Changes

- wrap actual `AgentToolNode` callback execution with Spring AI's standard `ToolCallingObservationDocumentation.TOOL_CALL`
- populate `ToolCallingObservationContext` with the resolved tool definition, metadata, arguments, and result
- propagate an explicitly configured observation registry to the tool node
- inherit the registry from `CompileConfig` for starter-created agents
- retain `ObservationRegistry.NOOP` as the default
- cover both explicit and compile-config registry paths with a deterministic regression test

## User impact

Tool executions performed by graph agents now appear as standard `spring.ai.tool` observations in Micrometer/OpenTelemetry-compatible tracing backends, including tool name, input arguments, and output result. Tool execution semantics are unchanged.

## Validation

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -pl spring-ai-alibaba-agent-framework -Dtest=AgentToolObservationTest test
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -pl spring-ai-alibaba-agent-framework test
```

Result: 592 tests run, 0 failures, 0 errors, 167 skipped. Checkstyle and Spotless passed.

## Compatibility

No existing public API is changed. The tool node defaults to a no-op registry, so observation overhead is incurred only when a real registry is configured.

Fixes #4507
