### PR TITLE
fix(graph): remove unused MCP dependency

### DIFF
--- a/spring-ai-alibaba-graph-core/pom.xml
+++ b/spring-ai-alibaba-graph-core/pom.xml
@@ -189,11 +189,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
-            <artifactId>mcp</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>


### PR DESCRIPTION
### Describe what this PR does / why we need it

`spring-ai-alibaba-graph-core` no longer uses the MCP SDK directly. Keeping `io.modelcontextprotocol.sdk:mcp` as a compile dependency adds an unnecessary transitive dependency and retains version `0.14.0` in graph-core's dependency graph.

### Does this pull request fix one issue?

Fixes #4878

### Describe how you did it

Remove the unused direct `io.modelcontextprotocol.sdk:mcp` dependency from `spring-ai-alibaba-graph-core/pom.xml`.

No graph-core source imports or references MCP classes, so no source migration is needed.

### Describe how to verify it

```bash
JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.17-tem \
PATH=$HOME/.sdkman/candidates/java/17.0.17-tem/bin:$PATH \
./mvnw -pl spring-ai-alibaba-graph-core -am \
  -Dtest='*,!DatabaseStorePostgreSqlIntegrationTest' \
  -DfailIfNoTests=false test

JAVA_HOME=$HOME/.sdkman/candidates/java/17.0.17-tem \
PATH=$HOME/.sdkman/candidates/java/17.0.17-tem/bin:$PATH \
./mvnw -pl spring-ai-alibaba-graph-core -am \
  -DskipTests dependency:tree \
  -Dincludes=io.modelcontextprotocol.sdk:mcp

./mvnw -pl spring-ai-alibaba-graph-core -am \
  -DskipTests spotless:check checkstyle:check
```

本地结果：421 个测试通过，71 个 Docker/Testcontainers 相关用例因本机无 Docker 跳过；dependency tree 不再包含 MCP；Spotless、Checkstyle 和 `git diff --check` 均通过。

### Special notes for reviews

本 PR 只移除 graph-core 的直接依赖，不修改 `spring-ai-alibaba-starter-builtin-nodes` 或其他仍需要 MCP 的模块。
