### PR TITLE
fix(agent): validate WebFetchTool prompt before cache lookup and fetch

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchTool.java
@@ -173,6 +173,10 @@ public class WebFetchTool implements BiFunction<WebFetchTool.Request, ToolContex
 			return "Error: Invalid URL format: " + e.getMessage();
 		}
 
+		if (!StringUtils.hasText(prompt)) {
+			return "Error: Prompt cannot be empty or null";
+		}
+
 		// Upgrade HTTP to HTTPS if needed
 		if (url.startsWith("http://")) {
 			url = "https://" + url.substring(7);

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchToolTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/WebFetchToolTest.java
@@ -29,7 +29,9 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -83,6 +85,54 @@ class WebFetchToolTest {
 				new ToolContext(Collections.emptyMap()));
 		assertTrue(result.startsWith("Error:"));
 		assertTrue(result.contains("Invalid URL"));
+	}
+
+	@Test
+	void testNullPromptReturnsError() {
+		String result = webFetchTool.apply(new WebFetchTool.Request("https://localhost:1", null),
+				new ToolContext(Collections.emptyMap()));
+		assertTrue(result.startsWith("Error:"));
+		assertTrue(result.contains("Prompt cannot be empty or null"));
+	}
+
+	@Test
+	void testEmptyPromptReturnsError() {
+		String result = webFetchTool.apply(new WebFetchTool.Request("https://localhost:1", ""),
+				new ToolContext(Collections.emptyMap()));
+		assertTrue(result.startsWith("Error:"));
+		assertTrue(result.contains("Prompt cannot be empty or null"));
+	}
+
+	@Test
+	void testBlankPromptReturnsError() {
+		String result = webFetchTool.apply(new WebFetchTool.Request("https://localhost:1", "   "),
+				new ToolContext(Collections.emptyMap()));
+		assertTrue(result.startsWith("Error:"));
+		assertTrue(result.contains("Prompt cannot be empty or null"));
+	}
+
+	@Test
+	void testToolCallbackReturnsErrorForNullPrompt() {
+		ToolCallback toolCallback = WebFetchTool.builder(ChatClient.builder(mock(ChatModel.class)).build()).build();
+		String result = toolCallback.call("{\"url\":\"https://localhost:1\",\"prompt\":null}",
+				new ToolContext(Collections.emptyMap()));
+		assertTrue(result.contains("Error: Prompt cannot be empty or null"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testValidPromptUsesCache() throws Exception {
+		String url = "https://example.com";
+		String prompt = "Summarize";
+		String expected = "Cached summary";
+		Field cacheField = WebFetchTool.class.getDeclaredField("urlCache");
+		cacheField.setAccessible(true);
+		Cache<String, String> cache = (Cache<String, String>) cacheField.get(webFetchTool);
+		cache.put(url + "::prompt::" + prompt.hashCode(), expected);
+
+		String result = webFetchTool.apply(new WebFetchTool.Request(url, prompt),
+				new ToolContext(Collections.emptyMap()));
+		assertEquals(expected, result);
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

Validate null, empty, and blank WebFetchTool prompts before cache-key generation and fetching.

When a tool call supplies an explicit JSON `null` prompt, `buildCacheKey` throws a `NullPointerException` out of the tool callback instead of returning a tool error. The failing path is:

```text
ToolExecutionException: Cannot invoke "String.hashCode()" because "prompt" is null
Caused by: NullPointerException at WebFetchTool.buildCacheKey
```

For empty or blank prompts, the tool performs a fetch even though there is no request to run on the fetched content. The request metadata already marks `prompt` as required; this validation completes that contract before cache lookup and fetch.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Add a `StringUtils.hasText(prompt)` guard after URL validation and return `Error: Prompt cannot be empty or null`, matching the adjacent URL validation wording. Add regression coverage for direct null, empty, blank, JSON explicit null, and valid prompts, with the valid-prompt control hitting a pre-seeded cache entry.

### Describe how to verify it

- `./mvnw -q -ntp -pl :spring-ai-alibaba-agent-framework -am -Dtest=WebFetchToolTest test`
- `./mvnw -q -ntp checkstyle:check`

### Special notes for reviews

For a valid URL with an empty or blank prompt, this changes the previous fetch-and-summarize behavior to return a tool error. The request metadata already marks `prompt` as required, and the validation runs before cache lookup and tool execution.
