### PR TITLE
feat(agent): add QA assistant multi-agent demo with knowledge base and web search

### DIFF
--- a/examples/multiagent-patterns/qa-assistant/README.md
+++ b/examples/multiagent-patterns/qa-assistant/README.md
@@ -1,0 +1,135 @@
+# QA Assistant Example
+
+This example implements a **multi-agent QA (Question & Answer) assistant** with Spring AI Alibaba. A central supervisor agent coordinates specialized agents (knowledge base and web search) by calling them as **tools** via `AgentTool`.
+
+## Architecture
+
+- **Supervisor (main agent)**  
+  Receives user questions, decides which specialized agent(s) to call, and synthesizes results. It only sees high-level tools: `search_knowledge_base` and `search_web`.
+
+- **Knowledge base agent**  
+  Searches the enterprise knowledge base to find accurate answers to company-specific questions. Exposed to the supervisor as the tool `search_knowledge_base`.
+
+- **Web search agent**  
+  Searches the web for up-to-date information on general topics. Exposed as the tool `search_web`.
+
+Specialized agents are **stateless** from the user's perspective; the supervisor keeps the conversation and delegates one-off tasks to them.
+
+## Design choices (aligned with the reference)
+
+1. **Specialized agents as tools**  
+   Knowledge base and web search agents are wrapped with `AgentTool.getFunctionToolCallback(agent)` so the supervisor invokes them as tools.
+
+2. **Instruction and input type**  
+   Each specialized agent has:
+   - **Instruction**: system behavior (e.g. "You are a knowledge base assistant…", "You are a web search assistant…").
+   - **inputType(String.class)**: the supervisor passes a single natural-language query string; the framework wraps it as the tool's `input` parameter.
+
+3. **Tool-per-agent**  
+   One tool per specialized agent (`search_knowledge_base`, `search_web`) for clear routing and descriptions.
+
+4. **Stub APIs**  
+   Knowledge base and web search "API" calls are stubbed. In production you would replace these with real vector database / search engine integrations.
+
+## Project layout
+
+```
+examples/multiagent-patterns/qa-assistant/
+├── README.md
+├── pom.xml
+└── src/main/
+    ├── java/.../qa/
+    │   ├── QaAssistantApplication.java      # Spring Boot entry
+    │   ├── QaAssistantConfig.java           # Beans: kbAgent, webAgent, qaSupervisorAgent
+    │   ├── QaAssistantRunner.java           # Optional demo runner (see below)
+    │   ├── QaAgentStaticLoader.java         # Exposes agent to Spring AI Alibaba Studio
+    │   └── tools/
+    │       ├── KnowledgeBaseTools.java      # search_knowledge_base, list_knowledge_categories
+    │       └── WebSearchTools.java          # search_web, fetch_web_page
+    └── resources/
+        └── application.yml
+```
+
+## How to run
+
+### Prerequisites
+
+- JDK 17+
+- Maven 3.6+
+- **DashScope API key** for the chat model.
+
+Set your API key:
+
+```bash
+export AI_DASHSCOPE_API_KEY=your-dashscope-api-key
+```
+
+### Build
+
+From the repo root:
+
+```bash
+./mvnw -pl :qa-assistant -am -B package -DskipTests
+```
+
+Or from this directory (if the parent POM is available):
+
+```bash
+cd examples/multiagent-patterns/qa-assistant
+mvn -B package -DskipTests
+```
+
+### Run the application
+
+Default: the app starts **without** calling the model (no demo run):
+
+```bash
+java -jar target/qa-assistant-0.0.1-SNAPSHOT.jar
+# or
+./mvnw -pl :qa-assistant spring-boot:run
+```
+
+To run the **three demo scenarios** on startup:
+
+1. **Knowledge base only**: "What is our company's remote work policy?" (KB only).  
+2. **Web search only**: "What are the latest developments in AI agent frameworks in 2026?" (web only).  
+3. **Hybrid**: "How does our product compare to competitors in the market?" (KB + web).
+
+Set:
+
+```bash
+export qa-assistant.run-examples=true
+# or add to application.yml: qa-assistant.run-examples: true
+```
+
+Then start the app as above. The runner will call the supervisor with these three user messages and log the assistant replies.
+
+### Using the QA assistant in your own code
+
+Inject the supervisor agent and call it with a user message:
+
+```java
+@Qualifier("qaSupervisorAgent")
+@Autowired
+ReactAgent qaSupervisorAgent;
+
+// Single turn
+AssistantMessage response = qaSupervisorAgent.call(new UserMessage("What is our refund policy?"));
+String text = response.getText();
+```
+
+## Configuration
+
+- **`spring.ai.dashscope.api-key`**  
+  Required for the chat model. Defaults to `AI_DASHSCOPE_API_KEY` env var.
+
+- **`qa-assistant.run-examples`**  
+  If `true`, runs the three demo scenarios on startup. Default: `false`.
+
+## Example flow (hybrid question)
+
+1. User: "How does our product compare to competitors in the market?"
+2. Supervisor decides to call two tools: `search_knowledge_base` and `search_web`.
+3. **search_knowledge_base** (KB agent): finds product features from internal docs.
+4. **search_web** (web agent): finds market analysis and competitor information.
+5. Supervisor combines both results and replies to the user with a comprehensive answer.

