### PR TITLE
fix(agent): Serialize persistent ShellSession command transactions

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManager.java
@@ -466,7 +466,7 @@ public class ShellSessionManager {
 			}
 		}
 
-		CommandResult execute(String command, long timeoutMs, int maxOutputLines, Long maxOutputBytes) {
+		synchronized CommandResult execute(String command, long timeoutMs, int maxOutputLines, Long maxOutputBytes) {
 			if (process == null || !process.isAlive()) {
 				throw new IllegalStateException("Shell session is not running");
 			}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tool/CancellableAsyncToolCallbackTest.java
@@ -118,6 +118,7 @@ class CancellableAsyncToolCallbackTest {
 			AtomicBoolean sawCancellation = new AtomicBoolean(false);
 			CountDownLatch toolStarted = new CountDownLatch(1);
 			CountDownLatch cancellationChecked = new CountDownLatch(1);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 
 			DefaultCancellationToken token = new DefaultCancellationToken();
 
@@ -141,29 +142,35 @@ class CancellableAsyncToolCallbackTest {
 						cancellationChecked.countDown();
 
 						return "result";
-					});
+					}, executor);
 				}
 			};
 
-			// Start the tool
-			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
+			try {
+				// Start the tool
+				CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// Wait for tool to start
-			assertTrue(toolStarted.await(1, TimeUnit.SECONDS));
+				// Wait for tool to start - allow longer under CI load
+				assertTrue(toolStarted.await(5, TimeUnit.SECONDS));
 
-			// Cancel the token
-			token.cancel();
+				// Cancel the token
+				token.cancel();
 
-			// Wait for tool to check cancellation
-			assertTrue(cancellationChecked.await(1, TimeUnit.SECONDS));
+				// Wait for tool to check cancellation
+				assertTrue(cancellationChecked.await(5, TimeUnit.SECONDS));
 
-			// Tool should have seen the cancellation
-			assertTrue(sawCancellation.get());
+				// Tool should have seen the cancellation
+				assertTrue(sawCancellation.get());
+			}
+			finally {
+				executor.shutdownNow();
+			}
 		}
 
 		@Test
 		@DisplayName("tool should be able to throw on cancellation check")
 		void tool_shouldThrowOnCancellationCheck() {
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 			DefaultCancellationToken token = new DefaultCancellationToken();
 			token.cancel(); // Pre-cancel
 
@@ -175,22 +182,27 @@ class CancellableAsyncToolCallbackTest {
 						// This should throw ToolCancelledException
 						cancellationToken.throwIfCancelled();
 						return "result";
-					});
+					}, executor);
 				}
 			};
 
-			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
-
-			// Wait for completion and check it completed exceptionally
 			try {
-				future.join();
-				// Should not reach here
-				assertTrue(false, "Expected exception to be thrown");
+				CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
+
+				// Wait for completion and check it completed exceptionally
+				try {
+					future.join();
+					// Should not reach here
+					assertTrue(false, "Expected exception to be thrown");
+				}
+				catch (Exception e) {
+					// Should complete exceptionally with ToolCancelledException wrapped in CompletionException
+					assertTrue(e instanceof java.util.concurrent.CompletionException);
+					assertTrue(e.getCause() instanceof ToolCancelledException);
+				}
 			}
-			catch (Exception e) {
-				// Should complete exceptionally with ToolCancelledException wrapped in CompletionException
-				assertTrue(e instanceof java.util.concurrent.CompletionException);
-				assertTrue(e.getCause() instanceof ToolCancelledException);
+			finally {
+				executor.shutdownNow();
 			}
 		}
 
@@ -199,6 +211,7 @@ class CancellableAsyncToolCallbackTest {
 		void onCancelCallback_shouldBeInvoked() throws InterruptedException {
 			AtomicBoolean callbackInvoked = new AtomicBoolean(false);
 			CountDownLatch callbackLatch = new CountDownLatch(1);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 
 			DefaultCancellationToken token = new DefaultCancellationToken();
 
@@ -220,19 +233,24 @@ class CancellableAsyncToolCallbackTest {
 							Thread.currentThread().interrupt();
 						}
 						return "result";
-					});
+					}, executor);
 				}
 			};
 
-			// Start the tool
-			callback.callAsync("{}", new ToolContext(Map.of()), token);
+			try {
+				// Start the tool
+				callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// Cancel
-			token.cancel();
+				// Cancel
+				token.cancel();
 
-			// Callback should be invoked
-			assertTrue(callbackLatch.await(1, TimeUnit.SECONDS));
-			assertTrue(callbackInvoked.get());
+				// Callback should be invoked
+				assertTrue(callbackLatch.await(5, TimeUnit.SECONDS));
+				assertTrue(callbackInvoked.get());
+			}
+			finally {
+				executor.shutdownNow();
+			}
 		}
 
 	}
