### PR TITLE
fix(core): upgrade fastjson 1.2.83 to 2.0.58 to address CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
         <!-- Json -->
         <gson.version>2.10.1</gson.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>2.0.58</fastjson.version>
 
         <okhttp.version>4.12.0</okhttp.version>
 

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/pom.xml
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/pom.xml
@@ -57,7 +57,7 @@
         <testcontainers.version>1.19.3</testcontainers.version>
         <httpclient.version>4.5.14</httpclient.version>
         <jackson.version>2.18.4</jackson.version>
-        <fastjson.version>1.2.83</fastjson.version>
+        <fastjson.version>2.0.58</fastjson.version>
         <docker-java.version>3.5.3</docker-java.version>
     </properties>
 


### PR DESCRIPTION
## Problem

fastjson `1.2.63`~`1.2.83` are affected by known deserialization CVEs (reported in #4867). The project still pins `fastjson.version` to `1.2.83` in two places:

- root `pom.xml`
- `spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/pom.xml`

## Fix

Bump both `fastjson.version` properties to `2.0.58`.

`com.alibaba:fastjson` 2.0.x is the **fastjson2 compatibility package** — it keeps the legacy `com.alibaba.fastjson.*` API (`JSON`, `JSONObject`, `JSONArray`, `TypeReference`, `parseObject/parseArray/toJSONString`), so this is a drop-in version bump with **no source changes** to the 14 call sites across `agent-framework`, `builtin-nodes`, `config-nacos`, and `a2a-nacos`.

This version is already proven in-tree: `spring-ai-alibaba-admin-server-start` ships `com.alibaba:fastjson:2.0.58` today and uses the same legacy API. The `config-nacos` and `a2a-nacos` starters inherit the fixed version transitively via `agent-framework`.

## Verification

- Affected modules compile.
- `builtin-nodes` + `config-nacos` test suites pass (92 tests, 0 failures).
- `agent-framework` A2A tests pass (22 tests, 0 failures).
- `grep 1.2.83` across all poms returns nothing; `dependency:tree` confirms `config-nacos` now resolves `com.alibaba:fastjson:2.0.58`.

Closes #4867

🤖 Generated with [Claude Code](https://claude.com/claude-code)