--- a/examples/multiagent-patterns/qa-assistant/pom.xml
+++ b/examples/multiagent-patterns/qa-assistant/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.7</version>
+		<relativePath/>
+	</parent>
+
+	<groupId>com.alibaba.cloud.ai</groupId>
+	<artifactId>qa-assistant</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Examples::Multi-agents QA Assistant</name>
+	<description>QA assistant example using Spring AI Alibaba</description>
+
+	<properties>
+		<java.version>17</java.version>
+		<spring-ai.version>1.1.2</spring-ai.version>
+		<spring-ai-alibaba.version>1.1.2.2</spring-ai-alibaba.version>
+		<spring-ai-alibaba-extensions.version>1.1.2.2</spring-ai-alibaba-extensions.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.alibaba.cloud.ai</groupId>
+				<artifactId>spring-ai-alibaba-extensions-bom</artifactId>
+				<version>${spring-ai-alibaba-extensions.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.alibaba.cloud.ai</groupId>
+				<artifactId>spring-ai-alibaba-bom</artifactId>
+				<version>${spring-ai-alibaba.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-starter-dashscope</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-agent-framework</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-studio</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+			<id>sonatype-snapshots</id>
+			<name>Sonatype Snapshot Repository</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</repository>
+	</repositories>
+</project>

--- a/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAgentStaticLoader.java
+++ b/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAgentStaticLoader.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.qa;
+
+import com.alibaba.cloud.ai.agent.studio.loader.AgentLoader;
+import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import jakarta.annotation.Nonnull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Static Agent Loader for the QA assistant.
+ *
+ * <p>Exposes the QA supervisor agent (and optionally KB/web agents) through the
+ * AgentLoader interface for Spring AI Alibaba Studio. The main entry for Studio is
+ * the "qa_assistant" supervisor agent.
+ */
+@Component
+class QaAgentStaticLoader implements AgentLoader {
+
+	private static final String QA_AGENT_NAME = "qa_assistant";
+
+	private final Map<String, Agent> agents = new ConcurrentHashMap<>();
+
+	public QaAgentStaticLoader(@Qualifier("qaSupervisorAgent") ReactAgent qaSupervisorAgent) {
+		this.agents.put(QA_AGENT_NAME, qaSupervisorAgent);
+	}
+
+	@Override
+	@Nonnull
+	public List<String> listAgents() {
+		return agents.keySet().stream().toList();
+	}
+
+	@Override
+	public Agent loadAgent(String name) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("Agent name cannot be null or empty");
+		}
+		Agent agent = agents.get(name);
+		if (agent == null) {
+			throw new NoSuchElementException("Agent not found: " + name);
+		}
+		return agent;
+	}
+}

--- a/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAssistantApplication.java
+++ b/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAssistantApplication.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.qa;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+
+@SpringBootApplication
+public class QaAssistantApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(QaAssistantApplication.class, args);
+	}
+
+	@Bean
+	public ApplicationListener<ApplicationReadyEvent> applicationReadyEventListener(Environment environment) {
+		return event -> {
+			String port = environment.getProperty("server.port", "8080");
+			String contextPath = environment.getProperty("server.servlet.context-path", "");
+			String accessUrl = "http://localhost:" + port + contextPath + "/chatui/index.html";
+			System.out.println("\n🎉========================================🎉");
+			System.out.println("✅ QA Assistant example is ready!");
+			System.out.println("🚀 Chat with QA assistant: " + accessUrl);
+			System.out.println("🎉========================================🎉\n");
+		};
+	}
+}

