### PR TITLE
fix(graph): compress Redis checkpoint payloads compatibly

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/redis/RedisSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/redis/RedisSaver.java
@@ -37,11 +37,14 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 import org.redisson.api.RBucket;
 import org.redisson.api.RLock;
 import org.redisson.api.RMap;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.ByteArrayCodec;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -63,6 +66,7 @@ public class RedisSaver implements BaseCheckpointSaver {
 	private static final String FIELD_THREAD_ID = "thread_id";
 	private static final String FIELD_IS_RELEASED = "is_released";
 	private static final String FIELD_THREAD_NAME = "thread_name";
+	private static final byte[] CHECKPOINT_FORMAT_MAGIC = { 'S', 'A', 'A', 'C', 1 };
 	private final Serializer<Checkpoint> checkpointSerializer;
 	private RedissonClient redisson;
 	private final long ttl;
@@ -94,33 +98,64 @@ public class RedisSaver implements BaseCheckpointSaver {
 		return new Builder();
 	}
 
-	private String serializeCheckpoints(List<Checkpoint> checkpoints) throws IOException {
-		try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			 ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+	private byte[] serializeCheckpoints(List<Checkpoint> checkpoints) throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		baos.write(CHECKPOINT_FORMAT_MAGIC);
+		try (GZIPOutputStream gzip = new GZIPOutputStream(baos);
+			 ObjectOutputStream oos = new ObjectOutputStream(gzip)) {
 			oos.writeInt(checkpoints.size());
 			for (Checkpoint checkpoint : checkpoints) {
 				checkpointSerializer.write(checkpoint, oos);
 			}
-			oos.flush();
-			byte[] bytes = baos.toByteArray();
-			return Base64.getEncoder().encodeToString(bytes);
+		}
+		return baos.toByteArray();
+	}
+
+	private LinkedList<Checkpoint> deserializeCheckpoints(String contentKey) throws IOException, ClassNotFoundException {
+		RBucket<byte[]> binaryBucket = redisson.getBucket(contentKey, ByteArrayCodec.INSTANCE);
+		byte[] content = binaryBucket.get();
+		if (content == null || content.length == 0) {
+			return new LinkedList<>();
+		}
+		if (hasVersionedHeader(content)) {
+			try (ByteArrayInputStream bais = new ByteArrayInputStream(content, CHECKPOINT_FORMAT_MAGIC.length,
+					content.length - CHECKPOINT_FORMAT_MAGIC.length);
+				 GZIPInputStream gzip = new GZIPInputStream(bais);
+				 ObjectInputStream ois = new ObjectInputStream(gzip)) {
+				return readCheckpoints(ois);
+			}
+		}
+
+		String legacyContent = redisson.<String>getBucket(contentKey).get();
+		if (legacyContent == null || legacyContent.isEmpty()) {
+			return new LinkedList<>();
+		}
+		byte[] legacyBytes = Base64.getDecoder().decode(legacyContent);
+		try (ByteArrayInputStream bais = new ByteArrayInputStream(legacyBytes);
+			 ObjectInputStream ois = new ObjectInputStream(bais)) {
+			return readCheckpoints(ois);
 		}
 	}
 
-	private LinkedList<Checkpoint> deserializeCheckpoints(String content) throws IOException, ClassNotFoundException {
-		if (content == null || content.isEmpty()) {
-			return new LinkedList<>();
+	private boolean hasVersionedHeader(byte[] content) {
+		if (content.length < CHECKPOINT_FORMAT_MAGIC.length) {
+			return false;
 		}
-		byte[] bytes = Base64.getDecoder().decode(content);
-		try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-			 ObjectInputStream ois = new ObjectInputStream(bais)) {
+		for (int i = 0; i < CHECKPOINT_FORMAT_MAGIC.length; i++) {
+			if (content[i] != CHECKPOINT_FORMAT_MAGIC[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private LinkedList<Checkpoint> readCheckpoints(ObjectInputStream ois) throws IOException, ClassNotFoundException {
 			int size = ois.readInt();
 			LinkedList<Checkpoint> checkpoints = new LinkedList<>();
 			for (int i = 0; i < size; i++) {
 				checkpoints.add(checkpointSerializer.read(ois));
 			}
 			return checkpoints;
-		}
 	}
 
 	/**
@@ -209,9 +244,7 @@ public class RedisSaver implements BaseCheckpointSaver {
 			}
 
 			// Use thread_id to query checkpoints
-			RBucket<String> bucket = redisson.getBucket(CHECKPOINT_PREFIX + threadId);
-			String content = bucket.get();
-			return deserializeCheckpoints(content);
+			return deserializeCheckpoints(CHECKPOINT_PREFIX + threadId);
 
 		}
 		catch (InterruptedException e) {
@@ -251,9 +284,7 @@ public class RedisSaver implements BaseCheckpointSaver {
 			}
 
 			// Use thread_id to query checkpoints
-			RBucket<String> bucket = redisson.getBucket(CHECKPOINT_PREFIX + threadId);
-			String content = bucket.get();
-			LinkedList<Checkpoint> checkpoints = deserializeCheckpoints(content);
+			LinkedList<Checkpoint> checkpoints = deserializeCheckpoints(CHECKPOINT_PREFIX + threadId);
 
 			if (config.checkPointId().isPresent()) {
 				return config.checkPointId()
@@ -298,9 +329,8 @@ public class RedisSaver implements BaseCheckpointSaver {
 			String threadId = getOrCreateThreadId(threadName);
 
 			// Use thread_id as key for checkpoint storage
-			RBucket<String> bucket = redisson.getBucket(CHECKPOINT_PREFIX + threadId);
-			String content = bucket.get();
-			LinkedList<Checkpoint> checkpoints = deserializeCheckpoints(content);
+			String contentKey = CHECKPOINT_PREFIX + threadId;
+			LinkedList<Checkpoint> checkpoints = deserializeCheckpoints(contentKey);
 
 			if (config.checkPointId().isPresent()) {
 				// Replace Checkpoint
@@ -317,6 +347,7 @@ public class RedisSaver implements BaseCheckpointSaver {
 				checkpoints.push(checkpoint);
 			}
 
+			RBucket<byte[]> bucket = redisson.getBucket(contentKey, ByteArrayCodec.INSTANCE);
 			bucket.set(serializeCheckpoints(checkpoints));
 			if (ttl > 0) {
 				bucket.expire(java.time.Duration.ofMillis(ttlUnit.toMillis(ttl)));
@@ -374,9 +405,7 @@ public class RedisSaver implements BaseCheckpointSaver {
 
 			// Get checkpoints for Tag (using thread_id)
 			String contentKey = CHECKPOINT_PREFIX + threadId;
-			RBucket<String> bucket = redisson.getBucket(contentKey);
-			String content = bucket.get();
-			Collection<Checkpoint> checkpoints = deserializeCheckpoints(content);
+			Collection<Checkpoint> checkpoints = deserializeCheckpoints(contentKey);
 
 			return new Tag(threadName, checkpoints);
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/RedisSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/RedisSaverTest.java
@@ -26,12 +26,18 @@ import com.alibaba.cloud.ai.graph.checkpoint.Checkpoint;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.redis.RedisSaver;
 import com.alibaba.cloud.ai.graph.serializer.AgentInstructionMessage;
+import com.alibaba.cloud.ai.graph.serializer.Serializer;
 import com.alibaba.cloud.ai.graph.serializer.StateSerializer;
+import com.alibaba.cloud.ai.graph.serializer.check_point.CheckPointSerializer;
 import com.alibaba.cloud.ai.graph.serializer.plain_text.jackson.SpringAIJacksonStateSerializer;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +56,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.ByteArrayCodec;
 import org.redisson.config.Config;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -867,5 +874,64 @@ class RedisSaverTest {
 
 		executorService.shutdown();
 		executorService.awaitTermination(5, TimeUnit.SECONDS);
+	}
+
+	@Test
+	void testReadsAndMigratesLegacyBase64Payload() throws Exception {
+		String threadName = "test-legacy-migration-" + UUID.randomUUID();
+		String storedThreadId = UUID.randomUUID().toString();
+		RunnableConfig config = RunnableConfig.builder().threadId(threadName).build();
+		String contentKey = "graph:checkpoint:content:" + storedThreadId;
+
+		redisson.<String, String>getMap("graph:thread:meta:" + threadName).put("thread_id", storedThreadId);
+		redisson.<String, String>getMap("graph:thread:meta:" + threadName).put("is_released", "false");
+
+		Checkpoint legacyCheckpoint = Checkpoint.builder()
+				.id("legacy")
+				.state(Map.of("content", "repetitive checkpoint content ".repeat(4096)))
+				.nodeId("node1")
+				.nextNodeId("node2")
+				.build();
+		String legacyPayload = serializeLegacyCheckpoints(List.of(legacyCheckpoint));
+		redisson.<String>getBucket(contentKey).set(legacyPayload);
+
+		List<Checkpoint> legacyResult = (List<Checkpoint>) redisSaver.list(config);
+		assertEquals(1, legacyResult.size());
+		assertEquals("legacy", legacyResult.get(0).getId());
+
+		Checkpoint currentCheckpoint = Checkpoint.builder()
+				.id("current")
+				.state(Map.of("content", "repetitive checkpoint content ".repeat(4096)))
+				.nodeId("node2")
+				.nextNodeId("node3")
+				.build();
+		redisSaver.put(config, currentCheckpoint);
+
+		byte[] migratedPayload = redisson.<byte[]>getBucket(contentKey, ByteArrayCodec.INSTANCE).get();
+		assertNotNull(migratedPayload);
+		assertEquals('S', migratedPayload[0]);
+		assertEquals('A', migratedPayload[1]);
+		assertEquals('A', migratedPayload[2]);
+		assertEquals('C', migratedPayload[3]);
+		assertEquals(1, migratedPayload[4]);
+		assertTrue(migratedPayload.length < legacyPayload.getBytes(StandardCharsets.UTF_8).length);
+
+		List<Checkpoint> migratedResult = (List<Checkpoint>) redisSaver.list(config);
+		assertEquals(2, migratedResult.size());
+		assertTrue(migratedResult.stream().anyMatch(checkpoint -> "legacy".equals(checkpoint.getId())));
+		assertTrue(migratedResult.stream().anyMatch(checkpoint -> "current".equals(checkpoint.getId())));
+	}
+
+	private static String serializeLegacyCheckpoints(List<Checkpoint> checkpoints) throws Exception {
+		Serializer<Checkpoint> checkpointSerializer = new CheckPointSerializer(serializer);
+		try (ByteArrayOutputStream output = new ByteArrayOutputStream();
+			 ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+			objectOutput.writeInt(checkpoints.size());
+			for (Checkpoint checkpoint : checkpoints) {
+				checkpointSerializer.write(checkpoint, objectOutput);
+			}
+			objectOutput.flush();
+			return Base64.getEncoder().encodeToString(output.toByteArray());
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- store Redis checkpoint lists as versioned GZIP-compressed binary payloads through `ByteArrayCodec`
- preserve existing Redis keys, thread metadata, locking, and TTL behavior
- detect and read legacy Base64 payloads through the Redisson client's original default codec
- migrate legacy payloads automatically on the next successful checkpoint write
- cover legacy reads, migration, payload integrity, and compression effectiveness

## Why

`RedisSaver` currently rewrites the complete checkpoint history into one Base64 string. Repetitive conversation state therefore consumes substantially more Redis memory and network bandwidth than necessary. Directly replacing Base64 with raw GZIP would break existing data, so the new payload carries an explicit magic/version header and retains a legacy read path.

## Compatibility

Existing checkpoint keys and metadata remain unchanged. New writes use the binary format. Existing Base64 values remain readable and are rewritten in the new format only after a successful `put`.

Closes #4811
Related to #4638

## Validation

- `DOCKER_HOST=unix://$HOME/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=RedisSaverTest -DCI=true test`
- Valkey 8.1.2 Testcontainers integration suite: 18 passed, 0 failed, 0 errors, 0 skipped
- module compilation, Checkstyle, and Spotless passed
- legacy Base64 read and migration to compressed binary storage passed