### PR TITLE
fix(admin): make sidebar menu scrollable

### DIFF
--- a/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/SideMenuLayout.tsx
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/SideMenuLayout.tsx
@@ -296,34 +296,40 @@ export default function SideMenuLayout({ children }: { children: React.ReactNode
               className="shadow-lg border-r border-gray-200"
               style={{ height: '100vh', position: 'fixed', left: 0, top: 0, bottom: 0 }}
             >
-              <div className="p-6 border-b border-gray-200">
-                <h1 className="text-xl font-bold text-gray-800 flex items-center whitespace-nowrap overflow-hidden">
-                  <SettingOutlined className="mr-1 text-blue-500" />
-                  {!collapsed && 'SAA Admin'}
-                </h1>
-              </div>
+              <div className={styles.sidebar}>
+                <div className={`${styles['sidebar-fixed-section']} p-6 border-b border-gray-200`}>
+                  <h1 className="text-xl font-bold text-gray-800 flex items-center whitespace-nowrap overflow-hidden">
+                    <SettingOutlined className="mr-1 text-blue-500" />
+                    {!collapsed && 'SAA Admin'}
+                  </h1>
+                </div>
 
-              <Menu
-                mode="inline"
-                selectedKeys={[selectedKey]}
-                defaultOpenKeys={collapsed ? [] : ['studio']}
-                items={menuItems}
-                onClick={handleMenuClick}
-                className="border-r-0 mt-6"
-                inlineCollapsed={collapsed}
-              />
+                <div className={styles['sidebar-menu']}>
+                  <Menu
+                    mode="inline"
+                    selectedKeys={[selectedKey]}
+                    defaultOpenKeys={collapsed ? [] : ['studio']}
+                    items={menuItems}
+                    onClick={handleMenuClick}
+                    className="border-r-0 mt-6"
+                    inlineCollapsed={collapsed}
+                  />
+                </div>
 
-              <div className="absolute bottom-0 left-0 right-0 border-t border-gray-200 bg-white">
                 <div
-                  className="flex items-center justify-center p-4 cursor-pointer hover:bg-gray-50 transition-colors"
-                  onClick={() => setCollapsed(!collapsed)}
+                  className={`${styles['sidebar-fixed-section']} border-t border-gray-200 bg-white`}
                 >
-                  {collapsed ? (
-                    <MenuUnfoldOutlined className="text-gray-600 text-lg" />
-                  ) : (
-                    <MenuFoldOutlined className="text-gray-600 text-lg" />
-                  )}
-                  {!collapsed && <span className="ml-2 text-gray-600">收起菜单</span>}
+                  <div
+                    className="flex items-center justify-center p-4 cursor-pointer hover:bg-gray-50 transition-colors"
+                    onClick={() => setCollapsed(!collapsed)}
+                  >
+                    {collapsed ? (
+                      <MenuUnfoldOutlined className="text-gray-600 text-lg" />
+                    ) : (
+                      <MenuFoldOutlined className="text-gray-600 text-lg" />
+                    )}
+                    {!collapsed && <span className="ml-2 text-gray-600">收起菜单</span>}
+                  </div>
                 </div>
               </div>
             </Sider>
@@ -351,4 +357,3 @@ export default function SideMenuLayout({ children }: { children: React.ReactNode
     </PureLayout>
   );
 }
-

--- a/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/index.module.less
+++ b/spring-ai-alibaba-admin/frontend/packages/main/src/layouts/index.module.less
@@ -43,6 +43,24 @@
   cursor: pointer;
 }
 
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.sidebar-menu {
+  flex: 1;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.sidebar-fixed-section {
+  flex: none;
+}
+
 .menu-list {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
### Describe what this PR does / why we need it

When several sidebar sections are expanded, the menu becomes taller than the viewport and lower navigation items cannot be reached. This change makes the navigation area independently scrollable while keeping the logo and collapse control visible.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Changed the sidebar content to a full-height flex column.
- Made the menu area fill the remaining height with vertical overflow enabled.
- Kept the header and collapse control as fixed-size flex sections instead of absolutely positioning the footer.

### Describe how to verify it

- Run `fnm exec --using=20.20.2 npm --workspace main run build` from `spring-ai-alibaba-admin/frontend`.
- Open several sidebar sections in a viewport shorter than the expanded menu and verify the menu can scroll to every item while the collapse control remains visible.

### Special notes for reviews

None.