### PR TITLE
feat(agent): add agentic RAG multi-agent pattern example for #4018

### DIFF
--- a/examples/multiagent-patterns/agentic-rag/README.md
+++ b/examples/multiagent-patterns/agentic-rag/README.md
@@ -47,9 +47,10 @@ here, the number of retrieval rounds (including zero) is decided at runtime by t
 
 1. **Independent Q&A turns**  
    Each `AgenticRagService.run()` call invokes the graph with a fresh
-   `RunnableConfig` thread id. Compiled graphs register a `MemorySaver` checkpoint
-   saver by default, which replays state from a previous run on the same thread id;
-   a fresh id keeps every question isolated.
+   `RunnableConfig` thread id, because compiled graphs register a `MemorySaver` checkpoint
+   saver by default, which replays state from a previous run on the same thread id.
+   The graph is also compiled with `releaseThread(true)` so each one-shot thread's
+   checkpoint is released when the run completes, avoiding unbounded memory growth.
 
 2. **Quality gate only after retrieval**  
    The `check` node is skipped entirely when the router answered without retrieval,
@@ -122,7 +123,9 @@ From the repository root:
 
 ### Run the application
 
-Default: the app starts **without** calling the model (no demo run):
+The demo runner is disabled by default, but the application always seeds the in-memory
+vector store at startup, which sends the 6 knowledge-base documents through the
+configured embedding model — so a valid API key is required even without the runner:
 
 ```bash
 java -jar examples/multiagent-patterns/agentic-rag/target/agentic-rag-0.0.1-SNAPSHOT.jar

--- a/examples/multiagent-patterns/agentic-rag/README.md
+++ b/examples/multiagent-patterns/agentic-rag/README.md
@@ -31,8 +31,9 @@ is complete.
 
 The three LLM decision points are what make this pattern **agentic**:
 
-1. **classify** — routes to `retrieve` or answers directly, so conversational questions
-   never touch the vector store.
+1. **classify** — routes purely conversational questions straight to `answer`; every
+   product question goes to `retrieve`, even when the knowledge base may not hold the
+   answer (so the model reports missing information instead of inventing it).
 2. **answer** — answers strictly from the retrieved context and says so when the
    information is not available.
 3. **check** — a quality gate that detects incomplete answers, writes a more specific
@@ -80,8 +81,9 @@ The three runner questions demonstrate the pattern:
 | Question | What it shows |
 |----------|---------------|
 | `What is the refund policy for the annual plan?` | Retrieval needed; answered from the knowledge base. |
-| `What is your name and what can you help me with?` | Router answers directly — zero retrieval rounds. |
+| `What is your name and what can you help me with?` | Purely conversational — router answers directly, zero retrieval rounds. |
 | `Compare the refund policy of the annual plan with the monthly plan.` | May need 2+ retrieval rounds when the first pass only finds one of the two policies. |
+| `Where is Acme Analytics customer data hosted?` | A product fact the knowledge base does not contain — still routed through retrieval, and the honest answer is "not in the knowledge base" instead of a guess. |
 
 ## Project layout
 

--- a/examples/multiagent-patterns/agentic-rag/README.md
+++ b/examples/multiagent-patterns/agentic-rag/README.md
@@ -1,0 +1,162 @@
+# Agentic RAG Example
+
+This example implements the **agentic RAG** pattern with Spring AI Alibaba: instead of
+running a fixed retrieval pipeline for every question, the model itself decides whether
+to retrieve, and a quality gate re-runs retrieval with a refined query until the answer
+is complete.
+
+## Architecture
+
+```
+                    ┌────────────┐
+       question ──▶ │  classify  │  LLM: does the question need retrieval?
+                    └─────┬──────┘
+              retrieve   │         answer (no retrieval)
+              ┌──────────▼──────┐
+              │    retrieve     │  vector similarity search (no LLM)
+              └──────────┬──────┘
+                         ▼
+                    ┌────────────┐
+                    │   answer   │  LLM: answer from retrieved context
+                    └─────┬──────┘
+                          ▼
+                    ┌────────────┐
+                    │   check    │  LLM: is the answer complete and grounded?
+                    └─────┬──────┘
+                retry     │         done
+      (refined query ┌────▼─────┐
+       + retry_count)│   END    │
+                     └──────────┘
+```
+
+The three LLM decision points are what make this pattern **agentic**:
+
+1. **classify** — routes to `retrieve` or answers directly, so conversational questions
+   never touch the vector store.
+2. **answer** — answers strictly from the retrieved context and says so when the
+   information is not available.
+3. **check** — a quality gate that detects incomplete answers, writes a more specific
+   `search_query`, and routes back to `retrieve`. Up to **2 retries** (`CheckNode.MAX_RETRIES`),
+   so a question can trigger up to 3 retrieval rounds before the agent gives up.
+
+This contrasts with the fixed-pipeline RAG workflow in the `workflow` example
+(`rewrite → retrieve → prepare → agent`): there, retrieval always runs exactly once;
+here, the number of retrieval rounds (including zero) is decided at runtime by the model.
+
+## Design choices
+
+1. **Independent Q&A turns**  
+   Each `AgenticRagService.run()` call invokes the graph with a fresh
+   `RunnableConfig` thread id. Compiled graphs register a `MemorySaver` checkpoint
+   saver by default, which replays state from a previous run on the same thread id;
+   a fresh id keeps every question isolated.
+
+2. **Quality gate only after retrieval**  
+   The `check` node is skipped entirely when the router answered without retrieval,
+   so conversational questions never trigger a spurious retry loop.
+
+3. **Bounded retries**  
+   `CheckNode.MAX_RETRIES` (default `2`) bounds the answer → check → refine → retrieve
+   loop, so a question can trigger at most 3 retrieval rounds.
+
+## Demo scenario
+
+The knowledge base is an in-memory `SimpleVectorStore` seeded with 6 documents about a
+fictional SaaS product ("Acme Analytics"): pricing plans, refund policies, API rate
+limits, features, and support. Swap it for a persistent store (PostgreSQL + pgvector,
+Redis, ...) in production.
+
+The three runner questions demonstrate the pattern:
+
+| Question | What it shows |
+|----------|---------------|
+| `What is the refund policy for the annual plan?` | Retrieval needed; answered from the knowledge base. |
+| `What is your name and what can you help me with?` | Router answers directly — zero retrieval rounds. |
+| `Compare the refund policy of the annual plan with the monthly plan.` | May need 2+ retrieval rounds when the first pass only finds one of the two policies. |
+
+## Project layout
+
+```
+examples/multiagent-patterns/agentic-rag/
+├── README.md
+├── pom.xml
+└── src/main/
+    ├── java/.../agenticrag/
+    │   ├── AgenticRagApplication.java      # Spring Boot entry
+    │   ├── AgenticRagConfig.java           # Beans: vector store, graph, service, Studio agent
+    │   ├── AgenticRagService.java          # Runs a question through the graph
+    │   ├── AgenticRagRunner.java           # Optional demo runner (see below)
+    │   ├── AgentStaticLoader.java          # Registers the entry agent for Studio
+    │   ├── node/
+    │   │   ├── ClassifyNode.java           # Router: retrieve or answer directly
+    │   │   ├── RetrieveNode.java           # Vector similarity search
+    │   │   ├── AnswerNode.java             # Answer from retrieved context
+    │   │   └── CheckNode.java              # Quality gate: complete, or retry with a refined query
+    │   └── tools/
+    │       └── AgenticRagTools.java        # answer_question tool (Studio entry agent)
+    └── resources/
+        └── application.yml
+```
+
+## How to run
+
+### Prerequisites
+
+- JDK 17+
+- Maven 3.6+
+- **DashScope API key** for the chat model and the embedding model.
+
+Set your API key:
+
+```bash
+export AI_DASHSCOPE_API_KEY=your-dashscope-api-key
+```
+
+### Build
+
+From the repository root:
+
+```bash
+./mvnw -f examples/multiagent-patterns/agentic-rag -B package -DskipTests
+```
+
+### Run the application
+
+Default: the app starts **without** calling the model (no demo run):
+
+```bash
+java -jar examples/multiagent-patterns/agentic-rag/target/agentic-rag-0.0.1-SNAPSHOT.jar
+```
+
+To run the **three demo scenarios** on startup:
+
+```bash
+./mvnw -f examples/multiagent-patterns/agentic-rag spring-boot:run \
+  -Dspring-boot.run.arguments="--agentic-rag.runner.enabled=true"
+```
+
+The runner logs each question, the number of retrieval rounds performed, and the final
+answer.
+
+### Using the agentic RAG service in your own code
+
+```java
+AgenticRagService service = ...; // or @Autowired
+
+AgenticRagService.AgenticRagResult result = service.run("What is the refund policy for the annual plan?");
+String answer = result.answer();          // final answer
+int rounds = result.retrievalRounds();    // 0 = answered without retrieval
+```
+
+## Configuration
+
+- **`spring.ai.dashscope.api-key`**  
+  Required for the chat model and the embedding model. Defaults to the
+  `AI_DASHSCOPE_API_KEY` environment variable.
+
+- **`agentic-rag.runner.enabled`**  
+  If `true`, runs the three demo scenarios on startup. Default: `false`.
+
+- **`CheckNode.MAX_RETRIES`**  
+  Maximum number of retrieval retries after the first round (default `2`). Edit the
+  constant in `CheckNode` to change it.

--- a/examples/multiagent-patterns/agentic-rag/README.md
+++ b/examples/multiagent-patterns/agentic-rag/README.md
@@ -45,18 +45,26 @@ here, the number of retrieval rounds (including zero) is decided at runtime by t
 
 ## Design choices
 
-1. **Independent Q&A turns**  
-   Each `AgenticRagService.run()` call invokes the graph with a fresh
-   `RunnableConfig` thread id, because compiled graphs register a `MemorySaver` checkpoint
-   saver by default, which replays state from a previous run on the same thread id.
-   The graph is also compiled with `releaseThread(true)` so each one-shot thread's
-   checkpoint is released when the run completes, avoiding unbounded memory growth.
+1. **One-shot turns, no checkpoint saver**  
+   The graph is compiled with an empty `SaverConfig`. This demo treats every question
+   as an independent turn: `graph.invoke()` always starts from a fresh state, so
+   nothing from a previous run is replayed, and nothing is retained in memory after a
+   run completes — whether it succeeded or failed.
 
-2. **Quality gate only after retrieval**  
-   The `check` node is skipped entirely when the router answered without retrieval,
-   so conversational questions never trigger a spurious retry loop.
+2. **Documents accumulate across retrieval retries**  
+   The `documents` state key uses `AppendStrategy` with deduplication, so each retry
+   round adds its newly retrieved documents to the previous ones. A multi-part
+   question (for example, "compare the annual and monthly refund policies") can
+   combine facts retrieved in different rounds instead of seeing only the last round.
 
-3. **Bounded retries**  
+3. **Routing decision drives the prompt, not the document list**  
+   The `answer` node chooses the conversational prompt only when the router decided
+   to answer directly (`route == "answer"`). If the router chose retrieval but the
+   store returned no matches, the answer is still generated from the grounded prompt
+   and the quality gate still runs — the model reports missing information instead of
+   inventing facts. `check` is skipped only for direct answers.
+
+4. **Bounded retries**  
    `CheckNode.MAX_RETRIES` (default `2`) bounds the answer → check → refine → retrieve
    loop, so a question can trigger at most 3 retrieval rounds.
 

--- a/examples/multiagent-patterns/agentic-rag/README.md
+++ b/examples/multiagent-patterns/agentic-rag/README.md
@@ -76,7 +76,7 @@ fictional SaaS product ("Acme Analytics"): pricing plans, refund policies, API r
 limits, features, and support. Swap it for a persistent store (PostgreSQL + pgvector,
 Redis, ...) in production.
 
-The three runner questions demonstrate the pattern:
+The four runner questions demonstrate the pattern:
 
 | Question | What it shows |
 |----------|---------------|
@@ -141,7 +141,7 @@ configured embedding model — so a valid API key is required even without the r
 java -jar examples/multiagent-patterns/agentic-rag/target/agentic-rag-0.0.1-SNAPSHOT.jar
 ```
 
