### PR TITLE
fix(graph): preserve primitive arrays in message metadata on deserialization

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonDeserializer.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/serializer/plain_text/jackson/JacksonDeserializer.java
@@ -384,6 +384,13 @@ public interface JacksonDeserializer<T> {
 				if (PRIMITIVE_WRAPPER_TYPES.contains(className)) {
 					return convertPrimitiveWrapperType(className, payload);
 				}
+				// Jackson's WRAPPER_ARRAY default typing writes some primitive arrays with a
+				// scalar payload rather than a JSON array: byte[] becomes a base64 string and
+				// char[] becomes a plain string. Detect these so they round-trip as the
+				// original array type instead of degrading to a List of [typeId, payload].
+				if ((className.startsWith("[") || className.endsWith("[]")) && !payload.isNull()) {
+					return instantiateScalarPayloadArray(className, payload, objectMapper);
+				}
 			}
 
 			if (payload.isArray()) {
@@ -480,6 +487,29 @@ public interface JacksonDeserializer<T> {
 		}
 		catch (ClassNotFoundException ex) {
 			throw new IllegalStateException("Cannot instantiate array type: " + className, ex);
+		}
+	}
+
+	/**
+	 * Reconstruct a primitive array that Jackson's WRAPPER_ARRAY default typing serialized
+	 * with a scalar (non-array) payload. Notably {@code byte[]} is written as a base64
+	 * string and {@code char[]} as a plain string. Delegating to Jackson preserves the
+	 * exact array type so values such as Gemini {@code thoughtSignatures} ({@code List<byte[]>})
+	 * survive a serialize/clone round-trip.
+	 * @param className the serialized component type id (e.g. {@code [B} or {@code byte[]})
+	 * @param payload the scalar payload node
+	 * @param objectMapper the ObjectMapper to bind with
+	 * @return the reconstructed array
+	 * @throws IOException if binding fails
+	 */
+	private static Object instantiateScalarPayloadArray(String className, JsonNode payload, ObjectMapper objectMapper)
+			throws IOException {
+		try {
+			Class<?> arrayClass = resolveArrayClass(className);
+			return objectMapper.treeToValue(payload, arrayClass);
+		}
+		catch (ClassNotFoundException | IllegalArgumentException ex) {
+			throw new IOException("Cannot instantiate array type from scalar payload: " + className, ex);
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/PrimitiveArrayMetadataSerializationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/PrimitiveArrayMetadataSerializationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.plain_text;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
+import com.alibaba.cloud.ai.graph.state.AgentStateFactory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression tests for primitive arrays nested inside message metadata.
+ *
+ * <p>
+ * Jackson's WRAPPER_ARRAY default typing serializes some primitive arrays with a scalar
+ * payload rather than a JSON array ({@code byte[]} as a base64 string, {@code char[]} as
+ * a plain string). The custom {@code JacksonDeserializer} previously only recognized the
+ * array-payload form, so {@code byte[]} values silently degraded to
+ * {@code List["[B", "<base64>"]}. Gemini 3.x carries its {@code thoughtSignatures} as a
+ * {@code List<byte[]>} in the assistant message metadata, so the corruption produced a
+ * missing {@code thought_signature} 400 on the next tool-calling round-trip.
+ * </p>
+ *
+ * @see <a href="https://github.com/alibaba/spring-ai-alibaba/issues/4742">Issue #4742</a>
+ */
+class PrimitiveArrayMetadataSerializationTest {
+
+	private SpringAIJacksonStateSerializer serializer;
+
+	@BeforeEach
+	void setUp() {
+		AgentStateFactory<OverAllState> stateFactory = OverAllState::new;
+		serializer = new SpringAIJacksonStateSerializer(stateFactory);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> roundTrip(Map<String, Object> data) throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		serializer.writeData(data, oos);
+		oos.flush();
+
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		return serializer.readData(ois);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void thoughtSignaturesListOfByteArraysRoundTrips() throws Exception {
+		byte[] sig1 = new byte[] { 1, 2, 3, 4, 5 };
+		byte[] sig2 = new byte[] { -128, 0, 127, 42 };
+		List<byte[]> signatures = new ArrayList<>();
+		signatures.add(sig1);
+		signatures.add(sig2);
+
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("thoughtSignatures", signatures);
+
+		AssistantMessage original = AssistantMessage.builder()
+			.content("")
+			.properties(metadata)
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "read_skill", "{}")))
+			.build();
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("message", original);
+
+		Map<String, Object> restored = roundTrip(data);
+
+		AssistantMessage message = (AssistantMessage) restored.get("message");
+		assertNotNull(message);
+		Object restoredSignatures = message.getMetadata().get("thoughtSignatures");
+		assertInstanceOf(List.class, restoredSignatures);
+
+		List<Object> restoredList = (List<Object>) restoredSignatures;
+		assertEquals(2, restoredList.size());
+		assertInstanceOf(byte[].class, restoredList.get(0));
+		assertInstanceOf(byte[].class, restoredList.get(1));
+		assertArrayEquals(sig1, (byte[]) restoredList.get(0));
+		assertArrayEquals(sig2, (byte[]) restoredList.get(1));
+
+		// Tool call must survive too, so the next round is a valid assistant->tool pairing.
+		assertEquals(1, message.getToolCalls().size());
+		assertEquals("read_skill", message.getToolCalls().get(0).name());
+	}
+
+	@Test
+	void standaloneByteArrayInMetadataRoundTrips() throws Exception {
+		byte[] payload = new byte[] { 10, 20, 30, -1, 0 };
+
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("signature", payload);
+
+		AssistantMessage original = AssistantMessage.builder().content("hi").properties(metadata).build();
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("message", original);
+
+		Map<String, Object> restored = roundTrip(data);
+
+		AssistantMessage message = (AssistantMessage) restored.get("message");
+		Object restoredPayload = message.getMetadata().get("signature");
+		assertInstanceOf(byte[].class, restoredPayload);
+		assertArrayEquals(payload, (byte[]) restoredPayload);
+	}
+
+	@Test
+	void charArrayInMetadataRoundTrips() throws Exception {
+		char[] payload = new char[] { 'a', 'b', 'c' };
+
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("chars", payload);
+
+		AssistantMessage original = AssistantMessage.builder().content("hi").properties(metadata).build();
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("message", original);
+
+		Map<String, Object> restored = roundTrip(data);
+
+		AssistantMessage message = (AssistantMessage) restored.get("message");
+		Object restoredPayload = message.getMetadata().get("chars");
+		assertInstanceOf(char[].class, restoredPayload);
+		assertArrayEquals(payload, (char[]) restoredPayload);
+	}
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Uploading a multi-turn tool-calling conversation and resuming it drops/corrupts primitive-array values stored in message metadata. Concretely, Gemini 3.x carries its `thoughtSignatures` as a `List<byte[]>` inside `AssistantMessage` metadata; after one serialize/clone cycle the `byte[]` values are lost, and the second `generateContent` call fails:

```
400 Bad Request. Unable to submit request because function call `...`
in the 2. content block is missing a `thought_signature`.
```

Because graph state cloning between the model node and the tool node goes through the same Jackson serialize/deserialize path, the corruption also happens with `MemorySaver` (no DB involved), which matches the report in the issue.

### Does this pull request fix one issue?

Fixes #4742

### Describe how you did it

Root cause: Jackson's `WRAPPER_ARRAY` default typing serializes some primitive arrays with a **scalar** payload instead of a JSON array — `byte[]` is written as a base64 string and `char[]` as a plain string, e.g.:

```json
"thoughtSignatures": ["java.util.ArrayList", [ ["[B", "AQIDBAU="] ]]
```

`JacksonDeserializer#deserializeArrayNode` only reconstructed the typed-array form when the payload `isArray()`. For a `byte[]` the payload is a base64 **string**, and `"[B"` is not in `PRIMITIVE_WRAPPER_TYPES`, so it fell through to the generic branch and degraded to a plain `List["[B", "AQIDBAU="]` — the `byte[]` was lost.

Fix: in the non-array-payload branch, detect the primitive-array wrapper form (component type id starts with `[` or ends with `[]`) and delegate to Jackson (`treeToValue`) to bind it back to the exact array type via the existing `resolveArrayClass`. This covers `byte[]` (base64) and `char[]` (string) while leaving all other paths untouched.

### Describe how to verify it

New regression test `PrimitiveArrayMetadataSerializationTest` asserts round-trip for:
- `List<byte[]>` in `AssistantMessage` metadata (thoughtSignatures case, incl. tool call preserved),
- a standalone `byte[]`,
- a `char[]`.

```shell
./mvnw -pl spring-ai-alibaba-graph-core \
  -Dtest=PrimitiveArrayMetadataSerializationTest,SpringAIJacksonStateSerializerTest,JacksonContainerTypeRecognitionTest test
# Tests run: 18, Failures: 0, Errors: 0, Skipped: 0

./mvnw -pl spring-ai-alibaba-graph-core checkstyle:check spotless:check
# 0 Checkstyle violations; spotless OK
```

Before the fix, `List<byte[]>` restored as `List["[B", "AQIDBAU="]` (byte[] lost); after, it restores as a `List<byte[]>` with byte-identical content.

### Special notes for reviews

The change is confined to the deserializer's scalar-payload branch and reuses the existing `resolveArrayClass`. It does not alter the serialized on-disk format, so existing checkpoints remain readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)