### PR TITLE
docs(graph): clarify checkpoint resume semantics of invoke(Map, config)

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -640,7 +640,15 @@ public class CompiledGraph {
 
 	/**
 	 * Calls the graph execution and returns the final state.
-	 * 
+	 * <p>
+	 * Checkpoint semantics: when a checkpoint saver is configured, this method resumes from
+	 * a persisted checkpoint only when {@code config} explicitly requests it, either by
+	 * carrying a concrete checkpoint id ({@link RunnableConfig#withCheckPointId(String)}) or
+	 * by carrying resume metadata ({@link RunnableConfig#withResume()}). Calling
+	 * {@code invoke(Map.of(), config)} with neither reuses the persisted state but restarts
+	 * execution from {@code START}; use {@code invoke(Map.of(), config.withResume())} to
+	 * continue from the latest checkpoint's next node without knowing its id.
+	 *
 	 * @param inputs the input map
 	 * @param config the invoke configuration
 	 * @return an Optional containing the final state

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -83,6 +83,16 @@ public class GraphRunnerContext {
 		this.compiledGraph = compiledGraph;
 		this.config = config;
 
+		// Decide whether this run continues from a persisted checkpoint or starts over
+		// from START. A checkpoint is only resumed when the config explicitly asks for it,
+		// either by carrying a concrete checkpoint id or by carrying resume metadata
+		// (added via RunnableConfig.withResume() / RunnableConfig.builder(config).resume()).
+		//
+		// Note: passing a config that merely has a checkpoint saver / thread id (e.g.
+		// invoke(Map.of(), config) without a checkpoint id and without resume metadata)
+		// intentionally starts from START and only reuses the persisted state; it does NOT
+		// continue from the latest checkpoint's next node. To resume from the latest
+		// checkpoint without knowing its id, use config.withResume(). See RunnableConfig#withResume().
 		if (config.metadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY).isPresent() || config.checkPointId().isPresent()) {
 			initializeFromResume(initialState, config);
 		} else {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/RunnableConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/RunnableConfig.java
@@ -217,6 +217,19 @@ public final class RunnableConfig implements HasMetadata<RunnableConfig.Builder>
 	 * {@link #HUMAN_FEEDBACK_METADATA_KEY} with value {@code "placeholder"} to metadata.
 	 * Used when building a config for resuming a run (e.g. after human feedback is
 	 * collected and the graph is continued).
+	 * <p>
+	 * This is also the way to resume from the latest persisted checkpoint without knowing
+	 * its checkpoint id. A plain {@code invoke(Map.of(), config)} (config without a
+	 * checkpoint id and without resume metadata) reuses the persisted state but restarts
+	 * execution from {@code START}; adding this resume metadata makes the run continue from
+	 * the latest checkpoint's next node instead. For example:
+	 * <pre>{@code
+	 * // restarts from START, only the persisted state is reused
+	 * graph.invoke(Map.of(), config);
+	 *
+	 * // continues from the latest checkpoint's next node
+	 * graph.invoke(Map.of(), config.withResume());
+	 * }</pre>
 	 * @return a new RunnableConfig with human feedback placeholder metadata
 	 */
 	public RunnableConfig withResume() {
@@ -404,7 +417,10 @@ public final class RunnableConfig implements HasMetadata<RunnableConfig.Builder>
 		 * Adds resume metadata ({@link #HUMAN_FEEDBACK_METADATA_KEY} with value
 		 * {@code "placeholder"}) so the built config is suitable for resuming a run
 		 * (e.g. after human feedback). Equivalent to building and then calling
-		 * {@link RunnableConfig#withResume()}, but allows fluent builder usage.
+		 * {@link RunnableConfig#withResume()}, but allows fluent builder usage. This also
+		 * makes a subsequent {@code invoke}/{@code stream} continue from the latest
+		 * checkpoint's next node without an explicit checkpoint id; see
+		 * {@link RunnableConfig#withResume()} for details.
 		 * @return this builder for chaining
 		 */
 		public Builder resume() {


### PR DESCRIPTION
## What this PR does

Documents the existing checkpoint resume semantics that confused users in #4692. **No behavior change** — only Javadoc and inline comments are added.

## Background (#4692)

A user reported that `workflow.invoke(Map.of(), config)` with a `RedisSaver` restarts from the first node instead of resuming from the last checkpoint. As analyzed in the issue, this is not a `RedisSaver` bug:

- In `GraphRunnerContext`, a run only resumes from a persisted checkpoint's `nextNodeId` when the config carries a concrete `checkPointId` **or** resume metadata (added via `RunnableConfig.withResume()` / `RunnableConfig.builder(config).resume()`).
- Otherwise it reuses the persisted state but restarts from `START`.

Per maintainer @yuluo-yx's guidance in the issue, the preferred fix is to **document the API usage rather than change framework code** (multiple existing tests rely on `invoke(Map.of(), config)` restarting from `START`).

## Changes

- `GraphRunnerContext`: inline comment on the resume-vs-start branch explaining the two paths.
- `RunnableConfig#withResume()`: Javadoc now explains it is the way to resume from the latest checkpoint without a checkpoint id, with a before/after example.
- `RunnableConfig.Builder#resume()`: cross-reference added.
- `CompiledGraph#invoke(Map, RunnableConfig)`: Javadoc documents the checkpoint resume semantics and both usage forms.

## Testing

- `./mvnw -pl :spring-ai-alibaba-graph-core -am compile` passes.
- Docs-only change; no runtime behavior is affected.

Closes #4692

🤖 Generated with [Claude Code](https://claude.com/claude-code)