-To run the **three demo scenarios** on startup:
+To run the **four demo scenarios** on startup:
 
 ```bash
 ./mvnw -f examples/multiagent-patterns/agentic-rag spring-boot:run \
@@ -168,7 +168,7 @@ int rounds = result.retrievalRounds();    // 0 = answered without retrieval
   `AI_DASHSCOPE_API_KEY` environment variable.
 
 - **`agentic-rag.runner.enabled`**  
-  If `true`, runs the three demo scenarios on startup. Default: `false`.
+  If `true`, runs the four demo scenarios on startup. Default: `false`.
 
 - **`CheckNode.MAX_RETRIES`**  
   Maximum number of retrieval retries after the first round (default `2`). Edit the

--- a/examples/multiagent-patterns/agentic-rag/pom.xml
+++ b/examples/multiagent-patterns/agentic-rag/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.7</version>
+		<relativePath/>
+	</parent>
+
+	<groupId>com.alibaba.cloud.ai</groupId>
+	<artifactId>agentic-rag</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Examples::Multi-agents Agentic RAG</name>
+	<description>Agentic RAG pattern example using Spring AI Alibaba</description>
+
+	<properties>
+		<java.version>17</java.version>
+		<spring-ai.version>1.1.2</spring-ai.version>
+		<spring-ai-alibaba.version>1.1.2.2</spring-ai-alibaba.version>
+		<spring-ai-alibaba-extensions.version>1.1.2.2</spring-ai-alibaba-extensions.version>
+
+		<graalvm.polyglot.version>24.2.1</graalvm.polyglot.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.alibaba.cloud.ai</groupId>
+				<artifactId>spring-ai-alibaba-extensions-bom</artifactId>
+				<version>${spring-ai-alibaba-extensions.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.alibaba.cloud.ai</groupId>
+				<artifactId>spring-ai-alibaba-bom</artifactId>
+				<version>${spring-ai-alibaba.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-starter-dashscope</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-agent-framework</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba.cloud.ai</groupId>
+			<artifactId>spring-ai-alibaba-studio</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+			<id>sonatype-snapshots</id>
+			<name>Sonatype Snapshot Repository</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</repository>
+	</repositories>
+</project>

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgentStaticLoader.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgentStaticLoader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag;
+
+import com.alibaba.cloud.ai.agent.studio.loader.AgentLoader;
+import com.alibaba.cloud.ai.graph.agent.Agent;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import jakarta.annotation.Nonnull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Exposes the {@code agentic_rag} entry agent through the AgentLoader interface for
+ * Spring AI Alibaba Studio.
+ */
+@Component
+class AgentStaticLoader implements AgentLoader {
+
+	private static final String AGENT_NAME = "agentic_rag";
+
+	private final Map<String, Agent> agents = new ConcurrentHashMap<>();
+
+	public AgentStaticLoader(@Qualifier("agenticRagAgent") ReactAgent agenticRagAgent) {
+		this.agents.put(AGENT_NAME, agenticRagAgent);
+	}
+
+	@Override
+	@Nonnull
+	public List<String> listAgents() {
+		return agents.keySet().stream().toList();
+	}
+
+	@Override
+	public Agent loadAgent(String name) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("Agent name cannot be null or empty");
+		}
+		Agent agent = agents.get(name);
+		if (agent == null) {
+			throw new NoSuchElementException("Agent not found: " + name);
+		}
+		return agent;
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagApplication.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagApplication.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.cloud.ai.examples.multiagents.agenticrag;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -24,6 +26,8 @@ import org.springframework.core.env.Environment;
 
 @SpringBootApplication
 public class AgenticRagApplication {
+
+	private static final Logger log = LoggerFactory.getLogger(AgenticRagApplication.class);
 
 	public static void main(String[] args) {
 		SpringApplication.run(AgenticRagApplication.class, args);
@@ -35,10 +39,7 @@ public class AgenticRagApplication {
 			String port = environment.getProperty("server.port", "8080");
 			String contextPath = environment.getProperty("server.servlet.context-path", "");
 			String accessUrl = "http://localhost:" + port + contextPath + "/chatui/index.html";
-			System.out.println("\n🎉========================================🎉");
-			System.out.println("✅ Agentic RAG example is ready!");
-			System.out.println("🚀 Chat with the agent: " + accessUrl);
-			System.out.println("🎉========================================🎉\n");
+			log.info("Agentic RAG example is ready! Chat with the agent: {}", accessUrl);
 		};
 	}
 }

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagApplication.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagApplication.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+
+@SpringBootApplication
+public class AgenticRagApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AgenticRagApplication.class, args);
+	}
+
+	@Bean
+	public ApplicationListener<ApplicationReadyEvent> applicationReadyEventListener(Environment environment) {
+		return event -> {
+			String port = environment.getProperty("server.port", "8080");
+			String contextPath = environment.getProperty("server.servlet.context-path", "");
+			String accessUrl = "http://localhost:" + port + contextPath + "/chatui/index.html";
+			System.out.println("\n🎉========================================🎉");
+			System.out.println("✅ Agentic RAG example is ready!");
+			System.out.println("🚀 Chat with the agent: " + accessUrl);
+			System.out.println("🎉========================================🎉\n");
+		};
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
@@ -54,8 +54,8 @@ import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
  *
  * <p>In contrast to the fixed-pipeline RAG workflow in the {@code workflow} example
  * (rewrite → retrieve → prepare → agent), retrieval here is a tool the agent drives
- * dynamically, so simple questions skip retrieval entirely and complex questions can
- * trigger several retrieval rounds until the answer is complete.
+ * dynamically: purely conversational questions skip retrieval entirely, while product
+ * questions trigger one or more retrieval rounds until the answer is complete.
  */
 @Configuration
 public class AgenticRagConfig {
@@ -63,10 +63,10 @@ public class AgenticRagConfig {
 	private static final String CLASSIFY_PROMPT = """
 			You are the router of an agentic RAG system for a product knowledge base.
 			Decide whether answering the question REQUIRES retrieving information from the knowledge base.
-			The knowledge base contains: pricing plans, refund policies, API rate limits, features, and support information.
+			The knowledge base covers Acme Analytics product information: pricing plans, refund policies, API rate limits, features, and support.
 			Reply with exactly one word: RETRIEVE or ANSWER.
-			- RETRIEVE: the question asks about facts that may be in the knowledge base (pricing, refunds, API, features, support).
-			- ANSWER: the question is general or conversational, or it cannot be answered by the knowledge base.
+			- RETRIEVE: the question asks about Acme Analytics or its product in any way (pricing, refunds, API, features, support, or other product facts) — even if the knowledge base may not contain the answer.
+			- ANSWER: the question is purely general or conversational (greetings, "who are you", "what can you help me with") and does not ask about the product.
 
 			Question: %s
 			""";
@@ -86,7 +86,8 @@ public class AgenticRagConfig {
 	private static final String DIRECT_ANSWER_PROMPT = """
 			You are a customer support assistant for Acme Analytics, a SaaS analytics product.
 			Answer the question helpfully and conversationally. You may greet the user and
-			explain what you can help with; you do not need to consult the knowledge base.
+			explain what you can help with. If the question asks for a specific product fact
+			you are not sure about, say you would look it up in the knowledge base instead of guessing.
 
 			Question: %s
 			""";

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
@@ -21,9 +21,12 @@ import com.alibaba.cloud.ai.examples.multiagents.agenticrag.node.ClassifyNode;
 import com.alibaba.cloud.ai.examples.multiagents.agenticrag.node.RetrieveNode;
 import com.alibaba.cloud.ai.examples.multiagents.agenticrag.tools.AgenticRagTools;
 import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.CompileConfig;
 import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
@@ -81,6 +84,14 @@ public class AgenticRagConfig {
 			Question: %s
 			""";
 
+	private static final String DIRECT_ANSWER_PROMPT = """
+			You are a customer support assistant for Acme Analytics, a SaaS analytics product.
+			Answer the question helpfully and conversationally. You may greet the user and
+			explain what you can help with; you do not need to consult the knowledge base.
+
+			Question: %s
+			""";
+
 	private static final String CHECK_PROMPT = """
 			You are the quality gate of an agentic RAG system.
 			Determine whether the answer below is complete and grounded in the provided context for the question.
@@ -133,7 +144,7 @@ public class AgenticRagConfig {
 
 		ClassifyNode classifyNode = new ClassifyNode(chatModel, CLASSIFY_PROMPT);
 		RetrieveNode retrieveNode = new RetrieveNode(agenticRagVectorStore);
-		AnswerNode answerNode = new AnswerNode(chatModel, ANSWER_PROMPT);
+		AnswerNode answerNode = new AnswerNode(chatModel, ANSWER_PROMPT, DIRECT_ANSWER_PROMPT);
 		CheckNode checkNode = new CheckNode(chatModel, CHECK_PROMPT);
 
 		StateGraph graph = new StateGraph("agentic_rag", () -> {
@@ -163,7 +174,11 @@ public class AgenticRagConfig {
 						edge_async(state -> state.<String>value("route").filter("retry"::equals).orElse("done")),
 						Map.of("retry", "retrieve", "done", END));
 
-		return graph.compile();
+		// releaseThread(true) makes the MemorySaver drop the checkpoint of each
+		// one-shot thread once the run completes, so repeated Q&A turns do not
+		// accumulate state in memory.
+		SaverConfig saverConfig = SaverConfig.builder().register(new MemorySaver()).build();
+		return graph.compile(CompileConfig.builder().saverConfig(saverConfig).releaseThread(true).build());
 	}
 
 	@Bean

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
@@ -26,7 +26,6 @@ import com.alibaba.cloud.ai.graph.KeyStrategy;
 import com.alibaba.cloud.ai.graph.StateGraph;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.checkpoint.config.SaverConfig;
-import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.exception.GraphStateException;
 import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
@@ -152,7 +151,9 @@ public class AgenticRagConfig {
 			strategies.put("question", new ReplaceStrategy());
 			strategies.put("route", new ReplaceStrategy());
 			strategies.put("search_query", new ReplaceStrategy());
-			strategies.put("documents", new ReplaceStrategy());
+			// Documents accumulate (and deduplicate) across retrieval retries, so a
+			// multi-part question can combine facts from several rounds.
+			strategies.put("documents", new AppendStrategy(false));
 			strategies.put("final_answer", new ReplaceStrategy());
 			strategies.put("retry_count", new ReplaceStrategy());
 			strategies.put("retrieval_rounds", new ReplaceStrategy());
@@ -174,11 +175,10 @@ public class AgenticRagConfig {
 						edge_async(state -> state.<String>value("route").filter("retry"::equals).orElse("done")),
 						Map.of("retry", "retrieve", "done", END));
 
-		// releaseThread(true) makes the MemorySaver drop the checkpoint of each
-		// one-shot thread once the run completes, so repeated Q&A turns do not
-		// accumulate state in memory.
-		SaverConfig saverConfig = SaverConfig.builder().register(new MemorySaver()).build();
-		return graph.compile(CompileConfig.builder().saverConfig(saverConfig).releaseThread(true).build());
+		// This demo treats every question as a one-shot turn: compile without a
+		// checkpoint saver so no state is retained between runs — nothing is replayed
+		// on the next invoke and nothing accumulates on success or failure.
+		return graph.compile(CompileConfig.builder().saverConfig(SaverConfig.builder().build()).build());
 	}
 
 	@Bean

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagConfig.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag;
+
+import com.alibaba.cloud.ai.examples.multiagents.agenticrag.node.AnswerNode;
+import com.alibaba.cloud.ai.examples.multiagents.agenticrag.node.CheckNode;
+import com.alibaba.cloud.ai.examples.multiagents.agenticrag.node.ClassifyNode;
+import com.alibaba.cloud.ai.examples.multiagents.agenticrag.node.RetrieveNode;
+import com.alibaba.cloud.ai.examples.multiagents.agenticrag.tools.AgenticRagTools;
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.KeyStrategy;
+import com.alibaba.cloud.ai.graph.StateGraph;
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.exception.GraphStateException;
+import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
+import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.alibaba.cloud.ai.graph.StateGraph.END;
+import static com.alibaba.cloud.ai.graph.StateGraph.START;
+import static com.alibaba.cloud.ai.graph.action.AsyncEdgeAction.edge_async;
+import static com.alibaba.cloud.ai.graph.action.AsyncNodeAction.node_async;
+
+/**
+ * Agentic RAG pattern: the LLM decides whether retrieval is needed (classify), the
+ * answer is generated from the retrieved context (answer), and a quality gate checks
+ * whether the answer is complete and grounded (check). If not, the query is refined and
+ * retrieval runs again, up to a configurable number of rounds.
+ *
+ * <p>In contrast to the fixed-pipeline RAG workflow in the {@code workflow} example
+ * (rewrite → retrieve → prepare → agent), retrieval here is a tool the agent drives
+ * dynamically, so simple questions skip retrieval entirely and complex questions can
+ * trigger several retrieval rounds until the answer is complete.
+ */
+@Configuration
+public class AgenticRagConfig {
+
+	private static final String CLASSIFY_PROMPT = """
+			You are the router of an agentic RAG system for a product knowledge base.
+			Decide whether answering the question REQUIRES retrieving information from the knowledge base.
+			The knowledge base contains: pricing plans, refund policies, API rate limits, features, and support information.
+			Reply with exactly one word: RETRIEVE or ANSWER.
+			- RETRIEVE: the question asks about facts that may be in the knowledge base (pricing, refunds, API, features, support).
+			- ANSWER: the question is general or conversational, or it cannot be answered by the knowledge base.
+
+			Question: %s
+			""";
+
+	private static final String ANSWER_PROMPT = """
+			You are a customer support assistant for Acme Analytics, a SaaS analytics product.
+			Answer the question using ONLY the context below.
+			If the context does not contain the answer, state clearly that the information is not available in the knowledge base.
+			Respond concisely, citing the specific facts you used.
+
+			Context:
+			%s
+
+			Question: %s
+			""";
+
+	private static final String CHECK_PROMPT = """
+			You are the quality gate of an agentic RAG system.
+			Determine whether the answer below is complete and grounded in the provided context for the question.
+			- If the answer fully addresses the question using the context, reply with exactly: COMPLETE
+			- If the answer lacks required information (for example, the context misses part of the question, or the answer says the information is unavailable), reply with two lines:
+			  INCOMPLETE
+			  <a more specific search query that would find the missing information>
+
+			Question: %s
+
+			Context:
+			%s
+
+			Answer:
+			%s
+			""";
+
+	private static final String AGENT_PROMPT = """
+			You are the entry point of the agentic RAG demo.
+			Use the answer_question tool to answer the user's question about the product knowledge base.
+			""";
+
+	/**
+	 * In-memory vector store seeded with a small product knowledge base. In production,
+	 * replace this with a persistent store (PostgreSQL + pgvector, Redis, etc.).
+	 */
+	@Bean
+	public VectorStore agenticRagVectorStore(EmbeddingModel embeddingModel) {
+		VectorStore vectorStore = SimpleVectorStore.builder(embeddingModel).build();
+		List<Document> docs = List.of(
+				new Document("Pricing: The monthly plan costs $49 per month. The annual plan costs $490 per year and includes two months free.",
+						Map.of("source", "pricing")),
+				new Document("Refund policy: Annual plans can be refunded within 30 days of purchase for a full refund. After 30 days, refunds are prorated for the unused portion.",
+						Map.of("source", "refunds")),
+				new Document("Refund policy: Monthly plans are non-refundable. You can cancel at any time and the subscription ends at the end of the current billing period.",
+						Map.of("source", "refunds")),
+				new Document("API rate limits: The free tier allows 10 requests per minute. Paid plans allow 100 requests per minute. Enterprise plans have no rate limits.",
+						Map.of("source", "api")),
+				new Document("Features: Acme Analytics provides real-time dashboards, anomaly alerts, forecasting, and a public REST API.",
+						Map.of("source", "features")),
+				new Document("Support: Standard plans include email support with a 24-hour response time. Enterprise plans include 24/7 phone support and a dedicated account manager.",
+						Map.of("source", "support")));
+		vectorStore.add(docs);
+		return vectorStore;
+	}
+
+	@Bean
+	public CompiledGraph agenticRagGraph(ChatModel chatModel, VectorStore agenticRagVectorStore)
+			throws GraphStateException {
+
+		ClassifyNode classifyNode = new ClassifyNode(chatModel, CLASSIFY_PROMPT);
+		RetrieveNode retrieveNode = new RetrieveNode(agenticRagVectorStore);
+		AnswerNode answerNode = new AnswerNode(chatModel, ANSWER_PROMPT);
+		CheckNode checkNode = new CheckNode(chatModel, CHECK_PROMPT);
+
+		StateGraph graph = new StateGraph("agentic_rag", () -> {
+			Map<String, KeyStrategy> strategies = new HashMap<>();
+			strategies.put("question", new ReplaceStrategy());
+			strategies.put("route", new ReplaceStrategy());
+			strategies.put("search_query", new ReplaceStrategy());
+			strategies.put("documents", new ReplaceStrategy());
+			strategies.put("final_answer", new ReplaceStrategy());
+			strategies.put("retry_count", new ReplaceStrategy());
+			strategies.put("retrieval_rounds", new ReplaceStrategy());
+			strategies.put("messages", new AppendStrategy(false));
+			return strategies;
+		});
+
+		graph.addNode("classify", node_async(classifyNode))
+				.addNode("retrieve", node_async(retrieveNode))
+				.addNode("answer", node_async(answerNode))
+				.addNode("check", node_async(checkNode))
+				.addEdge(START, "classify")
+				.addConditionalEdges("classify",
+						edge_async(state -> state.<String>value("route").filter("retrieve"::equals).orElse("answer")),
+						Map.of("retrieve", "retrieve", "answer", "answer"))
+				.addEdge("retrieve", "answer")
+				.addEdge("answer", "check")
+				.addConditionalEdges("check",
+						edge_async(state -> state.<String>value("route").filter("retry"::equals).orElse("done")),
+						Map.of("retry", "retrieve", "done", END));
+
+		return graph.compile();
+	}
+
+	@Bean
+	public AgenticRagService agenticRagService(CompiledGraph agenticRagGraph) {
+		return new AgenticRagService(agenticRagGraph);
+	}
+
+	/**
+	 * Entry agent for Spring AI Alibaba Studio: exposes the agentic RAG graph as a
+	 * chat agent whose single tool is the graph itself.
+	 */
+	@Bean
+	public ReactAgent agenticRagAgent(ChatModel chatModel, AgenticRagService agenticRagService) {
+		return ReactAgent.builder()
+				.name("agentic_rag")
+				.description("Answers questions about the product knowledge base using agentic RAG: decides whether to retrieve, and iterates until the answer is complete.")
+				.systemPrompt(AGENT_PROMPT)
+				.model(chatModel)
+				.methodTools(new AgenticRagTools(agenticRagService))
+				.inputType(String.class)
+				.build();
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagRunner.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagRunner.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Optional demo runner. Set {@code agentic-rag.runner.enabled=true} to run the three
+ * demo scenarios on startup: a retrieval question, a conversational question that
+ * skips retrieval, and a question that may require several retrieval rounds.
+ */
+@Component
+@ConditionalOnProperty(name = "agentic-rag.runner.enabled", havingValue = "true")
+public class AgenticRagRunner implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(AgenticRagRunner.class);
+
+	private static final List<String> DEMO_QUESTIONS = List.of(
+			"What is the refund policy for the annual plan?",
+			"What is your name and what can you help me with?",
+			"Compare the refund policy of the annual plan with the monthly plan.");
+
+	private final AgenticRagService agenticRagService;
+
+	public AgenticRagRunner(AgenticRagService agenticRagService) {
+		this.agenticRagService = agenticRagService;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) {
+		for (String question : DEMO_QUESTIONS) {
+			try {
+				AgenticRagService.AgenticRagResult result = agenticRagService.run(question);
+				log.info("=== Question: {}", result.question());
+				log.info("=== Retrieval rounds: {}", result.retrievalRounds());
+				log.info("=== Answer:\n{}", result.answer());
+			}
+			catch (Exception e) {
+				log.error("Demo question failed: {}", question, e);
+			}
+		}
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagRunner.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagRunner.java
@@ -25,9 +25,10 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 /**
- * Optional demo runner. Set {@code agentic-rag.runner.enabled=true} to run the three
+ * Optional demo runner. Set {@code agentic-rag.runner.enabled=true} to run the four
  * demo scenarios on startup: a retrieval question, a conversational question that
- * skips retrieval, and a question that may require several retrieval rounds.
+ * skips retrieval, a comparison question that may need several retrieval rounds, and
+ * a product question the knowledge base does not contain.
  */
 @Component
 @ConditionalOnProperty(name = "agentic-rag.runner.enabled", havingValue = "true")

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagRunner.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagRunner.java
@@ -38,7 +38,8 @@ public class AgenticRagRunner implements ApplicationRunner {
 	private static final List<String> DEMO_QUESTIONS = List.of(
 			"What is the refund policy for the annual plan?",
 			"What is your name and what can you help me with?",
-			"Compare the refund policy of the annual plan with the monthly plan.");
+			"Compare the refund policy of the annual plan with the monthly plan.",
+			"Where is Acme Analytics customer data hosted?");
 
 	private final AgenticRagService agenticRagService;
 

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagService.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag;
+
+import com.alibaba.cloud.ai.graph.CompiledGraph;
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Invokes the agentic RAG graph (classify → [retrieve] → answer → check) for a question
+ * and exposes the final answer together with how many retrieval rounds were performed.
+ */
+public class AgenticRagService {
+
+	private static final Logger log = LoggerFactory.getLogger(AgenticRagService.class);
+
+	private final CompiledGraph graph;
+
+	public AgenticRagService(CompiledGraph graph) {
+		this.graph = graph;
+	}
+
+	public AgenticRagResult run(String question) throws GraphRunnerException {
+		Map<String, Object> inputs = Map.of("question", question);
+		// Each run is an independent Q&A turn: give it a fresh thread id so the
+		// checkpoint saver (a MemorySaver by default) does not replay state
+		// (documents, retrieval counters) from a previous run.
+		RunnableConfig config = RunnableConfig.builder()
+			.threadId(UUID.randomUUID().toString())
+			.build();
+		Optional<OverAllState> resultOpt = graph.invoke(inputs, config);
+
+		if (resultOpt.isEmpty()) {
+			return new AgenticRagResult(question, "No result from graph.", 0);
+		}
+
+		OverAllState state = resultOpt.get();
+		String answer = state.value("final_answer").map(Object::toString).orElse("");
+		int retrievalRounds = state.value("retrieval_rounds")
+				.map(Object::toString)
+				.map(Integer::parseInt)
+				.orElse(0);
+
+		log.debug("Agentic RAG completed, retrieval rounds={}, answer length={}", retrievalRounds, answer.length());
+
+		return new AgenticRagResult(question, answer, retrievalRounds);
+	}
+
+	public record AgenticRagResult(String question, String answer, int retrievalRounds) {
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagService.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/AgenticRagService.java
@@ -17,14 +17,12 @@ package com.alibaba.cloud.ai.examples.multiagents.agenticrag;
 
 import com.alibaba.cloud.ai.graph.CompiledGraph;
 import com.alibaba.cloud.ai.graph.OverAllState;
-import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * Invokes the agentic RAG graph (classify → [retrieve] → answer → check) for a question
@@ -42,13 +40,10 @@ public class AgenticRagService {
 
 	public AgenticRagResult run(String question) throws GraphRunnerException {
 		Map<String, Object> inputs = Map.of("question", question);
-		// Each run is an independent Q&A turn: give it a fresh thread id so the
-		// checkpoint saver (a MemorySaver by default) does not replay state
-		// (documents, retrieval counters) from a previous run.
-		RunnableConfig config = RunnableConfig.builder()
-			.threadId(UUID.randomUUID().toString())
-			.build();
-		Optional<OverAllState> resultOpt = graph.invoke(inputs, config);
+		// The graph is compiled without a checkpoint saver, so every invoke starts
+		// from a fresh state: nothing from a previous run (documents, retrieval
+		// counters) is replayed, and nothing is retained on success or failure.
+		Optional<OverAllState> resultOpt = graph.invoke(inputs);
 
 		if (resultOpt.isEmpty()) {
 			return new AgenticRagResult(question, "No result from graph.", 0);

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/AnswerNode.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/AnswerNode.java
@@ -24,9 +24,11 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Generates the answer from the retrieved context (or, when the router decided no
- * retrieval was needed, from the direct conversational prompt). Writes the result to
- * the {@code final_answer} state key.
+ * Generates the answer. When the router chose to answer directly ({@code route ==
+ * "answer"}), a conversational prompt is used; otherwise the answer is grounded in the
+ * retrieved context. The choice follows the routing decision rather than whether the
+ * document list happens to be non-empty, so an empty retrieval still produces an honest
+ * "not in the knowledge base" answer instead of unconstrained generation.
  */
 public class AnswerNode implements NodeAction {
 
@@ -45,14 +47,16 @@ public class AnswerNode implements NodeAction {
 	@Override
 	public Map<String, Object> apply(OverAllState state) throws Exception {
 		String question = state.value("question").map(Object::toString).orElse("");
-		@SuppressWarnings("unchecked")
-		List<String> docs = (List<String>) state.value("documents").orElse(List.of());
+		String route = state.value("route").map(Object::toString).orElse("");
 		String prompt;
-		if (docs.isEmpty()) {
+		if ("answer".equals(route)) {
 			prompt = directAnswerPromptTemplate.formatted(question);
 		}
 		else {
-			prompt = answerPromptTemplate.formatted(String.join("\n\n", docs), question);
+			@SuppressWarnings("unchecked")
+			List<String> docs = (List<String>) state.value("documents").orElse(List.of());
+			String context = docs.isEmpty() ? "(no context retrieved)" : String.join("\n\n", docs);
+			prompt = answerPromptTemplate.formatted(context, question);
 		}
 		String answer = chatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
 		return Map.of("final_answer", answer != null ? answer.trim() : "");

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/AnswerNode.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/AnswerNode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generates the answer from the retrieved context (or directly from the model when the
+ * router decided no retrieval was needed). Writes the result to the {@code final_answer}
+ * state key.
+ */
+public class AnswerNode implements NodeAction {
+
+	private final ChatModel chatModel;
+
+	private final String promptTemplate;
+
+	public AnswerNode(ChatModel chatModel, String promptTemplate) {
+		this.chatModel = chatModel;
+		this.promptTemplate = promptTemplate;
+	}
+
+	@Override
+	public Map<String, Object> apply(OverAllState state) throws Exception {
+		String question = state.value("question").map(Object::toString).orElse("");
+		@SuppressWarnings("unchecked")
+		List<String> docs = (List<String>) state.value("documents").orElse(List.of());
+		String context = docs.isEmpty() ? "(no context retrieved)" : String.join("\n\n", docs);
+		String prompt = promptTemplate.formatted(context, question);
+		String answer = chatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
+		return Map.of("final_answer", answer != null ? answer.trim() : "");
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/AnswerNode.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/AnswerNode.java
@@ -24,19 +24,22 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Generates the answer from the retrieved context (or directly from the model when the
- * router decided no retrieval was needed). Writes the result to the {@code final_answer}
- * state key.
+ * Generates the answer from the retrieved context (or, when the router decided no
+ * retrieval was needed, from the direct conversational prompt). Writes the result to
+ * the {@code final_answer} state key.
  */
 public class AnswerNode implements NodeAction {
 
 	private final ChatModel chatModel;
 
-	private final String promptTemplate;
+	private final String answerPromptTemplate;
 
-	public AnswerNode(ChatModel chatModel, String promptTemplate) {
+	private final String directAnswerPromptTemplate;
+
+	public AnswerNode(ChatModel chatModel, String answerPromptTemplate, String directAnswerPromptTemplate) {
 		this.chatModel = chatModel;
-		this.promptTemplate = promptTemplate;
+		this.answerPromptTemplate = answerPromptTemplate;
+		this.directAnswerPromptTemplate = directAnswerPromptTemplate;
 	}
 
 	@Override
@@ -44,8 +47,13 @@ public class AnswerNode implements NodeAction {
 		String question = state.value("question").map(Object::toString).orElse("");
 		@SuppressWarnings("unchecked")
 		List<String> docs = (List<String>) state.value("documents").orElse(List.of());
-		String context = docs.isEmpty() ? "(no context retrieved)" : String.join("\n\n", docs);
-		String prompt = promptTemplate.formatted(context, question);
+		String prompt;
+		if (docs.isEmpty()) {
+			prompt = directAnswerPromptTemplate.formatted(question);
+		}
+		else {
+			prompt = answerPromptTemplate.formatted(String.join("\n\n", docs), question);
+		}
 		String answer = chatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
 		return Map.of("final_answer", answer != null ? answer.trim() : "");
 	}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/CheckNode.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/CheckNode.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Quality gate: verifies that the answer is complete and grounded in the retrieved
+ * context. When the answer is incomplete, refines the search query and routes back to
+ * the {@code retrieve} node, up to {@link #MAX_RETRIES} rounds.
+ */
+public class CheckNode implements NodeAction {
+
+	private static final int MAX_RETRIES = 2;
+
+	private final ChatModel chatModel;
+
+	private final String promptTemplate;
+
+	public CheckNode(ChatModel chatModel, String promptTemplate) {
+		this.chatModel = chatModel;
+		this.promptTemplate = promptTemplate;
+	}
+
+	@Override
+	public Map<String, Object> apply(OverAllState state) throws Exception {
+		int retryCount = state.value("retry_count")
+				.map(Object::toString)
+				.map(Integer::parseInt)
+				.orElse(0);
+		if (retryCount >= MAX_RETRIES) {
+			return Map.of("route", "done");
+		}
+
+		String question = state.value("question").map(Object::toString).orElse("");
+		String answer = state.value("final_answer").map(Object::toString).orElse("");
+		@SuppressWarnings("unchecked")
+		List<String> docs = (List<String>) state.value("documents").orElse(List.of());
+
+		// Direct answers (no retrieval) are final: the quality gate only applies to
+		// answers grounded in retrieved context.
+		if (docs.isEmpty()) {
+			return Map.of("route", "done");
+		}
+
+		String context = String.join("\n\n", docs);
+
+		String prompt = promptTemplate.formatted(question, context, answer);
+		String response = chatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
+		if (response != null && response.trim().toUpperCase().startsWith("INCOMPLETE")) {
+			String improvedQuery = extractImprovedQuery(response, question);
+			return Map.of("route", "retry", "search_query", improvedQuery, "retry_count", retryCount + 1);
+		}
+		return Map.of("route", "done");
+	}
+
+	/**
+	 * The model replies with {@code INCOMPLETE} followed by a refined search query on
+	 * the next non-empty line. Falls back to the original question when parsing fails.
+	 */
+	private String extractImprovedQuery(String response, String fallbackQuery) {
+		for (String line : response.split("\n")) {
+			String trimmed = line.trim();
+			if (!trimmed.isEmpty() && !trimmed.equalsIgnoreCase("INCOMPLETE")) {
+				return trimmed;
+			}
+		}
+		return fallbackQuery;
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/CheckNode.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/CheckNode.java
@@ -44,9 +44,9 @@ public class CheckNode implements NodeAction {
 	@Override
 	public Map<String, Object> apply(OverAllState state) throws Exception {
 		int retryCount = state.value("retry_count")
-				.map(Object::toString)
-				.map(Integer::parseInt)
-				.orElse(0);
+			.map(Object::toString)
+			.map(Integer::parseInt)
+			.orElse(0);
 		if (retryCount >= MAX_RETRIES) {
 			return Map.of("route", "done");
 		}
@@ -56,13 +56,15 @@ public class CheckNode implements NodeAction {
 		@SuppressWarnings("unchecked")
 		List<String> docs = (List<String>) state.value("documents").orElse(List.of());
 
-		// Direct answers (no retrieval) are final: the quality gate only applies to
-		// answers grounded in retrieved context.
-		if (docs.isEmpty()) {
+		// Direct answers (the router chose not to retrieve) are final. The gate only
+		// applies to answers produced by the retrieval path — including an empty
+		// retrieval, which must be checked so the model reports missing information
+		// instead of inventing facts.
+		if ("answer".equals(state.value("route").map(Object::toString).orElse(""))) {
 			return Map.of("route", "done");
 		}
 
-		String context = String.join("\n\n", docs);
+		String context = docs.isEmpty() ? "(no context retrieved)" : String.join("\n\n", docs);
 
 		String prompt = promptTemplate.formatted(question, context, answer);
 		String response = chatModel.call(new Prompt(prompt)).getResult().getOutput().getText();

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/ClassifyNode.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/ClassifyNode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.Map;
+
+/**
+ * Decides whether the question requires knowledge base retrieval. Writes the routing
+ * decision to the {@code route} state key, consumed by the conditional edge from the
+ * {@code classify} node.
+ */
+public class ClassifyNode implements NodeAction {
+
+	private final ChatModel chatModel;
+
+	private final String promptTemplate;
+
+	public ClassifyNode(ChatModel chatModel, String promptTemplate) {
+		this.chatModel = chatModel;
+		this.promptTemplate = promptTemplate;
+	}
+
+	@Override
+	public Map<String, Object> apply(OverAllState state) throws Exception {
+		String question = state.value("question").map(Object::toString).orElse("");
+		String prompt = promptTemplate.formatted(question);
+		String response = chatModel.call(new Prompt(prompt)).getResult().getOutput().getText();
+		String route = response != null && response.trim().toUpperCase().startsWith("RETRIEVE") ? "retrieve" : "answer";
+		return Map.of("route", route);
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/RetrieveNode.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/node/RetrieveNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.action.NodeAction;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Retrieves documents from the vector store. Uses the refined {@code search_query}
+ * when available (set by the quality gate on a retry), otherwise the original question.
+ */
+public class RetrieveNode implements NodeAction {
+
+	private static final int TOP_K = 3;
+
+	private final VectorStore vectorStore;
+
+	public RetrieveNode(VectorStore vectorStore) {
+		this.vectorStore = vectorStore;
+	}
+
+	@Override
+	public Map<String, Object> apply(OverAllState state) throws Exception {
+		String query = state.value("search_query")
+				.map(Object::toString)
+				.orElse(state.value("question").map(Object::toString).orElse(""));
+		List<Document> docs = vectorStore.similaritySearch(SearchRequest.builder().query(query).topK(TOP_K).build());
+		List<String> contents = docs.stream().map(Document::getText).toList();
+		int rounds = state.value("retry_count")
+				.map(Object::toString)
+				.map(Integer::parseInt)
+				.orElse(0) + 1;
+		return Map.of("documents", contents, "retrieval_rounds", rounds);
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/tools/AgenticRagTools.java
+++ b/examples/multiagent-patterns/agentic-rag/src/main/java/com/alibaba/cloud/ai/examples/multiagents/agenticrag/tools/AgenticRagTools.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.examples.multiagents.agenticrag.tools;
+
+import com.alibaba.cloud.ai.examples.multiagents.agenticrag.AgenticRagService;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+/**
+ * Tool that exposes the agentic RAG graph as a single callable for the Studio entry
+ * agent. The graph decides internally whether and how many times to retrieve.
+ */
+public class AgenticRagTools {
+
+	private final AgenticRagService agenticRagService;
+
+	public AgenticRagTools(AgenticRagService agenticRagService) {
+		this.agenticRagService = agenticRagService;
+	}
+
+	@Tool(name = "answer_question", description = "Answers a question about the Acme Analytics product knowledge base (pricing, refunds, API rate limits, features, support) using agentic RAG.")
+	public String answerQuestion(@ToolParam(description = "The question to answer") String question) {
+		try {
+			return agenticRagService.run(question).answer();
+		}
+		catch (Exception e) {
+			return "Failed to answer: " + e.getMessage();
+		}
+	}
+}

--- a/examples/multiagent-patterns/agentic-rag/src/main/resources/application.yml
+++ b/examples/multiagent-patterns/agentic-rag/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: agentic-rag
+  ai:
+    dashscope:
+      api-key: ${AI_DASHSCOPE_API_KEY:}
+
+# Set to true to run the three demo scenarios on startup (see AgenticRagRunner).
+# Default: false (app starts without calling the model).
+agentic-rag:
+  runner:
+    enabled: false

--- a/examples/multiagent-patterns/agentic-rag/src/main/resources/application.yml
+++ b/examples/multiagent-patterns/agentic-rag/src/main/resources/application.yml
@@ -6,7 +6,8 @@ spring:
       api-key: ${AI_DASHSCOPE_API_KEY:}
 
 # Set to true to run the three demo scenarios on startup (see AgenticRagRunner).
-# Default: false (app starts without calling the model).
+# Default: false. Note: the in-memory vector store is still seeded at startup, which
+# requires a valid API key for the embedding model.
 agentic-rag:
   runner:
     enabled: false

--- a/examples/multiagent-patterns/agentic-rag/src/main/resources/application.yml
+++ b/examples/multiagent-patterns/agentic-rag/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     dashscope:
       api-key: ${AI_DASHSCOPE_API_KEY:}
 
-# Set to true to run the three demo scenarios on startup (see AgenticRagRunner).
+# Set to true to run the four demo scenarios on startup (see AgenticRagRunner).
 # Default: false. Note: the in-memory vector store is still seeded at startup, which
 # requires a valid API key for the embedding model.
 agentic-rag:


### PR DESCRIPTION
Closes part of #4018 (multi-agent demo examples).

This PR adds an **agentic RAG** example to `examples/multiagent-patterns/agentic-rag`, covering the Agentic RAG pattern listed in the issue. It complements the existing fixed-pipeline RAG workflow in `examples/multiagent-patterns/workflow` (rewrite → retrieve → prepare → agent), where retrieval always runs exactly once.

### Flow

```
classify (LLM: retrieve needed?) --retrieve--> retrieve (vector search)
        |                                            |
        +-------------answer (no retrieval)          v
                                            answer (LLM, grounded in context)
                                                      |
                                                   check (LLM quality gate)
                                                      |--retry (refined search_query, max 2)---> retrieve
                                                      +--done--> END