@@ -351,6 +369,7 @@ class CancellableAsyncToolCallbackTest {
 		void simulatedTimeout_shouldTriggerCancellationCallback() throws InterruptedException {
 			AtomicBoolean cleanupPerformed = new AtomicBoolean(false);
 			CountDownLatch cleanupLatch = new CountDownLatch(1);
+			ExecutorService executor = Executors.newSingleThreadExecutor();
 
 			DefaultCancellationToken token = new DefaultCancellationToken();
 
@@ -379,7 +398,7 @@ class CancellableAsyncToolCallbackTest {
 							}
 						}
 						return "completed";
-					});
+					}, executor);
 				}
 
 				@Override
@@ -388,21 +407,26 @@ class CancellableAsyncToolCallbackTest {
 				}
 			};
 
-			// Start the tool
-			CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
-
-			// Simulate what AgentToolNode does on timeout
 			try {
-				future.orTimeout(100, TimeUnit.MILLISECONDS).join();
-			}
-			catch (Exception e) {
-				// Timeout occurred - cancel the token (this is what AgentToolNode now does)
-				token.cancel();
-			}
+				// Start the tool
+				CompletableFuture<String> future = callback.callAsync("{}", new ToolContext(Map.of()), token);
 
-			// Cleanup should be performed
-			assertTrue(cleanupLatch.await(1, TimeUnit.SECONDS));
-			assertTrue(cleanupPerformed.get());
+				// Simulate what AgentToolNode does on timeout
+				try {
+					future.orTimeout(100, TimeUnit.MILLISECONDS).join();
+				}
+				catch (Exception e) {
+					// Timeout occurred - cancel the token (this is what AgentToolNode now does)
+					token.cancel();
+				}
+
+				// Cleanup should be performed
+				assertTrue(cleanupLatch.await(5, TimeUnit.SECONDS));
+				assertTrue(cleanupPerformed.get());
+			}
+			finally {
+				executor.shutdownNow();
+			}
 		}
 
 		@Test

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManagerTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/ShellSessionManagerTest.java
@@ -29,6 +29,11 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -113,6 +118,51 @@ class ShellSessionManagerTest {
 
 		assertTrue(ShellSessionManager.isSessionInRegistry(threadId),
 				"Session should be registered in global registry with threadId");
+	}
+
+	/**
+	 * A persistent session has one stdin stream and one output queue, so concurrent
+	 * commands must not consume each other's output or completion markers.
+	 */
+	@Test
+	void testConcurrentCommandsInSameSessionRemainIsolated() throws Exception {
+		sessionManager = createSessionManager();
+		sessionManager.initialize(config);
+
+		boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+		String firstCommand = isWindows ? "ping -n 2 127.0.0.1 > nul && echo first-only"
+				: "sleep 0.2; printf 'first-only\\n'";
+		String secondCommand = isWindows ? "ping -n 2 127.0.0.1 > nul && echo second-only"
+				: "sleep 0.2; printf 'second-only\\n'";
+
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<ShellSessionManager.CommandResult> first = executor.submit(() -> {
+				start.await();
+				return sessionManager.executeCommand(firstCommand, config);
+			});
+			Future<ShellSessionManager.CommandResult> second = executor.submit(() -> {
+				start.await();
+				return sessionManager.executeCommand(secondCommand, config);
+			});
+			start.countDown();
+
+			ShellSessionManager.CommandResult firstResult = first.get(5, TimeUnit.SECONDS);
+			ShellSessionManager.CommandResult secondResult = second.get(5, TimeUnit.SECONDS);
+			assertFalse(firstResult.isTimedOut());
+			assertFalse(secondResult.isTimedOut());
+			assertTrue(firstResult.getOutput().contains("first-only"));
+			assertFalse(firstResult.getOutput().contains("second-only"));
+			assertTrue(secondResult.getOutput().contains("second-only"));
+			assertFalse(secondResult.getOutput().contains("first-only"));
+		}
+		catch (ExecutionException e) {
+			throw (e.getCause() instanceof Exception exception) ? exception : e;
+		}
+		finally {
+			executor.shutdownNow();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Serialize command execution within one persistent `ShellSession` so shared stdin and output markers cannot interleave across parallel tool calls.
- Add a concurrent regression test proving each command response contains only its own output.

Fixes #4873

## Tests

- `./mvnw -pl spring-ai-alibaba-agent-framework -am -Dtest=ShellSessionManagerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl spring-ai-alibaba-agent-framework -am test`
- `./mvnw -pl spring-ai-alibaba-agent-framework -am spotless:check checkstyle:check`
