### PR TITLE
fix(admin): bootstrap frontend workspaces in order

### DIFF
--- a/spring-ai-alibaba-admin/frontend/package-lock.json
+++ b/spring-ai-alibaba-admin/frontend/package-lock.json
@@ -42876,7 +42876,6 @@
     },
     "packages/main": {
       "version": "0.0.1",
-      "hasInstallScript": true,
       "dependencies": {
         "@ant-design/icons": "^5",
         "@codemirror/lang-json": "^6.0.2",

--- a/spring-ai-alibaba-admin/frontend/package.json
+++ b/spring-ai-alibaba-admin/frontend/package.json
@@ -10,14 +10,15 @@
   "scripts": {
     "build:app": "cd packages/main && npm run build && cd ..",
     "build:flow": "cd packages/spark-flow && npm run build && cd ..",
+    "setup:app": "npm run setup --workspace=main",
     "build:subtree": "npm run clear",
     "build:subtree:java": "npm run build:subtree && npm install && npm run build:flow && BACK_END=java npm run build:app",
     "build:subtree:python": "npm run build:subtree && npm install && npm run build:flow && BACK_END=python npm run build:app",
     "clear": "rimraf node_modules packages/spark-flow/node_modules packages/main/node_modules packages/main/src/.umi",
     "lint": "umi lint {packages/main/src,packages/spark-flow/src}/**/*.{ts,tsx,less} --fix",
     "prepare": "husky install",
-    "re-install": "npm run clear && npm install && npm run build:flow",
-    "re-install:flow": "npm run build:flow && rimraf packages/main/node_modules && npm install"
+    "re-install": "npm run clear && npm install && npm run build:flow && npm run setup:app",
+    "re-install:flow": "npm run build:flow && rimraf packages/main/node_modules && npm install && npm run setup:app"
   },
   "lint-staged": {
     "*.{jsx,ts,tsx,css,less}": [

--- a/spring-ai-alibaba-admin/frontend/packages/main/package.json
+++ b/spring-ai-alibaba-admin/frontend/packages/main/package.json
@@ -4,7 +4,6 @@
   "scripts": {
     "build": "cross-env DID_YOU_KNOW=none umi build",
     "dev": "cross-env DID_YOU_KNOW=none umi dev",
-    "postinstall": "umi setup",
     "setup": "umi setup",
     "start": "npm run dev"
   },


### PR DESCRIPTION
## Root cause

The `main` workspace ran `umi setup` from its `postinstall` lifecycle during every root `npm install`. Its Umi alias resolves `@spark-ai/flow` to `packages/spark-flow/dist`, but the root `re-install` script built that directory only after `npm install`. On a clean checkout, setup therefore failed before the script could build its prerequisite.

## Changes

- remove the order-dependent `main` workspace `postinstall`
- add an explicit root `setup:app` command
- run app setup after `build:flow` in both reinstall workflows
- update package-lock lifecycle metadata

## User impact

A clean Admin frontend checkout can install workspace dependencies without requiring a pre-existing generated `spark-flow/dist`. The documented reinstall workflow then builds spark-flow before Umi resolves the app alias and generates setup files.

## Validation

Validated from a checkout with no frontend `node_modules` or spark-flow `dist`:

```bash
npm install
npm run build:flow
npm run setup:app
BACK_END=java npm run build:app
```

Results with Node 20.20.2 / npm 10.8.2:

- clean dependency installation completed (3,147 packages)
- spark-flow library and declarations built successfully
- `umi setup` completed successfully
- Java backend production app build completed successfully
- Webpack compiled successfully in approximately 19 seconds
- all three JSON files parse successfully

Node 24 was also checked: dependency installation and spark-flow build passed, while Umi's existing `spdy/http-deceiver` dependency failed because Node 24 removed the internal `http_parser` binding. Re-running setup/build on the repository-supported Node 20 path passed and isolates that unrelated runtime compatibility limitation.

## Compatibility

No runtime application code or dependency versions change. Existing build commands keep the same outputs; only lifecycle ordering changes.

Fixes #3995
