### PR TITLE
fix(graph): honor checkpoint retention in RedisSaver

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/redis/RedisSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/redis/RedisSaver.java
@@ -346,6 +346,7 @@ public class RedisSaver implements BaseCheckpointSaver {
 				// Add Checkpoint
 				checkpoints.push(checkpoint);
 			}
+			retainLatestCheckpoints(checkpoints, config);
 
 			RBucket<byte[]> bucket = redisson.getBucket(contentKey, ByteArrayCodec.INSTANCE);
 			bucket.set(serializeCheckpoints(checkpoints));

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/RedisSaverTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/RedisSaverTest.java
@@ -829,6 +829,65 @@ class RedisSaverTest {
 		assertTrue(allCheckpoints.stream().anyMatch(cp -> "cp2".equals(cp.getId())));
 	}
 
+	@Test
+	void testCheckpointRetention() throws Exception {
+		String threadName = "test-retention-thread-" + UUID.randomUUID();
+		RunnableConfig config = RunnableConfig.builder().threadId(threadName).checkpointsNumRetained(2).build();
+
+		Checkpoint cp1 = Checkpoint.builder().id("cp1").state(Map.of()).nodeId("node1").nextNodeId("node2").build();
+		Checkpoint cp2 = Checkpoint.builder().id("cp2").state(Map.of()).nodeId("node2").nextNodeId("node3").build();
+		Checkpoint cp3 = Checkpoint.builder().id("cp3").state(Map.of()).nodeId("node3").nextNodeId("node4").build();
+
+		redisSaver.put(config, cp1);
+		redisSaver.put(config, cp2);
+		redisSaver.put(config, cp3);
+
+		List<Checkpoint> checkpoints = (List<Checkpoint>) redisSaver.list(config);
+		assertEquals(List.of("cp3", "cp2"), checkpoints.stream().map(Checkpoint::getId).toList());
+		assertEquals("cp3", redisSaver.get(config).orElseThrow().getId());
+		assertTrue(redisSaver.get(RunnableConfig.builder(config).checkPointId("cp1").build()).isEmpty());
+	}
+
+	@Test
+	void testCheckpointRetentionAfterUpdate() throws Exception {
+		String threadName = "test-retention-update-thread-" + UUID.randomUUID();
+		RunnableConfig config = RunnableConfig.builder().threadId(threadName).build();
+		Checkpoint cp1 = Checkpoint.builder().id("cp1").state(Map.of()).nodeId("node1").nextNodeId("node2").build();
+		Checkpoint cp2 = Checkpoint.builder().id("cp2").state(Map.of("version", 1)).nodeId("node2").nextNodeId("node3").build();
+		Checkpoint cp3 = Checkpoint.builder().id("cp3").state(Map.of()).nodeId("node3").nextNodeId("node4").build();
+
+		redisSaver.put(config, cp1);
+		redisSaver.put(config, cp2);
+		redisSaver.put(config, cp3);
+		RunnableConfig updateConfig = RunnableConfig.builder(config).checkPointId("cp2").checkpointsNumRetained(2).build();
+		Checkpoint updatedCp2 = Checkpoint.builder()
+				.id("cp2")
+				.state(Map.of("version", 2))
+				.nodeId("node2")
+				.nextNodeId("node3")
+				.build();
+
+		redisSaver.put(updateConfig, updatedCp2);
+
+		List<Checkpoint> checkpoints = (List<Checkpoint>) redisSaver.list(config);
+		assertEquals(List.of("cp3", "cp2"), checkpoints.stream().map(Checkpoint::getId).toList());
+		assertEquals(2, redisSaver.get(updateConfig).orElseThrow().getState().get("version"));
+		assertTrue(redisSaver.get(RunnableConfig.builder(config).checkPointId("cp1").build()).isEmpty());
+	}
+
+	@Test
+	void testCheckpointsWithoutRetentionAreNotPruned() throws Exception {
+		String threadName = "test-no-retention-thread-" + UUID.randomUUID();
+		RunnableConfig config = RunnableConfig.builder().threadId(threadName).build();
+
+		redisSaver.put(config, Checkpoint.builder().id("cp1").state(Map.of()).nodeId("node1").nextNodeId("node2").build());
+		redisSaver.put(config, Checkpoint.builder().id("cp2").state(Map.of()).nodeId("node2").nextNodeId("node3").build());
+		redisSaver.put(config, Checkpoint.builder().id("cp3").state(Map.of()).nodeId("node3").nextNodeId("node4").build());
+
+		List<Checkpoint> checkpoints = (List<Checkpoint>) redisSaver.list(config);
+		assertEquals(List.of("cp3", "cp2", "cp1"), checkpoints.stream().map(Checkpoint::getId).toList());
+	}
+
 	/**
 	 * Test concurrent access to the same thread_name with locks.
 	 */


### PR DESCRIPTION
### Describe what this PR does / why we need it

Aligns `RedisSaver` with the existing checkpoint retention behavior defined by `BaseCheckpointSaver`.

`MemorySaver` and JDBC-based savers already honor `checkpoints.numRetained`, while `RedisSaver` previously persisted the full checkpoint list without applying the retention policy.

Related to #4898.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Applied the existing `retainLatestCheckpoints` logic in `RedisSaver.put()` before serializing and writing checkpoints back to Redis.

No public API or retention semantics were changed.

Added regression tests covering checkpoint retention, update behavior, latest-checkpoint retrieval, and eviction of old checkpoints.

### Describe how to verify it

Run:

`RedisSaverTest`

Verification result:

* 21 tests passed
* 0 failures
* 0 errors
* 0 skipped
* `git diff --check` passed

### Special notes for reviews

The retention logic is applied within the existing Redis write/lock flow and reuses the behavior already implemented by other saver backends.

Redis TTL behavior is unchanged.
