### PR TITLE
fix(graph): cap ParallelNode core pool size to prevent IllegalArgumentException on hosts with >100 CPU cores

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/ParallelNode.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/internal/node/ParallelNode.java
@@ -173,17 +173,35 @@ public class ParallelNode extends Node {
 	 * Calculate optimal core pool size based on system resources and workload characteristics.
 	 * For mixed IO/CPU workloads, 2x CPU cores is typically optimal.
 	 * Minimum of 4 threads to ensure reasonable parallelism on small systems.
+	 * The result is capped by {@link #calculateMaximumPoolSize(int)} so that the
+	 * {@code corePoolSize <= maximumPoolSize} invariant required by
+	 * {@link ThreadPoolExecutor} always holds.
 	 * 
 	 * @return optimal core pool size
 	 */
 	private static int calculateCorePoolSize() {
 		int cpuCores = Runtime.getRuntime().availableProcessors();
+		int finalCorePoolSize = calculateCorePoolSize(cpuCores);
+		logger.info("Calculated core pool size: {} (CPU cores: {})", finalCorePoolSize, cpuCores);
+		return finalCorePoolSize;
+	}
+
+	/**
+	 * Calculate optimal core pool size for the given number of CPU cores.
+	 * Visible for testing.
+	 * 
+	 * @param cpuCores number of available CPU cores
+	 * @return optimal core pool size, never greater than the maximum pool size
+	 */
+	static int calculateCorePoolSize(int cpuCores) {
 		// For mixed workloads, 2x CPU cores is typically optimal
 		int corePoolSize = cpuCores * 2;
 		// Ensure minimum of 4 threads for reasonable parallelism on small systems
 		int finalCorePoolSize = Math.max(corePoolSize, 4);
-		logger.info("Calculated core pool size: {} (CPU cores: {})", finalCorePoolSize, cpuCores);
-		return finalCorePoolSize;
+		// The maximum pool size is capped, so the core pool size must respect that cap too:
+		// ThreadPoolExecutor rejects corePoolSize > maximumPoolSize with IllegalArgumentException,
+		// which would break this class' static initializer on hosts with more than 100 CPU cores
+		return Math.min(finalCorePoolSize, calculateMaximumPoolSize(cpuCores));
 	}
 
 	/**
@@ -194,11 +212,22 @@ public class ParallelNode extends Node {
 	 */
 	private static int calculateMaximumPoolSize() {
 		int cpuCores = Runtime.getRuntime().availableProcessors();
-		// Allow for handling burst workloads with 4x CPU cores
-		// Cap at reasonable maximum to prevent resource exhaustion
-		int maxPoolSize = Math.min(cpuCores * 4, 200);
+		int maxPoolSize = calculateMaximumPoolSize(cpuCores);
 		logger.info("Calculated maximum pool size: {} (CPU cores: {})", maxPoolSize, cpuCores);
 		return maxPoolSize;
+	}
+
+	/**
+	 * Calculate maximum pool size for the given number of CPU cores.
+	 * Visible for testing.
+	 * 
+	 * @param cpuCores number of available CPU cores
+	 * @return maximum pool size
+	 */
+	static int calculateMaximumPoolSize(int cpuCores) {
+		// Allow for handling burst workloads with 4x CPU cores
+		// Cap at reasonable maximum to prevent resource exhaustion
+		return Math.min(cpuCores * 4, 200);
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/Issue4875ReproductionTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/internal/node/Issue4875ReproductionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.internal.node;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Issue #4875 Reproduction Test: ParallelNode's static initializer fails on hosts with
+ * more than 100 CPU cores.
+ *
+ * <p>The default executor was built with an unbounded core pool size
+ * ({@code max(cores * 2, 4)}) but a capped maximum pool size
+ * ({@code min(cores * 4, 200)}). For any host reporting more than 100 available
+ * processors the core pool size exceeds the maximum pool size, so
+ * {@link java.util.concurrent.ThreadPoolExecutor}'s constructor throws
+ * {@code IllegalArgumentException}. Because the executor is a static field, that failure
+ * surfaced as {@code ExceptionInInitializerError} and left the class permanently
+ * unusable for the lifetime of the JVM.
+ */
+class Issue4875ReproductionTest {
+
+	/**
+	 * The upper bound applied to the maximum pool size, see
+	 * {@code ParallelNode#calculateMaximumPoolSize(int)}.
+	 */
+	private static final int MAX_POOL_SIZE_CAP = 200;
+
+	@ParameterizedTest
+	@ValueSource(ints = { 1, 2, 4, 8, 16, 50, 100, 101, 128, 256, 512 })
+	void corePoolSizeNeverExceedsMaximumPoolSize(int cpuCores) {
+		int corePoolSize = ParallelNode.calculateCorePoolSize(cpuCores);
+		int maximumPoolSize = ParallelNode.calculateMaximumPoolSize(cpuCores);
+
+		assertTrue(corePoolSize <= maximumPoolSize,
+				"corePoolSize (" + corePoolSize + ") must not exceed maximumPoolSize (" + maximumPoolSize
+						+ ") for " + cpuCores + " CPU cores");
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 1, 2, 4, 8, 16, 50, 100, 101, 128, 256, 512 })
+	void threadPoolExecutorAcceptsTheCalculatedSizing(int cpuCores) {
+		int corePoolSize = ParallelNode.calculateCorePoolSize(cpuCores);
+		int maximumPoolSize = ParallelNode.calculateMaximumPoolSize(cpuCores);
+
+		assertDoesNotThrow(() -> new java.util.concurrent.ThreadPoolExecutor(corePoolSize, maximumPoolSize, 60L,
+				java.util.concurrent.TimeUnit.SECONDS, new java.util.concurrent.LinkedBlockingQueue<>(1000))
+			.shutdownNow(), "ThreadPoolExecutor rejected the sizing calculated for " + cpuCores + " CPU cores");
+	}
+
+	/**
+	 * Hosts with 100 cores or fewer were never affected; their sizing must stay exactly
+	 * as before so the fix does not silently change existing behaviour.
+	 */
+	@ParameterizedTest
+	@ValueSource(ints = { 1, 2, 4, 8, 16, 50, 100 })
+	void sizingIsUnchangedForHostsUpTo100Cores(int cpuCores) {
+		assertEquals(Math.max(cpuCores * 2, 4), ParallelNode.calculateCorePoolSize(cpuCores));
+		assertEquals(Math.min(cpuCores * 4, MAX_POOL_SIZE_CAP), ParallelNode.calculateMaximumPoolSize(cpuCores));
+	}
+
+	/**
+	 * Above the cap the core pool size saturates at the maximum pool size instead of
+	 * growing past it.
+	 */
+	@ParameterizedTest
+	@ValueSource(ints = { 101, 128, 256, 512 })
+	void corePoolSizeSaturatesAtTheCapForLargeHosts(int cpuCores) {
+		assertEquals(MAX_POOL_SIZE_CAP, ParallelNode.calculateCorePoolSize(cpuCores));
+		assertEquals(MAX_POOL_SIZE_CAP, ParallelNode.calculateMaximumPoolSize(cpuCores));
+	}
+
+	/**
+	 * Guards the actual regression: loading the class must not fail, whatever the core
+	 * count of the machine running the build happens to be.
+	 */
+	@Test
+	void classInitializationSucceeds() {
+		assertDoesNotThrow(() -> Class.forName(ParallelNode.class.getName()));
+	}
+
+}


### PR DESCRIPTION
Fixes #4875

### What this PR does

`ParallelNode`'s default executor is built from two independently computed values:

```java
corePoolSize    = Math.max(cores * 2, 4)        // no upper bound
maximumPoolSize = Math.min(cores * 4, 200)      // capped at 200
```

On hosts with **more than 100 CPU cores** the core pool size exceeds the capped maximum pool size (e.g. 128 cores → core = 256, max = 200). `ThreadPoolExecutor`'s constructor rejects `maximumPoolSize < corePoolSize` with `IllegalArgumentException`, and because `DEFAULT_EXECUTOR` is a static field the failure surfaces as `ExceptionInInitializerError`. From then on the class is permanently unusable in that JVM, and every parallel execution fails with `NoClassDefFoundError: Could not initialize class ...ParallelNode`.

This PR caps the core pool size by the maximum pool size, so the `corePoolSize <= maximumPoolSize` invariant always holds:

```java
finalCorePoolSize = Math.min(finalCorePoolSize, calculateMaximumPoolSize(cpuCores));
```

To make the sizing testable without depending on the number of cores of the build machine, both `calculateCorePoolSize()` and `calculateMaximumPoolSize()` were split into a no-arg method that reads `Runtime.getRuntime().availableProcessors()` and a package-private overload taking the core count. No public API is added and the calculation itself is unchanged apart from the new cap.

Behaviour is unchanged for hosts with 100 cores or fewer (`2 * cores <= 200` already holds there); only the previously broken >100-core case is affected, where the core pool size now saturates at 200 instead of being rejected.

### Why it matters

The failure is deterministic on large bare-metal hosts, and its symptoms are hard to diagnose: `NoClassDefFoundError` is an `Error`, so Reactor's `throwIfFatal` treats it as fatal and the error ends up dropped downstream. The reactive chain terminates without emitting anything, so the run dies silently and the caller simply hangs until an external timeout fires. We hit this in production on a 128-core server, where agent runs hung for 25+ minutes with no error surfaced to the client.

### How it was verified

**1. Reproduced the original failure** by loading `ParallelNode` from the released `spring-ai-alibaba-graph-core-1.1.2.0` jar under JDK 20 with a simulated core count:

```
$ java -XX:ActiveProcessorCount=128 -cp <graph-core + deps> Repro
availableProcessors = 128
INFO ...ParallelNode -- Calculated core pool size: 256 (CPU cores: 128)
INFO ...ParallelNode -- Calculated maximum pool size: 200 (CPU cores: 128)
RESULT: FAILED -> java.lang.ExceptionInInitializerError
  caused by: java.lang.IllegalArgumentException
    at java.base/java.util.concurrent.ThreadPoolExecutor.<init>(ThreadPoolExecutor.java:1311)
    at com.alibaba.cloud.ai.graph.internal.node.ParallelNode$3.<init>(ParallelNode.java:148)
    at com.alibaba.cloud.ai.graph.internal.node.ParallelNode.<clinit>(ParallelNode.java:135)
```

Boundary confirmed by the same harness: **100 cores → loads OK**, **101 cores → fails** (core = 202 > max = 200).

**2. Confirmed the fix** with the patched class on the same harness — 8 / 100 / 101 / 128 / 512 cores all load successfully, and the sizing for small hosts is untouched (8 cores → core = 16, max = 32, exactly as before). For >100 cores the core pool size now saturates at 200.

**3. Added `Issue4875ReproductionTest`** (in `com.alibaba.cloud.ai.graph.internal.node`, following the existing `IssueNNNNReproductionTest` convention), which:
  * asserts `corePoolSize <= maximumPoolSize` for core counts 1 … 512, including the 100/101 boundary;
  * feeds the calculated sizing into a real `ThreadPoolExecutor` to prove the constructor accepts it;
  * pins the sizing for ≤100 cores so the fix cannot silently change existing behaviour;
  * asserts that loading `ParallelNode` does not throw.

The test was executed with the JUnit Platform console launcher against both variants, to make sure it actually catches the regression:

| Variant | Result |
| --- | --- |
| With this fix | **34 tests successful, 0 failed** |
| Same code without the `Math.min` cap | **12 tests failed** (the 101 / 128 / 256 / 512-core cases) |

Note: I don't have a full local Maven environment for this repository, so `mvn clean package` / `checkstyle` / `spotless` were not run — the change follows the surrounding formatting (tabs, comment style) by hand, and the verification above was done by compiling the patched class and the new test directly against the module's jars. Please let CI validate the full build; I'll gladly follow up on any style or test feedback.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
