### PR TITLE
fix(graph): escape thread id in FileSystemSaver release

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaver.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaver.java
@@ -334,7 +334,7 @@ public class FileSystemSaver implements BaseCheckpointSaver {
 			return;
 		}
 
-		var versionPattern = Pattern.compile(format("%s-v(\\d+)\\%s$", getBaseName(config), EXTENSION));
+		var versionPattern = Pattern.compile(format("%s-v(\\d+)\\%s$", Pattern.quote(getBaseName(config)), EXTENSION));
 
 		int maxVersion = 0;
 		try (var stream = Files.list(targetFolder)) {

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaverCacheTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/checkpoint/savers/file/FileSystemSaverCacheTest.java
@@ -104,6 +104,26 @@ public class FileSystemSaverCacheTest {
 	}
 
 	@Test
+	public void releaseShouldTreatRegexMetacharactersInThreadIdAsLiterals() throws Exception {
+		FileSystemSaver saver = FileSystemSaver.builder()
+				.targetFolder(tempDir)
+				.build();
+		RunnableConfig config = config("[");
+		Checkpoint checkpoint = checkpoint("v1");
+
+		saver.put(config, checkpoint);
+		assertTrue(Files.exists(tempDir.resolve("thread-[.saver")));
+
+		var tag = saver.release(config);
+
+		assertEquals("[", tag.threadId());
+		assertEquals(1, tag.checkpoints().size());
+		assertEquals(checkpoint.getId(), tag.checkpoints().iterator().next().getId());
+		assertFalse(Files.exists(tempDir.resolve("thread-[.saver")));
+		assertTrue(Files.exists(tempDir.resolve("thread-[-v1.saver")));
+	}
+
+	@Test
 	public void shouldRetainOnlyLatestCheckpoints() throws Exception {
 		FileSystemSaver saver = FileSystemSaver.builder()
 				.targetFolder(tempDir)


### PR DESCRIPTION
### Describe what this PR does / why we need it

`FileSystemSaver.release()` currently treats the dynamically generated checkpoint base name as part of a regular expression.

When a valid `threadId` contains regex metacharacters, such as `[`, `put()` succeeds but `release()` fails with a `PatternSyntaxException`.

This PR makes the dynamic base name match literally when locating checkpoint history files.

### Does this pull request fix one issue?

Fixes #4919

### Describe how you did it

Escaped the dynamic base name with `Pattern.quote(...)` before using it in the release-file matching regex.

The change does not modify checkpoint file names, public APIs, or behavior for normal thread IDs.

Added a regression test covering a `threadId` containing `[`.

### Describe how to verify it

Ran the targeted FileSystemSaver tests:

* `FileSystemSaverCacheTest`: 6 passed
* `FileSystemSaverDeleteFileTest`: 1 passed
* Total: 7 passed, 0 failures, 0 errors

`git diff --check` also passed.

### Special notes for reviews

The fix only changes regex matching during `release()`; checkpoint persistence and file naming behavior remain unchanged.
