### PR TITLE
fix(graph): 修复 updateState 使用 asNode 时状态重复合并

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/CompiledGraph.java
@@ -374,7 +374,7 @@ public class CompiledGraph {
 			throw RunnableErrors.missingEdge.exception(nodeId);
 		}
 		if (route.id() != null) {
-			return new Command(route.id(), state);
+			return new Command(route.id());
 		}
 		if (route.value() != null) {
 			OverAllState derefState = stateGraph.getStateFactory().apply(state);
@@ -384,7 +384,7 @@ public class CompiledGraph {
 			if (edgeCondition.isMultiCommand()) {
 				// Multi-command action - route to ConditionalParallelNode
 				String conditionalParallelNodeId = ParallelNode.formatNodeId(nodeId);
-				return new Command(conditionalParallelNodeId, state);
+				return new Command(conditionalParallelNodeId);
 			} else {
 				// Single Command action
 				var singleAction = edgeCondition.singleAction();
@@ -396,8 +396,7 @@ public class CompiledGraph {
 					throw RunnableErrors.missingNodeInEdgeMapping.exception(nodeId, newRoute);
 				}
 
-				var currentState = OverAllState.updateState(state, command.update(), keyStrategyMap);
-				return new Command(result, currentState);
+				return new Command(result, command.update());
 			}
 		}
 		throw RunnableErrors.executionError.exception(format("invalid edge value for nodeId: [%s] !", nodeId));

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/InterruptionTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/InterruptionTest.java
@@ -17,10 +17,17 @@ package com.alibaba.cloud.ai.graph;
 
 import com.alibaba.cloud.ai.graph.action.AsyncNodeAction;
 import com.alibaba.cloud.ai.graph.action.AsyncNodeActionWithConfig;
+import com.alibaba.cloud.ai.graph.action.AsyncCommandAction;
+import com.alibaba.cloud.ai.graph.action.AsyncMultiCommandAction;
+import com.alibaba.cloud.ai.graph.action.Command;
 import com.alibaba.cloud.ai.graph.action.InterruptableAction;
 import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
+import com.alibaba.cloud.ai.graph.action.MultiCommand;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+import com.alibaba.cloud.ai.graph.state.StateSnapshot;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import com.alibaba.cloud.ai.graph.utils.EdgeMappings;
 
@@ -160,6 +167,111 @@ public class InterruptionTest {
 			.collectList()
 			.block();
 		assertIterableEquals(List.of("C", END), results);
+	}
+
+	@Test
+	void updateStateAsNodeShouldNotReappendExistingAppendState() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		KeyStrategyFactory keyStrategyFactory = () -> Map.of(
+				"messages", new AppendStrategy(),
+				"human_feedback", new ReplaceStrategy(),
+				"edge_updates", new AppendStrategy());
+
+		CompiledGraph workflow = new StateGraph(keyStrategyFactory)
+			.addNode("step_1", node_async((state, config) -> Map.of("messages", "Step 1")))
+			.addNode("human_feedback", node_async((state, config) -> Map.of()))
+			.addNode("step_3", node_async((state, config) -> Map.of("messages", "Step 3")))
+			.addEdge(START, "step_1")
+			.addEdge("step_1", "human_feedback")
+			.addConditionalEdges("human_feedback",
+					AsyncCommandAction.node_async((state, currentConfig) ->
+							new Command("next", Map.of("edge_updates", "recorded"))),
+					Map.of("next", "step_3", "wait", END))
+			.addEdge("step_3", END)
+			.compile(CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build())
+				.interruptBefore("human_feedback")
+				.build());
+
+		RunnableConfig config = RunnableConfig.builder().threadId("issue-4886").build();
+		workflow.stream(Map.of("messages", "build"), config).blockLast();
+
+		StateSnapshot checkpoint = workflow.lastStateOf(config).orElseThrow();
+		assertIterableEquals(List.of("build", "Step 1"),
+				(List<?>) checkpoint.state().value("messages").orElseThrow());
+
+		RunnableConfig updatedConfig = workflow.updateState(checkpoint.config(), Map.of("human_feedback", "next"),
+				"human_feedback");
+		StateSnapshot updatedCheckpoint = workflow.stateOf(updatedConfig).orElseThrow();
+
+		assertEquals(List.of("build", "Step 1"), updatedCheckpoint.state().value("messages").orElseThrow());
+		assertEquals("next", updatedCheckpoint.state().value("human_feedback").orElseThrow());
+		assertEquals(List.of("recorded"), updatedCheckpoint.state().value("edge_updates").orElseThrow());
+	}
+
+	@Test
+	void updateStateAsNodeShouldNotReappendExistingAppendStateForStaticEdge() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		KeyStrategyFactory keyStrategyFactory = () -> Map.of(
+				"messages", new AppendStrategy(),
+				"human_feedback", new ReplaceStrategy());
+
+		CompiledGraph workflow = new StateGraph(keyStrategyFactory)
+			.addNode("step_1", node_async((state, config) -> Map.of("messages", "Step 1")))
+			.addNode("human_feedback", node_async((state, config) -> Map.of()))
+			.addNode("step_3", node_async((state, config) -> Map.of("messages", "Step 3")))
+			.addEdge(START, "step_1")
+			.addEdge("step_1", "human_feedback")
+			.addEdge("human_feedback", "step_3")
+			.addEdge("step_3", END)
+			.compile(CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build())
+				.interruptBefore("human_feedback")
+				.build());
+
+		RunnableConfig config = RunnableConfig.builder().threadId("issue-4886-static").build();
+		workflow.stream(Map.of("messages", "build"), config).blockLast();
+
+		RunnableConfig updatedConfig = workflow.updateState(workflow.lastStateOf(config).orElseThrow().config(),
+				Map.of("human_feedback", "next"), "human_feedback");
+		StateSnapshot updatedCheckpoint = workflow.stateOf(updatedConfig).orElseThrow();
+
+		assertEquals(List.of("build", "Step 1"), updatedCheckpoint.state().value("messages").orElseThrow());
+		assertEquals("step_3", updatedConfig.nextNode().orElseThrow());
+	}
+
+	@Test
+	void updateStateAsNodeShouldNotReappendExistingAppendStateForMultiCommandRoute() throws Exception {
+		MemorySaver saver = MemorySaver.builder().build();
+		KeyStrategyFactory keyStrategyFactory = () -> Map.of(
+				"messages", new AppendStrategy(),
+				"human_feedback", new ReplaceStrategy());
+
+		CompiledGraph workflow = new StateGraph(keyStrategyFactory)
+			.addNode("step_1", node_async((state, config) -> Map.of("messages", "Step 1")))
+			.addNode("human_feedback", node_async((state, config) -> Map.of()))
+			.addNode("step_3", node_async((state, config) -> Map.of("messages", "Step 3")))
+			.addEdge(START, "step_1")
+			.addEdge("step_1", "human_feedback")
+			.addParallelConditionalEdges("human_feedback",
+					AsyncMultiCommandAction.node_async((state, currentConfig) ->
+							new MultiCommand(List.of("next"), Map.of("edge_update", "deferred"))),
+					Map.of("next", "step_3"))
+			.addEdge("step_3", END)
+			.compile(CompileConfig.builder()
+				.saverConfig(SaverConfig.builder().register(saver).build())
+				.interruptBefore("human_feedback")
+				.build());
+
+		RunnableConfig config = RunnableConfig.builder().threadId("issue-4886-multi").build();
+		workflow.stream(Map.of("messages", "build"), config).blockLast();
+
+		RunnableConfig updatedConfig = workflow.updateState(workflow.lastStateOf(config).orElseThrow().config(),
+				Map.of("human_feedback", "next"), "human_feedback");
+		StateSnapshot updatedCheckpoint = workflow.stateOf(updatedConfig).orElseThrow();
+
+		assertEquals(List.of("build", "Step 1"), updatedCheckpoint.state().value("messages").orElseThrow());
+		assertFalse(updatedCheckpoint.state().value("edge_update").isPresent());
 	}
 
 	/**


### PR DESCRIPTION
### 问题背景

在调用 `CompiledGraph.updateState(config, values, asNode)` 时，如果已有状态使用 `AppendStrategy`，指定 `asNode` 后可能导致已有数据被重复追加。

例如更新前：

```text
messages = ["build", "Step 1"]
```

执行三参数 `updateState` 后错误变为：

```text
messages = ["build", "Step 1", "build", "Step 1"]
```

### 根因

`updateState(..., asNode)` 会先更新 checkpoint，再根据 `asNode` 计算后续路由。

原实现中，路由计算返回的 `Command.update()` 携带的是已经合并后的完整 state snapshot。随后该结果又被作为 state delta 合并进 checkpoint，导致 `AppendStrategy` 对已有数据再次执行追加。

### 修复方案

统一保持 `Command.update()` 的增量语义，避免将完整 state 再次作为增量合并：

- 静态边只返回目标节点，不携带已有 state。
- 单条件边直接保留原始 `command.update()`。
- Multi-command 路由不携带已有 state，实际更新继续由 `ConditionalParallelNode` 处理。
- 增加 static、single conditional、multi-command 三种路由场景的回归测试，同时验证条件边自身的 update 不会丢失。

### 测试验证

相关 Graph 测试：

```bash
./mvnw -pl :spring-ai-alibaba-graph-core -Dtest=InterruptionTest,StateGraphMemorySaverTest,StateGraphTest,CompiledSubGraphTest test
```

```text
Tests run: 57, Failures: 0, Errors: 0, Skipped: 1
```

`graph-core` 模块测试：

```bash
./mvnw -pl :spring-ai-alibaba-graph-core '-Dtest=*,!DatabaseStorePostgreSqlIntegrationTest' test
```

```text
Tests run: 425, Failures: 0, Errors: 0, Skipped: 72
```

Checkstyle：0 violations。

### 影响范围

本次修改不涉及 public API，也不改变 `Checkpoint`、`OverAllState` 或 `AppendStrategy` 的全局语义，仅修正 `updateState(..., asNode)` 路由过程中的 state update 语义。

### 关联 Issue

关联 #4886。

本 PR 聚焦修复其中的状态重复问题，不调整 Issue 中另外提到的恢复节点选择行为。