### PR TITLE
fix(doc): pass checkpoint history to chat model

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/core/MemoryExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/graph/core/MemoryExample.java
@@ -32,6 +32,10 @@ import com.alibaba.cloud.ai.graph.store.StoreItem;
 import com.alibaba.cloud.ai.graph.store.stores.MemoryStore;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 
 import java.util.HashMap;
 import java.util.List;
@@ -71,10 +75,10 @@ public class MemoryExample {
 			List<Map<String, String>> messages =
 					(List<Map<String, String>>) state.value("messages").orElse(List.of());
 
-			// 使用 ChatClient 调用 AI 模型
+			// 将检查点恢复出的完整历史传给模型，而不是只发送当前轮消息
 			ChatClient chatClient = chatClientBuilder.build();
 			String response = chatClient.prompt()
-					.user(messages.get(messages.size() - 1).get("content"))
+					.messages(toChatMessages(messages))
 					.call()
 					.content();
 
@@ -111,6 +115,22 @@ public class MemoryExample {
 		)), config);
 		// AI 将能够记住之前的对话，回答 "Bob"
 		System.out.println("Short-term memory example executed");
+	}
+
+	static List<Message> toChatMessages(List<Map<String, String>> messages) {
+		return messages.stream()
+				.map(MemoryExample::toChatMessage)
+				.toList();
+	}
+
+	private static Message toChatMessage(Map<String, String> message) {
+		String content = message.get("content");
+		return switch (message.get("role")) {
+			case "user" -> new UserMessage(content);
+			case "assistant" -> new AssistantMessage(content);
+			case "system" -> new SystemMessage(content);
+			default -> throw new IllegalArgumentException("Unsupported message role: " + message.get("role"));
+		};
 	}
 
 	/**
@@ -397,4 +417,3 @@ public class MemoryExample {
 		}
 	}
 }
-

--- a/examples/documentation/src/test/java/com/alibaba/cloud/ai/examples/documentation/graph/core/MemoryExampleTest.java
+++ b/examples/documentation/src/test/java/com/alibaba/cloud/ai/examples/documentation/graph/core/MemoryExampleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.documentation.graph.core;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class MemoryExampleTest {
+
+	@Test
+	void shouldConvertEntireCheckpointHistoryToChatMessages() {
+		List<Map<String, String>> history = List.of(
+				Map.of("role", "system", "content", "Remember user details"),
+				Map.of("role", "user", "content", "My name is Bob"),
+				Map.of("role", "assistant", "content", "Hello Bob"),
+				Map.of("role", "user", "content", "What is my name?"));
+
+		List<Message> messages = MemoryExample.toChatMessages(history);
+
+		assertEquals(4, messages.size());
+		assertInstanceOf(SystemMessage.class, messages.get(0));
+		assertInstanceOf(UserMessage.class, messages.get(1));
+		assertInstanceOf(AssistantMessage.class, messages.get(2));
+		assertInstanceOf(UserMessage.class, messages.get(3));
+		assertEquals("My name is Bob", messages.get(1).getText());
+		assertEquals("What is my name?", messages.get(3).getText());
+	}
+
+}


### PR DESCRIPTION
## Summary

- pass the full checkpoint-restored conversation to `ChatClient` in the short-term memory example
- convert the example state maps into role-aware Spring AI messages
- add a regression test covering ordered system, user, and assistant history

## Root cause

`MemorySaver` correctly restored and appended the conversation state, but the example selected only `messages.get(messages.size() - 1)` when constructing the model request. The model therefore received only the current user turn and could not recall details such as the user name from earlier turns.

## Validation

- `./mvnw -f examples/documentation/pom.xml -Dtest=MemoryExampleTest test`
- all 46 documentation example sources compiled
- 1 test passed, 0 failures

Fixes #4186