### PR TITLE
docs(doc): add ReactAgent Langfuse observability demo

### DIFF
--- a/examples/documentation/pom.xml
+++ b/examples/documentation/pom.xml
@@ -173,4 +173,28 @@
 		</repository>
 	</repositories>
 
+	<profiles>
+		<profile>
+			<id>langfuse</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.alibaba.cloud.ai</groupId>
+					<artifactId>spring-ai-alibaba-starter-graph-observation</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-actuator</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>io.micrometer</groupId>
+					<artifactId>micrometer-tracing-bridge-otel</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>io.opentelemetry</groupId>
+					<artifactId>opentelemetry-exporter-otlp</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
+
 </project>

--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/observability/LangfuseObservabilityExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/observability/LangfuseObservabilityExample.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.documentation.framework.advanced.observability;
+
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.UUID;
+
+/**
+ * Sends ReactAgent and model observations to Langfuse through OTLP.
+ *
+ * <p>Run this application with the {@code langfuse} Maven profile and the
+ * OpenTelemetry environment variables documented in this package's README.
+ */
+@SpringBootApplication
+public class LangfuseObservabilityExample {
+
+	public static void main(String[] args) {
+		SpringApplication.run(LangfuseObservabilityExample.class, args);
+	}
+
+	@Bean
+	ReactAgent langfuseReactAgent(ChatModel chatModel, ObservationRegistry observationRegistry)
+			throws GraphRunnerException {
+		return ReactAgent.builder()
+				.name("langfuse_observability_agent")
+				.description("A ReactAgent instrumented with Micrometer Observation")
+				.systemPrompt("You are a concise and helpful assistant.")
+				.model(chatModel)
+				.observationRegistry(observationRegistry)
+				.build();
+	}
+
+	@Bean
+	CommandLineRunner runObservedAgent(ReactAgent agent, ObservationRegistry observationRegistry) {
+		return args -> {
+			String prompt = "Explain in one sentence why observability is useful for AI agents.";
+			String sessionId = UUID.randomUUID().toString();
+			Observation observation = Observation.createNotStarted("react-agent.invoke", observationRegistry)
+				.contextualName("langfuse-observability-agent")
+				.highCardinalityKeyValue("langfuse.trace.name", "react-agent-demo")
+				.highCardinalityKeyValue("langfuse.session.id", sessionId)
+				.highCardinalityKeyValue("langfuse.user.id", "documentation-user")
+				.highCardinalityKeyValue("langfuse.observation.input", prompt)
+				.start();
+
+			try (Observation.Scope ignored = observation.openScope()) {
+				AssistantMessage response = agent.call(prompt);
+				observation.highCardinalityKeyValue("langfuse.observation.output", response.getText());
+				System.out.println(response.getText());
+			}
+			catch (Exception ex) {
+				observation.error(ex);
+				throw ex;
+			}
+			finally {
+				observation.stop();
+			}
+		};
+	}
+
+}

--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/observability/README.md
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/advanced/observability/README.md
@@ -1,0 +1,46 @@
+# ReactAgent observability with Langfuse
+
+This example exports the ReactAgent graph, model, and tool observations to
+Langfuse through OpenTelemetry Protocol (OTLP).
+
+## Prerequisites
+
+- A DashScope API key
+- A Langfuse project and its public/secret API keys
+- Java 17 or later
+
+Create the HTTP Basic credential expected by Langfuse:
+
+```shell
+export LANGFUSE_AUTH_STRING=$(printf '%s' 'pk-lf-...:sk-lf-...' | base64)
+```
+
+Set the DashScope key. The example defaults to Langfuse's EU Cloud trace
+endpoint; set `LANGFUSE_OTLP_TRACES_ENDPOINT` to the `/v1/traces` endpoint for
+another Langfuse Cloud region or a self-hosted deployment:
+
+```shell
+export AI_DASHSCOPE_API_KEY=your-dashscope-api-key
+# Optional:
+# export LANGFUSE_OTLP_TRACES_ENDPOINT=https://us.cloud.langfuse.com/api/public/otel/v1/traces
+```
+
+## Run
+
+From the repository root:
+
+```shell
+./mvnw -f examples/documentation/pom.xml spring-boot:run \
+  -Plangfuse \
+  -Dspring-boot.run.main-class=com.alibaba.cloud.ai.examples.documentation.framework.advanced.observability.LangfuseObservabilityExample \
+  -Dspring-boot.run.arguments=--spring.config.name=application-langfuse
+```
+
+The application runs one ReactAgent request and prints the answer. Langfuse
+receives a root `react-agent-demo` trace containing the nested graph and model
+observations. The example uses a generated session ID and the fixed
+`documentation-user` user ID; replace those values with application identifiers
+in production.
+
+Prompt and completion capture is enabled for demonstration. Review the data
+privacy requirements of your application before enabling it in production.

--- a/examples/documentation/src/main/resources/application-langfuse.yml
+++ b/examples/documentation/src/main/resources/application-langfuse.yml
@@ -1,0 +1,39 @@
+spring:
+  application:
+    name: react-agent-langfuse-demo
+  ai:
+    dashscope:
+      api-key: ${AI_DASHSCOPE_API_KEY}
+      chat:
+        options:
+          model: ${DASHSCOPE_MODEL:qwen-plus}
+    chat:
+      observations:
+        log-prompt: true
+        log-completion: true
+    mcp:
+      client:
+        enabled: false
+    alibaba:
+      a2a:
+        nacos:
+          discovery:
+            enabled: false
+          registry:
+            enabled: false
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: ${LANGFUSE_OTLP_TRACES_ENDPOINT:https://cloud.langfuse.com/api/public/otel/v1/traces}
+      headers:
+        Authorization: Basic ${LANGFUSE_AUTH_STRING}
+        x-langfuse-ingestion-version: "4"
+
+logging:
+  level:
+    com.alibaba.cloud.ai: INFO
+    org.springframework.ai: INFO


### PR DESCRIPTION
## Summary

- add a runnable ReactAgent observability example backed by Micrometer and OTLP
- add a dedicated `langfuse` Maven profile so observability dependencies do not affect other documentation examples
- document Langfuse authentication, regional trace endpoints, and privacy considerations
- attach Langfuse trace/session/user/input/output attributes to a parent observation so graph and model spans are grouped together

## Testing

- `JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -f examples/documentation/pom.xml -Plangfuse clean test`
- `JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./mvnw -f examples/documentation/pom.xml clean test`

Closes #4788