```

Three LLM decision points make it agentic:

1. **classify** routes conversational questions directly to `answer` (zero retrieval rounds).
2. **answer** answers strictly from the retrieved context.
3. **check** detects incomplete answers, refines the search query, and re-runs retrieval — bounded by `CheckNode.MAX_RETRIES` (default 2), so up to 3 retrieval rounds.

### Design choices

- **Independent Q&A turns**: `AgenticRagService.run()` compiles the graph with an empty `SaverConfig.builder().build()` — no checkpoint saver is registered, so each `run()` starts from fresh state instead of replaying the previous turn’s documents and retrieval counters.
- **Quality gate only after retrieval**: `check` is skipped when the router answered without retrieving, so conversational questions never enter a retry loop.
- **Studio integration**: an `AgentStaticLoader` registers the `agentic_rag` entry agent (with a single `answer_question` tool) for Spring AI Alibaba Studio.

### Structure

- 4 graph nodes (`ClassifyNode`, `RetrieveNode`, `AnswerNode`, `CheckNode`) + service, runner, Studio agent loader
- In-memory `SimpleVectorStore` seeded with a small product knowledge base (pricing, refunds, API limits, features, support) — swappable for a persistent store
- 3 demo scenarios runnable via `--agentic-rag.runner.enabled=true`: retrieval question (1 round), conversational question (0 rounds), comparison question (2 rounds)

### Verification

- `mvn -f examples/multiagent-patterns/agentic-rag clean package` passes (JDK 17).
- Verified the three scenarios with a stubbed `ChatModel`/`EmbeddingModel` (0, 1, and 2 retrieval rounds respectively, quality gate retry loop), following the existing examples' pattern of no test sources in the example module.

Follows the structure and code style of the existing `supervisor` and `workflow` examples (same parent POM, DashScope starter, license headers).
