### PR TITLE
fix(agent): use configured fallback after routing retries fail

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNode.java
@@ -103,7 +103,19 @@ public class RoutingNode implements MultiCommandAction {
 		// Prepare messages with instruction if available
 		List<Message> messagesWithInstruction = prepareMessagesWithInstruction(messages);
 		
-		RoutingDecision decision = getDecisionWithRetry(messagesWithInstruction, DEFAULT_MAX_RETRIES);
+		RoutingDecision decision;
+		try {
+			decision = getDecisionWithRetry(messagesWithInstruction, DEFAULT_MAX_RETRIES);
+		}
+		catch (Exception e) {
+			MultiCommand fallbackCommand = createFallbackCommand(state, messages);
+			if (fallbackCommand != null) {
+				logger.warn("RoutingAgent {} exhausted routing retries. Routing to fallback agent {}.",
+						rootAgent.name(), fallbackCommand.gotoNodes().get(0));
+				return fallbackCommand;
+			}
+			throw e;
+		}
 		List<String> decisionValues = decision.getAgentNames();
 
 		// Validate all agent names are valid
@@ -132,6 +144,28 @@ public class RoutingNode implements MultiCommandAction {
 			throw new IllegalStateException(
 					"RoutingAgent " + rootAgent.name() + " failed to get valid decision after retries. Invalid agents: " + invalidAgents + ".");
 		}
+	}
+
+	private MultiCommand createFallbackCommand(OverAllState state, List<Message> messages) {
+		if (!(rootAgent instanceof LlmRoutingAgent llmRoutingAgent)) {
+			return null;
+		}
+
+		String fallbackAgent = llmRoutingAgent.getFallbackAgent();
+		if (!StringUtils.hasText(fallbackAgent)
+				|| subAgents.stream().noneMatch(agent -> agent.name().equals(fallbackAgent))) {
+			return null;
+		}
+
+		String fallbackInput = state.value("input").map(Object::toString).orElseGet(() -> {
+			for (int i = messages.size() - 1; i >= 0; i--) {
+				if (messages.get(i) instanceof UserMessage userMessage) {
+					return userMessage.getText();
+				}
+			}
+			return "";
+		});
+		return new MultiCommand(List.of(fallbackAgent), Map.of(fallbackAgent + "_input", fallbackInput));
 	}
 
 	/**
@@ -296,4 +330,3 @@ public class RoutingNode implements MultiCommandAction {
 	public record AgentRouting(String agent, String query) {
 	}
 }
-

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/flow/node/RoutingNodeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.flow.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.action.MultiCommand;
+import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.flow.agent.LlmRoutingAgent;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RoutingNodeTest {
+
+	@Test
+	void routesToConfiguredFallbackAfterInvalidDecisions() throws Exception {
+		AtomicInteger modelCalls = new AtomicInteger();
+		ChatModel chatModel = invalidRoutingModel(modelCalls);
+		Agent writerAgent = mockAgent();
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, writerAgent, "writer_agent");
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writerAgent));
+		OverAllState state = new OverAllState(Map.of(
+				"input", "write a summary",
+				"messages", List.<Message>of(new UserMessage("write a summary"))));
+
+		MultiCommand command = node.apply(state, RunnableConfig.builder().build());
+
+		assertEquals(3, modelCalls.get());
+		assertEquals(List.of("writer_agent"), command.gotoNodes());
+		assertEquals("write a summary", command.update().get("writer_agent_input"));
+	}
+
+	@Test
+	void throwsAfterInvalidDecisionsWhenFallbackIsNotConfigured() {
+		ChatModel chatModel = invalidRoutingModel(new AtomicInteger());
+		Agent writerAgent = mockAgent();
+		LlmRoutingAgent routingAgent = routingAgent(chatModel, writerAgent, null);
+		RoutingNode node = new RoutingNode(chatModel, routingAgent, List.of(writerAgent));
+		OverAllState state = new OverAllState(Map.of(
+				"messages", List.<Message>of(new UserMessage("write a summary"))));
+
+		assertThrows(IllegalStateException.class,
+				() -> node.apply(state, RunnableConfig.builder().build()));
+	}
+
+	private static ChatModel invalidRoutingModel(AtomicInteger modelCalls) {
+		return new ChatModel() {
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				modelCalls.incrementAndGet();
+				return new ChatResponse(List.of(new Generation(new AssistantMessage(
+						"{\"agents\":[{\"agent\":\"unknown_agent\",\"query\":\"ignored\"}]}"))));
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				return Flux.just(call(prompt));
+			}
+		};
+	}
+
+	private static Agent mockAgent() {
+		Agent writerAgent = mock(Agent.class);
+		when(writerAgent.name()).thenReturn("writer_agent");
+		when(writerAgent.description()).thenReturn("Writes text");
+		return writerAgent;
+	}
+
+	private static LlmRoutingAgent routingAgent(ChatModel chatModel, Agent writerAgent, String fallbackAgent) {
+		LlmRoutingAgent.LlmRoutingAgentBuilder builder = LlmRoutingAgent.builder()
+				.name("router")
+				.description("Routes requests")
+				.model(chatModel)
+				.subAgents(List.of(writerAgent));
+		if (fallbackAgent != null) {
+			builder.fallbackAgent(fallbackAgent);
+		}
+		return builder.build();
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

`LlmRoutingAgent.fallbackAgent(...)` is currently stored but never used. When the routing model keeps returning an invalid agent, the router throws after its retries even when a valid fallback sub-agent was configured.

### Does this pull request fix one issue?

Fixes #4880

### Describe how you did it

After the existing routing retries are exhausted, route to the configured fallback only when its name matches a registered sub-agent. The fallback receives the original input through its existing `{agentName}_input` state key. When no valid fallback is configured, the existing exception behavior is preserved.

### Describe how to verify it

```bash
./mvnw -pl :spring-ai-alibaba-agent-framework -am -Dtest=RoutingNodeTest -Dsurefire.failIfNoSpecifiedTests=false test
```

The focused tests use an in-memory model that always returns an unknown agent and verify both the fallback path and the unchanged no-fallback failure path. Checkstyle reports zero violations and Spotless makes no changes.

### Special notes for reviews

None.