### PR TITLE
feat(admin): Skills management and saa-admin Docker deploy

### DIFF
--- a/spring-ai-alibaba-admin/.gitignore
+++ b/spring-ai-alibaba-admin/.gitignore
@@ -44,6 +44,12 @@ docker/middleware/nacos/*
 docker/middleware/redis/*
 docker/middleware/rocketmq/*
 
+# Local saa-admin deployment runtime data (owned by container UIDs)
+docker/saa-admin/data/
+docker/saa-admin/.env
+docker/saa-admin/**/*.rdb
+docker/saa-admin/**/*.aof
+
 
 # windows os
 /extensions/

--- a/spring-ai-alibaba-admin/docker/saa-admin/.gitignore
+++ b/spring-ai-alibaba-admin/docker/saa-admin/.gitignore
@@ -1,0 +1,5 @@
+# Runtime volumes created by Docker (often root/999 owned, not readable by host user)
+/data/
+.env
+*.rdb
+*.aof

--- a/spring-ai-alibaba-admin/docker/saa-admin/README.md
+++ b/spring-ai-alibaba-admin/docker/saa-admin/README.md
@@ -1,0 +1,37 @@
+# SAA Admin 本机 Docker 部署
+
+面向当前主机（已有 WeKnora / Nuwax 等占用常用端口）的完整栈部署。
+
+## 访问地址
+
+| 服务 | 地址 |
+|------|------|
+| Admin UI | http://172.30.10.28:9080/admin |
+| OTLP (traces) | http://172.30.10.28:14318/v1/traces |
+| Kibana | http://127.0.0.1:15601 |
+| Nacos | http://127.0.0.1:17848/nacos |
+
+## 启动
+
+```bash
+cd docker/saa-admin
+# 可选：在 .env 中设置 DASHSCOPE_API_KEY
+docker compose up -d --build
+```
+
+## 停止
+
+```bash
+cd docker/saa-admin
+docker compose down
+```
+
+## 模型配置
+
+编辑同目录 `model-config.yml`（默认 DashScope 模板），并在 `.env` 中设置：
+
+```bash
+DASHSCOPE_API_KEY=sk-xxx
+```
+
+然后 `docker compose up -d admin` 重启 Admin 容器。

--- a/spring-ai-alibaba-admin/docker/saa-admin/conf/loongcollector/otlp_pipeline.yaml
+++ b/spring-ai-alibaba-admin/docker/saa-admin/conf/loongcollector/otlp_pipeline.yaml
@@ -1,0 +1,21 @@
+enable: true
+inputs:
+  - Type: service_otlp
+    Protocals:
+      HTTP:
+        Endpoint: 0.0.0.0:4318
+        MaxRecvMsgSizeMiB: 64
+        ReadTimeoutSec: 10
+        ShutdownTimeoutSec: 5
+flushers:
+  - Type: flusher_stdout
+    OnlyStdout: true
+    Tags: true
+  - Type: flusher_elasticsearch
+    Addresses:
+      - http://elasticsearch:9200
+    Index: loongsuite_traces
+    Authentication:
+      PlainText:
+        Username: elastic
+        Password: elastic

--- a/spring-ai-alibaba-admin/docker/saa-admin/conf/mysql/my.cnf
+++ b/spring-ai-alibaba-admin/docker/saa-admin/conf/mysql/my.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+slow_query_log=1
+log_queries_not_using_indexes=1
+default-time-zone='+8:00'

--- a/spring-ai-alibaba-admin/docker/saa-admin/conf/rocketmq/rmq-proxy.json
+++ b/spring-ai-alibaba-admin/docker/saa-admin/conf/rocketmq/rmq-proxy.json
@@ -1,0 +1,5 @@
+{
+  "rocketMQClusterName": "DefaultCluster",
+  "remotingListenPort": 18080,
+  "grpcServerPort": 18081
+}

