### PR TITLE
fix(graph): support primitive arrays in append APIs

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/AppenderChannel.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/AppenderChannel.java
@@ -18,8 +18,8 @@ package com.alibaba.cloud.ai.graph.state;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -150,6 +150,15 @@ public class AppenderChannel<T> implements Channel<List<T>> {
 		}
 	}
 
+	private static List<Object> arrayToList(Object array) {
+		int length = Array.getLength(array);
+		List<Object> result = new ArrayList<>(length);
+		for (int i = 0; i < length; i++) {
+			result.add(Array.get(array, i));
+		}
+		return result;
+	}
+
 	/**
 	 * Represents a record for data removal operations with generic types.
 	 *
@@ -215,7 +224,7 @@ public class AppenderChannel<T> implements Channel<List<T>> {
 				list = (List<Object>) newValue;
 			}
 			else if (newValue.getClass().isArray()) {
-				list = Arrays.asList((T[]) newValue);
+				list = arrayToList(newValue);
 			}
 			if (list != null) {
 				if (list.isEmpty()) {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/state/strategy/AppendStrategy.java
@@ -19,8 +19,8 @@ import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.state.AppenderChannel;
 import com.alibaba.cloud.ai.graph.state.ReplaceAllWith;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +66,7 @@ public class AppendStrategy implements KeyStrategy {
 			list = new ArrayList<>((List<?>) newValue);
 		}
 		else if (newValue.getClass().isArray()) {
-			list = Arrays.asList((Object[]) newValue);
+			list = arrayToList(newValue);
 		}
 		else if (newValue instanceof Collection) {
 			list = new ArrayList<>((Collection<?>) newValue);
@@ -110,6 +110,15 @@ public class AppendStrategy implements KeyStrategy {
 			}
 			return arrayResult;
 		}
+	}
+
+	private static List<Object> arrayToList(Object array) {
+		int length = Array.getLength(array);
+		List<Object> result = new ArrayList<>(length);
+		for (int i = 0; i < length; i++) {
+			result.add(Array.get(array, i));
+		}
+		return result;
 	}
 
 	private static void removeFromList(List<Object> result, AppenderChannel.RemoveIdentifier<Object> removeIdentifier) {

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/PrimitiveArrayAppendTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/state/PrimitiveArrayAppendTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.state;
+
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PrimitiveArrayAppendTest {
+
+	@Test
+	void appendStrategySupportsPrimitiveArrays() {
+		AppendStrategy strategy = new AppendStrategy();
+
+		Object result = strategy.apply(List.of(0.5F), new float[] { 1.5F, 2.5F });
+
+		assertEquals(List.of(0.5F, 1.5F, 2.5F), result);
+	}
+
+	@Test
+	void appenderChannelSupportsPrimitiveArrays() {
+		AppenderChannel<Integer> channel = AppenderChannel.of(ArrayList::new);
+
+		Object result = channel.update("values", new ArrayList<>(List.of(1)), new int[] { 2, 3 });
+
+		assertEquals(List.of(1, 2, 3), result);
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

`AppendStrategy` and `AppenderChannel` treat arrays as appendable collections, but both cast every array to a reference array. Primitive arrays such as `float[]` embeddings or `int[]` state values therefore fail with `ClassCastException` instead of being appended.

This change converts arrays through `java.lang.reflect.Array`, which works for both primitive and reference arrays and preserves the existing boxed-list append semantics.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Replace the invalid `Object[]`/`T[]` casts with reflective array iteration.
- Apply the same behavior to both the current `AppendStrategy` API and the legacy/public `AppenderChannel` API.
- Add regression tests covering `float[]` and `int[]` inputs.

### Describe how to verify it

```bash
./mvnw -pl spring-ai-alibaba-graph-core -Dtest=PrimitiveArrayAppendTest test
./mvnw -pl spring-ai-alibaba-graph-core '-Dtest=!DatabaseStorePostgreSqlIntegrationTest' test
./mvnw -pl spring-ai-alibaba-graph-core -DskipTests spotless:check checkstyle:check package
```

The graph-core suite completed with 409 tests, 0 failures, and 0 errors after excluding the Docker-only PostgreSQL integration test.

### Special notes for reviews

No external service or model API is required to reproduce or verify this fix. Reference-array behavior remains unchanged.