--- a/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAssistantConfig.java
+++ b/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAssistantConfig.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.qa;
+
+import com.alibaba.cloud.ai.examples.multiagents.qa.tools.KnowledgeBaseTools;
+import com.alibaba.cloud.ai.examples.multiagents.qa.tools.WebSearchTools;
+import com.alibaba.cloud.ai.graph.agent.AgentTool;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the QA assistant: stub tools, knowledge base agent, web search agent,
+ * and supervisor agent. Specialized agents (knowledge base, web search) are wrapped as tools
+ * via {@link AgentTool} and configured with {@link ReactAgent#systemPrompt(String)} and
+ * {@link ReactAgent.Builder#inputType(java.lang.reflect.Type)}.
+ */
+@Configuration
+public class QaAssistantConfig {
+
+	private static final String KB_AGENT_PROMPT = """
+			You are a knowledge base assistant. \
+			Search the enterprise knowledge base to find accurate answers to user questions. \
+			Use search_knowledge_base to look up relevant documents. \
+			When you find relevant information, synthesize a clear and concise answer. \
+			If the knowledge base doesn't contain the answer, clearly state that you couldn't find relevant information.
+			""";
+
+	private static final String WEB_AGENT_PROMPT = """
+			You are a web search assistant. \
+			Search the web to find up-to-date information for user questions. \
+			Use search_web to look up relevant information from the internet. \
+			When you find relevant results, synthesize a clear and concise answer with source references. \
+			Always cite the sources you found.
+			""";
+
+	private static final String SUPERVISOR_PROMPT = """
+			You are a helpful QA assistant. \
+			You can search the enterprise knowledge base and the web to answer user questions. \
+			Break down user queries and decide which tool(s) to use. \
+			For company-internal questions, prefer the knowledge base. \
+			For general or up-to-date information, use web search. \
+			Combine results from both sources when appropriate to provide comprehensive answers.
+			""";
+
+	private static final String KB_SEARCH_DESCRIPTION = """
+			Search the enterprise knowledge base for relevant documents and answers.
+			Use this when the user asks company-specific questions, product documentation,
+			internal policies, or any information that may exist in the knowledge base.
+			Input: Natural language query (e.g., 'What is our refund policy?')
+			""";
+
+	private static final String WEB_SEARCH_DESCRIPTION = """
+			Search the web for up-to-date information.
+			Use this when the user asks general knowledge questions, current events,
+			or when the knowledge base doesn't have the answer.
+			Input: Natural language query (e.g., 'What are the latest AI trends in 2026?')
+			""";
+
+	@Bean
+	public MemorySaver memorySaver() {
+		return new MemorySaver();
+	}
+
+	@Bean
+	public KnowledgeBaseTools knowledgeBaseTools() {
+		return new KnowledgeBaseTools();
+	}
+
+	@Bean
+	public WebSearchTools webSearchTools() {
+		return new WebSearchTools();
+	}
+
+	@Bean
+	public ReactAgent kbAgent(ChatModel chatModel, KnowledgeBaseTools knowledgeBaseTools) {
+		return ReactAgent.builder()
+				.name("search_knowledge_base")
+				.description(KB_SEARCH_DESCRIPTION)
+				.systemPrompt(KB_AGENT_PROMPT)
+				.model(chatModel)
+				.methodTools(knowledgeBaseTools)
+				.inputType(String.class)
+				.build();
+	}
+
+	@Bean
+	public ReactAgent webAgent(ChatModel chatModel, WebSearchTools webSearchTools) {
+		return ReactAgent.builder()
+				.name("search_web")
+				.description(WEB_SEARCH_DESCRIPTION)
+				.systemPrompt(WEB_AGENT_PROMPT)
+				.model(chatModel)
+				.methodTools(webSearchTools)
+				.inputType(String.class)
+				.build();
+	}
+
+	@Bean
+	public ReactAgent qaSupervisorAgent(ChatModel chatModel, ReactAgent kbAgent, ReactAgent webAgent, MemorySaver memorySaver) {
+		return ReactAgent.builder()
+				.name("qa_assistant")
+				.systemPrompt(SUPERVISOR_PROMPT)
+				.model(chatModel)
+				.saver(memorySaver)
+				.tools(
+						AgentTool.getFunctionToolCallback(kbAgent),
+						AgentTool.getFunctionToolCallback(webAgent))
+				.build();
+	}
+}

--- a/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAssistantRunner.java
+++ b/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/QaAssistantRunner.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.qa;
+
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Runs the QA assistant demo when {@code qa-assistant.run-examples=true}.
+ * Executes three scenarios: knowledge-base-only, web-search-only, and hybrid (both).
+ */
+@Component
+@Order(1)
+@ConditionalOnProperty(name = "qa-assistant.run-examples", havingValue = "true")
+public class QaAssistantRunner implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(QaAssistantRunner.class);
+
+	private final ReactAgent qaSupervisorAgent;
+
+	public QaAssistantRunner(@Qualifier("qaSupervisorAgent") ReactAgent qaSupervisorAgent) {
+		this.qaSupervisorAgent = qaSupervisorAgent;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) throws Exception {
+		// Example 1: Knowledge base only (company-specific question)
+		String query1 = "What is our company's remote work policy?";
+		log.info("User request: {}", query1);
+		log.info("---");
+		AssistantMessage response1 = qaSupervisorAgent.call(new UserMessage(query1));
+		log.info("Assistant: {}", response1.getText());
+		log.info("");
+
+		// Example 2: Web search only (general knowledge question)
+		String query2 = "What are the latest developments in AI agent frameworks in 2026?";
+		log.info("User request: {}", query2);
+		log.info("---");
+		AssistantMessage response2 = qaSupervisorAgent.call(new UserMessage(query2));
+		log.info("Assistant: {}", response2.getText());
+		log.info("");
+
+		// Example 3: Hybrid question (knowledge base + web search)
+		String query3 = "How does our product compare to competitors in the market?";
+		log.info("User request: {}", query3);
+		log.info("---");
+		AssistantMessage response3 = qaSupervisorAgent.call(new UserMessage(query3));
+		log.info("Assistant: {}", response3.getText());
+	}
+}

--- a/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/tools/KnowledgeBaseTools.java
+++ b/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/tools/KnowledgeBaseTools.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.qa.tools;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import java.util.Map;
+
+/**
+ * Stub knowledge base API tools for the QA assistant example.
+ * In production these would call a vector database or enterprise search service.
+ */
+public class KnowledgeBaseTools {
+
+	private static final Map<String, String> KNOWLEDGE_BASE = Map.of(
+			"remote work policy", """
+					Remote Work Policy: Employees may work remotely up to 3 days per week with manager approval.
+					Core collaboration hours are 10:00-15:00. Remote work requests must be submitted
+					through the HR system at least 48 hours in advance.
+					""",
+			"refund policy", """
+					Refund Policy: Customers may request a full refund within 30 days of purchase.
+					After 30 days, store credit may be issued at the discretion of customer service.
+					Refunds are processed within 5-7 business days.
+					""",
+			"product features", """
+					Product Features: Our platform supports multi-agent orchestration, real-time monitoring,
+					auto-scaling, and integration with 50+ enterprise systems. Key differentiators include
+					low-latency inference and built-in governance controls.
+					"""
+	);
+
+	@Tool(name = "search_knowledge_base", description = "Search the enterprise knowledge base for relevant documents and answers.")
+	public String searchKnowledgeBase(
+			@ToolParam(description = "The search query to look up in the knowledge base") String query) {
+
+		// Simulate knowledge base search with keyword matching
+		String lowerQuery = query.toLowerCase();
+		for (Map.Entry<String, String> entry : KNOWLEDGE_BASE.entrySet()) {
+			if (lowerQuery.contains(entry.getKey())) {
+				return String.format("Found in knowledge base:\n%s", entry.getValue());
+			}
+		}
+
+		return "No relevant documents found in the knowledge base for: " + query;
+	}
+
+	@Tool(name = "list_knowledge_categories", description = "List all available categories in the knowledge base.")
+	public String listKnowledgeCategories() {
+		return "Available categories: " + String.join(", ", KNOWLEDGE_BASE.keySet());
+	}
+}

--- a/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/tools/WebSearchTools.java
+++ b/examples/multiagent-patterns/qa-assistant/src/main/java/com/alibaba/cloud/ai/examples/multiagents/qa/tools/WebSearchTools.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.qa.tools;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import java.util.Map;
+
+/**
+ * Stub web search API tools for the QA assistant example.
+ * In production these would call a search engine API like Google, Bing, or Brave Search.
+ */
+public class WebSearchTools {
+
+	private static final Map<String, String> WEB_RESULTS = Map.of(
+			"ai agent frameworks", """
+					Top AI Agent Frameworks in 2026:
+					1. LangChain / LangGraph - Most widely adopted, strong ecosystem
+					2. Spring AI Alibaba - Enterprise-focused, Java-native agent framework
+					3. CrewAI - Role-based multi-agent orchestration
+					4. AutoGen - Microsoft's conversational agent framework
+					5. MetaGPT - Multi-agent software development
+					Source: https://github.com/topics/ai-agent
+					""",
+			"competitors", """
+					Market Analysis - AI Agent Platform Competitors:
+					- Vendor A: Strong in NLP, weak in multi-agent orchestration
+					- Vendor B: Good UI, limited enterprise integration
+					- Vendor C: Open-source, smaller community
+					Our platform leads in enterprise integration and governance features.
+					Source: Industry Report 2026
+					"""
+	);
+
+	@Tool(name = "search_web", description = "Search the web for up-to-date information using a search engine.")
+	public String searchWeb(
+			@ToolParam(description = "The search query") String query,
+			@ToolParam(description = "Maximum number of results to return", required = false) Integer maxResults) {
+
+		int limit = maxResults != null ? maxResults : 5;
+		String lowerQuery = query.toLowerCase();
+
+		for (Map.Entry<String, String> entry : WEB_RESULTS.entrySet()) {
+			if (lowerQuery.contains(entry.getKey())) {
+				return String.format("Web search results (top %d):\n%s", limit, entry.getValue());
+			}
+		}
+
+		return String.format("Web search for '%s': No specific results found. Try rephrasing your query.", query);
+	}
+
+	@Tool(name = "fetch_web_page", description = "Fetch and extract content from a specific URL.")
+	public String fetchWebPage(
+			@ToolParam(description = "The URL to fetch") String url) {
+		return String.format("Fetched content from %s: [Page content would be extracted here]", url);
+	}
+}

--- a/examples/multiagent-patterns/qa-assistant/src/main/resources/application.yml
+++ b/examples/multiagent-patterns/qa-assistant/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  application:
+    name: qa-assistant
+  ai:
+    dashscope:
+      api-key: ${AI_DASHSCOPE_API_KEY:}
+
+# Set to true to run the three demo scenarios on startup.
+# Default: false (app starts without calling the model).
+qa-assistant:
+  run-examples: false


### PR DESCRIPTION
## Description

This PR adds a new multi-agent QA (Question & Answer) assistant example to `examples/multiagent-patterns/`, addressing issue #4018.

The example demonstrates the **supervisor pattern** with Spring AI Alibaba: a central supervisor agent coordinates two specialized agents — a knowledge base agent and a web search agent — by calling them as tools via `AgentTool`.

## What's included

- **Supervisor agent**: routes user questions to the appropriate specialist(s)
- **Knowledge base agent**: searches enterprise knowledge base for company-specific answers
- **Web search agent**: searches the web for general/up-to-date information
- **3 demo scenarios**: KB-only, web-only, and hybrid (both)
- **Stub APIs**: all external dependencies are stubbed for easy local testing
- **Studio integration**: `QaAgentStaticLoader` exposes the agent to Spring AI Alibaba Studio
- **README**: architecture, design choices, project layout, and how-to-run guide

## Design choices

1. Follows the same structure and patterns as the existing `supervisor` example
2. All external APIs are stubbed (vector DB, search engine) — replace with real integrations in production
3. Supports Spring AI Alibaba Studio via `AgentLoader` interface
4. Configurable demo runner via `qa-assistant.run-examples` property

## Related issue

Closes #4018

## Checklist

- [x] Follows existing project structure and naming conventions
- [x] Includes README with architecture and run instructions
- [x] pom.xml follows existing example format
- [x] All external dependencies are stubbed (no real API calls)
- [x] Spring AI Alibaba Studio integration included