--- a/spring-ai-alibaba-admin/docker/saa-admin/docker-compose.yml
+++ b/spring-ai-alibaba-admin/docker/saa-admin/docker-compose.yml
@@ -1,0 +1,305 @@
+# Spring AI Alibaba Admin — full stack for this host
+# Avoids host port conflicts with WeKnora / Nuwax / Docmost.
+# Access: http://172.30.10.28:9080/admin
+
+name: saa-admin
+
+services:
+  mysql:
+    container_name: saa-mysql
+    restart: always
+    image: sca-registry.cn-hangzhou.cr.aliyuncs.com/dubbo/mysql:8.0.35
+    user: "${UID}:${GID}"
+    env_file:
+      - ./mysql.env
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    volumes:
+      - ./data/mysql:/var/lib/mysql
+      - ./conf/mysql:/etc/mysql/conf.d
+      - ./init/mysql:/docker-entrypoint-initdb.d/
+    ports:
+      - "13316:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
+    networks:
+      - saa-net
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.2
+    container_name: saa-elasticsearch
+    restart: always
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - cluster.name=saa-es-cluster
+      - node.name=saa-es-node-1
+      - bootstrap.memory_lock=true
+      - http.cors.enabled=true
+      - http.cors.allow-origin="*"
+      - action.destructive_requires_name=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - "19200:9200"
+      - "19300:9300"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+    networks:
+      - saa-net
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:9.1.2
+    container_name: saa-kibana
+    restart: always
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - xpack.security.enabled=false
+    ports:
+      - "15601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - saa-net
+
+  elasticsearch-init:
+    image: curlimages/curl:latest
+    container_name: saa-elasticsearch-init
+    restart: "no"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    volumes:
+      - ./init/elasticsearch:/scripts
+    working_dir: /scripts
+    command: ["sh", "init-indices.sh"]
+    networks:
+      - saa-net
+
+  loongcollector:
+    image: sls-opensource-registry.cn-shanghai.cr.aliyuncs.com/loongcollector-community-edition/loongcollector:3.1.4
+    container_name: saa-loongcollector
+    restart: always
+    depends_on:
+      elasticsearch-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./conf/loongcollector:/usr/local/loongcollector/conf/continuous_pipeline_config/local
+    ports:
+      # OTLP HTTP for agent apps on LAN
+      - "${LAN_IP}:14318:4318"
+    networks:
+      - saa-net
+
+  nacos:
+    container_name: saa-nacos
+    restart: always
+    image: nacos/nacos-server:v2.4.3
+    ports:
+      - "17080:8080"
+      - "17848:8848"
+      - "19848:9848"
+    environment:
+      - MODE=standalone
+      - NACOS_AUTH_TOKEN=dG9rZW5hbHNka2ZqbGFza2RqZmxhc2tkamZsYXNrZGpmb3dpZWpmbztzZGxm
+      - NACOS_AUTH_IDENTITY_KEY=admin
+      - NACOS_AUTH_IDENTITY_VALUE=admin
+      - JVM_XMS=256m
+      - JVM_XMX=512m
+    volumes:
+      - ./data/nacos/logs:/home/nacos/logs
+      - ./data/nacos/data:/home/nacos/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8848/nacos/"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 40s
+    networks:
+      - saa-net
+
+  redis:
+    restart: always
+    image: redis:7.2.5
+    container_name: saa-redis
+    ports:
+      - "16380:6379"
+    volumes:
+      - ./data/redis:/data
+    command: redis-server
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - saa-net
+
+  rmq-namesrv:
+    image: apache/rocketmq:5.3.2
+    container_name: saa-rmq-namesrv
+    restart: always
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - NAMESRV_ADDR=rmq-namesrv:9876
+      - HEAP_OPTS=-Xms128M -Xmx256M -Xmn128M
+    ports:
+      - "19876:9876"
+    networks:
+      - saa-net
+    command: sh mqnamesrv
+    healthcheck:
+      test: ["CMD", "sh", "-c", "ps aux | grep mqnamesrv | grep -v grep || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  rmq-broker:
+    image: apache/rocketmq:5.3.2
+    container_name: saa-rmq-broker
+    restart: always
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - NAMESRV_ADDR=rmq-namesrv:9876
+      - HEAP_OPTS=-Xms256M -Xmx512M -Xmn256M -XX:MaxDirectMemorySize=128M
+    volumes:
+      - ./data/rocketmq/store:/home/rocketmq/store
+    ports:
+      - "10909:10909"
+      - "10911:10911"
+      - "10912:10912"
+    depends_on:
+      rmq-namesrv:
+        condition: service_healthy
+    networks:
+      - saa-net
+    command: sh mqbroker
+    healthcheck:
+      test: ["CMD", "sh", "-c", "ps aux | grep mqbroker | grep -v grep || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  rmq-proxy:
+    image: apache/rocketmq:5.3.2
+    container_name: saa-rmq-proxy
+    restart: always
+    volumes:
+      - ./conf/rocketmq:/home/rocketmq/conf
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - NAMESRV_ADDR=rmq-namesrv:9876
+      - HEAP_OPTS=-Xms128M -Xmx256M -Xmn128M
+    networks:
+      - saa-net
+    depends_on:
+      rmq-broker:
+        condition: service_healthy
+      rmq-namesrv:
+        condition: service_healthy
+    ports:
+      - "18080:18080"
+      - "18081:18081"
+    command: sh mqproxy -pc /home/rocketmq/conf/rmq-proxy.json
+
+  init-topic:
+    image: apache/rocketmq:5.3.2
+    container_name: saa-rmq-init-topic
+    restart: "no"
+    depends_on:
+      rmq-namesrv:
+        condition: service_healthy
+      rmq-broker:
+        condition: service_healthy
+    networks:
+      - saa-net
+    entrypoint: >
+      sh -c "
+        echo 'Waiting for RocketMQ...' &&
+        sleep 30 &&
+        until sh mqadmin clusterList -n rmq-namesrv:9876; do
+          echo 'Waiting for RocketMQ cluster...' &&
+          sleep 10
+        done &&
+        sh mqadmin updateTopic -n rmq-namesrv:9876 -t topic_saa_studio_document_index -c DefaultCluster -a +message.type=NORMAL &&
+        sh mqadmin updateSubGroup -n rmq-namesrv:9876 -g group_saa_studio_document_index -c DefaultCluster &&
+        echo 'Topic creation completed'
+      "
+
+  admin:
+    container_name: saa-admin
+    restart: always
+    build:
+      context: ../..
+      dockerfile: spring-ai-alibaba-admin-server-start/Dockerfile
+    image: spring-ai-admin-server:local
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+      nacos:
+        condition: service_healthy
+      rmq-proxy:
+        condition: service_started
+    ports:
+      # LAN access — 8080 is used by WeKnora
+      - "${LAN_IP}:${ADMIN_HOST_PORT}:8080"
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/admin?useUnicode=true&characterEncoding=utf-8&zeroDateTimeBehavior=convertToNull&allowMultiQueries=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Shanghai
+      - SPRING_DATASOURCE_USERNAME=admin
+      - SPRING_DATASOURCE_PASSWORD=admin
+      - SPRING_REDIS_HOST=redis
+      - SPRING_REDIS_PORT=6379
+      - SPRING_ELASTICSEARCH_URIS=http://elasticsearch:9200
+      - SPRING_ELASTICSEARCH_URL=http://elasticsearch:9200
+      - NACOS_SERVER_ADDR=nacos:8848
+      - ROCKETMQ_ENDPOINTS=rmq-proxy:18080
+      - MANAGEMENT_OTLP_TRACING_EXPORT_ENDPOINT=http://loongcollector:4318/v1/traces
+      - MODEL_CONFIG_FILE=/app/model-config.yml
+      - DASHSCOPE_API_KEY=${DASHSCOPE_API_KEY:-}
+      - SEEAPI_API_KEY=${SEEAPI_API_KEY:-}
+      - SPRING_AI_ALIBABA_STUDIO_STORAGE_PATH=/app/storage
+    volumes:
+      - ./model-config.yml:/app/model-config.yml:ro
+      - ./data/admin-storage:/app/storage
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+      start_period: 120s
+    networks:
+      - saa-net
+
+volumes:
+  elasticsearch_data:
+    driver: local
+
+networks:
+  saa-net:
+    driver: bridge
+    name: saa-admin-net

--- a/spring-ai-alibaba-admin/docker/saa-admin/init/elasticsearch/init-indices.sh
+++ b/spring-ai-alibaba-admin/docker/saa-admin/init/elasticsearch/init-indices.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+# 设置重试次数和延迟
+MAX_RETRIES=3
+RETRY_DELAY=10
+HEALTH_CHECK_RETRIES=12
+HEALTH_CHECK_DELAY=5
+
+# 颜色输出函数
+log_info() {
+    echo -e "\033[32m[INFO]\033[0m $1"
+}
+
+log_warn() {
+    echo -e "\033[33m[WARN]\033[0m $1"
+}
+
+log_error() {
+    echo -e "\033[31m[ERROR]\033[0m $1"
+}
+
+log_success() {
+    echo -e "\033[32m[SUCCESS]\033[0m $1"
+}
+
+# 重试函数
+retry_operation() {
+    local operation_name="$1"
+    local command="$2"
+    local retry_count=0
+    
+    log_info "开始执行: $operation_name"
+    
+    while [ $retry_count -lt $MAX_RETRIES ]; do
+        if eval "$command"; then
+            log_success "$operation_name 执行成功"
+            return 0
+        else
+            retry_count=$((retry_count + 1))
+            if [ $retry_count -lt $MAX_RETRIES ]; then
+                log_warn "$operation_name 执行失败，${RETRY_DELAY}秒后进行第 $retry_count 次重试..."
+                sleep $RETRY_DELAY
+            else
+                log_error "$operation_name 执行失败，已重试 $MAX_RETRIES 次，退出"
+                return 1
+            fi
+        fi
+    done
+}
+
+# 检查 Elasticsearch 集群健康状态
+check_cluster_health() {
+    local retry_count=0
+    
+    log_info "检查 Elasticsearch 集群健康状态..."
+    
+    while [ $retry_count -lt $HEALTH_CHECK_RETRIES ]; do
+        local health_status=$(curl -s "http://elasticsearch:9200/_cluster/health" 2>/dev/null)
+        
+        if [ $? -eq 0 ] && echo "$health_status" | grep -q '"status":"green"\|"status":"yellow"'; then
+            local status=$(echo "$health_status" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
+            log_success "Elasticsearch 集群状态: $status"
+            return 0
+        else
+            retry_count=$((retry_count + 1))
+            if [ $retry_count -lt $HEALTH_CHECK_RETRIES ]; then
+                log_warn "集群未就绪，${HEALTH_CHECK_DELAY}秒后重试... (${retry_count}/${HEALTH_CHECK_RETRIES})"
+                sleep $HEALTH_CHECK_DELAY
+            else
+                log_error "Elasticsearch 集群健康检查失败，已重试 $HEALTH_CHECK_RETRIES 次"
+                return 1
+            fi
+        fi
+    done
+}
+
+# 等待 Elasticsearch 启动
+log_info "等待 Elasticsearch 启动..."
+until curl -s http://elasticsearch:9200/_cluster/health > /dev/null 2>&1; do
+    log_info "等待 Elasticsearch 启动..."
+    sleep 5
+done
+
+log_success "Elasticsearch 已启动"
+
+# 检查集群健康状态
+if ! check_cluster_health; then
+    log_error "Elasticsearch 集群健康检查失败，退出初始化"
+    exit 1
+fi
+
+log_info "开始创建索引和配置..."
+
+# 创建 pipeline
+log_info "创建 parsing_loongsuite_traces pipeline..."
+pipeline_command='curl -X PUT "http://elasticsearch:9200/_ingest/pipeline/parsing_loongsuite_traces" \
+  -H "Content-Type: application/json" \
+  -d '"'"'{
+    "processors": [
+      {
+        "json": {
+          "field": "contents.attribute",
+          "target_field": "attributes"
+        }
+      },
+      {
+        "json": {
+          "field": "contents.resource",
+          "target_field": "resources"
+        }
+      },
+      {
+        "json": {
+          "field": "contents.links",
+          "target_field": "spanLinks"
+        }
+      },
+      {
+        "json": {
+          "field": "contents.logs",
+          "target_field": "spanEvents"
+        }
+      },
+      {
+        "remove": {
+          "field": [
+            "contents.attribute",
+            "contents.resource",
+            "contents.links",
+            "contents.logs"
+          ]
+        }
+      },
+      {
+        "rename": {
+          "field": "contents",
+          "target_field": "metadata"
+        }
+      },
+      {
+        "script": {
+          "source": "Map usage = new HashMap();\nlong total = 0;\nif (ctx.attributes.containsKey(\"gen_ai.usage.input_tokens\")) {\n  long input = Long.parseLong(ctx.attributes[\"gen_ai.usage.input_tokens\"]);\n  usage[\"input_tokens\"] = input;\n  total = total + input;\n}\nif (ctx.attributes.containsKey(\"gen_ai.usage.output_tokens\")) {\n  long output = Long.parseLong(ctx.attributes[\"gen_ai.usage.output_tokens\"]);\n  usage[\"output_tokens\"] = output;\n  total = total + output;\n}\nusage[\"total_tokens\"] = total;\nctx.usage = usage;"
+        }
+      }
+    ]
+  }'"'"''
+
+if ! retry_operation "创建 parsing_loongsuite_traces pipeline" "$pipeline_command"; then
+    log_error "创建 pipeline 失败，退出初始化"
+    exit 1
+fi
+
+# 验证 pipeline 创建成功
+log_info "验证 pipeline 创建是否成功..."
+pipeline_verification_command='curl -s -f "http://elasticsearch:9200/_ingest/pipeline/parsing_loongsuite_traces" > /dev/null'
+
+if ! retry_operation "验证 pipeline 创建" "$pipeline_verification_command"; then
+    log_error "Pipeline 验证失败，退出初始化"
+    exit 1
+fi
+
+# 创建索引
+log_info "创建 loongsuite_traces 索引..."
+index_command='curl -X PUT "http://elasticsearch:9200/loongsuite_traces" \
+  -H "Content-Type: application/json" \
+  -d '"'"'{
+    "settings": {
+      "index.default_pipeline": "parsing_loongsuite_traces"
+    },
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "properties": {
+            "duration": {
+              "type": "long"
+            },
+            "end": {
+              "type": "long"
+            },
+            "host": {
+              "type": "keyword"
+            },
+            "kind": {
+              "type": "text"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "otlp": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "keyword"
+                },
+                "version": {
+                  "type": "version"
+                }
+              }
+            },
+            "parentSpanID": {
+              "type": "text"
+            },
+            "service": {
+              "type": "keyword"
+            },
+            "spanID": {
+              "type": "text"
+            },
+            "start": {
+              "type": "long"
+            },
+            "statusCode": {
+              "type": "text"
+            },
+            "statusMessage": {
+              "type": "keyword"
+            },
+            "traceID": {
+              "type": "text"
+            },
+            "traceState": {
+              "type": "keyword"
+            }
+          }
+        },
+        "tags": {
+          "type": "object"
+        },
+        "time": {
+          "type": "long"
+        },
+        "attributes": {
+          "type": "flattened"
+        },
+        "resources": {
+          "type": "flattened"
+        },
+        "spanEvents": {
+          "type": "nested",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "attribute": {
+              "type": "flattened"
+            },
+            "time": {
+              "type": "long"
+            }
+          }
+        },
+        "spanLinks": {
+          "type": "nested",
+          "properties": {
+            "spanID": {
+              "type": "text"
+            },
+            "traceID": {
+              "type": "text"
+            },
+            "attribute": {
+              "type": "flattened"
+            }
+          }
+        },
+        "usage": {
+          "type": "object",
+          "properties": {
+            "input_tokens": {
+              "type": "long"
+            },
+            "output_tokens": {
+              "type": "long"
+            },
+            "total_tokens": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }'"'"''
+
+if ! retry_operation "创建 loongsuite_traces 索引" "$index_command"; then
+    log_error "创建索引失败，退出初始化"
+    exit 1
+fi
+
+# 等待索引创建完成
+log_info "等待索引创建完成..."
+sleep 5
+
+# 验证索引创建成功
+log_info "验证索引创建是否成功..."
+verification_command='curl -s -f "http://elasticsearch:9200/loongsuite_traces/_mapping" > /dev/null'
+
+if ! retry_operation "验证索引创建" "$verification_command"; then
+    log_error "索引验证失败，退出初始化"
+    exit 1
+fi
+
+# 最终验证：检查索引状态
+log_info "检查索引状态..."
+index_status_command='curl -s "http://elasticsearch:9200/_cat/indices/loongsuite_traces?v"'
+
+if ! retry_operation "检查索引状态" "$index_status_command"; then
+    log_error "索引状态检查失败，退出初始化"
+    exit 1
+fi
+
+log_success "索引创建完成！"
+log_success "Elasticsearch 初始化成功！"
+exit 0

--- a/spring-ai-alibaba-admin/docker/saa-admin/init/mysql/admin-schema.sql
+++ b/spring-ai-alibaba-admin/docker/saa-admin/init/mysql/admin-schema.sql
@@ -1,0 +1,380 @@
+/******************************************/
+/*  SAA Admin Database Tables        */
+/******************************************/
+
+
+/******************************************/
+/*   TableName = dataset                  */
+/******************************************/
+
+DROP TABLE IF EXISTS dataset;
+CREATE TABLE dataset
+(
+    id             BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    name           VARCHAR(255) NOT NULL COMMENT 'Dataset name',
+    description    TEXT                  DEFAULT NULL COMMENT 'Dataset description',
+    columns_config LONGTEXT              DEFAULT NULL COMMENT 'Column structure configuration (JSON format)',
+    create_time    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    update_time    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    deleted        TINYINT(1)   NOT NULL DEFAULT 0 COMMENT 'Logical delete flag: 0-not deleted, 1-deleted',
+    PRIMARY KEY (id),
+    KEY            idx_deleted (deleted)
+) ENGINE = InnoDB
+AUTO_INCREMENT = 10000
+DEFAULT CHARSET = utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+COMMENT ='Evaluation Dataset Table';
+
+
+/******************************************/
+/*   TableName = dataset_version          */
+/******************************************/
+DROP TABLE IF EXISTS dataset_version;
+CREATE TABLE dataset_version
+(
+    id            BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    dataset_id    BIGINT(20) UNSIGNED NOT NULL COMMENT 'Dataset ID',
+    version       VARCHAR(32) NOT NULL COMMENT 'Version number',
+    description   TEXT                 DEFAULT NULL COMMENT 'Version description',
+    data_count    INT(11) NOT NULL DEFAULT 0 COMMENT 'Data count for this version',
+    status        VARCHAR(32) NOT NULL DEFAULT 'DRAFT' COMMENT 'Version status: DRAFT, PUBLISHED, ARCHIVED',
+    experiments   TEXT                 DEFAULT NULL COMMENT 'Experiment collection (one-to-many relationship, JSON format)',
+    dataset_items TEXT                 DEFAULT NULL COMMENT 'Dataset item collection (one-to-many relationship, JSON format)',
+    create_time   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    update_time   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_dataset_version (dataset_id, version),
+    KEY           idx_dataset_id (dataset_id),
+    CONSTRAINT fk_dataset_version_dataset FOREIGN KEY (dataset_id) REFERENCES dataset (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+AUTO_INCREMENT = 10000
+DEFAULT CHARSET = utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+COMMENT ='Dataset Version Table';
+
+
+/******************************************/
+/*   TableName = dataset_item             */
+/******************************************/
+DROP TABLE IF EXISTS dataset_item;
+CREATE TABLE dataset_item
+(
+    id             BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    dataset_id     BIGINT(20) UNSIGNED NOT NULL COMMENT 'Dataset ID',
+    columns_config LONGTEXT             DEFAULT NULL COMMENT 'Column structure configuration (JSON format)',
+    data_content   LONGTEXT    NOT NULL COMMENT 'Data content (JSON format)',
+    create_time    DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    update_time    DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    deleted        TINYINT(1)  NOT NULL DEFAULT 0 COMMENT 'Logical delete flag: 0-not deleted, 1-deleted',
+    PRIMARY KEY (id),
+    KEY            idx_dataset_id (dataset_id),
+    KEY            idx_deleted (deleted),
+    CONSTRAINT fk_dataset_item_dataset FOREIGN KEY (dataset_id) REFERENCES dataset (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+AUTO_INCREMENT = 10000
+DEFAULT CHARSET = utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+COMMENT ='Dataset Item Table';
+
+
+/******************************************/
+/*   TableName = evaluator                */
+/******************************************/
+DROP TABLE IF EXISTS evaluator;
+CREATE TABLE evaluator
+(
+    id          BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    name        VARCHAR(255) NOT NULL COMMENT 'Evaluator name',
+    description TEXT                  DEFAULT NULL COMMENT 'Evaluator description',
+    create_time DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    update_time DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    deleted     TINYINT(1)   NOT NULL DEFAULT 0 COMMENT 'Logical delete flag: 0-not deleted, 1-deleted',
+    PRIMARY KEY (id),
+    KEY         idx_deleted (deleted)
+) ENGINE = InnoDB
+AUTO_INCREMENT = 10000
+DEFAULT CHARSET = utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+COMMENT ='Evaluator Table';
+
+/******************************************/
+/*   TableName = evaluator_version        */
+/******************************************/
+
+DROP TABLE IF EXISTS evaluator_version;
+CREATE TABLE evaluator_version
+(
+    id            BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    evaluator_id  BIGINT(20) UNSIGNED NOT NULL COMMENT 'Evaluator ID',
+    description   TEXT                 DEFAULT NULL COMMENT 'Evaluator description',
+    version       VARCHAR(32) NOT NULL COMMENT 'Version number',
+    model_config  TEXT        NOT NULL COMMENT 'Model config',
+    prompt        LONGTEXT             DEFAULT NULL COMMENT 'Prompt configuration (JSON format)',
+    variables     LONGTEXT             DEFAULT NULL COMMENT 'The variable parameters in the evaluator prompt',
+    status        VARCHAR(32)          DEFAULT NULL COMMENT 'Version status: DRAFT, PUBLISHED, ARCHIVED',
+    experiments   TEXT                 DEFAULT NULL COMMENT 'Experiment collection (one-to-many relationship, JSON format)',
+    create_time   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    update_time   DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_evaluator_version (evaluator_id, version),
+    KEY           idx_evaluator_id (evaluator_id),
+    CONSTRAINT fk_evaluator_version_evaluator FOREIGN KEY (evaluator_id) REFERENCES evaluator (id) ON DELETE CASCADE
+) ENGINE = InnoDB
+AUTO_INCREMENT = 10000
+DEFAULT CHARSET = utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+COMMENT ='Evaluator Version Table';
+
+/******************************************/
+/*  TableName = evaluator_prompt_template */
+/******************************************/
+
+DROP TABLE IF EXISTS evaluator_template;
+CREATE TABLE evaluator_template
+(
+    id                     BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    evaluator_template_key VARCHAR(255) NOT NULL,
+    template_desc          VARCHAR(255) DEFAULT NULL,
+    template               LONGTEXT,
+    variables              LONGTEXT     DEFAULT NULL,
+    model_config           LONGTEXT     DEFAULT NULL COMMENT '推荐使用的模型参数',
+    PRIMARY KEY (id),
+    UNIQUE KEY evaluator_template_key_UNIQUE (evaluator_template_key),
+    KEY         idx_template_desc (template_desc)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+
+/******************************************/
+/*   TableName = experiment               */
+/******************************************/
+DROP TABLE IF EXISTS experiment;
+CREATE TABLE experiment
+(
+    id                       BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    name                     VARCHAR(255) NOT NULL COMMENT 'Experiment name',
+    description              TEXT                  DEFAULT NULL COMMENT 'Experiment description',
+    dataset_id               BIGINT(20) UNSIGNED NOT NULL COMMENT 'Dataset ID',
+    dataset_version_id       BIGINT(20) UNSIGNED NOT NULL COMMENT 'Dataset version ID',
+    dataset_version          VARCHAR(32)  NOT NULL COMMENT 'Dataset version',
+    evaluation_object_config LONGTEXT              DEFAULT NULL COMMENT 'Evaluation object configuration (JSON format)',
+    evaluator_config         TEXT         NOT NULL COMMENT 'Evaluator Config',
+    status                   VARCHAR(32)  NOT NULL DEFAULT 'DRAFT' COMMENT 'Status: DRAFT, RUNNING, COMPLETED, FAILED, STOPPED',
+    progress                 INT(3) NOT NULL DEFAULT 0 COMMENT 'Progress percentage: 0-100',
+    complete_time            DATETIME              DEFAULT NULL COMMENT 'Complete time',
+    create_time              DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    update_time              DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    PRIMARY KEY (id),
+    KEY                      idx_dataset_id (dataset_id),
+    KEY                      idx_dataset_version_id (dataset_version_id),
+    KEY                      idx_status (status),
+    KEY                      idx_create_time (create_time)
+) ENGINE = InnoDB
+AUTO_INCREMENT = 10000
+DEFAULT CHARSET = utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+COMMENT ='Experiment Table';
+
+/******************************************/
+/*   TableName = experiment_result        */
+/******************************************/
+DROP TABLE IF EXISTS experiment_result;
+CREATE TABLE experiment_result
+(
+    id                   BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    experiment_id        BIGINT(20) UNSIGNED NOT NULL COMMENT 'Experiment ID',
+    input                LONGTEXT NOT NULL COMMENT 'Input content',
+    actual_output        LONGTEXT NOT NULL COMMENT 'Actual output from evaluation object',
+    reference_output     LONGTEXT COMMENT 'Reference output for comparison',
+    score                DECIMAL(3, 2)     DEFAULT NULL COMMENT 'Evaluation score: 0.0-1.0',
+    reason               TEXT              DEFAULT NULL COMMENT 'Evaluation reason',
+    evaluation_time      DATETIME          DEFAULT NULL COMMENT 'Evaluation execution time',
+    evaluator_version_id BIGINT(20) UNSIGNED NOT NULL COMMENT 'Evaluator version ID',
+    create_time          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    update_time          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    PRIMARY KEY (id),
+    KEY                  idx_experiment_id (experiment_id),
+    KEY                  idx_evaluator_version_id (evaluator_version_id),
+    KEY                  idx_create_time (create_time)
+) ENGINE = InnoDB
+AUTO_INCREMENT = 10000
+DEFAULT CHARSET = utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+COMMENT ='Experiment Result Table';
+
+
+/******************************************/
+/*   table = prompt                       */
+/******************************************/
+
+DROP TABLE IF EXISTS prompt;
+CREATE TABLE prompt
+(
+    id             BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    prompt_key     VARCHAR(255) NOT NULL,
+    prompt_desc    VARCHAR(255) DEFAULT NULL,
+    latest_version VARCHAR(32)  DEFAULT NULL,
+    tags           VARCHAR(255) DEFAULT NULL,
+    create_time    DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    update_time    DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '更新时间',
+    PRIMARY KEY (id),
+    UNIQUE KEY prompt_key_UNIQUE (prompt_key),
+    KEY         idx_create_time (create_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+/******************************************/
+/*   table = prompt_version               */
+/******************************************/
+
+DROP TABLE IF EXISTS prompt_version;
+CREATE TABLE prompt_version
+(
+    id               BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    version          VARCHAR(32)  NOT NULL,
+    prompt_key       VARCHAR(255) NOT NULL,
+    version_desc     VARCHAR(255)          DEFAULT NULL,
+    template         LONGTEXT COMMENT 'Prompt模版内容',
+    variables        LONGTEXT              DEFAULT NULL COMMENT 'Prompt模版里的可变参数',
+    model_config     LONGTEXT              DEFAULT NULL COMMENT '调试该prompt的模型参数,JSON',
+    status           VARCHAR(32)  NOT NULL DEFAULT 'pre' COMMENT '版本状态：pre-预发布版本，release-正式版本',
+    create_time      DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3) COMMENT '创建时间',
+    previous_version VARCHAR(32)           DEFAULT NULL COMMENT '前置版本，用于对比',
+    PRIMARY KEY (id),
+    UNIQUE KEY prompt_key_version_UNIQUE (prompt_key,version),
+    KEY         idx_prompt_key (prompt_key),
+    KEY         idx_status (status),
+    KEY         idx_create_time (create_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+/******************************************/
+/*   table = prompt_build_template        */
+/******************************************/
+
+DROP TABLE IF EXISTS prompt_build_template;
+CREATE TABLE prompt_build_template
+(
+    id                  BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'Primary Key ID',
+    prompt_template_key VARCHAR(255) NOT NULL,
+    tags                VARCHAR(255) DEFAULT NULL,
+    template_desc       VARCHAR(255) DEFAULT NULL,
+    template            LONGTEXT,
+    variables           LONGTEXT     DEFAULT NULL,
+    model_config        LONGTEXT     DEFAULT NULL COMMENT '推荐使用的模型参数',
+    PRIMARY KEY (id),
+    UNIQUE KEY prompt_template_key_UNIQUE (prompt_template_key),
+    KEY         idx_tags (tags)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+/******************************************/
+/*   table = model_config                 */
+/******************************************/
+DROP TABLE IF EXISTS `model_config`;
+CREATE TABLE `model_config` (
+  `id` bigint NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `name` varchar(100) NOT NULL COMMENT '模型名称',
+  `provider` varchar(50) NOT NULL COMMENT '提供商(openai, azure, etc)',
+  `model_name` varchar(100) NOT NULL COMMENT '模型标识符(gpt-4, gpt-3.5-turbo等)',
+  `base_url` varchar(500) NOT NULL COMMENT '模型服务地址',
+  `api_key` varchar(500) NOT NULL COMMENT 'API密钥',
+  `default_parameters` json COMMENT '默认参数配置(JSON格式)',
+  `supported_parameters` json COMMENT '支持的参数定义(JSON格式)',
+  `status` tinyint NOT NULL DEFAULT 1 COMMENT '状态:1-启用,0-禁用',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT '逻辑删除标识：0-未删除，1-已删除',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_name` (`name`),
+  KEY `idx_provider` (`provider`),
+  KEY `idx_status` (`status`),
+  KEY `idx_create_time` (`create_time`),
+  KEY `idx_deleted` (`deleted`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='模型配置表';
+
+
+
+
+
+-- ===================================================
+-- Prompt模块测试数据
+-- ===================================================
+
+
+
+-- ===================================================
+-- 3. prompt_build_template表测试数据
+-- ===================================================
+
+-- 对话式AI模板
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('conversational_ai', 'chat,dialogue', '对话式AI模板',
+        '你是一个{{role}}，具有以下特点：\n{{personality}}\n\n在与用户对话时，请遵循以下原则：\n1. {{principle_1}}\n2. {{principle_2}}\n3. {{principle_3}}\n\n用户：{{user_input}}\n\n请回复：',
+        'role,personality,principle_1,principle_2,principle_3,user_input',
+        '{"model": "qwen-max", "temperature": 0.7, "max_tokens": 2000}');
+
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('社交媒体推销文案', 'social,goods,promotion', '社交媒体推销文案生成Prompt模板',
+        '你是一个擅长撰写社交媒体文案的 AI 助手，请根据提供的产品信息生成一条适合发布在{{platform}}平台的推广文案。\n\n要求：\n\n1. 使用轻松、亲切的口吻，像朋友分享好物；\n\n2. 结尾添加相关话题标签，如 #好物推荐；',
+        'platform',
+        '{"model": "qwen-max", "temperature": 0.7, "max_tokens": 2000}');
+
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('商品推广文案', 'goods,promotion', '商品推广Prompt模板',
+        '请为以下商品写一段推广文案：商品名称：{{product_name}}  商品特点：{{features}}',
+        'product_name,features',
+        '{"model": "qwen-max", "temperature": 0.7, "max_tokens": 2000}');
+
+-- 任务执行模板
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('task_executor', 'task,execution', '任务执行模板',
+        '你是一个专业的{{domain}}专家，请完成以下任务：\n\n## 任务描述\n{{task_description}}\n\n## 输入信息\n{{input_data}}\n\n## 输出要求\n{{output_requirements}}\n\n## 约束条件\n{{constraints}}\n\n请按要求完成任务：',
+        'domain,task_description,input_data,output_requirements,constraints',
+        '{"model": "qwen-max", "temperature": 0.3, "max_tokens": 3000}');
+
+-- 分析报告模板
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('analysis_report', 'analysis,report', '分析报告模板',
+        '请对以下{{analysis_subject}}进行深入分析：\n\n## 分析对象\n{{subject_details}}\n\n## 分析维度\n{{analysis_dimensions}}\n\n## 参考标准\n{{reference_standards}}\n\n## 报告结构\n1. 摘要\n2. 详细分析\n3. 关键发现\n4. 结论和建议\n\n请生成完整的分析报告：',
+        'analysis_subject,subject_details,analysis_dimensions,reference_standards',
+        '{"model": "qwen-max", "temperature": 0.4, "max_tokens": 4000}');
+
+-- 创意生成模板
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('creative_generator', 'creative,generation', '创意生成模板',
+        '请为{{project_type}}项目生成创意方案：\n\n## 项目背景\n{{background}}\n\n## 目标群体\n{{target_audience}}\n\n## 核心需求\n{{core_requirements}}\n\n## 创意约束\n{{creative_constraints}}\n\n## 输出要求\n- 提供3-5个不同的创意方向\n- 每个方向包含核心概念和执行要点\n- 评估可行性和预期效果\n\n请开始生成创意：',
+        'project_type,background,target_audience,core_requirements,creative_constraints',
+        '{"model": "qwen-max", "temperature": 0.9, "max_tokens": 3000}');
+
+-- 问题解决模板
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('problem_solver', 'problem,solution', '问题解决模板',
+        '作为{{expert_role}}，请帮助解决以下问题：\n\n## 问题描述\n{{problem_description}}\n\n## 现状分析\n{{current_situation}}\n\n## 已尝试方案\n{{attempted_solutions}}\n\n## 限制条件\n{{limitations}}\n\n## 解决方案要求\n1. 分析问题根因\n2. 提供多个可选方案\n3. 评估方案的可行性和风险\n4. 推荐最优方案和实施步骤\n\n请提供解决方案：',
+        'expert_role,problem_description,current_situation,attempted_solutions,limitations',
+        '{"model": "qwen-max", "temperature": 0.5, "max_tokens": 3500}');
+
+-- 教学辅导模板
+INSERT INTO prompt_build_template (prompt_template_key, tags, template_desc, template, variables, model_config)
+VALUES ('teaching_assistant', 'education,teaching', '教学辅导模板',
+        '你是一位经验丰富的{{subject}}老师，请为学生提供学习指导：\n\n## 学生信息\n- 学习水平：{{student_level}}\n- 学习目标：{{learning_goal}}\n\n## 教学内容\n{{teaching_content}}\n\n## 学生问题\n{{student_question}}\n\n## 教学要求\n1. 用简单易懂的语言解释\n2. 提供具体的例子\n3. 给出练习建议\n4. 鼓励学生思考\n\n请开始教学：',
+        'subject,student_level,learning_goal,teaching_content,student_question',
+        '{"model": "qwen-max", "temperature": 0.6, "max_tokens": 2500}');
+
+-- ===================================================
+-- 4. evaluator_template表测试数据
+-- ===================================================
+
+-- 文本相似度评估模板
+INSERT INTO evaluator_template (evaluator_template_key, template_desc, template, variables, model_config)
+VALUES ('text_similarity', '文本相似度评估',
+        '请评估以下两个文本的相似度，分数范围为0-1，保留两位小数。\n\n文本1：{{reference_output}}\n\n文本2：{{actual_output}}\n\n相似度分数：',
+        'reference_output,actual_output',
+        '{"modelId": "qwen-max", "temperature": 0.1, "max_tokens": 100}');
+
+-- 代码质量评估模板
+INSERT INTO evaluator_template (evaluator_template_key, template_desc, template, variables, model_config)
+VALUES ('code_quality', '代码质量评估',
+        '请评估以下代码的质量，从可读性、效率和最佳实践三个方面进行分析，并给出0-1的总分，保留两位小数。\n\n代码：\n{{code}}\n\n评估报告：',
+        'code',
+        '{"modelId": "qwen-max", "temperature": 0.2, "max_tokens": 1000}');
+
+-- 情感分析评估模板
+INSERT INTO evaluator_template (evaluator_template_key, template_desc, template, variables, model_config)
+VALUES ('sentiment_analysis', '情感分析评估',
+        '请分析以下文本的情感倾向，输出-1到1之间的情感分数，其中-1表示非常负面，0表示中性，1表示非常正面，保留两位小数。\n\n文本：{{text}}\n\n情感分数：',
+        'text',
+        '{"modelId": "qwen-max", "temperature": 0.1, "max_tokens": 200}');
+

--- a/spring-ai-alibaba-admin/docker/saa-admin/init/mysql/agentscope-schema.sql
+++ b/spring-ai-alibaba-admin/docker/saa-admin/init/mysql/agentscope-schema.sql
@@ -1,0 +1,513 @@
+/******************************************/
+/*   table = account                      */
+/******************************************/
+DROP TABLE IF EXISTS `account`;
+CREATE TABLE `account`
+(
+
+    `id`             BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `account_id`     VARCHAR(64)                        NOT NULL COMMENT 'account id',
+    `username`       VARCHAR(255)                       NOT NULL COMMENT 'account name',
+    `email`          VARCHAR(255)                                DEFAULT NULL COMMENT 'account email',
+    `mobile`         VARCHAR(255)                                DEFAULT NULL COMMENT 'account mobile',
+    `password`       VARCHAR(255)                       NOT NULL COMMENT 'password',
+    `nickname`       VARCHAR(255)                                DEFAULT NULL COMMENT 'nickname',
+    `icon`           VARCHAR(255)                                DEFAULT NULL COMMENT 'account icon',
+    `type`           VARCHAR(64)                        NOT NULL COMMENT 'type: basic, admin',
+    `status`         TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0- deleted, 1- normal',
+    `gmt_create`     DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_last_login` DATETIME                                    DEFAULT NULL COMMENT 'account last login time',
+    `creator`        VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`       VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_account_id` (`account_id`),
+    KEY `idx_email_password` (`username`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='account info';
+
+/******************************************/
+/*   table = application                  */
+/******************************************/
+DROP TABLE IF EXISTS `application`;
+CREATE TABLE `application`
+(
+    `id`           BIGINT UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `workspace_id` VARCHAR(64)                    NOT NULL COMMENT 'workspace id',
+    `app_id`       VARCHAR(64)                    NOT NULL COMMENT 'app id',
+    `name`         VARCHAR(255)                   NOT NULL COMMENT 'app name',
+    `description`  VARCHAR(4096)                           DEFAULT NULL COMMENT 'app description',
+    `icon`         VARCHAR(255)                            DEFAULT NULL COMMENT 'app icon',
+    `source`       VARCHAR(64)                    NOT NULL COMMENT 'app source',
+    `type`         VARCHAR(64)                    NOT NULL COMMENT 'type, agent, workflow',
+    `status`       TINYINT(4)                     NOT NULL DEFAULT 1 COMMENT 'status, 0-deleted 1-draft; 2-published; 3-publishedEditing',
+    `gmt_create`   DATETIME                       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                    NOT NULL COMMENT '创建者uid',
+    `modifier`     VARCHAR(64)                    NOT NULL COMMENT '修改者uid',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_app_id` (`app_id`),
+    KEY `idx_workspace_type` (`workspace_id`, `type`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='app info';
+
+/******************************************/
+/*   table = application_version          */
+/******************************************/
+DROP TABLE IF EXISTS `application_version`;
+CREATE TABLE `application_version`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `app_id`       VARCHAR(64)                        NOT NULL COMMENT 'app id',
+    `workspace_id` VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `config`       LONGTEXT                                    DEFAULT NULL COMMENT 'app config',
+    `status`       TINYINT(4)                         NOT NULL COMMENT 'status, 0-deleted 1-draft; 2-published; 3-publishedEditing',
+    `version`      VARCHAR(32)                        NOT NULL DEFAULT '0.0.1' COMMENT 'version name',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'version description',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (id),
+    KEY `idx_workspace_app_version` (`workspace_id`, `app_id`, `version`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='app version info';
+
+/******************************************/
+/*   table = workspace                    */
+/******************************************/
+DROP TABLE if exists `workspace`;
+CREATE TABLE `workspace`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `workspace_id` VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `account_id`   VARCHAR(64)                        NOT NULL COMMENT 'account id',
+    `status`       TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `name`         VARCHAR(255)                       NOT NULL COMMENT 'workspace name',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'workspace description',
+    `config`       TEXT                                        DEFAULT NULL COMMENT 'workspace config',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    PRIMARY KEY (id),
+    UNIQUE KEY `uk_workspace_id` (`workspace_id`),
+    KEY `idx_account_id` (`account_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='workspace info';
+
+/******************************************/
+/*   table = api_key                       */
+/******************************************/
+DROP TABLE IF EXISTS `api_key`;
+CREATE TABLE `api_key`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `account_id`   VARCHAR(64)                        NOT NULL COMMENT 'uid',
+    `api_key`      VARCHAR(512)                       NOT NULL COMMENT 'api key',
+    `status`       TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'api key description',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    PRIMARY KEY (id),
+    UNIQUE KEY `uk_api_key` (`api_key`),
+    KEY `idx_account_id` (`account_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='api key info';
+
+/******************************************/
+/*   table = plugin                       */
+/******************************************/
+DROP TABLE IF EXISTS `plugin`;
+CREATE TABLE `plugin`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `plugin_id`    VARCHAR(64)                        NOT NULL COMMENT 'biz id',
+    `workspace_id` VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `type`         VARCHAR(64)                        NOT NULL COMMENT 'type: 1: official, 2: custom',
+    `status`       TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `name`         VARCHAR(255)                       NOT NULL COMMENT 'plugin name',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'plugin description',
+    `config`       TEXT                                        DEFAULT NULL COMMENT 'plugin config',
+    `source`       VARCHAR(64)                        NOT NULL COMMENT 'plugin source',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (id),
+    UNIQUE KEY `uk_plugin_id` (`plugin_id`),
+    KEY `idx_workspace_type` (`workspace_id`, `type`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='plugin info';
+
+
+/******************************************/
+/*   table = tool                         */
+/******************************************/
+DROP TABLE IF EXISTS `tool`;
+CREATE TABLE `tool`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `plugin_id`    VARCHAR(64)                        NOT NULL COMMENT 'plugin id',
+    `tool_id`      VARCHAR(64)                        NOT NULL COMMENT 'tool id',
+    `workspace_id` VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `status`       TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `enabled`      TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'enabled: 0-disabled, 1-enabled',
+    `test_status`  TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'test status: 1: not tested, 2: passed, 3: failed',
+    `name`         VARCHAR(255)                       NOT NULL COMMENT 'tool name',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'tool description',
+    `config`       LONGTEXT                           NOT NULL COMMENT 'tool config',
+    `api_schema`   LONGTEXT                           NOT NULL COMMENT 'tool api schema',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (id),
+    UNIQUE KEY `uk_tool_id` (`tool_id`),
+    KEY `idx_workspace_plugin` (`workspace_id`, `plugin_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='tool info';
+
+/******************************************/
+/*   table = knowledge_base                      */
+/******************************************/
+DROP TABLE IF EXISTS `knowledge_base`;
+CREATE TABLE `knowledge_base`
+(
+    `id`             BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `workspace_id`   VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `kb_id`          VARCHAR(64)                        NOT NULL COMMENT 'knowledge base id',
+    `type`           VARCHAR(64)                        NOT NULL COMMENT 'unstructured',
+    `status`         TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `name`           VARCHAR(255)                       NOT NULL COMMENT 'knowledge base name',
+    `description`    VARCHAR(4096)                               DEFAULT NULL COMMENT 'knowledge base description',
+    `process_config` TEXT                                        DEFAULT NULL COMMENT 'process config',
+    `index_config`   TEXT                                        DEFAULT NULL COMMENT 'index config',
+    `search_config`  TEXT                                        DEFAULT NULL COMMENT 'search config',
+    `total_docs`     BIGINT(20) UNSIGNED                NOT NULL DEFAULT 0 comment 'total docs count',
+    `gmt_create`     DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`        VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`       VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (id),
+    UNIQUE KEY `uk_kb_id` (`kb_id`),
+    KEY `idx_workspace_status_name` (`workspace_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='knowledge base info';
+
+/******************************************/
+/*   table = document                      */
+/******************************************/
+DROP TABLE IF EXISTS `document`;
+CREATE TABLE `document`
+(
+    `id`             BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `workspace_id`   VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `kb_id`          VARCHAR(64)                        NOT NULL COMMENT 'knowledge base id',
+    `doc_id`         VARCHAR(64)                        NOT NULL COMMENT 'document id',
+    `type`           varchar(64)                        NOT NULL COMMENT 'type: file, url',
+    `status`         TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `enabled`        TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'enabled: 0-disabled, 1-enabled',
+    `name`           VARCHAR(255)                       NOT NULL COMMENT 'document name',
+    `format`         VARCHAR(64)                        NOT NULL COMMENT 'document format',
+    `size`           BIGINT(20)                         NOT NULL DEFAULT 0 COMMENT 'document size',
+    `metadata`       TEXT                                        DEFAULT NULL COMMENT 'document metadata',
+    `index_status`   TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'Index status: 1: pending, 2: processing, 3: completed',
+    `path`           VARCHAR(512)                       NOT NULL COMMENT 'storage path',
+    `parsed_path`    VARCHAR(512)                                DEFAULT NULL COMMENT 'parsed path',
+    `process_config` TEXT                                        DEFAULT NULL COMMENT 'document chunk config',
+    `source`         VARCHAR(255)                                DEFAULT NULL COMMENT 'doc source',
+    `error`          TEXT                                        DEFAULT NULL COMMENT '',
+    `gmt_create`     TIMESTAMP                          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified`   TIMESTAMP                          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`        VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`       VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (id),
+    UNIQUE KEY `uk_document_id` (`doc_id`),
+    KEY `idx_workspace_kb` (`workspace_id`, `kb_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='document info';
+
+/******************************************/
+/*   DatabaseName = agentscope   */
+/*   TableName = application_component   */
+/******************************************/
+DROP TABLE IF EXISTS `application_component`;
+CREATE TABLE `application_component`
+(
+    `id`           bigint unsigned NOT NULL AUTO_INCREMENT COMMENT 'pk',
+    `gmt_create`   datetime        NOT NULL COMMENT 'create time',
+    `gmt_modified` datetime        NOT NULL COMMENT 'modified time',
+    `code`         varchar(64)     NOT NULL COMMENT 'component code',
+    `name`         varchar(128)    NOT NULL COMMENT 'name',
+    `workspace_id` varchar(64)     NOT NULL COMMENT 'workspace id',
+    `type`         varchar(64)     NOT NULL COMMENT 'type, agent, workflow',
+    `app_id`       varchar(64)   DEFAULT NULL,
+    `config`       longtext COMMENT 'component config',
+    `description`  varchar(4096) DEFAULT NULL COMMENT 'description ',
+    `status`       tinyint       DEFAULT NULL COMMENT 'status：0-deleted, 1, normal, 2-published',
+    `creator`      varchar(64)   DEFAULT NULL COMMENT 'creator uid',
+    `modifier`     varchar(64)   DEFAULT NULL COMMENT 'modifier uid',
+    `need_update`  tinyint       DEFAULT NULL COMMENT '0-no need update, 1-need update',
+    PRIMARY KEY (`id`),
+    KEY `idx_workspace_type_status_appcode` (`workspace_id`, `type`, `app_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='app component info';
+
+/******************************************/
+/*   table = reference                    */
+/******************************************/
+DROP TABLE IF EXISTS `reference`;
+CREATE TABLE `reference`
+(
+    `id`           BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'pk',
+    `gmt_create`   DATETIME            NOT NULL COMMENT 'create time',
+    `gmt_modified` DATETIME            NOT NULL COMMENT 'modified time',
+    `main_code`    VARCHAR(64)         NOT NULL COMMENT 'entity code',
+    `main_type`    TINYINT             NOT NULL COMMENT 'entity time',
+    `refer_code`   VARCHAR(64)         NOT NULL COMMENT 'refer code',
+    `refer_type`   TINYINT             NOT NULL COMMENT 'refer type',
+    `workspace_id` VARCHAR(64)         NOT NULL DEFAULT '1' COMMENT 'workspace id',
+    PRIMARY KEY (`id`),
+    KEY `idx_refer_code` (`refer_code`),
+    KEY `idx_main_code_workspace_type` (`workspace_id`, `main_code`, `main_type`)
+) DEFAULT CHARACTER SET = utf8mb4 COMMENT ='reference info';
+
+
+/******************************************/
+/*   table = mcp_server                   */
+/******************************************/
+DROP TABLE IF EXISTS `mcp_server`;
+CREATE TABLE `mcp_server`
+(
+    `id`            BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'pk',
+    `gmt_create`    DATETIME            NOT NULL COMMENT 'create time',
+    `gmt_modified`  DATETIME            NOT NULL COMMENT 'modified time',
+    `server_code`   VARCHAR(64)         NOT NULL COMMENT 'server code',
+    `name`          VARCHAR(64)         NOT NULL COMMENT 'server name',
+    `description`   VARCHAR(1024)       NULL COMMENT 'description',
+    `source`        VARCHAR(128)        NULL COMMENT 'server source',
+    `deploy_env`    VARCHAR(16)         NULL COMMENT 'deploy environment local/remote',
+    `type`          VARCHAR(32)         NOT NULL COMMENT 'server type OFFICIAL/CUSTOMER',
+    `deploy_config` TEXT                NOT NULL COMMENT 'deploy config',
+    `workspace_id`  VARCHAR(64)         NULL COMMENT 'workspace id',
+    `account_id`    VARCHAR(64)         NULL COMMENT 'uid',
+    `status`        TINYINT             NOT NULL COMMENT 'status 0 unable 1 normal 3 deleted',
+    `biz_type`      VARCHAR(512)        NULL COMMENT 'biz type',
+    `detail_config` TEXT                NULL COMMENT 'server detail',
+    `host`          VARCHAR(1024)       NULL COMMENT 'host address',
+    `install_type`  VARCHAR(32)         NULL COMMENT 'install_type npx/uvx/sse',
+    PRIMARY KEY (`id`),
+    KEY `idx_code` (`server_code`),
+    KEY `idx_server_name` (`name`),
+    KEY `idx_name_status` (`status`, `name`),
+    KEY `idx_type` (`type`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='mcp server info';
+
+/******************************************/
+/*   DatabaseName = agentscope   */
+/*   TableName = skill                       */
+/******************************************/
+DROP TABLE IF EXISTS `skill`;
+CREATE TABLE `skill`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `skill_id`     VARCHAR(64)                        NOT NULL COMMENT 'biz id',
+    `workspace_id` VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `name`         VARCHAR(255)                       NOT NULL COMMENT 'display name',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'skill description',
+    `skill_name`   VARCHAR(64)                        NOT NULL COMMENT 'SKILL.md name field',
+    `storage_path` VARCHAR(1024)                      NOT NULL COMMENT 'extracted skill root path',
+    `status`       TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `source`       VARCHAR(64)                        NOT NULL DEFAULT 'user' COMMENT 'skill source',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_skill_id` (`skill_id`),
+    KEY `idx_workspace_status` (`workspace_id`, `status`),
+    KEY `idx_workspace_skill_name` (`workspace_id`, `skill_name`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='agent skill info';
+
+/******************************************/
+/*   DatabaseName = agentscope   */
+/*   TableName = provider   */
+/******************************************/
+CREATE TABLE `provider`
+(
+    `id`                    bigint       NOT NULL AUTO_INCREMENT COMMENT 'pk',
+    `workspace_id`          varchar(64)           DEFAULT NULL COMMENT 'workspace id',
+    `icon`                  varchar(255)          DEFAULT NULL COMMENT 'provider icon',
+    `name`                  varchar(255)          DEFAULT NULL COMMENT 'provider name',
+    `description`           varchar(1024)         DEFAULT NULL COMMENT 'provider description',
+    `provider`              varchar(255) NOT NULL COMMENT 'provider',
+    `enable`                tinyint(1)            DEFAULT '1' COMMENT 'enable, 0: disabled, 1: enabled',
+    `source`                varchar(64)  NOT NULL DEFAULT 'preset' COMMENT 'source, preset, custom',
+    `credential`            varchar(1024)         DEFAULT NULL COMMENT 'access credential，json',
+    `supported_model_types` varchar(255)          DEFAULT NULL COMMENT 'model type',
+    `protocol`              varchar(64)           DEFAULT NULL COMMENT 'protocol, openai',
+    `gmt_create`            datetime              DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+    `gmt_modified`          datetime              DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'modified time',
+    `creator`               varchar(64)           DEFAULT NULL COMMENT 'creator',
+    `modifier`              varchar(64)           DEFAULT NULL COMMENT 'modifier',
+    PRIMARY KEY (`id`),
+    KEY `idx_account_workspace_provider` (`workspace_id`, `provider`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='provider info';
+
+
+/******************************************/
+/*   DatabaseName = agentscope   */
+/*   TableName = model   */
+/******************************************/
+CREATE TABLE `model`
+(
+    `id`           bigint       NOT NULL AUTO_INCREMENT COMMENT 'pk',
+    `workspace_id` varchar(64)           DEFAULT NULL COMMENT 'workspace id',
+    `icon`         varchar(255)          DEFAULT NULL COMMENT 'icon',
+    `name`         varchar(100)          DEFAULT NULL COMMENT 'model name',
+    `type`         varchar(100)          DEFAULT 'LLM' COMMENT 'model type: LLM',
+    `mode`         varchar(100)          DEFAULT 'chat' COMMENT 'mode',
+    `model_id`     varchar(100) NOT NULL COMMENT 'model id',
+    `provider`     varchar(100) NOT NULL COMMENT 'provider',
+    `enable`       tinyint(1)            DEFAULT '1' COMMENT 'enable, 0: disabled, 1: enabled',
+    `tags`         varchar(255)          DEFAULT NULL COMMENT 'tags',
+    `source`       varchar(100) NOT NULL DEFAULT 'preset' COMMENT 'source, preset, custom',
+    `gmt_create`   datetime              DEFAULT CURRENT_TIMESTAMP COMMENT 'create time',
+    `gmt_modified` datetime              DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'modified time',
+    `creator`      varchar(64)           DEFAULT NULL COMMENT 'creator',
+    `modifier`     varchar(64)           DEFAULT NULL COMMENT 'modifier',
+    PRIMARY KEY (`id`),
+    KEY `idx_account_workspace_provider_model` (`workspace_id`, `provider`, `model_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='model info';
+
+#init account
+INSERT INTO account (account_id, username, email, mobile, password, type, status, gmt_create,
+                     gmt_modified, creator, modifier)
+VALUES ('10000', 'saa', 'ken.lj.hz@gmail.com', null,
+        '$argon2id$v=19$m=66536,t=2,p=1$KSDQowfZxDjKLqBtxFNRng$znU0oQFQs2shR9la4S11n7d0LpGApmSBXvDOXuhbR40', 'admin', 1,
+        now(), now(), '10000', '10000');
+
+#init workspace
+INSERT INTO workspace (workspace_id, account_id, status, name, description, config, gmt_create, gmt_modified,
+                                  creator, modifier)
+VALUES ('1', '10000', 1, 'Default Workspace', 'Default Workspace', null, now(), now(), '10000', '10000');
+
+#init model
+INSERT INTO provider (workspace_id, icon, name, description, provider, enable, source, credential,
+                                 supported_model_types, protocol, gmt_create, gmt_modified, creator, modifier)
+VALUES ( '1', null, 'Tongyi', 'Tongyi', 'Tongyi', 1, 'preset','{"endpoint":"https://dashscope.aliyuncs.com/compatible-mode"}',
+        null, 'OpenAI', now(), now(), null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-max','llm','chat','qwen-max','Tongyi',1,'web_search,function_call','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-max-latest','llm','chat','qwen-max-latest','Tongyi',1,'web_search,function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-plus','llm','chat','qwen-plus','Tongyi',1,'web_search,function_call','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-plus-latest','llm','chat','qwen-plus-latest','Tongyi',1,'web_search,function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-turbo','llm','chat','qwen-turbo','Tongyi',1,'web_search,function_call','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-turbo-latest','llm','chat','qwen-turbo-latest','Tongyi',1,'web_search,function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-235b-a22b','llm','chat','qwen3-235b-a22b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-30b-a3b','llm','chat','qwen3-30b-a3b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-32b','llm','chat','qwen3-32b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-14b','llm','chat','qwen3-14b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-8b','llm','chat','qwen3-8b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-4b','llm','chat','qwen3-4b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-1.7b','llm','chat','qwen3-1.7b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen3-0.6b','llm','chat','qwen3-0.6b','Tongyi',1,'function_call,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-vl-max','llm','chat','qwen-vl-max','Tongyi',1,'vision,function_call','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwen-vl-plus','llm','chat','qwen-vl-plus','Tongyi',1,'vision,function_call','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qvq-max','llm','chat','qvq-max','Tongyi',1,'vision,reasoning','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'qwq-plus','llm','chat','qwq-plus','Tongyi',1,'reasoning,function_call','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'text-embedding-v1','text_embedding','chat','text-embedding-v1','Tongyi',1,'embedding','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'text-embedding-v2','text_embedding','chat','text-embedding-v2','Tongyi',1,'embedding','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'text-embedding-v3','text_embedding','chat','text-embedding-v3','Tongyi',1,'embedding','preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'gte-rerank-v2','rerank','chat','gte-rerank-v2','Tongyi',1,null,'preset',now(),now(),null,null);
+
+INSERT INTO `model` (`workspace_id`,`icon`,`name`,`type`,`mode`,`model_id`,`provider`,`enable`,`tags`,`source`,`gmt_create`,`gmt_modified`,`creator`,`modifier`) VALUES ('1',null,'deepseek-r1','llm','chat','deepseek-r1','Tongyi',1,'reasoning','preset',now(),now(),null,null);
+
+/******************************************/
+/*   table = agent_schema                 */
+/******************************************/
+DROP TABLE IF EXISTS `agent_schema`;
+CREATE TABLE `agent_schema`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `agent_id`     VARCHAR(64)                                 DEFAULT NULL COMMENT 'agent id',
+    `workspace_id` VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `name`         VARCHAR(255)                       NOT NULL COMMENT 'agent name',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'agent description',
+    `type`         VARCHAR(64)                        NOT NULL COMMENT 'agent type: ReactAgent, ParallelAgent, SequentialAgent, LLMRoutingAgent, LoopAgent',
+    `instruction`  TEXT                                        DEFAULT NULL COMMENT 'system instruction',
+    `input_keys`   TEXT                                        DEFAULT NULL COMMENT 'input keys JSON',
+    `output_key`   VARCHAR(255)                                DEFAULT NULL COMMENT 'output key',
+    `handle`       LONGTEXT                                    DEFAULT NULL COMMENT 'handle configuration JSON',
+    `sub_agents`   LONGTEXT                                    DEFAULT NULL COMMENT 'sub agents configuration JSON',
+    `yaml_schema`  LONGTEXT                                    DEFAULT NULL COMMENT 'generated YAML schema',
+    `status`       VARCHAR(64)                        NOT NULL DEFAULT 'DRAFT' COMMENT 'agent status: DRAFT, PUBLISHED, ARCHIVED',
+    `enabled`      TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'enabled: 0-disabled, 1-enabled',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_agent_id` (`agent_id`),
+    KEY `idx_workspace_type` (`workspace_id`, `type`),
+    KEY `idx_workspace_status` (`workspace_id`, `status`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='agent schema info';

--- a/spring-ai-alibaba-admin/docker/saa-admin/init/mysql/skill-migration.sql
+++ b/spring-ai-alibaba-admin/docker/saa-admin/init/mysql/skill-migration.sql
@@ -1,0 +1,24 @@
+-- Incremental migration for existing deployments
+CREATE TABLE IF NOT EXISTS `skill`
+(
+    `id`           BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL COMMENT 'pk',
+    `skill_id`     VARCHAR(64)                        NOT NULL COMMENT 'biz id',
+    `workspace_id` VARCHAR(64)                        NOT NULL COMMENT 'workspace id',
+    `name`         VARCHAR(255)                       NOT NULL COMMENT 'display name',
+    `description`  VARCHAR(4096)                               DEFAULT NULL COMMENT 'skill description',
+    `skill_name`   VARCHAR(64)                        NOT NULL COMMENT 'SKILL.md name field',
+    `storage_path` VARCHAR(1024)                      NOT NULL COMMENT 'extracted skill root path',
+    `status`       TINYINT(4)                         NOT NULL DEFAULT 1 COMMENT 'status: 0-deleted, 1-normal',
+    `source`       VARCHAR(64)                        NOT NULL DEFAULT 'user' COMMENT 'skill source',
+    `gmt_create`   DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `gmt_modified` DATETIME                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `creator`      VARCHAR(64)                        NOT NULL COMMENT 'creator uid',
+    `modifier`     VARCHAR(64)                        NOT NULL COMMENT 'modifier uid',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_skill_id` (`skill_id`),
+    KEY `idx_workspace_status` (`workspace_id`, `status`),
+    KEY `idx_workspace_skill_name` (`workspace_id`, `skill_name`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 10000
+  DEFAULT CHARSET = utf8mb4
+    COMMENT ='agent skill info';

--- a/spring-ai-alibaba-admin/docker/saa-admin/model-config.yml
+++ b/spring-ai-alibaba-admin/docker/saa-admin/model-config.yml
@@ -1,0 +1,52 @@
+models:
+  - id: 1
+    name: DeepSeek-V4-Flash
+    provider: openai
+    modelName: DeepSeek-V4-Flash
+    baseUrl: https://seeapi.zhidaoauto.com
+    apiKey: ${SEEAPI_API_KEY}
+    status: 1
+    defaultParameters:
+      temperature: 0.7
+      maxTokens: 8192
+    supportedParameters:
+      - name: temperature
+        type: number
+        minValue: 0
+        maxValue: 2
+        defaultValue: 0.7
+        required: false
+        description: 采样温度
+      - name: maxTokens
+        type: number
+        minValue: 1
+        maxValue: 8192
+        defaultValue: 4096
+        required: false
+        description: 最大输出token
+
+  - id: 2
+    name: MiniMax-M2.7
+    provider: openai
+    modelName: MiniMax-M2.7
+    baseUrl: https://seeapi.zhidaoauto.com
+    apiKey: ${SEEAPI_API_KEY}
+    status: 1
+    defaultParameters:
+      temperature: 0.7
+      maxTokens: 8192
+    supportedParameters:
+      - name: temperature
+        type: number
+        minValue: 0
+        maxValue: 2
+        defaultValue: 0.7
+        required: false
+        description: 采样温度
+      - name: maxTokens
+        type: number
+        minValue: 1
+        maxValue: 8192
+        defaultValue: 4096
+        required: false
+        description: 最大输出token

--- a/spring-ai-alibaba-admin/docker/saa-admin/mysql.env
+++ b/spring-ai-alibaba-admin/docker/saa-admin/mysql.env
@@ -1,0 +1,7 @@
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=admin
+MYSQL_USER=admin
+MYSQL_PASSWORD=admin
+LANG=C.UTF-8
+# 设置MySQL容器时区为上海
+TZ=Asia/Shanghai

--- a/spring-ai-alibaba-admin/frontend/packages/main/.umirc.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/.umirc.ts
@@ -121,6 +121,10 @@ export default defineConfig({
       component: 'Component/Plugin/Tools/List',
     },
     {
+      path: '/component/skill/:id',
+      component: 'Component/Skill/Detail',
+    },
+    {
       path: '/knowledge',
       component: 'Knowledge/List/index',
     },

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/components/Card/List.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/components/Card/List.tsx
@@ -47,7 +47,7 @@ const CardList: React.FC<IProps> = (props) => {
 
   if (!props.children?.length && !props.loading)
     return (
-      <div className="loading-center pt-[20px]">
+      <div className="loading-center" style={{ paddingTop: 24 }}>
         <Empty
           title={
             props.isSearch

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/components/Card/ProCard.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/components/Card/ProCard.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import styles from './index.module.less';
 
 export interface ProCardInfo {
-  content: string;
+  label?: string;
+  content: React.ReactNode;
 }
 
 export interface ProCardProps {
@@ -37,7 +38,9 @@ const ProCard: React.FC<ProCardProps> = ({
         <div className={styles.headerLeft}>
           {logo && <div className={styles.logo}>{logo}</div>}
           <div className={styles.titleWrapper}>
-            <h3 className={styles.title}>{title}</h3>
+            <h3 className={styles.title} title={title}>
+              {title}
+            </h3>
             {statusNode && <div className={styles.status}>{statusNode}</div>}
           </div>
         </div>
@@ -47,7 +50,12 @@ const ProCard: React.FC<ProCardProps> = ({
         <div className={styles.cardBody}>
           {info.map((item, index) => (
             <div key={index} className={styles.infoItem}>
-              <span className={styles.content}>{item.content}</span>
+              {item.label ? (
+                <span className={styles.label}>{item.label}</span>
+              ) : null}
+              <span className={styles.content} title={typeof item.content === 'string' ? item.content : undefined}>
+                {item.content}
+              </span>
             </div>
           ))}
         </div>

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/components/Card/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/components/Card/index.module.less
@@ -1,17 +1,18 @@
 .card {
   position: relative;
   display: flex;
-  padding: 20px;
+  padding: 16px;
   flex-direction: column;
-  border-radius: 6px;
+  border-radius: 8px;
   border: 1px solid var(--ag-ant-color-border-secondary);
-  background-color: var(--ag-ant-color-bg-base);
+  background-color: var(--ag-ant-color-bg-container);
   cursor: pointer;
-  transition: 0.4s ease;
+  transition: 0.2s ease;
   overflow: hidden;
+  box-sizing: border-box;
 
   &:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
     border-color: var(--ag-ant-color-primary);
 
     .operate-container {
@@ -27,9 +28,11 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: radial-gradient(26% 84% at 4% 4%,
-        rgba(221, 220, 229, 0.2) 0%,
-        rgba(159, 159, 159, 0) 94%);
+    background: radial-gradient(
+      26% 84% at 4% 4%,
+      rgba(221, 220, 229, 0.16) 0%,
+      rgba(159, 159, 159, 0) 94%
+    );
     pointer-events: none;
     z-index: 1;
   }
@@ -42,20 +45,21 @@
 .card-footer {
   display: flex;
   align-items: center;
-  margin-top: 20px;
+  margin-top: 16px;
 }
 
 .info-label {
-  width: 100px;
+  width: 64px;
+  flex-shrink: 0;
   font-size: 12px;
   line-height: 20px;
   color: var(--ag-ant-color-text-tertiary);
   letter-spacing: 0.4px;
 }
 
-
 .info-content {
   flex: 1;
+  min-width: 0;
   font-size: 12px;
   line-height: 20px;
   color: var(--ag-ant-color-text-secondary);
@@ -74,12 +78,12 @@
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 12px 20px 20px;
-  border-radius: 6px;
+  padding: 12px 16px 16px;
+  border-radius: 8px;
   gap: 8px;
   align-items: center;
-  background-color: var(--ag-ant-color-bg-base);
-  transition: opacity 0.3s;
+  background-color: var(--ag-ant-color-bg-container);
+  transition: opacity 0.2s;
 }
 
 .avatar {
@@ -89,70 +93,89 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--ag-ant-color-bg-base);
+  background-color: var(--ag-ant-color-fill-tertiary);
+  flex-shrink: 0;
 }
 
 .container {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  align-items: stretch;
   gap: 20px;
-  margin: 0 20px 20px 20px;
+  margin: 0 0 20px;
+  width: 100%;
+  box-sizing: border-box;
 
-  .card {
-    width: calc((100% - 40px) / 3);
-  }
-
-  @media screen and (min-width: 1440px) {
-    .card {
-      width: calc((100% - 60px) / 4);
-    }
-  }
-
-  @media screen and (min-width: 1920px) {
-    .card {
-      width: calc((100% - 80px) / 5);
-    }
+  .card,
+  .proCard {
+    width: 100%;
+    min-width: 0;
   }
 }
 
 .pagination {
-  padding: 20px;
-  justify-items: flex-end;
+  padding: 12px 0;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .loading {
   display: flex;
-  min-height: calc(100vh - 350px);
+  min-height: calc(100vh - 280px);
   width: 100%;
   justify-content: center;
   align-items: center;
 }
 
 .proCard {
-  padding: 16px;
+  padding: 0 !important;
   border-radius: 8px;
-  transition: all 0.3s ease;
+  border: 1px solid var(--ag-ant-color-border-secondary);
+  background: var(--ag-ant-color-bg-container);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &:hover {
+    border-color: var(--ag-ant-color-primary);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  :global {
+    .ag-ant-card-body {
+      padding: 16px !important;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+    }
+  }
 }
 
 .cardHeader {
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .headerLeft {
   display: flex;
   align-items: center;
   gap: 12px;
+  min-width: 0;
 }
 
 .logo {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .titleWrapper {
   flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -160,24 +183,33 @@
 
 .title {
   margin: 0;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
-  color: #333;
+  line-height: 22px;
+  color: var(--ag-ant-color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .status {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .cardBody {
-  margin-bottom: 16px;
+  margin-bottom: 12px;
+  flex: 1;
+  min-height: 0;
 }
 
 .infoItem {
   display: flex;
   margin-bottom: 8px;
   align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
 }
 
 .infoItem:last-child {
@@ -185,31 +217,57 @@
 }
 
 .label {
-  color: #666;
-  margin-right: 8px;
+  color: var(--ag-ant-color-text-tertiary);
+  margin-right: 0;
   flex-shrink: 0;
+  width: 64px;
+  font-size: 12px;
+  line-height: 20px;
 }
 
 .content {
-  color: #333;
+  color: var(--ag-ant-color-text-secondary);
   flex: 1;
-  word-break: break-all;
+  min-width: 0;
+  font-size: 12px;
+  line-height: 20px;
+  overflow: hidden;
+  word-break: break-word;
+
+  &:not(:has(*)) {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
 }
 
 .cardFooter {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
   padding-top: 12px;
-  border-top: 1px solid #f0f0f0;
+  margin-top: auto;
+  border-top: 1px solid var(--ag-ant-color-border-secondary);
+  min-width: 0;
 }
 
 .footerDesc {
-  flex: 1;
+  width: 100%;
+  min-width: 0;
+  font-size: 12px;
+  line-height: 20px;
+  color: var(--ag-ant-color-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .footerOperate {
   display: flex;
   gap: 8px;
   align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+  min-width: 0;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/components/InnerLayout/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/components/InnerLayout/index.module.less
@@ -46,12 +46,14 @@
     }
 
     .left {
-      gap: 4px;
+      gap: 12px;
+      min-width: 0;
 
       .back-icon {
         width: 32px;
         font-size: 20px;
-        margin-right: 6px;
+        margin-right: 4px;
+        flex-shrink: 0;
       }
     }
 
@@ -64,6 +66,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      min-width: 0;
     }
 
     .middle {
@@ -151,6 +154,9 @@
   .content-area {
     height: 0;
     flex: 1;
+    padding: 16px 20px 0;
+    box-sizing: border-box;
+    min-height: 0;
 
     :global {
       .ag-ant-spin-nested-loading,
@@ -164,9 +170,10 @@
   .bottom {
     background-color: var(--ag-ant-color-bg-base);
     border-top: 1px solid var(--ag-ant-color-border-secondary);
-    padding: 16px 24px;
+    padding: 12px 20px;
     display: flex;
     gap: 8px;
+    align-items: center;
   }
 
   .vertical-center {
@@ -192,7 +199,7 @@
 
   .tabs {
     max-width: 100%;
-    padding: 0 8px;
+    padding: 0 12px;
     :global {
       .ag-spark-segmented-tab-bar {
         margin-bottom: 0;

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/components/InnerLayout/utils.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/components/InnerLayout/utils.ts
@@ -60,13 +60,15 @@ export const useInnerLayout = (): {
 
   // Special handling for bottom area - wrap content in a div
   const bottomPortal = (children: React.ReactNode) => {
-    // Default styles
     const style: React.CSSProperties = {
       backgroundColor: 'var(--ag-ant-color-bg-base)',
       borderTop: '1px solid var(--ag-ant-color-border-secondary)',
-      padding: '16px 24px',
+      padding: '12px 20px',
       display: 'flex',
       gap: 8,
+      alignItems: 'center',
+      width: '100%',
+      boxSizing: 'border-box',
     };
 
     return baseBottomPortal(

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/components/Search/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/components/Search/index.module.less
@@ -1,3 +1,11 @@
+.wrap {
+  display: inline-block;
+  vertical-align: top;
+  margin-bottom: 24px;
+  max-width: 100%;
+}
+
 .input {
   width: 320px;
+  max-width: 100%;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/components/Search/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/components/Search/index.tsx
@@ -38,15 +38,17 @@ const Search: React.FC<SearchProps> = ({
   };
 
   return (
-    <Input
-      className={classNames(styles['input'], className)}
-      prefix={<IconFont type="spark-search-line" />}
-      placeholder={placeholder}
-      value={value}
-      onChange={handleChange}
-      onPressEnter={handleSearch}
-      allowClear
-    />
+    <div className={styles.wrap}>
+      <Input
+        className={classNames(styles['input'], className)}
+        prefix={<IconFont type="spark-search-line" />}
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        onPressEnter={handleSearch}
+        allowClear
+      />
+    </div>
   );
 };
 

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/i18n/locales/en-us.json
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/i18n/locales/en-us.json
@@ -757,6 +757,7 @@
   "main.pages.Component.Plugin.components.OutputParamsConfig.index.type": "Type",
   "main.pages.Component.Plugin.components.OutputParamsConfig.index.addOutputParameter": "Add Output Parameter",
   "main.pages.Component.index.plugin": "Plugin",
+  "main.pages.Component.index.skill": "Skills",
   "main.pages.Component.index.workflow": "Workflow",
   "main.pages.Component.index.intelligentAgent": "Agent",
   "main.pages.Component.index.componentManagement": "Component Management",

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/i18n/locales/ja-jp.json
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/i18n/locales/ja-jp.json
@@ -757,6 +757,7 @@
   "main.pages.Component.Plugin.components.OutputParamsConfig.index.type": "タイプ",
   "main.pages.Component.Plugin.components.OutputParamsConfig.index.addOutputParameter": "出力パラメータを追加",
   "main.pages.Component.index.plugin": "プラグイン",
+  "main.pages.Component.index.skill": "Skills",
   "main.pages.Component.index.workflow": "ワークフロー",
   "main.pages.Component.index.intelligentAgent": "インテリジェントエージェント",
   "main.pages.Component.index.componentManagement": "コンポーネント管理",

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/i18n/locales/zh-cn.json
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/i18n/locales/zh-cn.json
@@ -757,6 +757,7 @@
   "main.pages.Component.Plugin.components.OutputParamsConfig.index.type": "类型",
   "main.pages.Component.Plugin.components.OutputParamsConfig.index.addOutputParameter": "增加出参",
   "main.pages.Component.index.plugin": "插件",
+  "main.pages.Component.index.skill": "Skills",
   "main.pages.Component.index.workflow": "工作流",
   "main.pages.Component.index.intelligentAgent": "智能体",
   "main.pages.Component.index.componentManagement": "组件管理",

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/SideMenuLayout.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/SideMenuLayout.tsx
@@ -294,26 +294,58 @@ export default function SideMenuLayout({ children }: { children: React.ReactNode
               collapsed={collapsed}
               theme="light"
               className="shadow-lg border-r border-gray-200"
-              style={{ height: '100vh', position: 'fixed', left: 0, top: 0, bottom: 0 }}
+              style={{
+                height: '100vh',
+                position: 'fixed',
+                left: 0,
+                top: 0,
+                bottom: 0,
+                overflow: 'hidden',
+              }}
             >
-              <div className="p-6 border-b border-gray-200">
-                <h1 className="text-xl font-bold text-gray-800 flex items-center whitespace-nowrap overflow-hidden">
-                  <SettingOutlined className="mr-1 text-blue-500" />
+              <div
+                style={{
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  overflow: 'hidden',
+                }}
+              >
+              <div
+                className="p-4 border-b border-gray-200"
+                style={{ flexShrink: 0 }}
+              >
+                <h1 className="text-xl font-bold text-gray-800 flex items-center whitespace-nowrap overflow-hidden m-0">
+                  <SettingOutlined className="mr-2 text-blue-500" />
                   {!collapsed && 'SAA Admin'}
                 </h1>
               </div>
 
-              <Menu
-                mode="inline"
-                selectedKeys={[selectedKey]}
-                defaultOpenKeys={collapsed ? [] : ['studio']}
-                items={menuItems}
-                onClick={handleMenuClick}
-                className="border-r-0 mt-6"
-                inlineCollapsed={collapsed}
-              />
+              <div
+                style={{
+                  flex: 1,
+                  minHeight: 0,
+                  overflowY: 'auto',
+                  overflowX: 'hidden',
+                  paddingBottom: 8,
+                }}
+              >
+                <Menu
+                  mode="inline"
+                  selectedKeys={[selectedKey]}
+                  defaultOpenKeys={collapsed ? [] : ['studio']}
+                  items={menuItems}
+                  onClick={handleMenuClick}
+                  className="border-r-0"
+                  style={{ borderInlineEnd: 'none' }}
+                  inlineCollapsed={collapsed}
+                />
+              </div>
 
-              <div className="absolute bottom-0 left-0 right-0 border-t border-gray-200 bg-white">
+              <div
+                className="border-t border-gray-200 bg-white"
+                style={{ flexShrink: 0 }}
+              >
                 <div
                   className="flex items-center justify-center p-4 cursor-pointer hover:bg-gray-50 transition-colors"
                   onClick={() => setCollapsed(!collapsed)}
@@ -323,12 +355,21 @@ export default function SideMenuLayout({ children }: { children: React.ReactNode
                   ) : (
                     <MenuFoldOutlined className="text-gray-600 text-lg" />
                   )}
-                  {!collapsed && <span className="ml-2 text-gray-600">收起菜单</span>}
+                  {!collapsed && (
+                    <span className="ml-2 text-gray-600">收起菜单</span>
+                  )}
                 </div>
+              </div>
               </div>
             </Sider>
 
-            <AntLayout style={{ marginLeft: collapsed ? 80 : 256, transition: 'margin-left 0.2s' }}>
+            <AntLayout
+              style={{
+                marginLeft: collapsed ? 80 : 256,
+                transition: 'margin-left 0.2s',
+                background: 'var(--ag-ant-color-bg-layout, #f5f5f5)',
+              }}
+            >
               <Header
                 right={
                   <>
@@ -340,8 +381,25 @@ export default function SideMenuLayout({ children }: { children: React.ReactNode
                 }
               />
               <Content className="overflow-hidden">
-                <div className="h-full overflow-y-auto bg-gray-50" style={{ minHeight: 'calc(100vh - 56px)' }}>
-                  {children}
+                <div
+                  className="h-full overflow-hidden"
+                  style={{
+                    minHeight: 'calc(100vh - 56px)',
+                    background: 'var(--ag-ant-color-bg-layout, #f5f5f5)',
+                    padding: '0 12px 12px 12px',
+                    boxSizing: 'border-box',
+                  }}
+                >
+                  <div
+                    className="h-full overflow-hidden"
+                    style={{
+                      background: 'var(--ag-ant-color-bg-base)',
+                      borderRadius: 8,
+                      border: '1px solid var(--ag-ant-color-border-secondary)',
+                    }}
+                  >
+                    {children}
+                  </div>
                 </div>
               </Content>
             </AntLayout>

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/index.module.less
@@ -17,7 +17,7 @@
 .body {
   height: 0;
   flex: 1;
-  margin: 0 8px 8px 8px;
+  margin: 0 12px 12px 12px;
   border: 1px solid var(--ag-ant-color-border-secondary);
   background-color: var(--ag-ant-color-bg-base);
   border-radius: 8px;
@@ -119,5 +119,12 @@
 
   .ag-ant-table-wrapper .ag-ant-table-container table>thead>tr:first-child>*:last-child {
     border-radius: 0;
+  }
+
+  .ag-ant-layout-sider-children {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/AgentSchema/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/AgentSchema/index.module.less
@@ -5,6 +5,7 @@
     flex: none !important; // 覆盖flex: 1
     min-height: auto !important;
     overflow: visible !important;
+    padding: 0 !important;
   }
 }
 

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AppList.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AppList.tsx
@@ -253,7 +253,6 @@ export default function () {
           })}
           value={state.name}
           onChange={(val) => setState({ name: val })}
-          className={'mx-[20px] my-[16px]'}
           onSearch={handleSearch}
         />
       )}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/AssistantConfig/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/AssistantConfig/index.module.less
@@ -107,7 +107,8 @@
 .container {
   height: 100%;
   display: flex;
-  background-color: var(--ag-ant-color-border-secondary);
+  background-color: var(--ag-ant-color-fill-tertiary);
+  overflow: hidden;
 
   .divider {
     width: 1px;
@@ -144,15 +145,28 @@
   position: relative;
   height: 100%;
   flex: 1;
-  border-left: 1px solid var(--ag-ant-color-border-secondary);
+  border-left: none;
   border-bottom: none;
   width: 100%;
+  background: var(--ag-ant-color-bg-base);
 }
 
 .title {
   font-size: 16px;
   font-weight: 600;
   line-height: 32px;
+}
+
+.configHeader {
+  padding: 24px 28px 12px 32px;
+  box-sizing: border-box;
+}
+
+.modelConfigWrap {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: 16px;
 }
 
 .formTitle {
@@ -193,14 +207,16 @@
 
 .divider1 {
   position: relative;
-  width: 1px;
+  width: 8px;
   height: 100%;
+  background: var(--ag-ant-color-fill-tertiary);
 
   img {
     width: 16px;
     height: 100%;
     position: absolute;
-    left: -1px;
+    left: 50%;
+    transform: translateX(-50%);
     cursor: col-resize !important;
     opacity: 0;
     user-select: none;
@@ -210,13 +226,16 @@
 .resizeHandle {
   cursor: col-resize !important;
   outline: none;
-  width: 1px;
+  width: 8px;
   display: flex;
   justify-content: stretch;
   align-items: stretch;
   transition: background-color 0.2s linear;
+  background: var(--ag-ant-color-fill-tertiary);
 
   &:hover {
+    background: var(--ag-ant-color-primary-bg);
+
     .divider1 {
       background-color: var(--ag-ant-color-primary-hover);
     }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/AssistantConfig/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/AssistantConfig/index.tsx
@@ -16,6 +16,7 @@ import HistoryPanelComp from '../HistoryPanel/HistoryPanelComp';
 import KnowledgeBaseSelectorComp from '../KnowledgeSelectorComp';
 import MCPSelectorComp from '../MCPSelectorComp';
 import PluginSelectorComp from '../PluginSelectorComp';
+import SkillSelectorComp from '../SkillSelectorComp';
 import WorkFlowSelectorComp from '../WorkFlowSelectorComp';
 import styles from './index.module.less';
 import ModelConfig from './modelConfig';
@@ -90,12 +91,16 @@ export default function AssistantConfig() {
           defaultSizePercentage={widthLayout.leftWidth}
           id={getUniqueId().left}
           order={1}
-          style={{ overflowY: 'auto' }}
+          style={{
+            overflowY: 'auto',
+            background: 'var(--ag-ant-color-bg-base)',
+          }}
         >
           <ConfigProvider componentDisabled={appState.readonly}>
-            <div className="p-[8px_20px]">
+            <div className={styles.configHeader}>
               <Flex
                 justify="space-between"
+                align="center"
                 className={classNames(styles.title, 'w-full')}
               >
                 {$i18n.get({
@@ -103,13 +108,15 @@ export default function AssistantConfig() {
                   dm: 'API配置',
                 })}
 
-                <ModelConfig></ModelConfig>
+                <div className={styles.modelConfigWrap}>
+                  <ModelConfig></ModelConfig>
+                </div>
               </Flex>
             </div>
             <div className={styles.configTimelineContainer}>
               <Timeline
                 className={styles.configTimeline}
-                style={{ padding: '0 20px', marginTop: 8 }}
+                style={{ padding: '8px 24px 24px', marginTop: 0 }}
                 items={compact([
                 {
                   children: (
@@ -175,6 +182,7 @@ export default function AssistantConfig() {
                       </div>
                       <MCPSelectorComp />
                       <PluginSelectorComp />
+                      <SkillSelectorComp />
                       <AgentSelectorComp />
                       <WorkFlowSelectorComp />
                     </div>

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/ComponentSelectorDrawer/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/ComponentSelectorDrawer/index.tsx
@@ -197,7 +197,7 @@ export default function ComponentSelectorDrawer(props: IProps) {
       title={renderTitle}
     >
       <Flex className="h-full" vertical gap={16}>
-        <Flex justify="space-between" align="center">
+        <Flex justify="space-between" align="center" className="mb-[24px]">
           <Input.Search
             className={styles.search}
             placeholder={$i18n.get({

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/SelectedConfigItem/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/SelectedConfigItem/index.tsx
@@ -16,46 +16,58 @@ export default (props: {
   return (
     <Flex
       justify="space-between"
+      align="center"
+      gap={8}
       style={{ background: 'var(--ag-ant-color-fill-tertiary)' }}
-      className="w-full height-[32px] rounded-[6px] p-[6px_12px]"
+      className="w-full rounded-[8px] px-[12px] py-[8px]"
     >
       <Flex
-        gap={4}
-        className="flex flex-1 items-center title"
-        style={{ width: 'calc(100% - 24px)' }}
+        gap={8}
+        align="center"
+        className="flex-1 min-w-0"
+        style={{ width: 0 }}
       >
-        <IconFont type={props.iconType} size="small"></IconFont>
+        <IconFont type={props.iconType} size="small" />
         <Typography.Text
           ellipsis={{ tooltip: renderTooltip(props.name) }}
-          style={{ color: 'var(--ag-ant-color-text-base)', width: '112px' }}
-          className="text-[12px] text-normal leading-[20px]"
+          style={{
+            color: 'var(--ag-ant-color-text-base)',
+            maxWidth: 140,
+            flexShrink: 0,
+          }}
+          className="text-[12px] leading-[20px]"
         >
           {props.name}
         </Typography.Text>
-        <Typography.Text
-          style={{
-            width: 'calc(100% - 140px)',
-            color: 'var(--ag-ant-color-text-tertiary)',
-          }}
-          ellipsis={{ tooltip: renderTooltip(props?.description || '') }}
-        >
-          {props?.description}
-        </Typography.Text>
-        <Popover content={props.weightInfo?.description}>
+        {props.description ? (
           <Typography.Text
             style={{
-              color: 'var(--ag-ant-color-text-description)',
-              fontSize: '12px',
-              flexShrink: 0,
-              marginRight: '12px',
+              flex: 1,
+              minWidth: 0,
+              color: 'var(--ag-ant-color-text-tertiary)',
             }}
+            ellipsis={{ tooltip: renderTooltip(props.description) }}
+            className="text-[12px] leading-[20px]"
           >
-            {props.weightInfo?.label}
-            {props.weightInfo?.value}
+            {props.description}
           </Typography.Text>
-        </Popover>
+        ) : null}
+        {props.weightInfo ? (
+          <Popover content={props.weightInfo.description}>
+            <Typography.Text
+              style={{
+                color: 'var(--ag-ant-color-text-description)',
+                fontSize: 12,
+                flexShrink: 0,
+              }}
+            >
+              {props.weightInfo.label}
+              {props.weightInfo.value}
+            </Typography.Text>
+          </Popover>
+        ) : null}
       </Flex>
-      {props.rightArea}
+      <div style={{ flexShrink: 0 }}>{props.rightArea}</div>
     </Flex>
   );
 };

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/SkillSelectorComp/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/components/SkillSelectorComp/index.tsx
@@ -1,0 +1,133 @@
+import $i18n from '@/i18n';
+import { SkillSelectDrawer } from '@/pages/App/components/SkillSelector';
+import { ISkill, SKILL_MAX_LIMIT } from '@/types/skill';
+import { Button, HelpIcon, IconFont } from '@spark-ai/design';
+import { useSetState } from 'ahooks';
+import { Divider, Flex } from 'antd';
+import cls from 'classnames';
+import { useContext, useEffect } from 'react';
+import { AssistantAppContext } from '../../AssistantAppContext';
+import SelectedConfigItem from '../SelectedConfigItem';
+import styles from '../MCPSelectorComp/index.module.less';
+
+export function SelectedSkillItem({
+  item,
+  handleRemove,
+}: {
+  item: ISkill;
+  handleRemove: (item: ISkill) => void;
+}) {
+  return (
+    <SelectedConfigItem
+      iconType="spark-paper-line"
+      name={item.name}
+      description={item.description || item.skill_name}
+      rightArea={
+        <IconFont
+          type="spark-delete-line"
+          isCursorPointer
+          onClick={() => handleRemove(item)}
+        />
+      }
+    />
+  );
+}
+
+export default function SkillSelectorComp() {
+  const { appState, onAppConfigChange } = useContext(AssistantAppContext);
+  const { skills = [] as ISkill[] } = appState.appBasicConfig?.config || {};
+  const [state, setState] = useSetState({
+    expand: false,
+    selectVisible: false,
+  });
+
+  const onSelectSkills = (val: ISkill[]) => {
+    onAppConfigChange({ skills: val });
+  };
+
+  useEffect(() => {
+    if (skills.length) {
+      setState({ expand: true });
+    }
+  }, [skills]);
+
+  return (
+    <Flex vertical gap={6} className="mb-[20px]">
+      <Flex justify="space-between" align="center">
+        <Flex
+          gap={8}
+          className="text-[13px] font-medium leading-[20px]"
+          style={{ color: 'var(--ag-ant-color-text)' }}
+          align="center"
+        >
+          <Flex align="center">
+            <span>
+              {$i18n.get({
+                id: 'main.components.SkillSelectorComp.index.skill',
+                dm: 'Skills',
+              })}
+            </span>
+            <HelpIcon
+              content={$i18n.get({
+                id: 'main.components.SkillSelectorComp.index.help',
+                dm: '智能体可按需加载 SKILL.md 指令包（渐进式披露），通过 read_skill 读取完整内容。',
+              })}
+            />
+          </Flex>
+          <span
+            className="text-[12px] leading-[20px]"
+            style={{ color: 'var(--ag-ant-color-text-tertiary)' }}
+          >
+            {skills.length}/{SKILL_MAX_LIMIT}
+          </span>
+        </Flex>
+        <span>
+          <Button
+            style={{ padding: 0 }}
+            onClick={() => setState({ selectVisible: true })}
+            iconType="spark-plus-line"
+            type="text"
+            size="small"
+          >
+            Skill
+          </Button>
+          <Divider type="vertical" className="ml-[16px] mr-[16px]" />
+          <IconFont
+            onClick={() => setState({ expand: !state.expand })}
+            className={cls(styles['expand-btn'], !state.expand && styles.hidden)}
+            type="spark-up-line"
+            isCursorPointer
+          />
+        </span>
+      </Flex>
+      {state.expand && (
+        <Flex vertical gap={8}>
+          {skills.map(
+            (item) =>
+              item && (
+                <SelectedSkillItem
+                  key={item.skill_id}
+                  item={item}
+                  handleRemove={() =>
+                    onSelectSkills(
+                      skills.filter((s) => s.skill_id !== item.skill_id),
+                    )
+                  }
+                />
+              ),
+          )}
+        </Flex>
+      )}
+      {state.selectVisible && (
+        <SkillSelectDrawer
+          selectedSkills={skills}
+          onOk={(val) => {
+            onSelectSkills(val);
+            setState({ selectVisible: false, expand: true });
+          }}
+          onClose={() => setState({ selectVisible: false })}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/AssistantAppEdit/index.tsx
@@ -14,6 +14,7 @@ import { getKnowledgeListByCodes } from '@/services/knowledge';
 import { listMcpServersByCodes } from '@/services/mcp';
 import { getModelDetail } from '@/services/modelService';
 import { getPluginToolsByIds } from '@/services/plugin';
+import { listSkillsByIds } from '@/services/skill';
 import { convertDifyToSpringAI } from '@/services/difyConverter';
 import { IAppComponentListItem } from '@/types/appComponent';
 import {
@@ -28,6 +29,7 @@ import { IKnowledgeListItem } from '@/types/knowledge';
 import { IMcpServer } from '@/types/mcp';
 import { IModel } from '@/types/modelService';
 import { PluginTool } from '@/types/plugin';
+import { ISkill } from '@/types/skill';
 import { Empty, IconFont, renderTooltip } from '@spark-ai/design';
 import { useDebounceFn, useSetState } from 'ahooks';
 import { Flex, Spin, Typography, message } from 'antd';
@@ -62,6 +64,13 @@ export const queryMCPsByCodes = (codes?: string[]): Promise<IMcpServer[]> => {
   });
 };
 
+export const querySkillsByIds = (ids?: string[]): Promise<ISkill[]> => {
+  if (!ids?.length) return Promise.resolve([]);
+  return listSkillsByIds(ids).then((res) => {
+    return res.data.filter((item) => !!item) || [];
+  });
+};
+
 export const queryComponentsByCodes = (
   codes?: string[],
 ): Promise<IAppComponentListItem[]> => {
@@ -84,6 +93,7 @@ export const transformAppData = (
   const {
     tools,
     mcp_servers,
+    skills,
     file_search,
     agent_components,
     workflow_components,
@@ -94,6 +104,7 @@ export const transformAppData = (
     model: extraConfig.model?.model_id,
     tools: tools?.map((item) => ({ id: item.tool_id })) || [],
     mcp_servers: mcp_servers?.map((item) => ({ id: item.server_code })) || [],
+    skills: skills?.map((item) => ({ id: item.skill_id })) || [],
     agent_components: agent_components?.map((item) => item.code) || [],
     workflow_components: workflow_components?.map((item) => item.code) || [],
     file_search: {
@@ -187,6 +198,9 @@ export default function AssistantAppEdit() {
     const mcp_servers = await queryMCPsByCodes(
       appDetail.config.mcp_servers?.map((item) => item.id) || [],
     );
+    const skills = await querySkillsByIds(
+      appDetail.config.skills?.map((item) => item.id) || [],
+    );
     const agent_components = await queryComponentsByCodes(
       appDetail.config.agent_components,
     );
@@ -202,6 +216,7 @@ export default function AssistantAppEdit() {
         ...appDetail.config,
         tools,
         mcp_servers,
+        skills,
         agent_components,
         workflow_components,
         model,
@@ -574,6 +589,7 @@ export default function AssistantAppEdit() {
           ) : (
             <InnerLayout
               loading={state.loading}
+              styles={{ contentArea: { padding: 0 } }}
               onTabChange={(key) => {
                 setState({ activeKey: key });
               }}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/Workflow/components/ComponentSelectorModal/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/Workflow/components/ComponentSelectorModal/index.tsx
@@ -144,7 +144,7 @@ export default function ComponentSelectorModal(
             options={tabs}
           />
         </div>
-        <Flex className="px-[24px]" justify="space-between">
+        <Flex className="px-[24px] mb-[24px]" justify="space-between" align="center">
           <Input.Search
             className={styles.search}
             value={state.name}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/Workflow/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/Workflow/index.tsx
@@ -587,6 +587,7 @@ function Workflow() {
         <InnerLayout
           loading={state.loading}
           fullScreen={true}
+          styles={{ contentArea: { padding: 0 } }}
           activeTab={activeTab}
           onTabChange={(val) => {
             setActiveTab(val);

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/ChannelConfig/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/ChannelConfig/index.module.less
@@ -1,11 +1,12 @@
 .container {
-  padding: 24px 0;
-  max-width: 1440px;
-  width: calc(100% - 264px);
+  padding: 16px 20px 24px;
+  max-width: 960px;
+  width: 100%;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  box-sizing: border-box;
 
   .title {
     font-size: 16px;
@@ -16,16 +17,18 @@
 
 .card {
   display: flex;
-  padding: 20px;
-  border-radius: 6px;
-  background: var(--ag-ant-color-bg-base);
+  align-items: flex-start;
+  padding: 16px 20px;
+  border-radius: 8px;
+  background: var(--ag-ant-color-bg-container);
   border: 1px solid var(--ag-ant-color-border-secondary);
-  gap: 8px;
+  gap: 12px;
+  box-sizing: border-box;
 
   .img-con {
     border: 1px solid var(--ag-ant-color-border-secondary);
-    border-radius: 6px;
-    margin-right: 8px;
+    border-radius: 8px;
+    flex-shrink: 0;
     width: 48px;
     height: 48px;
     display: flex;
@@ -49,4 +52,9 @@
     line-height: 20px;
     color: var(--ag-ant-color-text-tertiary);
   }
+}
+
+.disabled {
+  opacity: 0.6;
+  pointer-events: none;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/KnowledgeSelector/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/KnowledgeSelector/index.tsx
@@ -138,7 +138,7 @@ export default function KnowledgeSelector(props: IKnowledgeSelectorProps) {
 
   return (
     <>
-      <div className="flex-justify-between px-[24px]">
+      <div className="flex justify-between items-start px-[24px]">
         <Search
           onSearch={handleSearch}
           placeholder={$i18n.get({

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/MCPSelector/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/MCPSelector/index.tsx
@@ -71,7 +71,7 @@ const MCPServerSelector = (props: IMCPServerSelectorProps) => {
 
   return (
     <>
-      <Flex justify="space-between" className="mb-[16px]">
+      <Flex justify="space-between" className="mb-[24px]">
         <Input
           onChange={onInputChange}
           prefix={<IconFont type="spark-search-line" />}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/PluginSelector/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/PluginSelector/index.tsx
@@ -69,7 +69,7 @@ export default function ToolSelector(props: IProps) {
   return (
     <Flex className={classNames('p-[8px]', props.className)} vertical>
       {
-        <Flex justify="space-between" align="center">
+        <Flex justify="space-between" align="center" className="mb-[24px]">
           <Input.Search
             style={{ width: 280 }}
             width={280}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/SkillSelector/SkillListItem/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/SkillSelector/SkillListItem/index.module.less
@@ -1,0 +1,90 @@
+.wrapper {
+  padding: 16px;
+  border: 1px solid var(--ag-ant-color-border-secondary);
+  background-color: var(--ag-ant-color-bg-container);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+
+  &:hover:not(.active):not(.disabled) {
+    border-color: var(--ag-ant-color-primary);
+  }
+
+  &.active {
+    border-color: var(--ag-ant-color-primary);
+    box-shadow: 0 4px 6px 0 var(--ag-ant-color-5);
+  }
+
+  &.disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+}
+
+.row {
+  width: 100%;
+  min-width: 0;
+}
+
+.logo {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  border: 1px solid var(--ag-ant-color-border-secondary);
+  background: var(--ag-ant-color-fill-tertiary);
+  color: var(--ag-ant-color-primary);
+}
+
+.logoIcon {
+  font-size: 20px;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.header {
+  gap: 8px;
+  min-width: 0;
+}
+
+.title {
+  flex: 1;
+  min-width: 0;
+  font-size: 15px !important;
+  font-weight: 600 !important;
+  line-height: 22px !important;
+  color: var(--ag-ant-color-text-base) !important;
+}
+
+.badge {
+  flex-shrink: 0;
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--ag-ant-color-text-tertiary);
+  padding: 1px 8px;
+  border-radius: 4px;
+  background: var(--ag-ant-color-fill-tertiary);
+}
+
+.skillName {
+  font-size: 12px !important;
+  line-height: 18px !important;
+  color: var(--ag-ant-color-text-tertiary) !important;
+  max-width: 100%;
+}
+
+.desc {
+  max-width: 100%;
+  min-height: 20px;
+  margin-top: 2px !important;
+  line-height: 20px !important;
+  font-size: 12px !important;
+  color: var(--ag-ant-color-text-secondary) !important;
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/SkillSelector/SkillListItem/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/SkillSelector/SkillListItem/index.tsx
@@ -1,0 +1,90 @@
+import $i18n from '@/i18n';
+import { ISkill } from '@/types/skill';
+import { IconFont, renderTooltip } from '@spark-ai/design';
+import { Checkbox, Flex, Typography } from 'antd';
+import classNames from 'classnames';
+import styles from './index.module.less';
+
+interface IProps {
+  item: ISkill;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export default function SkillListItem(props: IProps) {
+  const { item, checked, disabled, onChange } = props;
+
+  const handleToggle = () => {
+    if (disabled && !checked) return;
+    onChange(!checked);
+  };
+
+  return (
+    <div
+      className={classNames(styles.wrapper, {
+        [styles.active]: checked,
+        [styles.disabled]: disabled && !checked,
+      })}
+      onClick={handleToggle}
+    >
+      <Flex gap={12} align="flex-start" className={styles.row}>
+        <Checkbox
+          checked={checked}
+          disabled={disabled && !checked}
+          onClick={(e) => e.stopPropagation()}
+          onChange={(e) => {
+            if (disabled && !checked) return;
+            onChange(e.target.checked);
+          }}
+          style={{ marginTop: 10 }}
+        />
+        <Flex
+          align="center"
+          justify="center"
+          className={styles.logo}
+        >
+          <IconFont type="spark-paper-line" className={styles.logoIcon} />
+        </Flex>
+        <div className={styles.content}>
+          <Flex justify="space-between" align="center" className={styles.header}>
+            <Typography.Text
+              className={styles.title}
+              ellipsis={{ tooltip: renderTooltip(item.name) }}
+            >
+              {item.name}
+            </Typography.Text>
+            {item.source ? (
+              <span className={styles.badge}>
+                {item.source === 'upload'
+                  ? $i18n.get({
+                      id: 'main.pages.App.components.SkillSelector.SkillListItem.upload',
+                      dm: '上传',
+                    })
+                  : item.source}
+              </span>
+            ) : null}
+          </Flex>
+          <Typography.Text
+            className={styles.skillName}
+            ellipsis={{ tooltip: renderTooltip(item.skill_name) }}
+          >
+            {item.skill_name}
+          </Typography.Text>
+          {item.description ? (
+            <Typography.Paragraph
+              className={styles.desc}
+              style={{ marginBottom: 0 }}
+              ellipsis={{
+                rows: 1,
+                tooltip: renderTooltip(item.description),
+              }}
+            >
+              {item.description}
+            </Typography.Paragraph>
+          ) : null}
+        </div>
+      </Flex>
+    </div>
+  );
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/SkillSelector/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/components/SkillSelector/index.tsx
@@ -1,0 +1,167 @@
+import $i18n from '@/i18n';
+import { CreateSkillBtn } from '@/pages/Component/Skill';
+import { listSkills } from '@/services/skill';
+import { ISkill, SKILL_MAX_LIMIT } from '@/types/skill';
+import {
+  Button,
+  Drawer,
+  Empty,
+  IconFont,
+  Input,
+  message,
+  Pagination,
+} from '@spark-ai/design';
+import { useSetState } from 'ahooks';
+import { Flex, Spin } from 'antd';
+import { debounce } from 'lodash-es';
+import { useEffect, useState } from 'react';
+import SkillListItem from './SkillListItem';
+
+export interface ISkillSelectorProps {
+  selectedSkills?: ISkill[];
+  onOk: (skills: ISkill[]) => void;
+  onClose: () => void;
+}
+
+export function SkillSelectDrawer(props: ISkillSelectorProps) {
+  const [filterParams, setFilterParams] = useSetState({
+    current: 1,
+    size: 10,
+    name: '',
+  });
+  const [total, setTotal] = useState(0);
+  const [list, setList] = useState<ISkill[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<ISkill[]>(props.selectedSkills || []);
+
+  const fetchList = () => {
+    setLoading(true);
+    listSkills(filterParams)
+      .then((res) => {
+        setList(res.data.records || []);
+        setTotal(res.data.total || 0);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchList();
+  }, [filterParams]);
+
+  const onInputChange = debounce((e) => {
+    setFilterParams({ current: 1, name: e.target.value });
+  }, 500);
+
+  const toggleSkill = (item: ISkill, checked: boolean) => {
+    if (checked) {
+      if (selected.length >= SKILL_MAX_LIMIT) {
+        message.warning(
+          $i18n.get({
+            id: 'main.pages.App.components.SkillSelector.reachedMaxLimit',
+            dm: '已达到最大数量限制',
+          }),
+        );
+        return;
+      }
+      setSelected([...selected, item]);
+    } else {
+      setSelected(selected.filter((s) => s.skill_id !== item.skill_id));
+    }
+  };
+
+  const reachedLimit = selected.length >= SKILL_MAX_LIMIT;
+
+  return (
+    <Drawer
+      title={$i18n.get({
+        id: 'main.pages.App.components.SkillSelector.title',
+        dm: '选择技能',
+      })}
+      open
+      width={560}
+      onClose={props.onClose}
+      footer={
+        <Flex justify="space-between" align="center" style={{ width: '100%' }}>
+          <span
+            style={{
+              fontSize: 12,
+              color: 'var(--ag-ant-color-text-tertiary)',
+            }}
+          >
+            {$i18n.get({
+              id: 'main.pages.App.components.SkillSelector.selected',
+              dm: '已选',
+            })}
+            {` ${selected.length}/${SKILL_MAX_LIMIT}`}
+          </span>
+          <Flex gap={8}>
+            <Button onClick={props.onClose}>
+              {$i18n.get({
+                id: 'main.pages.App.components.SkillSelector.cancel',
+                dm: '取消',
+              })}
+            </Button>
+            <Button type="primary" onClick={() => props.onOk(selected)}>
+              {$i18n.get({
+                id: 'main.pages.App.components.SkillSelector.confirm',
+                dm: '确定',
+              })}
+            </Button>
+          </Flex>
+        </Flex>
+      }
+    >
+      <Flex justify="space-between" align="center" className="mb-[24px]" gap={12}>
+        <Input
+          onChange={onInputChange}
+          prefix={<IconFont type="spark-search-line" />}
+          placeholder={$i18n.get({
+            id: 'main.pages.App.components.SkillSelector.search',
+            dm: '搜索技能',
+          })}
+          allowClear
+          style={{ width: 240 }}
+        />
+        <CreateSkillBtn onSuccess={fetchList} />
+      </Flex>
+      {loading ? (
+        <Flex justify="center" className="py-[48px]">
+          <Spin />
+        </Flex>
+      ) : list.length ? (
+        <Flex vertical gap={16}>
+          {list.map((item) => {
+            const checked = selected.some((s) => s.skill_id === item.skill_id);
+            return (
+              <SkillListItem
+                key={item.skill_id}
+                item={item}
+                checked={checked}
+                disabled={reachedLimit && !checked}
+                onChange={(next) => toggleSkill(item, next)}
+              />
+            );
+          })}
+          <Flex justify="flex-end" className="mt-[4px]">
+            <Pagination
+              pageSize={filterParams.size}
+              current={filterParams.current}
+              total={total}
+              hideOnSinglePage
+              onChange={(page, pageSize) =>
+                setFilterParams({ current: page, size: pageSize })
+              }
+            />
+          </Flex>
+        </Flex>
+      ) : (
+        <Empty
+          title={$i18n.get({
+            id: 'main.pages.App.components.SkillSelector.empty',
+            dm: '暂无技能',
+          })}
+        />
+      )}
+    </Drawer>
+  );
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/utils/index.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/App/utils/index.ts
@@ -87,6 +87,7 @@ const generateAgentConfig = () => {
     tools: {}, // plugin tools
     file_search: {},
     mcp_servers: [], // mcp servers
+    skills: [], // agent skills
     agent_components: [], // agent components
     workflow_components: [], // workflow components
   };

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/AppSelector/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/AppSelector/index.tsx
@@ -46,14 +46,16 @@ export const APP_ICON_IMAGE = {
 
 export default function AppSelector(props: IProps) {
   const navigate = useNavigate();
+  const list = props.list || [];
+
   const memoList = useMemo(() => {
     if (!props.value || (Array.isArray(props.value) && !props.value.length))
-      return props.list.map((item) => ({
+      return list.map((item) => ({
         ...item,
         isSelected: false,
       }));
 
-    return props.list.map((item) => {
+    return list.map((item) => {
       const isSelected = Array.isArray(props.value)
         ? props.value.includes(item.app_id)
         : props.value === item.app_id;
@@ -62,10 +64,10 @@ export default function AppSelector(props: IProps) {
         isSelected,
       };
     });
-  }, [props.value, props.list]);
+  }, [props.value, list]);
 
   if (props.loading) return <Spin className="loading-center" spinning />;
-  if (!props.list.length)
+  if (!list.length)
     return (
       <div className="loading-center">
         <Empty
@@ -224,8 +226,8 @@ export function AppSelectorModalByAppComponent(props: IAppModalProps) {
     })
       .then((res) => {
         setState({
-          list: res.records,
-          total: res.total,
+          list: res?.records || [],
+          total: res?.total || 0,
           loading: false,
         });
       })
@@ -257,8 +259,8 @@ export function AppSelectorModalByAppComponent(props: IAppModalProps) {
         dm: '选择应用',
       })}
     >
-      <Flex vertical gap={12}>
-        <Flex justify="space-between" align="center">
+      <Flex vertical gap={0}>
+        <Flex justify="space-between" align="flex-start">
           <Search
             className={styles.search}
             value={state.app_name}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/Card/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/Card/index.module.less
@@ -1,7 +1,10 @@
 .bottom {
   font-size: 12px;
   line-height: 20px;
-  color: var(--ag-ant-color-text-secondary);
+  color: var(--ag-ant-color-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .logo {

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/EditDrawer/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/EditDrawer/index.tsx
@@ -160,12 +160,27 @@ export default function EditDrawer(props: IProps) {
     );
   }, [state]);
 
+  const normalizeComponentConfig = (raw: any) => {
+    const inputRaw = raw?.input || {};
+    return {
+      input: {
+        user_params:
+          inputRaw.user_params ?? inputRaw.userParams ?? ([] as any[]),
+        system_params:
+          inputRaw.system_params ?? inputRaw.systemParams ?? ([] as any[]),
+      } as IConfigInput,
+      output: (raw?.output ?? []) as IOutputParamItem[],
+    };
+  };
+
   useMount(async () => {
     try {
       if (props.data.code) {
         const res = await getAppComponentDetailByCode(props.data.code);
         if (!res) return;
-        const componentDetailCfg = JSON.parse(res.config);
+        const componentDetailCfg = normalizeComponentConfig(
+          JSON.parse(res.config || '{}'),
+        );
         setState({
           input: componentDetailCfg.input,
           output: componentDetailCfg.output,
@@ -177,7 +192,9 @@ export default function EditDrawer(props: IProps) {
         });
       } else {
         const ret = await getConfigByAppId(props.data.app_id as string);
-        const componentParams = JSON.parse(ret.config);
+        const componentParams = normalizeComponentConfig(
+          JSON.parse(ret?.config || '{}'),
+        );
         setState({
           input: componentParams.input,
           output: componentParams.output,

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/InputParamsComp/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/InputParamsComp/index.tsx
@@ -50,9 +50,10 @@ interface IInputCompItemProps {
 
 export function InputCompItem(props: IInputCompItemProps) {
   const [expand, setExpand] = useState(true);
+  const params = props.params || [];
   const changeRowItem = (payload: Partial<IParamItem>, ind: number) => {
     props.onChange(
-      props.params.map((item, index) => ({
+      params.map((item, index) => ({
         ...item,
         ...(ind === index ? payload : {}),
       })),
@@ -125,7 +126,7 @@ export function InputCompItem(props: IInputCompItemProps) {
               })}
             </span>
           </Flex>
-          {props.params.map((item, index) => (
+          {params.map((item, index) => (
             <Flex
               key={`${item.field}_${index}`}
               className={styles['form-row-item']}
@@ -258,8 +259,11 @@ export function InputCompItem(props: IInputCompItemProps) {
 }
 
 export default function InputParamsComp(props: IProps) {
+  const userParams = props.input?.user_params || [];
+  const systemParams = props.input?.system_params || [];
+
   const handleChangeUserParams = (params: IParamItem[], code: string) => {
-    const newUserParams = props.input.user_params.map((item) => {
+    const newUserParams = userParams.map((item) => {
       if (item.code === code)
         return {
           ...item,
@@ -274,7 +278,7 @@ export default function InputParamsComp(props: IProps) {
 
   return (
     <Flex vertical gap={20}>
-      {props.input.user_params.map((item) => (
+      {userParams.map((item) => (
         <InputCompItem
           onChange={(val) => handleChangeUserParams(val, item.code)}
           name={item.name}
@@ -289,7 +293,7 @@ export default function InputParamsComp(props: IProps) {
           dm: '系统参数',
         })}
         onChange={(val) => props.onChange({ system_params: val })}
-        params={props.input.system_params}
+        params={systemParams}
         disabled={props.disabled}
       />
     </Flex>

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/OutputParamsComp/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/components/OutputParamsComp/index.tsx
@@ -30,7 +30,7 @@ export default function OutputParamsComp(props: IProps) {
           })}
         </span>
       </Flex>
-      {props.output.map((item, index) => (
+      {(props.output || []).map((item, index) => (
         <Flex gap={8} key={index}>
           <Input className="flex-1" value={item.field} disabled />
           <Input className="flex-1" value={item.type} disabled />

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/AppComponent/index.tsx
@@ -15,7 +15,6 @@ import {
 import { IconFont } from '@spark-ai/design';
 import { useSetState } from 'ahooks';
 import { Button, message, Modal } from 'antd';
-import classNames from 'classnames';
 import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AppSelectorModalByAppComponent } from './components/AppSelector';
@@ -61,8 +60,8 @@ export default function AppComponent(props: { type: IAppType }) {
     })
       .then((res) => {
         setState({
-          list: res.records,
-          total: res.total,
+          list: res?.records || [],
+          total: res?.total || 0,
         });
       })
       .finally(() => {
@@ -180,7 +179,6 @@ export default function AppComponent(props: { type: IAppType }) {
           })}
           value={state.name}
           onChange={(val) => setState({ name: val })}
-          className={classNames('mx-[20px] my-[16px]')}
           onSearch={handleSearch}
         />
       )}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Plugin/Info/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Plugin/Info/index.module.less
@@ -1,19 +1,21 @@
 .container {
-  max-width: 700px;
-  width: 70%;
-  padding: 40px 0;
+  max-width: 720px;
+  width: 100%;
+  padding: 16px 0 24px;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .title {
   font-size: 16px;
-  font-weight: 400;
+  font-weight: 500;
   color: var(--ag-ant-color-text-base);
-  margin-bottom: 20px;
+  margin-bottom: 16px;
+  line-height: 24px;
 }
 
 .bottom-bar {
-  width: 70%;
-  max-width: 700px;
+  width: 100%;
+  max-width: 720px;
   margin: 0 auto;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Plugin/List/List.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Plugin/List/List.tsx
@@ -22,7 +22,6 @@ export default function () {
 
   return (
     <CardList
-      className="pt-[20px]"
       loading={loading}
       emptyAction={
         <Button

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Plugin/Tools/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Plugin/Tools/index.module.less
@@ -1,10 +1,10 @@
 .form {
   position: relative;
-  padding: 40px 132px;
+  padding: 16px 0 24px;
 
   .form-content {
     max-width: 960px;
-    width: 80%;
+    width: 100%;
     margin: 0 auto;
   }
 
@@ -14,7 +14,7 @@
     .title {
       font-size: 16px;
       font-weight: 500;
-      margin-bottom: 20px;
+      margin-bottom: 16px;
       line-height: 24px;
 
       &.required {
@@ -140,7 +140,7 @@
   top: 120px;
   right: 24px;
   z-index: 10;
-  padding: 40px 24px;
+  padding: 16px;
 }
 
 .collapse {
@@ -148,7 +148,7 @@
 }
 
 .bottom-bar {
-  width: 80%;
+  width: 100%;
   max-width: 960px;
   margin: 0 auto;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/Card.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/Card.tsx
@@ -1,0 +1,103 @@
+import $i18n from '@/i18n';
+import { deleteSkill } from '@/services/skill';
+import { ISkill } from '@/types/skill';
+import { AlertDialog, IconButton, IconFont, message } from '@spark-ai/design';
+import { Button, Dropdown, Typography } from 'antd';
+import dayjs from 'dayjs';
+import { history } from 'umi';
+import styles from './index.module.less';
+
+export default function SkillCard(props: ISkill & { reload: () => void }) {
+  const goDetail = (e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    history.push(`/component/skill/${props.skill_id}`);
+  };
+
+  const handleDelete = () => {
+    AlertDialog.warning({
+      title: $i18n.get({
+        id: 'main.pages.Component.Skill.confirmDelete',
+        dm: '确认删除此技能吗',
+      }),
+      children: $i18n.get({
+        id: 'main.pages.Component.Skill.deleteTip',
+        dm: '删除后不可恢复，已挂载该技能的智能体可能失效，请谨慎操作',
+      }),
+      danger: true,
+      onOk: async () => {
+        await deleteSkill(props.skill_id);
+        message.success(
+          $i18n.get({
+            id: 'main.pages.Component.Skill.deleteSuccess',
+            dm: '删除成功',
+          }),
+        );
+        props.reload();
+      },
+    });
+  };
+
+  return (
+    <div className={styles.skillCard} onClick={() => goDetail()}>
+      <div className={styles.cardMain}>
+        <div className={styles.cardHeader}>
+          <div className={styles.logo}>
+            <IconFont type="spark-paper-line" />
+          </div>
+          <div className={styles.headerText}>
+            <Typography.Text className={styles.title} ellipsis={{ tooltip: true }}>
+              {props.name}
+            </Typography.Text>
+            <Typography.Text className={styles.skillName} ellipsis={{ tooltip: true }}>
+              {props.skill_name}
+            </Typography.Text>
+          </div>
+        </div>
+
+        <Typography.Paragraph
+          className={styles.desc}
+          ellipsis={{ rows: 2, tooltip: true }}
+        >
+          {props.description || '-'}
+        </Typography.Paragraph>
+
+        <div className={styles.meta}>
+          {$i18n.get({
+            id: 'main.pages.Component.Skill.updatedAt',
+            dm: '更新于',
+          })}
+          {dayjs(props.gmt_modified).format('YYYY-MM-DD HH:mm')}
+        </div>
+      </div>
+
+      <div className={styles.cardActions} onClick={(e) => e.stopPropagation()}>
+        <Button type="primary" block onClick={(e) => goDetail(e)}>
+          {$i18n.get({
+            id: 'main.pages.Component.Skill.viewContent',
+            dm: '查看内容',
+          })}
+        </Button>
+        <Dropdown
+          trigger={['click']}
+          menu={{
+            items: [
+              {
+                key: 'delete',
+                danger: true,
+                label: $i18n.get({
+                  id: 'main.pages.Component.Skill.delete',
+                  dm: '删除',
+                }),
+              },
+            ],
+            onClick: ({ key }) => {
+              if (key === 'delete') handleDelete();
+            },
+          }}
+        >
+          <IconButton shape="default" icon="spark-more-line" />
+        </Dropdown>
+      </div>
+    </div>
+  );
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/Detail.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/Detail.module.less
@@ -1,0 +1,90 @@
+.loading {
+  min-height: calc(100vh - 160px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0 0 16px;
+  box-sizing: border-box;
+}
+
+.header {
+  margin-bottom: 12px;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--ag-ant-color-text);
+  line-height: 28px;
+}
+
+.meta {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--ag-ant-color-text-tertiary);
+  line-height: 20px;
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  border: 1px solid var(--ag-ant-color-border-secondary);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--ag-ant-color-bg-container);
+}
+
+.treePane {
+  width: 280px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--ag-ant-color-border-secondary);
+  padding: 12px;
+  overflow: auto;
+  height: 100%;
+}
+
+.contentPane {
+  flex: 1;
+  min-width: 0;
+  padding: 12px 16px;
+  overflow: auto;
+  height: 100%;
+}
+
+.paneTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ag-ant-color-text-secondary);
+  margin-bottom: 12px;
+  word-break: break-all;
+}
+
+.contentLoading {
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.code {
+  margin: 0 !important;
+}
+
+.code pre {
+  margin: 0;
+  padding: 12px;
+  border-radius: 6px;
+  background: var(--ag-ant-color-fill-quaternary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+  line-height: 20px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--ag-ant-color-text);
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/Detail.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/Detail.tsx
@@ -1,0 +1,205 @@
+import InnerLayout from '@/components/InnerLayout';
+import $i18n from '@/i18n';
+import {
+  getSkill,
+  listSkillFiles,
+  readSkillFile,
+} from '@/services/skill';
+import {
+  ISkill,
+  ISkillFileContent,
+  ISkillFileNode,
+} from '@/types/skill';
+import { Empty } from '@spark-ai/design';
+import { FileOutlined, FolderOpenOutlined } from '@ant-design/icons';
+import { useMount } from 'ahooks';
+import { Flex, Spin, Tree, Typography } from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import { Key, useMemo, useState } from 'react';
+import { useParams } from 'umi';
+import styles from './Detail.module.less';
+
+function toTreeData(nodes: ISkillFileNode[]): DataNode[] {
+  return nodes.map((node) => ({
+    key: node.path,
+    title: node.name,
+    isLeaf: node.type === 'file',
+    icon:
+      node.type === 'directory' ? <FolderOpenOutlined /> : <FileOutlined />,
+    children: node.children?.length ? toTreeData(node.children) : undefined,
+  }));
+}
+
+function collectExpandKeys(nodes: ISkillFileNode[], depth = 0): string[] {
+  const keys: string[] = [];
+  for (const node of nodes) {
+    if (node.type === 'directory' && depth < 2) {
+      keys.push(node.path);
+      if (node.children?.length) {
+        keys.push(...collectExpandKeys(node.children, depth + 1));
+      }
+    }
+  }
+  return keys;
+}
+
+function findFirstFile(nodes: ISkillFileNode[]): string | null {
+  for (const node of nodes) {
+    if (node.type === 'file' && node.name.toLowerCase() === 'skill.md') {
+      return node.path;
+    }
+  }
+  for (const node of nodes) {
+    if (node.type === 'file') return node.path;
+    if (node.children?.length) {
+      const nested = findFirstFile(node.children);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+export default function SkillDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [skill, setSkill] = useState<ISkill | null>(null);
+  const [files, setFiles] = useState<ISkillFileNode[]>([]);
+  const [selectedPath, setSelectedPath] = useState<string>();
+  const [fileContent, setFileContent] = useState<ISkillFileContent | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [contentLoading, setContentLoading] = useState(false);
+  const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
+
+  const treeData = useMemo(() => toTreeData(files), [files]);
+
+  const loadFile = async (path: string) => {
+    if (!id) return;
+    setSelectedPath(path);
+    setContentLoading(true);
+    try {
+      const res = await readSkillFile(id, path);
+      setFileContent(res.data);
+    } finally {
+      setContentLoading(false);
+    }
+  };
+
+  useMount(async () => {
+    if (!id) return;
+    setLoading(true);
+    try {
+      const [skillRes, filesRes] = await Promise.all([
+        getSkill(id),
+        listSkillFiles(id),
+      ]);
+      setSkill(skillRes.data);
+      const tree = filesRes.data || [];
+      setFiles(tree);
+      setExpandedKeys(collectExpandKeys(tree));
+      const first = findFirstFile(tree);
+      if (first) {
+        await loadFile(first);
+      }
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  return (
+    <InnerLayout
+      breadcrumbLinks={[
+        {
+          title: $i18n.get({
+            id: 'main.pages.Component.index.componentManagement',
+            dm: '组件管理',
+          }),
+          path: '/component/skill',
+        },
+        {
+          title:
+            skill?.name ||
+            $i18n.get({
+              id: 'main.pages.Component.Skill.detail',
+              dm: '技能详情',
+            }),
+        },
+      ]}
+      loading={loading}
+    >
+      <div className={styles.page}>
+        <div className={styles.header}>
+          <div className={styles.title}>{skill?.name}</div>
+          <div className={styles.meta}>
+            skill_name: {skill?.skill_name}
+            {skill?.description ? ` · ${skill.description}` : ''}
+          </div>
+        </div>
+        <Flex className={styles.body}>
+          <div className={styles.treePane}>
+            <div className={styles.paneTitle}>
+              {$i18n.get({
+                id: 'main.pages.Component.Skill.fileTree',
+                dm: '文件树',
+              })}
+            </div>
+            {treeData.length ? (
+              <Tree
+                showIcon
+                treeData={treeData}
+                selectedKeys={selectedPath ? [selectedPath] : []}
+                expandedKeys={expandedKeys}
+                onExpand={(keys) => setExpandedKeys(keys)}
+                onSelect={(keys, info) => {
+                  if (!info.node.isLeaf) return;
+                  const key = String(keys[0] || '');
+                  if (key) loadFile(key);
+                }}
+              />
+            ) : (
+              <Empty
+                title={$i18n.get({
+                  id: 'main.pages.Component.Skill.noFiles',
+                  dm: '暂无文件',
+                })}
+              />
+            )}
+          </div>
+          <div className={styles.contentPane}>
+            <div className={styles.paneTitle}>
+              {selectedPath ||
+                $i18n.get({
+                  id: 'main.pages.Component.Skill.selectFile',
+                  dm: '选择文件查看内容',
+                })}
+            </div>
+            {contentLoading ? (
+              <div className={styles.contentLoading}>
+                <Spin />
+              </div>
+            ) : fileContent?.is_binary ? (
+              <Empty
+                title={$i18n.get({
+                  id: 'main.pages.Component.Skill.binaryFile',
+                  dm: '二进制文件，暂不支持预览',
+                })}
+                description={fileContent.path}
+              />
+            ) : fileContent?.content != null ? (
+              <Typography.Paragraph className={styles.code}>
+                <pre>{fileContent.content}</pre>
+              </Typography.Paragraph>
+            ) : (
+              <Empty
+                title={$i18n.get({
+                  id: 'main.pages.Component.Skill.selectFile',
+                  dm: '选择文件查看内容',
+                })}
+              />
+            )}
+          </div>
+        </Flex>
+      </div>
+    </InnerLayout>
+  );
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/index.module.less
@@ -1,0 +1,112 @@
+.grid {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  justify-content: stretch;
+  align-content: start;
+  gap: 20px;
+  margin: 0 0 20px;
+  width: 100%;
+  flex-wrap: unset !important;
+}
+
+.skillCard {
+  width: 100%;
+  min-height: 240px;
+  height: auto;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid var(--ag-ant-color-border-secondary);
+  background: var(--ag-ant-color-bg-container);
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+
+  &:hover {
+    border-color: var(--ag-ant-color-primary);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  }
+}
+
+.cardMain {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+}
+
+.logo {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ag-ant-color-fill-tertiary);
+  color: var(--ag-ant-color-primary);
+  font-size: 18px;
+}
+
+.headerText {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0 !important;
+  font-size: 15px !important;
+  font-weight: 600 !important;
+  line-height: 22px !important;
+  color: var(--ag-ant-color-text) !important;
+  max-width: 100%;
+}
+
+.skillName {
+  margin: 0 !important;
+  font-size: 12px !important;
+  line-height: 18px !important;
+  color: var(--ag-ant-color-text-tertiary) !important;
+  max-width: 100%;
+}
+
+.desc {
+  margin: 0 !important;
+  flex: 1;
+  min-height: 40px;
+  font-size: 13px !important;
+  line-height: 20px !important;
+  color: var(--ag-ant-color-text-secondary) !important;
+}
+
+.meta {
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--ag-ant-color-text-quaternary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--ag-ant-color-border-secondary);
+  flex-shrink: 0;
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/Skill/index.tsx
@@ -1,0 +1,223 @@
+import CardList from '@/components/Card/List';
+import { useInnerLayout } from '@/components/InnerLayout/utils';
+import $i18n from '@/i18n';
+import { createSkill, listSkills } from '@/services/skill';
+import { IPagingList, ISkill } from '@/types/skill';
+import {
+  Button,
+  IconFont,
+  Input,
+  message,
+  Modal,
+} from '@spark-ai/design';
+import { useMount, useSetState } from 'ahooks';
+import { Flex, Form, Input as AntdInput, Upload } from 'antd';
+import type { UploadFile } from 'antd/es/upload/interface';
+import { memo, useState } from 'react';
+import SkillCard from './Card';
+import styles from './index.module.less';
+
+export const CreateSkillBtn = memo((props: { onSuccess?: () => void }) => {
+  const [open, setOpen] = useState(false);
+  const [form] = Form.useForm();
+  const [fileList, setFileList] = useState<UploadFile[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleOk = async () => {
+    const values = await form.validateFields();
+    const file = fileList[0]?.originFileObj as File | undefined;
+    if (!file) {
+      message.warning(
+        $i18n.get({
+          id: 'main.pages.Component.Skill.uploadZipRequired',
+          dm: '请上传包含 SKILL.md 的 zip 包',
+        }),
+      );
+      return;
+    }
+    setLoading(true);
+    try {
+      await createSkill({
+        file,
+        name: values.name,
+        description: values.description,
+      });
+      message.success(
+        $i18n.get({
+          id: 'main.pages.Component.Skill.createSuccess',
+          dm: '技能创建成功',
+        }),
+      );
+      setOpen(false);
+      form.resetFields();
+      setFileList([]);
+      props.onSuccess?.();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        type="primary"
+        icon={<IconFont type="spark-plus-line" />}
+        onClick={() => setOpen(true)}
+      >
+        {$i18n.get({
+          id: 'main.pages.Component.Skill.uploadSkill',
+          dm: '上传技能',
+        })}
+      </Button>
+      <Modal
+        title={$i18n.get({
+          id: 'main.pages.Component.Skill.uploadSkill',
+          dm: '上传技能',
+        })}
+        open={open}
+        onCancel={() => setOpen(false)}
+        onOk={handleOk}
+        confirmLoading={loading}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical">
+          <Form.Item
+            label={$i18n.get({
+              id: 'main.pages.Component.Skill.zipPackage',
+              dm: '技能包 (zip)',
+            })}
+            required
+          >
+            <Upload
+              accept=".zip"
+              maxCount={1}
+              fileList={fileList}
+              beforeUpload={() => false}
+              onChange={({ fileList: next }) => setFileList(next)}
+            >
+              <Button>
+                {$i18n.get({
+                  id: 'main.pages.Component.Skill.selectZip',
+                  dm: '选择 zip 文件',
+                })}
+              </Button>
+            </Upload>
+          </Form.Item>
+          <Form.Item
+            name="name"
+            label={$i18n.get({
+              id: 'main.pages.Component.Skill.displayName',
+              dm: '展示名称（可选）',
+            })}
+          >
+            <Input
+              placeholder={$i18n.get({
+                id: 'main.pages.Component.Skill.displayNamePlaceholder',
+                dm: '默认使用 SKILL.md 中的 name',
+              })}
+            />
+          </Form.Item>
+          <Form.Item
+            name="description"
+            label={$i18n.get({
+              id: 'main.pages.Component.Skill.displayDesc',
+              dm: '描述（可选）',
+            })}
+          >
+            <AntdInput.TextArea rows={3} />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+});
+
+export default function SkillList() {
+  const { rightPortal } = useInnerLayout();
+  const [state, setState] = useSetState<{
+    list: ISkill[];
+    pageNo: number;
+    pageSize: number;
+    total: number;
+    loading: boolean;
+    name: string;
+  }>({
+    list: [],
+    pageNo: 1,
+    pageSize: 50,
+    total: 0,
+    loading: false,
+    name: '',
+  });
+
+  const fetchList = async (
+    extraParams: Partial<{ pageNo: number; pageSize: number; name: string }> = {},
+  ) => {
+    setState({ loading: true });
+    try {
+      const queryParams = {
+        current: extraParams.pageNo ?? state.pageNo,
+        size: extraParams.pageSize ?? state.pageSize,
+        name: extraParams.name ?? state.name,
+      };
+      const response = await listSkills(queryParams);
+      const pagingData = response.data as IPagingList<ISkill>;
+      setState({
+        list: pagingData.records || [],
+        total: pagingData.total || 0,
+        pageNo: queryParams.current,
+        pageSize: queryParams.size,
+      });
+    } finally {
+      setState({ loading: false });
+    }
+  };
+
+  useMount(() => {
+    fetchList();
+  });
+
+  return (
+    <>
+      {rightPortal(<CreateSkillBtn onSuccess={() => fetchList()} />)}
+      <Flex justify="space-between" align="center" className="mb-[24px]">
+        <Input
+          style={{ width: 240 }}
+          allowClear
+          prefix={<IconFont type="spark-search-line" />}
+          placeholder={$i18n.get({
+            id: 'main.pages.Component.Skill.searchPlaceholder',
+            dm: '搜索技能名称',
+          })}
+          onChange={(e) => {
+            const name = e.target.value;
+            setState({ name, pageNo: 1 });
+            fetchList({ name, pageNo: 1 });
+          }}
+        />
+      </Flex>
+      <CardList
+        className={styles.grid}
+        loading={state.loading}
+        pagination={{
+          current: state.pageNo,
+          total: state.total,
+          pageSize: state.pageSize,
+          onChange: (page, pageSize) =>
+            fetchList({ pageNo: page, pageSize }),
+        }}
+        emptyAction={<CreateSkillBtn onSuccess={() => fetchList()} />}
+        emptyProps={{
+          title: $i18n.get({
+            id: 'main.pages.Component.Skill.empty',
+            dm: '暂无技能，请上传包含 SKILL.md 的 zip 包',
+          }),
+        }}
+      >
+        {state.list.map((item) => (
+          <SkillCard key={item.skill_id} {...item} reload={() => fetchList()} />
+        ))}
+      </CardList>
+    </>
+  );
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Component/index.tsx
@@ -5,6 +5,7 @@ import { compact } from 'lodash-es';
 import { history, useParams } from 'umi';
 import AppComponent from './AppComponent';
 import PluginList from './Plugin/List';
+import SkillList from './Skill';
 
 const tabs = compact([
   process.env.BACK_END !== 'python' && {
@@ -14,6 +15,14 @@ const tabs = compact([
     }),
     key: 'plugin',
     children: <PluginList />,
+  },
+  process.env.BACK_END !== 'python' && {
+    label: $i18n.get({
+      id: 'main.pages.Component.index.skill',
+      dm: 'Skills',
+    }),
+    key: 'skill',
+    children: <SkillList />,
   },
   {
     label: $i18n.get({

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Knowledge/Detail/components/Search/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Knowledge/Detail/components/Search/index.module.less
@@ -1,7 +1,7 @@
 .search-container {
-  padding: 16px 20px;
+  padding: 16px 20px 24px;
   width: 100%;
-  height: 64px;
+  min-height: 64px;
   box-sizing: border-box;
 }
 

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Knowledge/List/components/Card/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Knowledge/List/components/Card/index.module.less
@@ -6,9 +6,12 @@
 }
 
 .update-time {
-  color: var(--ag-ant-color-text-secondary);
+  color: var(--ag-ant-color-text-tertiary);
   font-size: 12px;
   line-height: 20px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .document-count {

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Knowledge/List/index.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Knowledge/List/index.tsx
@@ -7,7 +7,6 @@ import { IGetKnowledgeListParams } from '@/types/knowledge';
 import { AlertDialog, Button, IconFont } from '@spark-ai/design';
 import { useMount, useSetState } from 'ahooks';
 import { Flex } from 'antd';
-import classNames from 'classnames';
 import { useRef } from 'react';
 import { history } from 'umi';
 import KnowledgeCard from './components/Card';
@@ -152,7 +151,7 @@ export default function () {
             })}
             value={state.name}
             onChange={(val) => setState({ name: val })}
-            className={classNames(styles['search'], 'mx-[20px] my-[16px]')}
+            className={styles['search']}
             onSearch={handleSearch}
           />
         )}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/MCP/Detail.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/MCP/Detail.module.less
@@ -1,3 +1,3 @@
 .tools-content {
-  padding: 40px 0;
+  padding: 16px 0 24px;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/MCP/Manage.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/MCP/Manage.module.less
@@ -1,3 +1,3 @@
 .container {
-  margin: 20px 0;
+  margin: 0;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/MCP/components/Overview/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/MCP/components/Overview/index.module.less
@@ -1,18 +1,23 @@
 .overview-container {
-  width: 80%;
-  max-width: 1200px;
-  padding: 40px 0;
+  width: 100%;
+  max-width: 960px;
+  padding: 16px 0 24px;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .loading {
-  padding: 24px;
+  padding: 24px 0;
   color: var(--ag-ant-color-text-secondary);
   font-size: 14px;
 }
 
 .info-item {
   margin-bottom: 20px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 
   .info-label {
     font-size: 14px;
@@ -39,7 +44,7 @@
 
   .code-container {
     overflow: auto;
-    width: 90%;
+    width: 100%;
 
     .code-block {
       padding: 0;

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/APIKeys/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/APIKeys/index.module.less
@@ -9,6 +9,10 @@
   }
 }
 
+.container {
+  padding-bottom: 8px;
+}
+
 .action-column {
   display: flex;
 

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/ModelService/Detail.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/ModelService/Detail.module.less
@@ -1,8 +1,9 @@
 .container {
-  width: 80%;
+  width: 100%;
   max-width: 960px;
   margin: 0 auto;
-  padding: 20px 0;
+  padding: 4px 0 24px;
+  box-sizing: border-box;
 }
 
 .info {

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/ModelService/components/ModelServiceCard/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/ModelService/components/ModelServiceCard/index.module.less
@@ -51,7 +51,11 @@
 
   .footer-desc-node {
     font-size: 12px;
-    color: var(--ag-ant-color-text-secondary);
+    line-height: 20px;
+    color: var(--ag-ant-color-text-tertiary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .provider-avatar {

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/ModelService/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/pages/Setting/ModelService/index.module.less
@@ -1,3 +1,3 @@
 .container {
-  padding: 20px 0;
+  padding: 4px 0 16px;
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/services/skill.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/services/skill.ts
@@ -1,0 +1,117 @@
+import { request } from '@/request';
+import { IApiResponse } from '@/types/common';
+import type {
+  IListSkillsParams,
+  IPagingList,
+  ISkill,
+  ISkillFileContent,
+  ISkillFileNode,
+} from '@/types/skill';
+
+export async function listSkills(
+  params: IListSkillsParams,
+): Promise<IApiResponse<IPagingList<ISkill>>> {
+  const response = await request({
+    url: '/console/v1/skills',
+    method: 'GET',
+    params,
+  });
+  return response.data as IApiResponse<IPagingList<ISkill>>;
+}
+
+export async function getSkill(
+  skillId: string,
+): Promise<IApiResponse<ISkill>> {
+  const response = await request({
+    url: `/console/v1/skills/${skillId}`,
+    method: 'GET',
+  });
+  return response.data as IApiResponse<ISkill>;
+}
+
+export async function listSkillFiles(
+  skillId: string,
+): Promise<IApiResponse<ISkillFileNode[]>> {
+  const response = await request({
+    url: `/console/v1/skills/${skillId}/files`,
+    method: 'GET',
+  });
+  return response.data as IApiResponse<ISkillFileNode[]>;
+}
+
+export async function readSkillFile(
+  skillId: string,
+  path: string,
+): Promise<IApiResponse<ISkillFileContent>> {
+  const response = await request({
+    url: `/console/v1/skills/${skillId}/file`,
+    method: 'GET',
+    params: { path },
+  });
+  return response.data as IApiResponse<ISkillFileContent>;
+}
+
+export async function deleteSkill(
+  skillId: string,
+): Promise<IApiResponse<null>> {
+  const response = await request({
+    url: `/console/v1/skills/${skillId}`,
+    method: 'DELETE',
+  });
+  return response.data as IApiResponse<null>;
+}
+
+export async function listSkillsByIds(
+  skillIds: string[],
+): Promise<IApiResponse<ISkill[]>> {
+  const response = await request({
+    url: '/console/v1/skills/query-by-ids',
+    method: 'POST',
+    data: skillIds,
+  });
+  return response.data as IApiResponse<ISkill[]>;
+}
+
+export async function createSkill(params: {
+  file: File;
+  name?: string;
+  description?: string;
+}): Promise<IApiResponse<string>> {
+  const formData = new FormData();
+  formData.append('file', params.file);
+  if (params.name) formData.append('name', params.name);
+  if (params.description) formData.append('description', params.description);
+
+  const response = await request({
+    url: '/console/v1/skills',
+    method: 'POST',
+    data: formData,
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+  return response.data as IApiResponse<string>;
+}
+
+export async function updateSkill(params: {
+  skillId: string;
+  file?: File;
+  name?: string;
+  description?: string;
+}): Promise<IApiResponse<null>> {
+  const formData = new FormData();
+  if (params.file) formData.append('file', params.file);
+  if (params.name) formData.append('name', params.name);
+  if (params.description !== undefined)
+    formData.append('description', params.description || '');
+
+  const response = await request({
+    url: `/console/v1/skills/${params.skillId}`,
+    method: 'PUT',
+    data: formData,
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+  return response.data as IApiResponse<null>;
+}

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/types/appManage.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/types/appManage.ts
@@ -6,6 +6,7 @@ import { IKnowledgeListItem } from './knowledge';
 import { IMcpServer } from './mcp';
 import { IModel } from './modelService';
 import { PluginTool } from './plugin';
+import { ISkill } from './skill';
 import { IBizEdge, IBizNode } from './workflow';
 
 // Application status mapping (keep i18n strings as is)
@@ -138,6 +139,7 @@ export interface IAssistantConfig {
     similarity_threshold?: number; // Similarity threshold
   };
   mcp_servers?: { id: string }[]; // MCP servers
+  skills?: { id: string }[]; // Agent skills
   agent_components?: string[]; // Agent components
   workflow_components?: string[]; // Workflow components
   modality_type?: ModalityType; // Interaction modality type
@@ -154,6 +156,7 @@ export interface IAssistantConfigWithInfos
     | 'model'
     | 'tools'
     | 'mcp_servers'
+    | 'skills'
     | 'agent_components'
     | 'workflow_components'
     | 'file_search'
@@ -161,6 +164,7 @@ export interface IAssistantConfigWithInfos
   model?: IModel;
   tools?: PluginTool[];
   mcp_servers?: IMcpServer[];
+  skills?: ISkill[];
   agent_components?: IAppComponentListItem[];
   workflow_components?: IAppComponentListItem[];
   file_search?: IAssistantConfig['file_search'] & {

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/types/chat.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/types/chat.ts
@@ -51,6 +51,8 @@ export interface IToolCall {
     | 'file_search_result' // File search result
     | 'mcp_tool_call' // MCP tool call
     | 'mcp_tool_result' // MCP tool result
+    | 'skill_tool_call'
+    | 'skill_tool_result'
     | 'component_tool_call' // Component call
     | 'component_tool_result'; // Component call result
 }

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/types/skill.ts
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/types/skill.ts
@@ -1,0 +1,41 @@
+export const SKILL_MAX_LIMIT = 10;
+
+export interface ISkill {
+  skill_id: string;
+  name: string;
+  description?: string;
+  skill_name: string;
+  storage_path?: string;
+  source?: string;
+  gmt_create?: string;
+  gmt_modified?: string;
+}
+
+export interface ISkillFileNode {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  size?: number;
+  children?: ISkillFileNode[];
+}
+
+export interface ISkillFileContent {
+  path: string;
+  content?: string;
+  is_binary?: boolean;
+  content_type?: string;
+  size?: number;
+}
+
+export interface IListSkillsParams {
+  current?: number;
+  size?: number;
+  name?: string;
+}
+
+export interface IPagingList<T> {
+  current: number;
+  size: number;
+  total: number;
+  records: T[];
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/BasicAgentExecutor.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/BasicAgentExecutor.java
@@ -35,14 +35,18 @@ import com.alibaba.cloud.ai.studio.runtime.domain.knowledgebase.DocumentChunk;
 import com.alibaba.cloud.ai.studio.runtime.utils.JsonUtils;
 import com.alibaba.cloud.ai.studio.core.base.service.McpServerService;
 import com.alibaba.cloud.ai.studio.core.base.service.PluginService;
+import com.alibaba.cloud.ai.studio.core.base.service.SkillService;
 import com.alibaba.cloud.ai.studio.core.base.service.ToolExecutionService;
 import com.alibaba.cloud.ai.studio.core.config.CommonConfig;
+import com.alibaba.cloud.ai.studio.core.config.StudioProperties;
 import com.alibaba.cloud.ai.studio.core.context.RequestContextHolder;
 import com.alibaba.cloud.ai.studio.core.model.llm.ModelFactory;
 import com.alibaba.cloud.ai.studio.core.base.manager.AppComponentManager;
 import com.alibaba.cloud.ai.studio.core.base.manager.DocumentRetrieverManager;
 import com.alibaba.cloud.ai.studio.core.base.manager.FileManager;
 import com.alibaba.cloud.ai.studio.core.rag.advisor.KnowledgeBaseRetrievalAdvisor;
+import com.alibaba.cloud.ai.studio.core.agent.skill.SkillPromptSupport;
+import com.alibaba.cloud.ai.studio.core.agent.skill.WorkspaceSkillRegistry;
 import com.alibaba.cloud.ai.studio.core.agent.tool.AgentToolCallback;
 import com.alibaba.cloud.ai.studio.core.agent.tool.CompositeToolCallbackProvider;
 import com.alibaba.cloud.ai.studio.core.agent.tool.ToolArgumentsHelper;
@@ -130,6 +134,12 @@ public class BasicAgentExecutor extends AbstractAgentExecutor {
 
 	/** Manager for file operations */
 	private final FileManager fileManager;
+
+	/** Service for managing skills */
+	private final SkillService skillService;
+
+	/** Studio storage properties */
+	private final StudioProperties studioProperties;
 
 	/**
 	 * Executes the agent request in streaming mode
@@ -313,8 +323,10 @@ public class BasicAgentExecutor extends AbstractAgentExecutor {
 
 		List<Message> messages = new ArrayList<>();
 		List<ChatMessage> chatMessages = request.getMessages();
-		if (StringUtils.isNotBlank(config.getInstructions())
-				&& !MessageRole.SYSTEM.getValue().equals(chatMessages.get(0).getRole().getValue())) {
+		boolean hasSystemMessage = !CollectionUtils.isEmpty(chatMessages)
+				&& MessageRole.SYSTEM.getValue().equals(chatMessages.get(0).getRole().getValue());
+		boolean hasSkills = !CollectionUtils.isEmpty(config.getSkills());
+		if ((StringUtils.isNotBlank(config.getInstructions()) || hasSkills) && !hasSystemMessage) {
 			Message message = buildInstructions(context, config.getInstructions());
 			messages.add(message);
 		}
@@ -367,6 +379,17 @@ public class BasicAgentExecutor extends AbstractAgentExecutor {
 			}
 		}
 
+		// Progressive disclosure for attached skills
+		if (!CollectionUtils.isEmpty(config.getSkills())) {
+			List<String> skillIds = config.getSkills()
+				.stream()
+				.map(AgentConfig.SkillRef::getId)
+				.filter(Objects::nonNull)
+				.toList();
+			WorkspaceSkillRegistry registry = new WorkspaceSkillRegistry(studioProperties, skillService.getSkills(skillIds));
+			instructions = SkillPromptSupport.appendToInstructions(instructions, registry);
+		}
+
 		// Handle custom prompt variables
 		List<AgentConfig.PromptVariable> promptVariables = config.getPromptVariables();
 		Map<String, Object> map = new HashMap<>();
@@ -400,6 +423,10 @@ public class BasicAgentExecutor extends AbstractAgentExecutor {
 			return new SystemMessage(instructions);
 		}
 
+		// Avoid SystemPromptTemplate interpreting `{...}` inside skill prompt sections
+		if (map.isEmpty() || !CollectionUtils.isEmpty(config.getSkills())) {
+			return new SystemMessage(StringUtils.defaultString(instructions));
+		}
 		return new SystemPromptTemplate(instructions).createMessage(map);
 	}
 
@@ -656,7 +683,7 @@ public class BasicAgentExecutor extends AbstractAgentExecutor {
 	private CompositeToolCallbackProvider buildToolCallbackProvider(AgentConfig config,
 			Map<String, Object> extraParams) {
 		return new CompositeToolCallbackProvider(config, pluginService, toolExecutionService, mcpServerService,
-				appComponentManager, extraParams);
+				appComponentManager, skillService, studioProperties, extraParams);
 	}
 
 	private Flux<AgentResponse> processToolCallsRecursively(ChatClient.Builder chatClientBuilder, ChatResponse response,

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillMdParser.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillMdParser.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.agent.skill;
+
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses SKILL.md YAML frontmatter and body.
+ *
+ * @since 1.0.0.3
+ */
+public final class SkillMdParser {
+
+	private static final Pattern FRONTMATTER = Pattern.compile("^---\\s*\\n(.*?)\\n---\\s*\\n?(.*)$", Pattern.DOTALL);
+
+	private SkillMdParser() {
+	}
+
+	public static ParsedSkillMd parse(String content) {
+		if (StringUtils.isBlank(content)) {
+			throw new IllegalArgumentException("SKILL.md is empty");
+		}
+
+		Matcher matcher = FRONTMATTER.matcher(content.trim());
+		if (!matcher.matches()) {
+			throw new IllegalArgumentException("SKILL.md must start with YAML frontmatter (---)");
+		}
+
+		Map<String, String> meta = parseSimpleYaml(matcher.group(1));
+		String name = StringUtils.trimToNull(meta.get("name"));
+		String description = StringUtils.trimToNull(meta.get("description"));
+		if (name == null) {
+			throw new IllegalArgumentException("SKILL.md frontmatter missing required field: name");
+		}
+		if (description == null) {
+			throw new IllegalArgumentException("SKILL.md frontmatter missing required field: description");
+		}
+		if (name.length() > 64) {
+			throw new IllegalArgumentException("SKILL.md name exceeds 64 characters");
+		}
+
+		ParsedSkillMd parsed = new ParsedSkillMd();
+		parsed.setName(name);
+		parsed.setDescription(description);
+		parsed.setBody(matcher.group(2) == null ? "" : matcher.group(2).trim());
+		parsed.setRaw(content);
+		return parsed;
+	}
+
+	/**
+	 * Simple key: value YAML parser for flat string fields.
+	 */
+	private static Map<String, String> parseSimpleYaml(String yaml) {
+		Map<String, String> result = new HashMap<>();
+		String[] lines = yaml.split("\\n");
+		String currentKey = null;
+		StringBuilder multiline = null;
+		for (String line : lines) {
+			if (multiline != null) {
+				if (line.startsWith("  ") || line.startsWith("\t") || line.isBlank()) {
+					if (!line.isBlank()) {
+						if (multiline.length() > 0) {
+							multiline.append(' ');
+						}
+						multiline.append(line.trim());
+					}
+					continue;
+				}
+				result.put(currentKey, multiline.toString().trim());
+				multiline = null;
+				currentKey = null;
+			}
+
+			int idx = line.indexOf(':');
+			if (idx <= 0) {
+				continue;
+			}
+			String key = line.substring(0, idx).trim();
+			String value = line.substring(idx + 1).trim();
+			if (value.startsWith("|") || value.startsWith(">")) {
+				currentKey = key;
+				multiline = new StringBuilder();
+				continue;
+			}
+			if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+				value = value.substring(1, value.length() - 1);
+			}
+			result.put(key, value);
+		}
+		if (multiline != null && currentKey != null) {
+			result.put(currentKey, multiline.toString().trim());
+		}
+		return result;
+	}
+
+	@Data
+	public static class ParsedSkillMd {
+
+		private String name;
+
+		private String description;
+
+		private String body;
+
+		private String raw;
+
+	}
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillMetadata.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillMetadata.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.agent.skill;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.io.Serializable;
+
+/**
+ * Runtime skill metadata for progressive disclosure.
+ *
+ * @since 1.0.0.3
+ */
+@Data
+@Builder
+public class SkillMetadata implements Serializable {
+
+	private String skillId;
+
+	private String name;
+
+	private String description;
+
+	private String skillPath;
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillPackageUtils.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillPackageUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.agent.skill;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Zip helpers for skill package extraction with path traversal protection.
+ *
+ * @since 1.0.0.3
+ */
+public final class SkillPackageUtils {
+
+	public static final String SKILL_MD = "SKILL.md";
+
+	private SkillPackageUtils() {
+	}
+
+	public static void extractZip(InputStream zipStream, Path targetDir) throws IOException {
+		Files.createDirectories(targetDir);
+		try (ZipInputStream zis = new ZipInputStream(zipStream)) {
+			ZipEntry entry;
+			while ((entry = zis.getNextEntry()) != null) {
+				String name = entry.getName();
+				if (StringUtils.isBlank(name) || name.contains("..")) {
+					throw new IOException("Illegal zip entry path: " + name);
+				}
+				Path dest = targetDir.resolve(name).normalize();
+				if (!dest.startsWith(targetDir.normalize())) {
+					throw new IOException("Zip entry escapes target directory: " + name);
+				}
+				if (entry.isDirectory()) {
+					Files.createDirectories(dest);
+				}
+				else {
+					Files.createDirectories(dest.getParent());
+					try (OutputStream os = Files.newOutputStream(dest)) {
+						zis.transferTo(os);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Resolves the skill root directory that contains SKILL.md.
+	 */
+	public static Path resolveSkillRoot(Path extractDir) throws IOException {
+		Path direct = extractDir.resolve(SKILL_MD);
+		if (Files.isRegularFile(direct)) {
+			return extractDir;
+		}
+
+		Path nested = null;
+		try (Stream<Path> stream = Files.list(extractDir)) {
+			for (Path child : stream.toList()) {
+				if (Files.isDirectory(child) && Files.isRegularFile(child.resolve(SKILL_MD))) {
+					if (nested != null) {
+						throw new IOException("Multiple skill directories found; package must contain exactly one skill");
+					}
+					nested = child;
+				}
+			}
+		}
+		if (nested == null) {
+			throw new IOException("SKILL.md not found in package root or a single subdirectory");
+		}
+		return nested;
+	}
+
+	public static void deleteRecursively(Path path) throws IOException {
+		if (path == null || !Files.exists(path)) {
+			return;
+		}
+		try (Stream<Path> walk = Files.walk(path)) {
+			walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+				try {
+					Files.deleteIfExists(p);
+				}
+				catch (IOException ignored) {
+					// best effort
+				}
+			});
+		}
+	}
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillPromptSupport.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/SkillPromptSupport.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.agent.skill;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+
+/**
+ * Builds progressive-disclosure skill prompt sections.
+ *
+ * @since 1.0.0.3
+ */
+public final class SkillPromptSupport {
+
+	public static final String LOAD_INSTRUCTIONS = """
+			## Skill loading instructions
+			- The list above only contains skill name, description and skillPath.
+			- When a task matches a skill, call tool `read_skill` with skill_name (or skill_path) to load the full SKILL.md body.
+			- After loading a skill, you may call `read_skill_resource` with skill_name and a relative_path under that skill directory (e.g. references/guide.md) to read bundled files.
+			- Do not invent skill content; always load via tools when needed.
+			""".trim();
+
+	private SkillPromptSupport() {
+	}
+
+	public static String buildPromptSection(WorkspaceSkillRegistry registry) {
+		if (registry == null || registry.isEmpty()) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder();
+		sb.append("## Available skills\n");
+		List<SkillMetadata> skills = registry.listAll();
+		for (SkillMetadata skill : skills) {
+			sb.append("- name: ").append(skill.getName()).append('\n');
+			sb.append("  description: ").append(StringUtils.defaultString(skill.getDescription())).append('\n');
+			sb.append("  skillPath: ").append(skill.getSkillPath()).append('\n');
+		}
+		sb.append('\n').append(LOAD_INSTRUCTIONS);
+		return sb.toString();
+	}
+
+	public static String appendToInstructions(String instructions, WorkspaceSkillRegistry registry) {
+		String section = buildPromptSection(registry);
+		if (StringUtils.isBlank(section)) {
+			return instructions;
+		}
+		if (StringUtils.isBlank(instructions)) {
+			return section;
+		}
+		return instructions + "\n\n" + section;
+	}
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/WorkspaceSkillRegistry.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/skill/WorkspaceSkillRegistry.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.agent.skill;
+
+import com.alibaba.cloud.ai.studio.core.config.StudioProperties;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.Skill;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * In-memory skill registry scoped to skills attached to an agent.
+ *
+ * @since 1.0.0.3
+ */
+public class WorkspaceSkillRegistry {
+
+	private final Map<String, SkillMetadata> byName = new LinkedHashMap<>();
+
+	private final Map<String, SkillMetadata> byPath = new LinkedHashMap<>();
+
+	private final StudioProperties studioProperties;
+
+	public WorkspaceSkillRegistry(StudioProperties studioProperties, List<Skill> skills) {
+		this.studioProperties = studioProperties;
+		if (skills == null) {
+			return;
+		}
+		for (Skill skill : skills) {
+			if (skill == null || StringUtils.isBlank(skill.getSkillName())
+					|| StringUtils.isBlank(skill.getStoragePath())) {
+				continue;
+			}
+			Path absolute = resolveAbsolute(skill.getStoragePath());
+			SkillMetadata meta = SkillMetadata.builder()
+				.skillId(skill.getSkillId())
+				.name(skill.getSkillName())
+				.description(StringUtils.defaultString(skill.getDescription()))
+				.skillPath(absolute.toAbsolutePath().normalize().toString())
+				.build();
+			byName.put(meta.getName(), meta);
+			byPath.put(meta.getSkillPath(), meta);
+		}
+	}
+
+	public List<SkillMetadata> listAll() {
+		return Collections.unmodifiableList(new ArrayList<>(byName.values()));
+	}
+
+	public boolean isEmpty() {
+		return byName.isEmpty();
+	}
+
+	public Optional<SkillMetadata> get(String skillName) {
+		if (StringUtils.isBlank(skillName)) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(byName.get(skillName.trim()));
+	}
+
+	public Optional<SkillMetadata> getByPath(String skillPath) {
+		if (StringUtils.isBlank(skillPath)) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(byPath.get(Path.of(skillPath).toAbsolutePath().normalize().toString()));
+	}
+
+	public String readSkillContent(String skillName) throws IOException {
+		SkillMetadata meta = get(skillName)
+			.orElseThrow(() -> new IllegalStateException("Skill not found: " + skillName));
+		return readBody(meta);
+	}
+
+	public String readSkillContentByPath(String skillPath) throws IOException {
+		SkillMetadata meta = getByPath(skillPath)
+			.orElseThrow(() -> new IllegalStateException("Skill not found: " + skillPath));
+		return readBody(meta);
+	}
+
+	public String readSkillResource(String skillName, String relativePath) throws IOException {
+		SkillMetadata meta = get(skillName)
+			.orElseThrow(() -> new IllegalStateException("Skill not found: " + skillName));
+		if (StringUtils.isBlank(relativePath)) {
+			throw new IllegalArgumentException("relative_path is required");
+		}
+		if (relativePath.contains("..")) {
+			throw new IllegalArgumentException("relative_path must not contain '..'");
+		}
+
+		Path skillRoot = Path.of(meta.getSkillPath()).toAbsolutePath().normalize();
+		Path target = skillRoot.resolve(relativePath).normalize();
+		if (!target.startsWith(skillRoot)) {
+			throw new IllegalArgumentException("relative_path escapes skill directory");
+		}
+		if (!Files.isRegularFile(target)) {
+			throw new IllegalStateException("Resource not found: " + relativePath);
+		}
+		return Files.readString(target, StandardCharsets.UTF_8);
+	}
+
+	private String readBody(SkillMetadata meta) throws IOException {
+		Path skillMd = Path.of(meta.getSkillPath()).resolve(SkillPackageUtils.SKILL_MD);
+		if (!Files.isRegularFile(skillMd)) {
+			throw new IllegalStateException("SKILL.md not found for skill: " + meta.getName());
+		}
+		SkillMdParser.ParsedSkillMd parsed = SkillMdParser.parse(Files.readString(skillMd, StandardCharsets.UTF_8));
+		return parsed.getBody();
+	}
+
+	private Path resolveAbsolute(String relativeStoragePath) {
+		return Path.of(studioProperties.getStoragePath(), relativeStoragePath).toAbsolutePath().normalize();
+	}
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/tool/CompositeToolCallbackProvider.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/tool/CompositeToolCallbackProvider.java
@@ -16,17 +16,21 @@
 
 package com.alibaba.cloud.ai.studio.core.agent.tool;
 
-import com.alibaba.cloud.ai.studio.runtime.enums.AppComponentTypeEnum;
+import com.alibaba.cloud.ai.studio.core.agent.skill.WorkspaceSkillRegistry;
+import com.alibaba.cloud.ai.studio.core.base.manager.AppComponentManager;
+import com.alibaba.cloud.ai.studio.core.base.service.McpServerService;
+import com.alibaba.cloud.ai.studio.core.base.service.PluginService;
+import com.alibaba.cloud.ai.studio.core.base.service.SkillService;
+import com.alibaba.cloud.ai.studio.core.base.service.ToolExecutionService;
+import com.alibaba.cloud.ai.studio.core.config.StudioProperties;
 import com.alibaba.cloud.ai.studio.runtime.domain.app.AgentConfig;
 import com.alibaba.cloud.ai.studio.runtime.domain.mcp.McpQuery;
 import com.alibaba.cloud.ai.studio.runtime.domain.mcp.McpServerDetail;
 import com.alibaba.cloud.ai.studio.runtime.domain.mcp.McpTool;
 import com.alibaba.cloud.ai.studio.runtime.domain.plugin.Tool;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.Skill;
 import com.alibaba.cloud.ai.studio.runtime.domain.tool.ToolCallSchema;
-import com.alibaba.cloud.ai.studio.core.base.service.McpServerService;
-import com.alibaba.cloud.ai.studio.core.base.service.PluginService;
-import com.alibaba.cloud.ai.studio.core.base.service.ToolExecutionService;
-import com.alibaba.cloud.ai.studio.core.base.manager.AppComponentManager;
+import com.alibaba.cloud.ai.studio.runtime.enums.AppComponentTypeEnum;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,8 +45,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * A composite tool callback provider that manages and provides tool callbacks from
- * multiple sources: plugins, MCP servers, and application components.
+ * Composite tool callback provider for plugins, MCP, app components and skills.
  *
  * @since 1.0.0.3
  */
@@ -50,78 +53,72 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CompositeToolCallbackProvider implements ToolCallbackProvider {
 
-	/** Configuration for the agent */
 	private final AgentConfig agentConfig;
 
-	/** Service for managing plugins */
 	private final PluginService pluginService;
 
-	/** Service for executing tools */
 	private final ToolExecutionService toolExecutionService;
 
-	/** Service for managing MCP servers */
 	private final McpServerService mcpServerService;
 
-	/** Manager for application components */
 	private final AppComponentManager appComponentManager;
 
-	/** Additional parameters for tool execution */
+	private final SkillService skillService;
+
+	private final StudioProperties studioProperties;
+
 	@Getter
 	private final Map<String, Object> extraParams;
 
 	private List<ToolCallback> toolCallbacks;
 
+	private WorkspaceSkillRegistry skillRegistry;
+
 	@NotNull
 	@Override
 	public ToolCallback[] getToolCallbacks() {
-		// cache tool callbacks info for performance issue.
 		if (toolCallbacks != null) {
 			return toolCallbacks.toArray(new ToolCallback[0]);
 		}
 
 		toolCallbacks = new ArrayList<>();
 
-		// build plugin tools
 		List<AgentConfig.Tool> pluginTools = agentConfig.getTools();
 		if (!CollectionUtils.isEmpty(pluginTools)) {
-			List<ToolCallback> pluginToolCallbacks = buildPluginToolCallbacks(pluginTools);
-			addToolCallbacks(toolCallbacks, pluginToolCallbacks);
+			addToolCallbacks(toolCallbacks, buildPluginToolCallbacks(pluginTools));
 		}
 
-		// build mcp tools
 		List<AgentConfig.McpServer> mcpServers = agentConfig.getMcpServers();
 		if (!CollectionUtils.isEmpty(mcpServers)) {
-			List<ToolCallback> mcpToolCallbacks = buildMcpToolCallbacks(mcpServers);
-			addToolCallbacks(toolCallbacks, mcpToolCallbacks);
+			addToolCallbacks(toolCallbacks, buildMcpToolCallbacks(mcpServers));
 		}
 
-		// build agent components
 		List<String> agentComponents = agentConfig.getAgentComponents();
 		if (!CollectionUtils.isEmpty(agentComponents)) {
-			List<ToolCallback> agentComponentCallbacks = buildAppComponentCallbacks(agentComponents,
-					AppComponentTypeEnum.Agent);
-			addToolCallbacks(toolCallbacks, agentComponentCallbacks);
+			addToolCallbacks(toolCallbacks, buildAppComponentCallbacks(agentComponents, AppComponentTypeEnum.Agent));
 		}
 
-		// build workflow components
 		List<String> workflowComponents = agentConfig.getWorkflowComponents();
 		if (!CollectionUtils.isEmpty(workflowComponents)) {
-			List<ToolCallback> workflowComponentCallbacks = buildAppComponentCallbacks(workflowComponents,
-					AppComponentTypeEnum.Workflow);
-			addToolCallbacks(toolCallbacks, workflowComponentCallbacks);
+			addToolCallbacks(toolCallbacks,
+					buildAppComponentCallbacks(workflowComponents, AppComponentTypeEnum.Workflow));
+		}
+
+		List<AgentConfig.SkillRef> skills = agentConfig.getSkills();
+		if (!CollectionUtils.isEmpty(skills)) {
+			addToolCallbacks(toolCallbacks, buildSkillToolCallbacks(skills));
 		}
 
 		return toolCallbacks.toArray(new ToolCallback[0]);
 	}
 
-	/**
-	 * Validates that there are no duplicate tool names in the provided callbacks.
-	 * <p>
-	 * This method ensures that each tool has a unique name, which is required for proper
-	 * tool resolution and execution.
-	 * @param toolCallbacks the tool callbacks to validate
-	 * @throws IllegalStateException if duplicate tool names are found
-	 */
+	public WorkspaceSkillRegistry getSkillRegistry() {
+		if (skillRegistry == null && !CollectionUtils.isEmpty(agentConfig.getSkills())) {
+			getToolCallbacks();
+		}
+		return skillRegistry;
+	}
+
 	private void validateToolCallbacks(ToolCallback[] toolCallbacks) {
 		List<String> duplicateToolNames = ToolUtils.getDuplicateToolNames(toolCallbacks);
 		if (!duplicateToolNames.isEmpty()) {
@@ -130,25 +127,20 @@ public class CompositeToolCallbackProvider implements ToolCallbackProvider {
 		}
 	}
 
-	/**
-	 * Creates a list of tool callbacks based on the provided configuration and services.
-	 */
 	public static List<ToolCallback> toolCallbacks(AgentConfig config, PluginService pluginService,
 			ToolExecutionService toolExecutionService, McpServerService mcpServerService,
-			AppComponentManager appComponentManager, Map<String, Object> extraParams) {
+			AppComponentManager appComponentManager, SkillService skillService, StudioProperties studioProperties,
+			Map<String, Object> extraParams) {
 		CompositeToolCallbackProvider provider = new CompositeToolCallbackProvider(config, pluginService,
-				toolExecutionService, mcpServerService, appComponentManager, extraParams);
+				toolExecutionService, mcpServerService, appComponentManager, skillService, studioProperties,
+				extraParams);
 		ToolCallback[] toolCallbacks = provider.getToolCallbacks();
 		if (ArrayUtils.isEmpty(toolCallbacks)) {
 			return List.of();
 		}
-
 		return List.of(toolCallbacks);
 	}
 
-	/**
-	 * Adds new tool callbacks to the list, skipping any duplicates.
-	 */
 	private void addToolCallbacks(List<ToolCallback> toolCallbacks, List<ToolCallback> newToolCallbacks) {
 		Set<String> existingNames = toolCallbacks.stream()
 			.map(callback -> callback.getToolDefinition().name())
@@ -165,9 +157,6 @@ public class CompositeToolCallbackProvider implements ToolCallbackProvider {
 		}).forEach(toolCallbacks::add);
 	}
 
-	/**
-	 * Builds tool callbacks from plugin tools.
-	 */
 	private List<ToolCallback> buildPluginToolCallbacks(List<AgentConfig.Tool> pluginTools) {
 		List<String> toolIds = pluginTools.stream().map(AgentConfig.Tool::getId).toList();
 		if (CollectionUtils.isEmpty(toolIds)) {
@@ -179,17 +168,11 @@ public class CompositeToolCallbackProvider implements ToolCallbackProvider {
 			return List.of();
 		}
 
-		List<ToolCallback> toolCallbacks = new ArrayList<>();
-		tools.forEach(tool -> {
-			toolCallbacks.add(new PluginToolCallback(toolExecutionService, tool, extraParams));
-		});
-
-		return toolCallbacks;
+		List<ToolCallback> callbacks = new ArrayList<>();
+		tools.forEach(tool -> callbacks.add(new PluginToolCallback(toolExecutionService, tool, extraParams)));
+		return callbacks;
 	}
 
-	/**
-	 * Builds tool callbacks from MCP server tools.
-	 */
 	private List<ToolCallback> buildMcpToolCallbacks(List<AgentConfig.McpServer> mcpServers) {
 		if (CollectionUtils.isEmpty(mcpServers)) {
 			return List.of();
@@ -203,21 +186,17 @@ public class CompositeToolCallbackProvider implements ToolCallbackProvider {
 			return List.of();
 		}
 
-		List<ToolCallback> toolCallbacks = new ArrayList<>();
+		List<ToolCallback> callbacks = new ArrayList<>();
 		for (McpServerDetail mcpServerDetail : mcpServerDetails) {
 			if (!CollectionUtils.isEmpty(mcpServerDetail.getTools())) {
 				for (McpTool tool : mcpServerDetail.getTools()) {
-					toolCallbacks.add(new McpToolCallback(mcpServerService, mcpServerDetail, tool, extraParams));
+					callbacks.add(new McpToolCallback(mcpServerService, mcpServerDetail, tool, extraParams));
 				}
 			}
 		}
-
-		return toolCallbacks;
+		return callbacks;
 	}
 
-	/**
-	 * Builds tool callbacks from application components.
-	 */
 	private List<ToolCallback> buildAppComponentCallbacks(List<String> agentComponents,
 			AppComponentTypeEnum componentType) {
 		if (CollectionUtils.isEmpty(agentComponents)) {
@@ -229,13 +208,23 @@ public class CompositeToolCallbackProvider implements ToolCallbackProvider {
 			return List.of();
 		}
 
-		List<ToolCallback> toolCallbacks = new ArrayList<>();
-		toolCallSchemaMap.forEach((key, value) -> {
-			toolCallbacks
-				.add(new AppComponentToolCallback(appComponentManager, key, value, extraParams, componentType));
-		});
+		List<ToolCallback> callbacks = new ArrayList<>();
+		toolCallSchemaMap.forEach((key, value) -> callbacks
+			.add(new AppComponentToolCallback(appComponentManager, key, value, extraParams, componentType)));
+		return callbacks;
+	}
 
-		return toolCallbacks;
+	private List<ToolCallback> buildSkillToolCallbacks(List<AgentConfig.SkillRef> skillRefs) {
+		List<String> skillIds = skillRefs.stream().map(AgentConfig.SkillRef::getId).filter(Objects::nonNull).toList();
+		if (CollectionUtils.isEmpty(skillIds)) {
+			return List.of();
+		}
+		List<Skill> skills = skillService.getSkills(skillIds);
+		this.skillRegistry = new WorkspaceSkillRegistry(studioProperties, skills);
+		if (skillRegistry.isEmpty()) {
+			return List.of();
+		}
+		return List.of(new SkillToolCallback(skillRegistry), new SkillResourceToolCallback(skillRegistry));
 	}
 
 }

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/tool/SkillResourceToolCallback.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/tool/SkillResourceToolCallback.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.agent.tool;
+
+import com.alibaba.cloud.ai.studio.core.agent.skill.WorkspaceSkillRegistry;
+import com.alibaba.cloud.ai.studio.runtime.domain.chat.ToolCallType;
+import com.alibaba.cloud.ai.studio.runtime.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.metadata.ToolMetadata;
+
+/**
+ * Tool callback for reading files under a skill directory.
+ *
+ * @since 1.0.0.3
+ */
+@RequiredArgsConstructor
+public class SkillResourceToolCallback implements AgentToolCallback {
+
+	public static final String TOOL_NAME = "read_skill_resource";
+
+	private static final String DESCRIPTION = """
+			Reads a file under a skill directory by relative_path (e.g. references/guide.md).
+			Path traversal outside the skill root is rejected.
+			""";
+
+	private static final String INPUT_SCHEMA = """
+			{
+			  "type": "object",
+			  "properties": {
+			    "skill_name": {
+			      "type": "string",
+			      "description": "Skill name from the available skills list"
+			    },
+			    "relative_path": {
+			      "type": "string",
+			      "description": "Relative path under the skill directory"
+			    }
+			  },
+			  "required": ["skill_name", "relative_path"],
+			  "additionalProperties": false
+			}
+			""";
+
+	private final WorkspaceSkillRegistry skillRegistry;
+
+	@NotNull
+	@Override
+	public ToolDefinition getToolDefinition() {
+		return ToolDefinition.builder().name(TOOL_NAME).description(DESCRIPTION).inputSchema(INPUT_SCHEMA).build();
+	}
+
+	@NotNull
+	@Override
+	public String call(@NotNull String functionInput) {
+		try {
+			JsonNode node = JsonUtils.fromJson(functionInput);
+			String skillName = text(node, "skill_name", "skillName");
+			String relativePath = text(node, "relative_path", "relativePath");
+			if (StringUtils.isBlank(skillName) || StringUtils.isBlank(relativePath)) {
+				return "Error: skill_name and relative_path are required";
+			}
+			return skillRegistry.readSkillResource(skillName.trim(), relativePath.trim());
+		}
+		catch (Exception e) {
+			return "Error: " + e.getMessage();
+		}
+	}
+
+	@NotNull
+	@Override
+	public ToolMetadata getToolMetadata() {
+		return ToolMetadata.builder().returnDirect(false).build();
+	}
+
+	@Override
+	public String getId() {
+		return TOOL_NAME;
+	}
+
+	@Override
+	public ToolCallType getToolCallType() {
+		return ToolCallType.SKILL_TOOL_CALL;
+	}
+
+	private static String text(JsonNode node, String primary, String secondary) {
+		if (node == null) {
+			return null;
+		}
+		if (node.has(primary) && !node.get(primary).isNull()) {
+			return node.get(primary).asText();
+		}
+		if (node.has(secondary) && !node.get(secondary).isNull()) {
+			return node.get(secondary).asText();
+		}
+		return null;
+	}
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/tool/SkillToolCallback.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/agent/tool/SkillToolCallback.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.agent.tool;
+
+import com.alibaba.cloud.ai.studio.core.agent.skill.SkillMetadata;
+import com.alibaba.cloud.ai.studio.core.agent.skill.WorkspaceSkillRegistry;
+import com.alibaba.cloud.ai.studio.runtime.domain.chat.ToolCallType;
+import com.alibaba.cloud.ai.studio.runtime.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.metadata.ToolMetadata;
+
+/**
+ * Tool callback for reading full SKILL.md content.
+ *
+ * @since 1.0.0.3
+ */
+@RequiredArgsConstructor
+public class SkillToolCallback implements AgentToolCallback {
+
+	public static final String TOOL_NAME = "read_skill";
+
+	private static final String DESCRIPTION = """
+			Reads the full content of a skill (SKILL.md body without frontmatter).
+			Provide skill_name and/or skill_path from the available skills list.
+			""";
+
+	private static final String INPUT_SCHEMA = """
+			{
+			  "type": "object",
+			  "properties": {
+			    "skill_name": {
+			      "type": "string",
+			      "description": "Skill name from the available skills list"
+			    },
+			    "skill_path": {
+			      "type": "string",
+			      "description": "Absolute skillPath from the available skills list"
+			    }
+			  },
+			  "additionalProperties": false
+			}
+			""";
+
+	private final WorkspaceSkillRegistry skillRegistry;
+
+	@NotNull
+	@Override
+	public ToolDefinition getToolDefinition() {
+		return ToolDefinition.builder().name(TOOL_NAME).description(DESCRIPTION).inputSchema(INPUT_SCHEMA).build();
+	}
+
+	@NotNull
+	@Override
+	public String call(@NotNull String functionInput) {
+		try {
+			JsonNode node = StringUtils.isBlank(functionInput) ? null : JsonUtils.fromJson(functionInput);
+			String skillName = text(node, "skill_name", "skillName");
+			String skillPath = text(node, "skill_path", "skillPath");
+			if (skillName == null && skillPath == null) {
+				return "Error: Either skill_name or skill_path is required";
+			}
+			if (skillName != null && skillPath != null) {
+				SkillMetadata byName = skillRegistry.get(skillName)
+					.orElseThrow(() -> new IllegalStateException("Skill not found: " + skillName));
+				SkillMetadata byPath = skillRegistry.getByPath(skillPath)
+					.orElseThrow(() -> new IllegalStateException("Skill not found: " + skillPath));
+				if (!byName.getName().equals(byPath.getName())) {
+					return "Error: skill_name and skill_path must refer to the same skill";
+				}
+				return skillRegistry.readSkillContent(byName.getName());
+			}
+			if (skillName != null) {
+				return skillRegistry.readSkillContent(skillName);
+			}
+			return skillRegistry.readSkillContentByPath(skillPath);
+		}
+		catch (Exception e) {
+			return "Error: " + e.getMessage();
+		}
+	}
+
+	@NotNull
+	@Override
+	public ToolMetadata getToolMetadata() {
+		return ToolMetadata.builder().returnDirect(false).build();
+	}
+
+	@Override
+	public String getId() {
+		return TOOL_NAME;
+	}
+
+	@Override
+	public ToolCallType getToolCallType() {
+		return ToolCallType.SKILL_TOOL_CALL;
+	}
+
+	private static String text(JsonNode node, String primary, String secondary) {
+		if (node == null) {
+			return null;
+		}
+		if (node.has(primary) && !node.get(primary).isNull()) {
+			String value = node.get(primary).asText();
+			return StringUtils.isBlank(value) ? null : value.trim();
+		}
+		if (node.has(secondary) && !node.get(secondary).isNull()) {
+			String value = node.get(secondary).asText();
+			return StringUtils.isBlank(value) ? null : value.trim();
+		}
+		return null;
+	}
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/constants/CacheConstants.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/constants/CacheConstants.java
@@ -34,6 +34,8 @@ public interface CacheConstants {
 	/** Cache key prefix for plugin and workspace */
 	String CACHE_PLUGIN_WORKSPACE_ID_PREFIX = "plugin:%s:%s";
 
+	String CACHE_SKILL_WORKSPACE_ID_PREFIX = "skill:%s:%s";
+
 	/** Cache key prefix for tool and workspace */
 	String CACHE_TOOL_WORKSPACE_ID_PREFIX = "tool:%s:%s";
 

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/entity/SkillEntity.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/entity/SkillEntity.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.base.entity;
+
+import com.alibaba.cloud.ai.studio.runtime.enums.SkillStatus;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.util.Date;
+
+/**
+ * Entity for agent skill.
+ *
+ * @since 1.0.0.3
+ */
+@Data
+@TableName("skill")
+public class SkillEntity {
+
+	@TableId(value = "id", type = IdType.AUTO)
+	private Long id;
+
+	@TableField("workspace_id")
+	private String workspaceId;
+
+	@TableField("skill_id")
+	private String skillId;
+
+	private String name;
+
+	private String description;
+
+	@TableField("skill_name")
+	private String skillName;
+
+	@TableField("storage_path")
+	private String storagePath;
+
+	private SkillStatus status;
+
+	private String source;
+
+	@TableField("gmt_create")
+	private Date gmtCreate;
+
+	@TableField("gmt_modified")
+	private Date gmtModified;
+
+	private String creator;
+
+	private String modifier;
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/mapper/SkillMapper.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/mapper/SkillMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.base.mapper;
+
+import com.alibaba.cloud.ai.studio.core.base.entity.SkillEntity;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+ * Mapper for skill table.
+ *
+ * @since 1.0.0.3
+ */
+public interface SkillMapper extends BaseMapper<SkillEntity> {
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/SkillService.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/SkillService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.base.service;
+
+import com.alibaba.cloud.ai.studio.runtime.domain.BaseQuery;
+import com.alibaba.cloud.ai.studio.runtime.domain.PagingList;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.Skill;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.SkillFileContent;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.SkillFileNode;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * Service for managing agent skills.
+ *
+ * @since 1.0.0.3
+ */
+public interface SkillService {
+
+	String createSkill(MultipartFile file, String name, String description);
+
+	void updateSkill(String skillId, MultipartFile file, String name, String description);
+
+	void deleteSkill(String skillId);
+
+	Skill getSkill(String skillId);
+
+	PagingList<Skill> listSkills(BaseQuery query);
+
+	List<Skill> getSkills(List<String> skillIds);
+
+	List<SkillFileNode> listSkillFiles(String skillId);
+
+	SkillFileContent readSkillFile(String skillId, String relativePath);
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/impl/SkillServiceImpl.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/base/service/impl/SkillServiceImpl.java
@@ -1,0 +1,449 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.core.base.service.impl;
+
+import com.alibaba.cloud.ai.studio.core.agent.skill.SkillMdParser;
+import com.alibaba.cloud.ai.studio.core.agent.skill.SkillPackageUtils;
+import com.alibaba.cloud.ai.studio.core.base.constants.CacheConstants;
+import com.alibaba.cloud.ai.studio.core.base.entity.SkillEntity;
+import com.alibaba.cloud.ai.studio.core.base.manager.RedisManager;
+import com.alibaba.cloud.ai.studio.core.base.mapper.SkillMapper;
+import com.alibaba.cloud.ai.studio.core.base.service.SkillService;
+import com.alibaba.cloud.ai.studio.core.config.StudioProperties;
+import com.alibaba.cloud.ai.studio.core.context.RequestContextHolder;
+import com.alibaba.cloud.ai.studio.core.utils.common.IdGenerator;
+import com.alibaba.cloud.ai.studio.runtime.domain.BaseQuery;
+import com.alibaba.cloud.ai.studio.runtime.domain.PagingList;
+import com.alibaba.cloud.ai.studio.runtime.domain.RequestContext;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.Skill;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.SkillFileContent;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.SkillFileNode;
+import com.alibaba.cloud.ai.studio.runtime.enums.ErrorCode;
+import com.alibaba.cloud.ai.studio.runtime.enums.SkillStatus;
+import com.alibaba.cloud.ai.studio.runtime.exception.BizException;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Skill service implementation.
+ *
+ * @since 1.0.0.3
+ */
+@Service
+public class SkillServiceImpl extends ServiceImpl<SkillMapper, SkillEntity> implements SkillService {
+
+	private final StudioProperties studioProperties;
+
+	private final RedisManager redisManager;
+
+	public SkillServiceImpl(StudioProperties studioProperties, RedisManager redisManager) {
+		this.studioProperties = studioProperties;
+		this.redisManager = redisManager;
+	}
+
+	@Override
+	public String createSkill(MultipartFile file, String name, String description) {
+		try {
+			RequestContext context = RequestContextHolder.getRequestContext();
+			validateZip(file);
+
+			String skillId = IdGenerator.idStr();
+			Path extractRoot = buildExtractRoot(context, skillId);
+			SkillMdParser.ParsedSkillMd parsed = unpackAndParse(file, extractRoot);
+
+			String displayName = StringUtils.defaultIfBlank(name, parsed.getName());
+			String displayDesc = StringUtils.defaultIfBlank(description, parsed.getDescription());
+
+			if (getBySkillName(context.getWorkspaceId(), parsed.getName()) != null) {
+				SkillPackageUtils.deleteRecursively(extractRoot);
+				throw new BizException(ErrorCode.SKILL_NAME_EXISTS.toError());
+			}
+			if (getByDisplayName(context.getWorkspaceId(), displayName) != null) {
+				SkillPackageUtils.deleteRecursively(extractRoot);
+				throw new BizException(ErrorCode.SKILL_NAME_EXISTS.toError());
+			}
+
+			SkillEntity entity = new SkillEntity();
+			entity.setSkillId(skillId);
+			entity.setWorkspaceId(context.getWorkspaceId());
+			entity.setName(displayName);
+			entity.setDescription(displayDesc);
+			entity.setSkillName(parsed.getName());
+			entity.setStoragePath(toRelativeStoragePath(extractRoot));
+			entity.setStatus(SkillStatus.NORMAL);
+			entity.setSource("user");
+			entity.setGmtCreate(new Date());
+			entity.setGmtModified(new Date());
+			entity.setCreator(context.getAccountId());
+			entity.setModifier(context.getAccountId());
+			this.save(entity);
+
+			redisManager.put(cacheKey(entity.getWorkspaceId(), entity.getSkillId()), entity);
+			return skillId;
+		}
+		catch (BizException e) {
+			throw e;
+		}
+		catch (Exception e) {
+			throw new BizException(ErrorCode.CREATE_SKILL_ERROR.toError(), e);
+		}
+	}
+
+	@Override
+	public void updateSkill(String skillId, MultipartFile file, String name, String description) {
+		try {
+			RequestContext context = RequestContextHolder.getRequestContext();
+			SkillEntity entity = getEntityById(context.getWorkspaceId(), skillId);
+			if (entity == null) {
+				throw new BizException(ErrorCode.SKILL_NOT_FOUND.toError());
+			}
+
+			if (file != null && !file.isEmpty()) {
+				validateZip(file);
+				Path extractRoot = resolveAbsolutePath(entity.getStoragePath());
+				SkillPackageUtils.deleteRecursively(extractRoot);
+				SkillMdParser.ParsedSkillMd parsed = unpackAndParse(file, extractRoot);
+
+				SkillEntity conflict = getBySkillName(context.getWorkspaceId(), parsed.getName());
+				if (conflict != null && !Objects.equals(conflict.getId(), entity.getId())) {
+					throw new BizException(ErrorCode.SKILL_NAME_EXISTS.toError());
+				}
+				entity.setSkillName(parsed.getName());
+				if (StringUtils.isBlank(name)) {
+					entity.setName(parsed.getName());
+				}
+				if (StringUtils.isBlank(description)) {
+					entity.setDescription(parsed.getDescription());
+				}
+			}
+
+			if (StringUtils.isNotBlank(name)) {
+				SkillEntity conflict = getByDisplayName(context.getWorkspaceId(), name);
+				if (conflict != null && !Objects.equals(conflict.getId(), entity.getId())) {
+					throw new BizException(ErrorCode.SKILL_NAME_EXISTS.toError());
+				}
+				entity.setName(name);
+			}
+			if (description != null) {
+				entity.setDescription(description);
+			}
+
+			entity.setGmtModified(new Date());
+			entity.setModifier(context.getAccountId());
+			this.updateById(entity);
+			redisManager.put(cacheKey(entity.getWorkspaceId(), entity.getSkillId()), entity);
+		}
+		catch (BizException e) {
+			throw e;
+		}
+		catch (Exception e) {
+			throw new BizException(ErrorCode.UPDATE_SKILL_ERROR.toError(), e);
+		}
+	}
+
+	@Override
+	public void deleteSkill(String skillId) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		SkillEntity entity = getEntityById(context.getWorkspaceId(), skillId);
+		if (entity == null) {
+			throw new BizException(ErrorCode.SKILL_NOT_FOUND.toError());
+		}
+		entity.setStatus(SkillStatus.DELETED);
+		entity.setGmtModified(new Date());
+		entity.setModifier(context.getAccountId());
+		this.updateById(entity);
+		redisManager.delete(cacheKey(entity.getWorkspaceId(), entity.getSkillId()));
+	}
+
+	@Override
+	public Skill getSkill(String skillId) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		SkillEntity entity = getEntityById(context.getWorkspaceId(), skillId);
+		if (entity == null) {
+			throw new BizException(ErrorCode.SKILL_NOT_FOUND.toError());
+		}
+		return toDto(entity);
+	}
+
+	@Override
+	public PagingList<Skill> listSkills(BaseQuery query) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		LambdaQueryWrapper<SkillEntity> wrapper = new LambdaQueryWrapper<>();
+		wrapper.eq(SkillEntity::getWorkspaceId, context.getWorkspaceId());
+		wrapper.ne(SkillEntity::getStatus, SkillStatus.DELETED.getStatus());
+		if (StringUtils.isNotBlank(query.getName())) {
+			wrapper.and(w -> w.like(SkillEntity::getName, query.getName())
+				.or()
+				.like(SkillEntity::getSkillName, query.getName()));
+		}
+		wrapper.orderByDesc(SkillEntity::getId);
+
+		Page<SkillEntity> page = new Page<>(query.getCurrent(), query.getSize());
+		IPage<SkillEntity> pageResult = this.page(page, wrapper);
+		List<Skill> skills = CollectionUtils.isEmpty(pageResult.getRecords()) ? new ArrayList<>()
+				: pageResult.getRecords().stream().map(this::toDto).toList();
+		return new PagingList<>(query.getCurrent(), query.getSize(), pageResult.getTotal(), skills);
+	}
+
+	@Override
+	public List<Skill> getSkills(List<String> skillIds) {
+		if (CollectionUtils.isEmpty(skillIds)) {
+			return List.of();
+		}
+		RequestContext context = RequestContextHolder.getRequestContext();
+		LambdaQueryWrapper<SkillEntity> wrapper = new LambdaQueryWrapper<>();
+		wrapper.eq(SkillEntity::getWorkspaceId, context.getWorkspaceId());
+		wrapper.in(SkillEntity::getSkillId, skillIds);
+		wrapper.ne(SkillEntity::getStatus, SkillStatus.DELETED.getStatus());
+		List<SkillEntity> entities = this.list(wrapper);
+		return entities.stream().map(this::toDto).toList();
+	}
+
+	@Override
+	public List<SkillFileNode> listSkillFiles(String skillId) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		SkillEntity entity = getEntityById(context.getWorkspaceId(), skillId);
+		if (entity == null) {
+			throw new BizException(ErrorCode.SKILL_NOT_FOUND.toError());
+		}
+		Path root = resolveAbsolutePath(entity.getStoragePath()).toAbsolutePath().normalize();
+		if (!Files.isDirectory(root)) {
+			throw new BizException(ErrorCode.SKILL_PACKAGE_INVALID.toError("skill storage directory not found"));
+		}
+		try {
+			return buildFileTree(root, root);
+		}
+		catch (IOException e) {
+			throw new BizException(ErrorCode.SYSTEM_ERROR.toError(), e);
+		}
+	}
+
+	@Override
+	public SkillFileContent readSkillFile(String skillId, String relativePath) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		SkillEntity entity = getEntityById(context.getWorkspaceId(), skillId);
+		if (entity == null) {
+			throw new BizException(ErrorCode.SKILL_NOT_FOUND.toError());
+		}
+		if (StringUtils.isBlank(relativePath) || relativePath.contains("..")) {
+			throw new BizException(ErrorCode.INVALID_PARAMS.toError("path", "invalid relative path"));
+		}
+		Path root = resolveAbsolutePath(entity.getStoragePath()).toAbsolutePath().normalize();
+		Path target = root.resolve(relativePath).normalize();
+		if (!target.startsWith(root) || !Files.isRegularFile(target)) {
+			throw new BizException(ErrorCode.FILE_NOT_FOUND.toError());
+		}
+		try {
+			long size = Files.size(target);
+			boolean binary = isBinaryFile(target);
+			String content = binary ? null : Files.readString(target, StandardCharsets.UTF_8);
+			String contentType = Files.probeContentType(target);
+			return SkillFileContent.builder()
+				.path(relativePath.replace('\\', '/'))
+				.content(content)
+				.binary(binary)
+				.contentType(contentType)
+				.size(size)
+				.build();
+		}
+		catch (IOException e) {
+			throw new BizException(ErrorCode.SYSTEM_ERROR.toError(), e);
+		}
+	}
+
+	private List<SkillFileNode> buildFileTree(Path root, Path current) throws IOException {
+		List<SkillFileNode> nodes = new ArrayList<>();
+		try (Stream<Path> stream = Files.list(current)) {
+			List<Path> children = stream.sorted(Comparator.comparing(p -> p.getFileName().toString().toLowerCase()))
+				.toList();
+			for (Path child : children) {
+				String relative = root.relativize(child).toString().replace('\\', '/');
+				if (Files.isDirectory(child)) {
+					nodes.add(SkillFileNode.builder()
+						.name(child.getFileName().toString())
+						.path(relative)
+						.type("directory")
+						.children(buildFileTree(root, child))
+						.build());
+				}
+				else if (Files.isRegularFile(child)) {
+					nodes.add(SkillFileNode.builder()
+						.name(child.getFileName().toString())
+						.path(relative)
+						.type("file")
+						.size(Files.size(child))
+						.build());
+				}
+			}
+		}
+		return nodes;
+	}
+
+	private boolean isBinaryFile(Path file) throws IOException {
+		String name = file.getFileName().toString().toLowerCase();
+		if (name.endsWith(".png") || name.endsWith(".jpg") || name.endsWith(".jpeg") || name.endsWith(".gif")
+				|| name.endsWith(".webp") || name.endsWith(".pdf") || name.endsWith(".zip") || name.endsWith(".gz")
+				|| name.endsWith(".jar") || name.endsWith(".class") || name.endsWith(".exe") || name.endsWith(".so")
+				|| name.endsWith(".dylib") || name.endsWith(".bin")) {
+			return true;
+		}
+		try (InputStream in = Files.newInputStream(file)) {
+			byte[] sample = in.readNBytes(8000);
+			for (byte b : sample) {
+				if (b == 0) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private SkillMdParser.ParsedSkillMd unpackAndParse(MultipartFile file, Path extractRoot) throws Exception {
+		try (InputStream in = file.getInputStream()) {
+			SkillPackageUtils.extractZip(in, extractRoot);
+		}
+		Path skillRoot;
+		try {
+			skillRoot = SkillPackageUtils.resolveSkillRoot(extractRoot);
+		}
+		catch (IOException e) {
+			SkillPackageUtils.deleteRecursively(extractRoot);
+			throw new BizException(ErrorCode.SKILL_PACKAGE_INVALID.toError(e.getMessage()));
+		}
+		// If nested, move contents up so storage_path points at skill root consistently
+		if (!skillRoot.equals(extractRoot)) {
+			Path staging = extractRoot.resolveSibling(extractRoot.getFileName() + "_staging");
+			SkillPackageUtils.deleteRecursively(staging);
+			Files.move(skillRoot, staging);
+			SkillPackageUtils.deleteRecursively(extractRoot);
+			Files.move(staging, extractRoot);
+			skillRoot = extractRoot;
+		}
+		String content = Files.readString(skillRoot.resolve(SkillPackageUtils.SKILL_MD), StandardCharsets.UTF_8);
+		try {
+			return SkillMdParser.parse(content);
+		}
+		catch (IllegalArgumentException e) {
+			SkillPackageUtils.deleteRecursively(extractRoot);
+			throw new BizException(ErrorCode.SKILL_PACKAGE_INVALID.toError(e.getMessage()));
+		}
+	}
+
+	private void validateZip(MultipartFile file) {
+		if (file == null || file.isEmpty()) {
+			throw new BizException(ErrorCode.MISSING_PARAMS.toError("file"));
+		}
+		String ext = FilenameUtils.getExtension(file.getOriginalFilename());
+		if (!"zip".equalsIgnoreCase(ext)) {
+			throw new BizException(ErrorCode.SKILL_PACKAGE_INVALID.toError("only .zip packages are supported"));
+		}
+	}
+
+	private Path buildExtractRoot(RequestContext context, String skillId) {
+		String relative = "skill" + File.separator + context.getAccountId() + File.separator + context.getWorkspaceId()
+				+ File.separator + skillId;
+		return Path.of(studioProperties.getStoragePath(), relative);
+	}
+
+	private String toRelativeStoragePath(Path absolute) {
+		Path storageRoot = Path.of(studioProperties.getStoragePath()).toAbsolutePath().normalize();
+		Path abs = absolute.toAbsolutePath().normalize();
+		return storageRoot.relativize(abs).toString().replace('\\', '/');
+	}
+
+	public Path resolveAbsolutePath(String relativeStoragePath) {
+		return Path.of(studioProperties.getStoragePath(), relativeStoragePath);
+	}
+
+	private SkillEntity getEntityById(String workspaceId, String skillId) {
+		String key = cacheKey(workspaceId, skillId);
+		SkillEntity cached = redisManager.get(key);
+		if (cached != null) {
+			if (Objects.equals(cached.getId(), CacheConstants.CACHE_EMPTY_ID)) {
+				return null;
+			}
+			if (cached.getStatus() == SkillStatus.DELETED) {
+				return null;
+			}
+			return cached;
+		}
+
+		LambdaQueryWrapper<SkillEntity> wrapper = new LambdaQueryWrapper<>();
+		wrapper.eq(SkillEntity::getWorkspaceId, workspaceId);
+		wrapper.eq(SkillEntity::getSkillId, skillId);
+		wrapper.ne(SkillEntity::getStatus, SkillStatus.DELETED.getStatus());
+		SkillEntity entity = this.getOne(wrapper);
+		if (entity != null) {
+			redisManager.put(key, entity);
+		}
+		return entity;
+	}
+
+	private SkillEntity getBySkillName(String workspaceId, String skillName) {
+		LambdaQueryWrapper<SkillEntity> wrapper = new LambdaQueryWrapper<>();
+		wrapper.eq(SkillEntity::getWorkspaceId, workspaceId);
+		wrapper.eq(SkillEntity::getSkillName, skillName);
+		wrapper.ne(SkillEntity::getStatus, SkillStatus.DELETED.getStatus());
+		return this.getOne(wrapper);
+	}
+
+	private SkillEntity getByDisplayName(String workspaceId, String name) {
+		LambdaQueryWrapper<SkillEntity> wrapper = new LambdaQueryWrapper<>();
+		wrapper.eq(SkillEntity::getWorkspaceId, workspaceId);
+		wrapper.eq(SkillEntity::getName, name);
+		wrapper.ne(SkillEntity::getStatus, SkillStatus.DELETED.getStatus());
+		return this.getOne(wrapper);
+	}
+
+	private Skill toDto(SkillEntity entity) {
+		return Skill.builder()
+			.skillId(entity.getSkillId())
+			.name(entity.getName())
+			.description(entity.getDescription())
+			.skillName(entity.getSkillName())
+			.storagePath(entity.getStoragePath())
+			.source(entity.getSource())
+			.gmtCreate(entity.getGmtCreate())
+			.gmtModified(entity.getGmtModified())
+			.build();
+	}
+
+	private String cacheKey(String workspaceId, String skillId) {
+		return String.format(CacheConstants.CACHE_SKILL_WORKSPACE_ID_PREFIX, workspaceId, skillId);
+	}
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/model/llm/ModelFactory.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/model/llm/ModelFactory.java
@@ -119,11 +119,13 @@ public class ModelFactory {
 		ModelCredential credential = getModelCredential(searchOptions.getRerankProvider(),
 				searchOptions.getRerankModel());
 
+		int topN = searchOptions.getTopK() != null ? searchOptions.getTopK() : 3;
+
 		return DashscopeReranker.builder()
 			.dashscopeApi(DashScopeApi.builder().apiKey(credential.getApiKey()).build())
 			.options(DashScopeRerankerOptions.builder()
 				.returnDocuments(false)
-				.topN(searchOptions.getTopK())
+				.topN(topN)
 				.model(searchOptions.getRerankModel())
 				.build())
 			.build();

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/app/AgentConfig.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/app/AgentConfig.java
@@ -57,6 +57,10 @@ public class AgentConfig implements AppConfig, Serializable {
 	@JsonProperty("mcp_servers")
 	private List<McpServer> mcpServers;
 
+	/** List of skills for the agent */
+	@JsonProperty("skills")
+	private List<SkillRef> skills;
+
 	/** List of agent component identifiers */
 	@JsonProperty("agent_components")
 	private List<String> agentComponents;
@@ -129,6 +133,15 @@ public class AgentConfig implements AppConfig, Serializable {
 
 		/** Type of the server */
 		private String type;
+
+	}
+
+	/** Configuration for agent skills */
+	@Data
+	public static class SkillRef implements Serializable {
+
+		/** Unique identifier for the skill */
+		private String id;
 
 	}
 

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/chat/ToolCallType.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/chat/ToolCallType.java
@@ -65,7 +65,15 @@ public enum ToolCallType {
 
 	/** Result of a file search operation */
 	@JsonProperty("file_search_result")
-	FILE_SEARCH_RESULT("file_search_result"),;
+	FILE_SEARCH_RESULT("file_search_result"),
+
+	/** Skill tool call type */
+	@JsonProperty("skill_tool_call")
+	SKILL_TOOL_CALL("skill_tool_call"),
+
+	/** Result of a skill tool call */
+	@JsonProperty("skill_tool_result")
+	SKILL_TOOL_RESULT("skill_tool_result"),;
 
 	/** The string value representing this tool call type */
 	private final String value;

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/component/AppComponentConfig.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/component/AppComponentConfig.java
@@ -17,6 +17,8 @@
 package com.alibaba.cloud.ai.studio.runtime.domain.component;
 
 import com.alibaba.cloud.ai.studio.runtime.enums.APIPluginValueSourceEnum;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.io.Serializable;
@@ -42,9 +44,13 @@ public class AppComponentConfig implements Serializable {
 	public static class Input {
 
 		/** User-defined parameters */
+		@JsonProperty("user_params")
+		@JsonAlias("userParams")
 		private List<UserParams> userParams = new ArrayList<>();
 
 		/** System-defined parameters */
+		@JsonProperty("system_params")
+		@JsonAlias("systemParams")
 		private List<Params> systemParams = new ArrayList<>();
 
 	}
@@ -82,6 +88,8 @@ public class AppComponentConfig implements Serializable {
 		private Boolean display = true;
 
 		/** Default value for the parameter */
+		@JsonProperty("default_value")
+		@JsonAlias("defaultValue")
 		private Object defaultValue;
 
 		/** Alternative name for the parameter */

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/skill/Skill.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/skill/Skill.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.runtime.domain.skill;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Agent skill domain model.
+ *
+ * @since 1.0.0.3
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Skill implements Serializable {
+
+	@JsonProperty("skill_id")
+	private String skillId;
+
+	private String name;
+
+	private String description;
+
+	@JsonProperty("skill_name")
+	private String skillName;
+
+	@JsonProperty("storage_path")
+	private String storagePath;
+
+	private String source = "user";
+
+	@JsonProperty("gmt_create")
+	private Date gmtCreate;
+
+	@JsonProperty("gmt_modified")
+	private Date gmtModified;
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/skill/SkillFileContent.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/skill/SkillFileContent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.runtime.domain.skill;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Skill file content response.
+ *
+ * @since 1.0.0.3
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SkillFileContent implements Serializable {
+
+	private String path;
+
+	private String content;
+
+	@JsonProperty("is_binary")
+	private boolean binary;
+
+	@JsonProperty("content_type")
+	private String contentType;
+
+	private Long size;
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/skill/SkillFileNode.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/domain/skill/SkillFileNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.runtime.domain.skill;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * File tree node for a skill package.
+ *
+ * @since 1.0.0.3
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SkillFileNode implements Serializable {
+
+	private String name;
+
+	/** Relative path from skill root, e.g. references/note.md */
+	private String path;
+
+	/** directory or file */
+	private String type;
+
+	private Long size;
+
+	@Builder.Default
+	private List<SkillFileNode> children = new ArrayList<>();
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/enums/ErrorCode.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/enums/ErrorCode.java
@@ -93,6 +93,19 @@ public enum ErrorCode {
 	BUILD_TOOL_RESULT_ERROR(500, RESPONSE_ERROR, "BuildToolResultError", "Failed to build tool result."),
 
 	/**
+	 * skill error code
+	 */
+	SKILL_NAME_EXISTS(400, INVALID_REQUEST_ERROR, "SkillNameExists", "Skill name already exists."),
+
+	CREATE_SKILL_ERROR(500, RESPONSE_ERROR, "CreateSkillError", "Failed to create skill."),
+
+	UPDATE_SKILL_ERROR(500, RESPONSE_ERROR, "UpdateSkillError", "Failed to update skill."),
+
+	SKILL_NOT_FOUND(404, RESPONSE_ERROR, "SkillNotFound", "Skill can not be found."),
+
+	SKILL_PACKAGE_INVALID(400, INVALID_REQUEST_ERROR, "SkillPackageInvalid", "Skill package is invalid, %s."),
+
+	/**
 	 * agent app error code
 	 */
 	CREATE_APP_ERROR(500, RESPONSE_ERROR, "CreateAppError", "Failed to create app."),

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/enums/SkillStatus.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-runtime/src/main/java/com/alibaba/cloud/ai/studio/runtime/enums/SkillStatus.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.runtime.enums;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Skill status enumeration.
+ *
+ * @since 1.0.0.3
+ */
+@Getter
+@AllArgsConstructor
+public enum SkillStatus {
+
+	@JsonProperty("deleted")
+	DELETED(0, "deleted"),
+
+	@JsonProperty("normal")
+	NORMAL(1, "normal");
+
+	@EnumValue
+	private final Integer status;
+
+	private final String value;
+
+}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/controller/SkillController.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/controller/SkillController.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.cloud.ai.studio.admin.builder.controller;
+
+import com.alibaba.cloud.ai.studio.core.base.service.SkillService;
+import com.alibaba.cloud.ai.studio.core.context.RequestContextHolder;
+import com.alibaba.cloud.ai.studio.runtime.domain.BaseQuery;
+import com.alibaba.cloud.ai.studio.runtime.domain.PagingList;
+import com.alibaba.cloud.ai.studio.runtime.domain.RequestContext;
+import com.alibaba.cloud.ai.studio.runtime.domain.Result;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.Skill;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.SkillFileContent;
+import com.alibaba.cloud.ai.studio.runtime.domain.skill.SkillFileNode;
+import com.alibaba.cloud.ai.studio.runtime.enums.ErrorCode;
+import com.alibaba.cloud.ai.studio.runtime.exception.BizException;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * REST APIs for agent skill management.
+ *
+ * @since 1.0.0.3
+ */
+@RestController
+@Tag(name = "skill")
+@RequestMapping("/console/v1/skills")
+public class SkillController {
+
+	private final SkillService skillService;
+
+	public SkillController(SkillService skillService) {
+		this.skillService = skillService;
+	}
+
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public Result<String> createSkill(@RequestPart("file") MultipartFile file,
+			@RequestParam(value = "name", required = false) String name,
+			@RequestParam(value = "description", required = false) String description) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		String skillId = skillService.createSkill(file, name, description);
+		return Result.success(context.getRequestId(), skillId);
+	}
+
+	@PutMapping(value = "/{skillId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public Result<Void> updateSkill(@PathVariable("skillId") String skillId,
+			@RequestPart(value = "file", required = false) MultipartFile file,
+			@RequestParam(value = "name", required = false) String name,
+			@RequestParam(value = "description", required = false) String description) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		if (StringUtils.isBlank(skillId)) {
+			throw new BizException(ErrorCode.MISSING_PARAMS.toError("skillId"));
+		}
+		skillService.updateSkill(skillId, file, name, description);
+		return Result.success(context.getRequestId(), null);
+	}
+
+	@DeleteMapping("/{skillId}")
+	public Result<Void> deleteSkill(@PathVariable("skillId") String skillId) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		if (Objects.isNull(skillId)) {
+			throw new BizException(ErrorCode.MISSING_PARAMS.toError("skillId"));
+		}
+		skillService.deleteSkill(skillId);
+		return Result.success(context.getRequestId(), null);
+	}
+
+	@GetMapping("/{skillId}")
+	public Result<Skill> getSkill(@PathVariable("skillId") String skillId) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		Skill skill = skillService.getSkill(skillId);
+		return Result.success(context.getRequestId(), skill);
+	}
+
+	@GetMapping("/{skillId}/files")
+	public Result<List<SkillFileNode>> listSkillFiles(@PathVariable("skillId") String skillId) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		List<SkillFileNode> files = skillService.listSkillFiles(skillId);
+		return Result.success(context.getRequestId(), files);
+	}
+
+	@GetMapping("/{skillId}/file")
+	public Result<SkillFileContent> readSkillFile(@PathVariable("skillId") String skillId,
+			@RequestParam("path") String path) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		if (StringUtils.isBlank(path)) {
+			throw new BizException(ErrorCode.MISSING_PARAMS.toError("path"));
+		}
+		SkillFileContent content = skillService.readSkillFile(skillId, path);
+		return Result.success(context.getRequestId(), content);
+	}
+
+	@GetMapping
+	public Result<PagingList<Skill>> listSkills(@ModelAttribute BaseQuery query) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		PagingList<Skill> skills = skillService.listSkills(query);
+		return Result.success(context.getRequestId(), skills);
+	}
+
+	@PostMapping("/query-by-ids")
+	public Result<List<Skill>> queryByIds(@RequestBody List<String> skillIds) {
+		RequestContext context = RequestContextHolder.getRequestContext();
+		List<Skill> skills = skillService.getSkills(skillIds);
+		return Result.success(context.getRequestId(), skills);
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add hybrid Skills management to Admin: DB schema, CRUD/ZIP upload APIs, workspace skill registry, and `read_skill` / `read_skill_resource` tools wired into the agent executor.
- Add frontend Skills list/detail UI plus skill selector on assistant config, with related layout/spacing polish.
- Add `docker/saa-admin` Compose stack (MySQL, ES, etc.) for local end-to-end Admin deployment, including skill storage volume and schema migration.

> Note: `spring-ai-alibaba/spring-ai-alibaba-admin` is archived; this PR targets the migrated tree under `spring-ai-alibaba-admin/` in this monorepo.

## Test plan
- [ ] `docker compose -f spring-ai-alibaba-admin/docker/saa-admin/docker-compose.yml up -d` brings up the stack and Admin UI is reachable
- [ ] Create/upload a Skill ZIP; list/detail and file tree render correctly
- [ ] Bind skills on an assistant; chat invokes skill tools and returns expected content
- [ ] Skill migration SQL applies cleanly on a fresh MySQL volume
- [ ] Admin frontend builds (`BACK_END=java npm run build:app` in admin frontend) without errors


Made with [Cursor](https://cursor.com)