### PR TITLE
fix(graph): scope resume metadata to target subgraph

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -90,6 +90,7 @@ import static com.alibaba.cloud.ai.graph.action.AsyncEdgeAction.edge_async;
 import static com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig.node_async;
 import static com.alibaba.cloud.ai.graph.agent.hook.InterruptionHook.INTERRUPTION_FEEDBACK_KEY;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.scopeResumeMetadata;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
 import static java.lang.String.format;
 
@@ -1004,6 +1005,7 @@ public class ReactAgent extends BaseAgent {
 			final boolean resumeSubgraph = config.metadata(resumeSubGraphId(nodeId), new TypeRef<Boolean>() {}).orElse(false);
 
 			RunnableConfig subGraphRunnableConfig = getSubGraphRunnableConfig(config);
+			subGraphRunnableConfig = scopeResumeMetadata(subGraphRunnableConfig, resumeSubgraph);
 			Flux<GraphResponse<NodeOutput>> subGraphResult;
 			Object parentMessages = null;
 

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/ResumableSubGraphAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/ResumableSubGraphAction.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.cloud.ai.graph.internal.node;
 
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+
 import static java.lang.String.format;
 
 /**
@@ -39,9 +41,24 @@ public interface ResumableSubGraphAction {
 		return format("resume_%s", subGraphId(nodeId));
 	}
 
+	/**
+	 * Removes parent resume metadata when the current subgraph is not the resume target.
+	 * Parent graph metadata is copied for every child invocation, but human feedback
+	 * belongs only to the interrupted child. Forwarding it to a later child makes that
+	 * child incorrectly initialize in resume mode.
+	 * @param config the isolated configuration created for the child graph
+	 * @param resumeSubgraph whether this child is the interrupted resume target
+	 * @return the scoped child configuration
+	 */
+	static RunnableConfig scopeResumeMetadata(RunnableConfig config, boolean resumeSubgraph) {
+		if (!resumeSubgraph) {
+			config.metadata().ifPresent(metadata -> metadata.remove(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY));
+		}
+		return config;
+	}
+
 	static String outputKeyToParent(String nodeId) {
 		return format("%s_%s", subGraphId(nodeId), OUTPUT_KEY_TO_PARENT_SUFFIX);
 	}
 
 }
-

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/SubCompiledGraphNodeAction.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.outputKeyToParent;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.resumeSubGraphId;
+import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.scopeResumeMetadata;
 import static com.alibaba.cloud.ai.graph.internal.node.ResumableSubGraphAction.subGraphId;
 import static java.lang.String.format;
 
@@ -92,6 +93,7 @@ public record SubCompiledGraphNodeAction(String nodeId, CompileConfig parentComp
 					.build();
 			}
 		}
+		subGraphRunnableConfig = scopeResumeMetadata(subGraphRunnableConfig, resumeSubgraph);
 
 		final CompletableFuture<Map<String, Object>> future = new CompletableFuture<>();
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CompiledSubGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/CompiledSubGraphTest.java
@@ -21,13 +21,16 @@ import com.alibaba.cloud.ai.graph.checkpoint.BaseCheckpointSaver;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.exception.SubGraphInterruptionException;
+import com.alibaba.cloud.ai.graph.internal.node.SubCompiledGraphNodeAction;
 import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 
 import static com.alibaba.cloud.ai.graph.StateGraph.END;
 import static com.alibaba.cloud.ai.graph.StateGraph.START;
@@ -133,6 +136,30 @@ public class CompiledSubGraphTest {
 
 		assertIterableEquals(List.of("parent", "child:context-value", "after:false"),
 				output.value("messages", List.class).orElseThrow());
+	}
+
+	@Test
+	public void testNonTargetSubgraphDoesNotReceiveParentResumeMetadata() throws Exception {
+		AtomicReference<RunnableConfig> childConfig = new AtomicReference<>();
+		var subGraph = new StateGraph(getStrategyFactory())
+			.addNode("child", AsyncNodeActionWithConfig.node_async((state, config) -> {
+				childConfig.set(config);
+				return Map.of("messages", "child");
+			}))
+			.addEdge(START, "child")
+			.addEdge("child", END)
+			.compile();
+		var action = new SubCompiledGraphNodeAction("later-child", CompileConfig.builder().build(), subGraph);
+		var parentResumeConfig = RunnableConfig.builder()
+			.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, "feedback")
+			.addMetadata("business-key", "business-value")
+			.build();
+
+		Map<String, Object> result = action.apply(new OverAllState(), parentResumeConfig).join();
+		((Flux<?>) result.values().iterator().next()).blockLast();
+
+		assertFalse(childConfig.get().metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isPresent());
+		assertTrue(childConfig.get().metadata("business-key").isPresent());
 	}
 
 	@Test


### PR DESCRIPTION
## Root cause

When a parent graph resumes an interrupted child, `GraphRunnerContext` adds a child-specific resume marker but retains the run-level `HUMAN_FEEDBACK` metadata. Child graph adapters copied all parent metadata into every subsequent child invocation. A later child that was not the resume target therefore saw `HUMAN_FEEDBACK`, initialized itself in resume mode, and failed with `Resume request without a valid checkpoint!` because it had never created a checkpoint.

## Changes

- scope human-feedback resume metadata to the child identified by the parent graph's resume marker
- remove only `HUMAN_FEEDBACK` from non-target child configs
- apply the same behavior to compiled subgraphs and ReactAgent-as-subgraph adapters
- retain unrelated run metadata and isolated child context behavior
- add a deterministic regression test proving a later child starts normally while business metadata still propagates

## User impact

Multi-agent workflows can resume a child interrupted by HITL and then continue to subsequent child agents without those agents being misclassified as resume requests.

## Validation

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core -Dtest=CompiledSubGraphTest test
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -pl spring-ai-alibaba-graph-core -Dtest='*,!DatabaseStorePostgreSqlIntegrationTest' test
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -pl spring-ai-alibaba-agent-framework test
```

Results:

- graph-core targeted: 6 tests, 0 failures/errors
- graph-core full excluding the Docker-only PostgreSQL Testcontainers test: 404 tests, 0 failures/errors, 71 skipped
- Agent Framework: 590 tests, 0 failures/errors, 167 skipped
- Checkstyle and Spotless passed

The unfiltered graph-core suite additionally ran 404 tests successfully, but the PostgreSQL Testcontainers test could not start because Docker is unavailable in the local environment.

## Compatibility

No public configuration or state API changes. Only the copied child configuration is modified; the parent configuration and unrelated metadata are preserved.

Fixes #4115
