### PR TITLE
feat(agent): support pluggable tool selection strategies

### DIFF
--- a/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/tutorials/mcp/RemoteMcpToolsExample.java
+++ b/examples/documentation/src/main/java/com/alibaba/cloud/ai/examples/documentation/framework/tutorials/mcp/RemoteMcpToolsExample.java
@@ -22,6 +22,7 @@ import com.alibaba.cloud.ai.graph.NodeOutput;
 import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.agent.Builder;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.interceptor.toolselection.ToolSelectionInterceptor;
 import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.exception.GraphRunnerException;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
@@ -306,6 +307,10 @@ public class RemoteMcpToolsExample {
                 .model(chatModel)
                 .description("Your Travel Assistant")
                 .instruction(instruction)
+                .interceptors(ToolSelectionInterceptor.builder()
+                        .selectionModel(chatModel)
+                        .maxTools(5)
+                        .build())
                 .saver(new MemorySaver());
         if (toolCallbackProvider != null) {
             builder.toolCallbackProviders(toolCallbackProvider);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/LlmToolSelectionStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/LlmToolSelectionStrategy.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptor.toolselection;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link ToolSelectionStrategy} that asks a chat model to select relevant tools.
+ */
+public final class LlmToolSelectionStrategy implements ToolSelectionStrategy {
+
+	private static final Logger logger = LoggerFactory.getLogger(LlmToolSelectionStrategy.class);
+
+	static final String DEFAULT_SYSTEM_PROMPT =
+			"Your goal is to select the most relevant tools for answering the user's query.";
+
+	private final ChatModel selectionModel;
+
+	private final String systemPrompt;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	public LlmToolSelectionStrategy(ChatModel selectionModel) {
+		this(selectionModel, DEFAULT_SYSTEM_PROMPT);
+	}
+
+	public LlmToolSelectionStrategy(ChatModel selectionModel, String systemPrompt) {
+		if (selectionModel == null) {
+			throw new IllegalArgumentException("selectionModel must not be null");
+		}
+		this.selectionModel = selectionModel;
+		this.systemPrompt = systemPrompt != null ? systemPrompt : DEFAULT_SYSTEM_PROMPT;
+	}
+
+	@Override
+	public List<String> select(ToolSelectionRequest request) {
+		StringBuilder toolList = new StringBuilder();
+		for (ToolMetadata tool : request.tools()) {
+			toolList.append("- ").append(tool.name());
+			if (tool.description() != null && !tool.description().isEmpty()) {
+				toolList.append(": ").append(tool.description());
+			}
+			toolList.append("\n");
+		}
+
+		String maxToolsInstruction = request.maxTools() != null
+				? "\nIMPORTANT: List the tool names in order of relevance. Select at most "
+						+ request.maxTools() + " tools."
+				: "";
+
+		List<Message> selectionMessages = List.of(
+				new SystemMessage(systemPrompt + maxToolsInstruction),
+				new UserMessage("Available tools:\n" + toolList + "\nUser query: " + request.query()
+						+ "\n\nRespond with a JSON object containing a 'tools' array with the selected tool names: "
+						+ "{\"tools\": [\"tool1\", \"tool2\"]}"));
+
+		var response = selectionModel.call(new Prompt(selectionMessages));
+		String responseText = response.getResult().getOutput().getText();
+		return parseToolSelection(responseText);
+	}
+
+	private List<String> parseToolSelection(String responseText) {
+		try {
+			ToolSelectionResponse response = objectMapper.readValue(responseText, ToolSelectionResponse.class);
+			return response.tools != null ? response.tools : List.of();
+		}
+		catch (Exception e) {
+			logger.debug("Failed to parse tool selection response", e);
+			return List.of();
+		}
+	}
+
+	private static class ToolSelectionResponse {
+
+		@JsonProperty("tools")
+		public List<String> tools;
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/LlmToolSelectionStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/LlmToolSelectionStrategy.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.graph.agent.interceptor.toolselection;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -82,12 +83,19 @@ public final class LlmToolSelectionStrategy implements ToolSelectionStrategy {
 
 	private List<String> parseToolSelection(String responseText) throws JsonProcessingException {
 		ToolSelectionResponse response = objectMapper.readValue(responseText, ToolSelectionResponse.class);
-		return response.tools != null ? response.tools : List.of();
+		return response.tools;
 	}
 
 	private static class ToolSelectionResponse {
 
-		@JsonProperty("tools")
-		public List<String> tools;
+		private final List<String> tools;
+
+		@JsonCreator
+		ToolSelectionResponse(@JsonProperty(value = "tools", required = true) List<String> tools) {
+			if (tools == null) {
+				throw new IllegalArgumentException("tools must not be null");
+			}
+			this.tools = tools;
+		}
 	}
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/LlmToolSelectionStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/LlmToolSelectionStrategy.java
@@ -16,6 +16,7 @@
 package com.alibaba.cloud.ai.graph.agent.interceptor.toolselection;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.ai.chat.messages.Message;
@@ -26,15 +27,10 @@ import org.springframework.ai.chat.prompt.Prompt;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * {@link ToolSelectionStrategy} that asks a chat model to select relevant tools.
  */
 public final class LlmToolSelectionStrategy implements ToolSelectionStrategy {
-
-	private static final Logger logger = LoggerFactory.getLogger(LlmToolSelectionStrategy.class);
 
 	static final String DEFAULT_SYSTEM_PROMPT =
 			"Your goal is to select the most relevant tools for answering the user's query.";
@@ -58,7 +54,7 @@ public final class LlmToolSelectionStrategy implements ToolSelectionStrategy {
 	}
 
 	@Override
-	public List<String> select(ToolSelectionRequest request) {
+	public List<String> select(ToolSelectionRequest request) throws JsonProcessingException {
 		StringBuilder toolList = new StringBuilder();
 		for (ToolMetadata tool : request.tools()) {
 			toolList.append("- ").append(tool.name());
@@ -84,15 +80,9 @@ public final class LlmToolSelectionStrategy implements ToolSelectionStrategy {
 		return parseToolSelection(responseText);
 	}
 
-	private List<String> parseToolSelection(String responseText) {
-		try {
-			ToolSelectionResponse response = objectMapper.readValue(responseText, ToolSelectionResponse.class);
-			return response.tools != null ? response.tools : List.of();
-		}
-		catch (Exception e) {
-			logger.debug("Failed to parse tool selection response", e);
-			return List.of();
-		}
+	private List<String> parseToolSelection(String responseText) throws JsonProcessingException {
+		ToolSelectionResponse response = objectMapper.readValue(responseText, ToolSelectionResponse.class);
+		return response.tools != null ? response.tools : List.of();
 	}
 
 	private static class ToolSelectionResponse {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolMetadata.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolMetadata.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptor.toolselection;
+
+/**
+ * Lightweight metadata used to select a tool without exposing its input schema.
+ *
+ * @param name tool name
+ * @param description tool description, or {@code null} when unavailable
+ */
+public record ToolMetadata(String name, String description) {
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
@@ -23,6 +23,7 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -96,6 +97,10 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 			List<String> selected = selectionStrategy.select(selectionRequest);
 			selectedToolNames = normalizeSelection(availableTools, selected);
 		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Tool selection interrupted", e);
+		}
 		catch (Exception e) {
 			log.warn("Tool selection failed, using all tools: {}", e.getMessage());
 			return handler.call(request);
@@ -108,9 +113,15 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 		List<String> filteredTools = availableTools.stream().filter(selectedToolNames::contains).toList();
 
 		// Create new request with filtered tools
-		ModelRequest filteredRequest = ModelRequest.builder(request)
-				.tools(filteredTools)
-				.build();
+		ModelRequest.Builder filteredRequestBuilder = ModelRequest.builder(request).tools(filteredTools);
+		if (filteredTools.isEmpty()) {
+			ToolCallingChatOptions options = request.getOptions() != null
+					? request.getOptions().copy()
+					: ToolCallingChatOptions.builder().build();
+			options.setToolCallbacks(List.of());
+			filteredRequestBuilder.options(options);
+		}
+		ModelRequest filteredRequest = filteredRequestBuilder.build();
 
 		return handler.call(filteredRequest);
 	}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
@@ -96,7 +96,7 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 			return handler.call(request);
 		}
 
-		Set<String> selectedToolNames;
+		List<String> selectedToolNames;
 		try {
 			ToolSelectionRequest selectionRequest = new ToolSelectionRequest(lastUserQuery,
 					buildToolMetadata(availableTools, request.getToolDescriptions(), dynamicTools),
@@ -117,20 +117,26 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 				selectedToolNames.size(), availableTools.size(), selectedToolNames);
 
 		// Filter tools based on selection
-		List<String> filteredTools = staticTools.stream().filter(selectedToolNames::contains).toList();
-		List<ToolCallback> filteredDynamicTools = dynamicTools.stream()
-				.filter(tool -> selectedToolNames.contains(tool.getToolDefinition().name()))
+		Set<String> staticToolNames = new HashSet<>(staticTools);
+		Map<String, ToolCallback> dynamicToolsByName = new HashMap<>();
+		for (ToolCallback dynamicTool : dynamicTools) {
+			dynamicToolsByName.putIfAbsent(dynamicTool.getToolDefinition().name(), dynamicTool);
+		}
+		List<String> filteredTools = selectedToolNames.stream().filter(staticToolNames::contains).toList();
+		List<ToolCallback> filteredDynamicTools = selectedToolNames.stream()
+				.map(dynamicToolsByName::get)
+				.filter(tool -> tool != null)
 				.toList();
 
 		// Create new request with filtered tools
 		ModelRequest.Builder filteredRequestBuilder = ModelRequest.builder(request)
 				.tools(filteredTools)
 				.dynamicToolCallbacks(filteredDynamicTools);
-		if (filteredTools.isEmpty()) {
+		if (request.getOptions() != null || filteredTools.isEmpty()) {
 			ToolCallingChatOptions options = request.getOptions() != null
 					? request.getOptions().copy()
 					: ToolCallingChatOptions.builder().build();
-			options.setToolCallbacks(List.of());
+			options.setToolCallbacks(orderSelectedCallbacks(request, dynamicToolsByName, selectedToolNames));
 			filteredRequestBuilder.options(options);
 		}
 		ModelRequest filteredRequest = filteredRequestBuilder.build();
@@ -171,7 +177,22 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 				.toList();
 	}
 
-	private Set<String> normalizeSelection(List<String> availableTools, List<String> selectedTools) {
+	private List<ToolCallback> orderSelectedCallbacks(ModelRequest request,
+			Map<String, ToolCallback> dynamicToolsByName, List<String> selectedToolNames) {
+		Map<String, ToolCallback> callbacksByName = new HashMap<>();
+		if (request.getOptions() != null && request.getOptions().getToolCallbacks() != null) {
+			for (ToolCallback callback : request.getOptions().getToolCallbacks()) {
+				callbacksByName.putIfAbsent(callback.getToolDefinition().name(), callback);
+			}
+		}
+		dynamicToolsByName.forEach(callbacksByName::putIfAbsent);
+		return selectedToolNames.stream()
+				.map(callbacksByName::get)
+				.filter(callback -> callback != null)
+				.toList();
+	}
+
+	private List<String> normalizeSelection(List<String> availableTools, List<String> selectedTools) {
 		Set<String> available = new HashSet<>(availableTools);
 		LinkedHashSet<String> normalized = new LinkedHashSet<>();
 
@@ -194,10 +215,10 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 		}
 
 		if (maxTools != null && normalized.size() > maxTools) {
-			return new LinkedHashSet<>(normalized.stream().limit(maxTools).toList());
+			return normalized.stream().limit(maxTools).toList();
 		}
 
-		return normalized;
+		return List.copyOf(normalized);
 	}
 
 	@Override

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
@@ -24,8 +24,10 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -75,7 +77,11 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 
 	@Override
 	public ModelResponse interceptModel(ModelRequest request, ModelCallHandler handler) {
-		List<String> availableTools = request.getTools();
+		List<String> staticTools = request.getTools() != null ? request.getTools() : List.of();
+		List<ToolCallback> dynamicTools = request.getDynamicToolCallbacks() != null
+				? request.getDynamicToolCallbacks()
+				: List.of();
+		List<String> availableTools = buildAvailableToolNames(staticTools, dynamicTools);
 
 		// If no tools or already within limit, skip selection
 		if (availableTools == null || availableTools.isEmpty() ||
@@ -93,7 +99,8 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 		Set<String> selectedToolNames;
 		try {
 			ToolSelectionRequest selectionRequest = new ToolSelectionRequest(lastUserQuery,
-					buildToolMetadata(availableTools, request.getToolDescriptions()), maxTools, request.getContext());
+					buildToolMetadata(availableTools, request.getToolDescriptions(), dynamicTools),
+					maxTools, request.getContext());
 			List<String> selected = selectionStrategy.select(selectionRequest);
 			selectedToolNames = normalizeSelection(availableTools, selected);
 		}
@@ -110,10 +117,15 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 				selectedToolNames.size(), availableTools.size(), selectedToolNames);
 
 		// Filter tools based on selection
-		List<String> filteredTools = availableTools.stream().filter(selectedToolNames::contains).toList();
+		List<String> filteredTools = staticTools.stream().filter(selectedToolNames::contains).toList();
+		List<ToolCallback> filteredDynamicTools = dynamicTools.stream()
+				.filter(tool -> selectedToolNames.contains(tool.getToolDefinition().name()))
+				.toList();
 
 		// Create new request with filtered tools
-		ModelRequest.Builder filteredRequestBuilder = ModelRequest.builder(request).tools(filteredTools);
+		ModelRequest.Builder filteredRequestBuilder = ModelRequest.builder(request)
+				.tools(filteredTools)
+				.dynamicToolCallbacks(filteredDynamicTools);
 		if (filteredTools.isEmpty()) {
 			ToolCallingChatOptions options = request.getOptions() != null
 					? request.getOptions().copy()
@@ -136,10 +148,26 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 		return null;
 	}
 
-	private List<ToolMetadata> buildToolMetadata(List<String> toolNames, Map<String, String> toolDescriptions) {
+	private List<String> buildAvailableToolNames(List<String> staticTools, List<ToolCallback> dynamicTools) {
+		LinkedHashSet<String> toolNames = new LinkedHashSet<>(staticTools);
+		for (ToolCallback dynamicTool : dynamicTools) {
+			toolNames.add(dynamicTool.getToolDefinition().name());
+		}
+		return List.copyOf(toolNames);
+	}
+
+	private List<ToolMetadata> buildToolMetadata(List<String> toolNames, Map<String, String> toolDescriptions,
+			List<ToolCallback> dynamicTools) {
+		Map<String, String> descriptions = new HashMap<>();
+		if (toolDescriptions != null) {
+			descriptions.putAll(toolDescriptions);
+		}
+		for (ToolCallback dynamicTool : dynamicTools) {
+			String name = dynamicTool.getToolDefinition().name();
+			descriptions.putIfAbsent(name, dynamicTool.getToolDefinition().description());
+		}
 		return toolNames.stream()
-				.map(toolName -> new ToolMetadata(toolName,
-						toolDescriptions != null ? toolDescriptions.get(toolName) : null))
+				.map(toolName -> new ToolMetadata(toolName, descriptions.get(toolName)))
 				.toList();
 	}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionInterceptor.java
@@ -21,30 +21,26 @@ import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 
 import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.ai.chat.prompt.Prompt;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Uses an LLM to select relevant tools before calling the main model.
+ * Selects relevant tools before calling the main model.
  *
  * When an agent has many tools available, this interceptor filters them down
  * to only the most relevant ones for the user's query. This reduces token usage
- * and helps the main model focus on the right tools.
+ * and helps the main model focus on the right tools. Selection can be performed
+ * by an LLM or by a custom {@link ToolSelectionStrategy}.
  *
  * Example:
  * ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
@@ -56,23 +52,20 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 
 	private static final Logger log = LoggerFactory.getLogger(ToolSelectionInterceptor.class);
 
-	private static final String DEFAULT_SYSTEM_PROMPT =
-			"Your goal is to select the most relevant tools for answering the user's query.";
+	private final ToolSelectionStrategy selectionStrategy;
 
-	private final ChatModel selectionModel;
-	private final String systemPrompt;
 	private final Integer maxTools;
+
 	private final Set<String> alwaysInclude;
-	private final ObjectMapper objectMapper;
 
 	private ToolSelectionInterceptor(Builder builder) {
-		this.selectionModel = builder.selectionModel;
-		this.systemPrompt = builder.systemPrompt;
+		this.selectionStrategy = builder.selectionStrategy != null
+				? builder.selectionStrategy
+				: new LlmToolSelectionStrategy(builder.selectionModel, builder.systemPrompt);
 		this.maxTools = builder.maxTools;
 		this.alwaysInclude = builder.alwaysInclude != null
-				? new HashSet<>(builder.alwaysInclude)
-				: new HashSet<>();
-		this.objectMapper = new ObjectMapper();
+				? new LinkedHashSet<>(builder.alwaysInclude)
+				: new LinkedHashSet<>();
 	}
 
 	public static Builder builder() {
@@ -96,16 +89,23 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 			return handler.call(request);
 		}
 
-		// Perform tool selection
-		Set<String> selectedToolNames = selectTools(availableTools, lastUserQuery, request.getToolDescriptions());
+		Set<String> selectedToolNames;
+		try {
+			ToolSelectionRequest selectionRequest = new ToolSelectionRequest(lastUserQuery,
+					buildToolMetadata(availableTools, request.getToolDescriptions()), maxTools, request.getContext());
+			List<String> selected = selectionStrategy.select(selectionRequest);
+			selectedToolNames = normalizeSelection(availableTools, selected);
+		}
+		catch (Exception e) {
+			log.warn("Tool selection failed, using all tools: {}", e.getMessage());
+			return handler.call(request);
+		}
 
 		log.info("Selected {} tools from {} available: {}",
 				selectedToolNames.size(), availableTools.size(), selectedToolNames);
 
 		// Filter tools based on selection
-		List<String> filteredTools = availableTools.stream()
-				.filter(selectedToolNames::contains)
-				.collect(Collectors.toList());
+		List<String> filteredTools = availableTools.stream().filter(selectedToolNames::contains).toList();
 
 		// Create new request with filtered tools
 		ModelRequest filteredRequest = ModelRequest.builder(request)
@@ -125,70 +125,40 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 		return null;
 	}
 
-	private Set<String> selectTools(List<String> toolNames, String userQuery, Map<String, String> toolDescriptions) {
-		try {
-			// Build tool list for prompt with descriptions
-			StringBuilder toolList = new StringBuilder();
-			for (String toolName : toolNames) {
-				toolList.append("- ").append(toolName);
-				if (toolDescriptions != null) {
-					String description = toolDescriptions.get(toolName);
-					if (description != null && !description.isEmpty()) {
-						toolList.append(": ").append(description);
-					}
-				}
-				toolList.append("\n");
-			}
-
-			String maxToolsInstruction = maxTools != null
-					? "\nIMPORTANT: List the tool names in order of relevance. " +
-					"Select at most " + maxTools + " tools."
-					: "";
-
-			// Create selection prompt
-			List<Message> selectionMessages = List.of(
-					new SystemMessage(systemPrompt + maxToolsInstruction),
-					new UserMessage("Available tools:\n" + toolList +
-							"\nUser query: " + userQuery +
-							"\n\nRespond with a JSON object containing a 'tools' array with the selected tool names: {\"tools\": [\"tool1\", \"tool2\"]}")
-			);
-
-			Prompt prompt = new Prompt(selectionMessages);
-			var response = selectionModel.call(prompt);
-			String responseText = response.getResult().getOutput().getText();
-
-			// Parse JSON response
-			Set<String> selected = parseToolSelection(responseText);
-
-			// Add always-include tools
-			selected.addAll(alwaysInclude);
-
-			// Limit to maxTools if specified
-			if (maxTools != null && selected.size() > maxTools) {
-				List<String> selectedList = new ArrayList<>(selected);
-				selected = new HashSet<>(selectedList.subList(0, maxTools));
-			}
-
-			return selected;
-
-		}
-		catch (Exception e) {
-			log.warn("Tool selection failed, using all tools: {}", e.getMessage());
-			return new HashSet<>(toolNames);
-		}
+	private List<ToolMetadata> buildToolMetadata(List<String> toolNames, Map<String, String> toolDescriptions) {
+		return toolNames.stream()
+				.map(toolName -> new ToolMetadata(toolName,
+						toolDescriptions != null ? toolDescriptions.get(toolName) : null))
+				.toList();
 	}
 
-	private Set<String> parseToolSelection(String responseText) {
-		try {
-			// Try to parse as JSON
-			ToolSelectionResponse response = objectMapper.readValue(responseText, ToolSelectionResponse.class);
-			return new HashSet<>(response.tools);
+	private Set<String> normalizeSelection(List<String> availableTools, List<String> selectedTools) {
+		Set<String> available = new HashSet<>(availableTools);
+		LinkedHashSet<String> normalized = new LinkedHashSet<>();
+
+		// Always-included tools take priority when maxTools is configured.
+		for (String toolName : alwaysInclude) {
+			if (available.contains(toolName)) {
+				normalized.add(toolName);
+			}
 		}
-		catch (Exception e) {
-			// Fallback: extract tool names from text
-			log.debug("Failed to parse JSON, using fallback extraction");
-			return new HashSet<>();
+
+		if (selectedTools != null) {
+			for (String toolName : selectedTools) {
+				if (available.contains(toolName)) {
+					normalized.add(toolName);
+				}
+				if (maxTools != null && normalized.size() >= maxTools) {
+					break;
+				}
+			}
 		}
+
+		if (maxTools != null && normalized.size() > maxTools) {
+			return new LinkedHashSet<>(normalized.stream().limit(maxTools).toList());
+		}
+
+		return normalized;
 	}
 
 	@Override
@@ -196,19 +166,30 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 		return "ToolSelection";
 	}
 
-	private static class ToolSelectionResponse {
-		@JsonProperty("tools")
-		public List<String> tools;
-	}
-
 	public static class Builder {
 		private ChatModel selectionModel;
-		private String systemPrompt = DEFAULT_SYSTEM_PROMPT;
+
+		private ToolSelectionStrategy selectionStrategy;
+
+		private String systemPrompt = LlmToolSelectionStrategy.DEFAULT_SYSTEM_PROMPT;
+
 		private Integer maxTools;
+
 		private Set<String> alwaysInclude;
 
 		public Builder selectionModel(ChatModel selectionModel) {
 			this.selectionModel = selectionModel;
+			return this;
+		}
+
+		/**
+		 * Use a custom strategy instead of an LLM to select tools. A custom strategy
+		 * can integrate lexical search, a vector store, or business routing rules.
+		 * @param selectionStrategy tool selection strategy
+		 * @return this builder
+		 */
+		public Builder selectionStrategy(ToolSelectionStrategy selectionStrategy) {
+			this.selectionStrategy = selectionStrategy;
 			return this;
 		}
 
@@ -231,13 +212,16 @@ public class ToolSelectionInterceptor extends ModelInterceptor {
 		}
 
 		public Builder alwaysInclude(String... toolNames) {
-			this.alwaysInclude = new HashSet<>(Arrays.asList(toolNames));
+			this.alwaysInclude = new LinkedHashSet<>(Arrays.asList(toolNames));
 			return this;
 		}
 
 		public ToolSelectionInterceptor build() {
-			if (selectionModel == null) {
-				throw new IllegalStateException("selectionModel is required");
+			if (selectionModel != null && selectionStrategy != null) {
+				throw new IllegalStateException("selectionModel and selectionStrategy are mutually exclusive");
+			}
+			if (selectionModel == null && selectionStrategy == null) {
+				throw new IllegalStateException("selectionModel or selectionStrategy is required");
 			}
 			return new ToolSelectionInterceptor(this);
 		}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionRequest.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptor.toolselection;
+
+import java.util.List;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Request passed to a {@link ToolSelectionStrategy}. It deliberately contains only
+ * lightweight tool metadata, so selectors do not need to receive full tool input
+ * schemas.
+ *
+ * @param query latest user query
+ * @param tools available tool metadata
+ * @param maxTools maximum number of tools to select, or {@code null} when unlimited
+ * @param context model request context
+ */
+public record ToolSelectionRequest(String query, List<ToolMetadata> tools, Integer maxTools,
+		Map<String, Object> context) {
+
+	public ToolSelectionRequest {
+		tools = tools != null ? List.copyOf(tools) : List.of();
+		context = context != null ? Collections.unmodifiableMap(new HashMap<>(context)) : Map.of();
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionStrategy.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/toolselection/ToolSelectionStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptor.toolselection;
+
+import java.util.List;
+
+/**
+ * Strategy for selecting relevant tools from lightweight tool metadata.
+ * Implementations may use an LLM, lexical search, a vector store, or business rules.
+ * Implementations should be thread-safe because an interceptor can serve concurrent
+ * agent requests.
+ */
+@FunctionalInterface
+public interface ToolSelectionStrategy {
+
+	/**
+	 * Select tool names in relevance order.
+	 * @param request selection request containing the query and lightweight metadata
+	 * @return selected tool names; unknown names are ignored by the interceptor
+	 * @throws Exception when selection fails
+	 */
+	List<String> select(ToolSelectionRequest request) throws Exception;
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptors;
+
+import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
+import com.alibaba.cloud.ai.graph.agent.interceptor.toolselection.ToolMetadata;
+import com.alibaba.cloud.ai.graph.agent.interceptor.toolselection.ToolSelectionInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.toolselection.ToolSelectionRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.toolselection.ToolSelectionStrategy;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class ToolSelectionStrategyTest {
+
+	@Test
+	void customStrategyReceivesOnlyLightweightMetadataAndFiltersTools() {
+		AtomicReference<ToolSelectionRequest> capturedSelectionRequest = new AtomicReference<>();
+		AtomicReference<ModelRequest> capturedModelRequest = new AtomicReference<>();
+		ToolSelectionStrategy strategy = request -> {
+			capturedSelectionRequest.set(request);
+			return List.of("weather_tool", "hotel_tool");
+		};
+
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(strategy)
+				.maxTools(2)
+				.build();
+		ModelRequest request = requestWithThreeTools();
+
+		interceptor.interceptModel(request, filteredRequest -> {
+			capturedModelRequest.set(filteredRequest);
+			return ModelResponse.of(new AssistantMessage("done"));
+		});
+
+		ToolSelectionRequest selectionRequest = capturedSelectionRequest.get();
+		assertEquals("Find weather and a hotel", selectionRequest.query());
+		assertEquals(2, selectionRequest.maxTools());
+		assertEquals(Map.of("tenant", "demo"), selectionRequest.context());
+		assertEquals(List.of(
+				new ToolMetadata("weather_tool", "Get weather"),
+				new ToolMetadata("ticket_tool", "Book tickets"),
+				new ToolMetadata("hotel_tool", "Find hotels")), selectionRequest.tools());
+		assertEquals(List.of("weather_tool", "hotel_tool"), capturedModelRequest.get().getTools());
+	}
+
+	@Test
+	void unknownAndDuplicateToolNamesAreIgnored() {
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(request -> List.of("unknown_tool", "hotel_tool", "hotel_tool"))
+				.maxTools(2)
+				.build();
+		AtomicReference<ModelRequest> capturedRequest = new AtomicReference<>();
+
+		interceptor.interceptModel(requestWithThreeTools(), request -> {
+			capturedRequest.set(request);
+			return ModelResponse.of(new AssistantMessage("done"));
+		});
+
+		assertEquals(List.of("hotel_tool"), capturedRequest.get().getTools());
+	}
+
+	@Test
+	void alwaysIncludedToolsTakePriorityWithinLimit() {
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(request -> List.of("weather_tool", "hotel_tool"))
+				.maxTools(2)
+				.alwaysInclude("ticket_tool")
+				.build();
+		AtomicReference<ModelRequest> capturedRequest = new AtomicReference<>();
+
+		interceptor.interceptModel(requestWithThreeTools(), request -> {
+			capturedRequest.set(request);
+			return ModelResponse.of(new AssistantMessage("done"));
+		});
+
+		assertEquals(List.of("weather_tool", "ticket_tool"), capturedRequest.get().getTools());
+	}
+
+	@Test
+	void strategyFailureFallsBackToOriginalRequest() {
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(request -> {
+					throw new IllegalStateException("index unavailable");
+				})
+				.maxTools(1)
+				.build();
+		ModelRequest originalRequest = requestWithThreeTools();
+		AtomicReference<ModelRequest> capturedRequest = new AtomicReference<>();
+
+		interceptor.interceptModel(originalRequest, request -> {
+			capturedRequest.set(request);
+			return ModelResponse.of(new AssistantMessage("done"));
+		});
+
+		assertSame(originalRequest, capturedRequest.get());
+	}
+
+	@Test
+	void selectionIsSkippedWhenToolCountIsWithinLimit() {
+		AtomicBoolean strategyCalled = new AtomicBoolean();
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(request -> {
+					strategyCalled.set(true);
+					return List.of();
+				})
+				.maxTools(3)
+				.build();
+
+		interceptor.interceptModel(requestWithThreeTools(),
+				request -> ModelResponse.of(new AssistantMessage("done")));
+
+		assertFalse(strategyCalled.get());
+	}
+
+	@Test
+	void builderRequiresExactlyOneSelectionMechanism() {
+		assertThrows(IllegalStateException.class, () -> ToolSelectionInterceptor.builder().build());
+		assertThrows(IllegalStateException.class, () -> ToolSelectionInterceptor.builder()
+				.selectionModel(mock(ChatModel.class))
+				.selectionStrategy(request -> List.of())
+				.build());
+	}
+
+	@Test
+	void selectedSchemaReachesModelAndSelectedToolExecutes() throws Exception {
+		AtomicReference<ToolSelectionRequest> capturedSelectionRequest = new AtomicReference<>();
+		AtomicReference<List<ToolCallback>> firstModelTools = new AtomicReference<>();
+		AtomicInteger weatherToolCalls = new AtomicInteger();
+		AtomicInteger ticketToolCalls = new AtomicInteger();
+		AtomicInteger modelCalls = new AtomicInteger();
+
+		ToolCallback weatherTool = tool("weather_tool", "Get weather",
+				"{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
+				weatherToolCalls);
+		ToolCallback ticketTool = tool("ticket_tool", "Book tickets",
+				"{\"type\":\"object\",\"properties\":{\"destination\":{\"type\":\"string\"}}}",
+				ticketToolCalls);
+
+		ChatModel model = new ChatModel() {
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				int invocation = modelCalls.getAndIncrement();
+				ToolCallingChatOptions options = (ToolCallingChatOptions) prompt.getOptions();
+				if (invocation == 0) {
+					firstModelTools.set(List.copyOf(options.getToolCallbacks()));
+					AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call-1", "function",
+							"weather_tool", "{\"city\":\"Shanghai\"}");
+					return response(AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build());
+				}
+				return response(new AssistantMessage("Sunny in Shanghai"));
+			}
+		};
+
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(request -> {
+					capturedSelectionRequest.compareAndSet(null, request);
+					return List.of("weather_tool");
+				})
+				.maxTools(1)
+				.build();
+		ReactAgent agent = ReactAgent.builder()
+				.name("tool-selection-test")
+				.model(model)
+				.tools(List.of(weatherTool, ticketTool))
+				.interceptors(interceptor)
+				.saver(new MemorySaver())
+				.build();
+
+		AssistantMessage result = agent.call("What is the weather in Shanghai?");
+
+		assertEquals("Sunny in Shanghai", result.getText());
+		assertEquals(List.of(
+				new ToolMetadata("weather_tool", "Get weather"),
+				new ToolMetadata("ticket_tool", "Book tickets")), capturedSelectionRequest.get().tools());
+		assertEquals(1, firstModelTools.get().size());
+		assertEquals("weather_tool", firstModelTools.get().get(0).getToolDefinition().name());
+		assertTrue(firstModelTools.get().get(0).getToolDefinition().inputSchema().contains("city"));
+		assertFalse(firstModelTools.get().get(0).getToolDefinition().inputSchema().contains("destination"));
+		assertEquals(1, weatherToolCalls.get());
+		assertEquals(0, ticketToolCalls.get());
+		assertEquals(2, modelCalls.get());
+	}
+
+	private ModelRequest requestWithThreeTools() {
+		return ModelRequest.builder()
+				.messages(List.of(new UserMessage("Find weather and a hotel")))
+				.tools(List.of("weather_tool", "ticket_tool", "hotel_tool"))
+				.toolDescriptions(Map.of(
+						"weather_tool", "Get weather",
+						"ticket_tool", "Book tickets",
+						"hotel_tool", "Find hotels"))
+				.context(Map.of("tenant", "demo"))
+				.build();
+	}
+
+	private ToolCallback tool(String name, String description, String inputSchema, AtomicInteger calls) {
+		return new ToolCallback() {
+			@Override
+			public ToolDefinition getToolDefinition() {
+				return ToolDefinition.builder()
+						.name(name)
+						.description(description)
+						.inputSchema(inputSchema)
+						.build();
+			}
+
+			@Override
+			public String call(String toolInput, ToolContext toolContext) {
+				calls.incrementAndGet();
+				return "Sunny in Shanghai";
+			}
+
+			@Override
+			public String call(String toolInput) {
+				return call(toolInput, new ToolContext(Map.of()));
+			}
+		};
+	}
+
+	private ChatResponse response(AssistantMessage message) {
+		return new ChatResponse(List.of(new Generation(message)));
+	}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
@@ -16,6 +16,8 @@
 package com.alibaba.cloud.ai.graph.agent.interceptors;
 
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import com.alibaba.cloud.ai.graph.agent.interceptor.toolselection.ToolMetadata;
@@ -224,37 +226,61 @@ class ToolSelectionStrategyTest {
 	@Test
 	void emptySelectionExposesNoSchemasToModel() throws Exception {
 		AtomicReference<List<ToolCallback>> modelTools = new AtomicReference<>();
+		AtomicReference<ToolSelectionRequest> capturedSelectionRequest = new AtomicReference<>();
 		AtomicInteger weatherToolCalls = new AtomicInteger();
 		AtomicInteger ticketToolCalls = new AtomicInteger();
+		AtomicInteger dynamicToolCalls = new AtomicInteger();
 		ToolCallback weatherTool = tool("weather_tool", "Get weather",
 				"{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
 				weatherToolCalls);
 		ToolCallback ticketTool = tool("ticket_tool", "Book tickets",
 				"{\"type\":\"object\",\"properties\":{\"destination\":{\"type\":\"string\"}}}",
 				ticketToolCalls);
+		ToolCallback dynamicTool = tool("dynamic_tool", "Dynamically loaded tool",
+				"{\"type\":\"object\",\"properties\":{\"dynamicInput\":{\"type\":\"string\"}}}",
+				dynamicToolCalls);
 		ChatModel model = prompt -> {
 			ToolCallingChatOptions options = (ToolCallingChatOptions) prompt.getOptions();
 			modelTools.set(List.copyOf(options.getToolCallbacks()));
 			return response(new AssistantMessage("No tool needed"));
 		};
 		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
-				.selectionStrategy(request -> List.of())
+				.selectionStrategy(request -> {
+					capturedSelectionRequest.set(request);
+					return List.of();
+				})
 				.maxTools(1)
 				.build();
+		ModelInterceptor dynamicToolInjector = new ModelInterceptor() {
+			@Override
+			public ModelResponse interceptModel(ModelRequest request, ModelCallHandler handler) {
+				return handler.call(ModelRequest.builder(request)
+						.dynamicToolCallbacks(List.of(dynamicTool))
+						.build());
+			}
+
+			@Override
+			public String getName() {
+				return "DynamicToolInjector";
+			}
+		};
 		ReactAgent agent = ReactAgent.builder()
 				.name("empty-tool-selection-test")
 				.model(model)
 				.tools(List.of(weatherTool, ticketTool))
-				.interceptors(interceptor)
+				.interceptors(dynamicToolInjector, interceptor)
 				.saver(new MemorySaver())
 				.build();
 
 		AssistantMessage result = agent.call("Say hello without using a tool");
 
 		assertEquals("No tool needed", result.getText());
+		assertTrue(capturedSelectionRequest.get().tools()
+				.contains(new ToolMetadata("dynamic_tool", "Dynamically loaded tool")));
 		assertTrue(modelTools.get().isEmpty());
 		assertEquals(0, weatherToolCalls.get());
 		assertEquals(0, ticketToolCalls.get());
+		assertEquals(0, dynamicToolCalls.get());
 	}
 
 	@Test

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
@@ -221,6 +221,68 @@ class ToolSelectionStrategyTest {
 		assertEquals(2, modelCalls.get());
 	}
 
+	@Test
+	void emptySelectionExposesNoSchemasToModel() throws Exception {
+		AtomicReference<List<ToolCallback>> modelTools = new AtomicReference<>();
+		AtomicInteger weatherToolCalls = new AtomicInteger();
+		AtomicInteger ticketToolCalls = new AtomicInteger();
+		ToolCallback weatherTool = tool("weather_tool", "Get weather",
+				"{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}",
+				weatherToolCalls);
+		ToolCallback ticketTool = tool("ticket_tool", "Book tickets",
+				"{\"type\":\"object\",\"properties\":{\"destination\":{\"type\":\"string\"}}}",
+				ticketToolCalls);
+		ChatModel model = prompt -> {
+			ToolCallingChatOptions options = (ToolCallingChatOptions) prompt.getOptions();
+			modelTools.set(List.copyOf(options.getToolCallbacks()));
+			return response(new AssistantMessage("No tool needed"));
+		};
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(request -> List.of())
+				.maxTools(1)
+				.build();
+		ReactAgent agent = ReactAgent.builder()
+				.name("empty-tool-selection-test")
+				.model(model)
+				.tools(List.of(weatherTool, ticketTool))
+				.interceptors(interceptor)
+				.saver(new MemorySaver())
+				.build();
+
+		AssistantMessage result = agent.call("Say hello without using a tool");
+
+		assertEquals("No tool needed", result.getText());
+		assertTrue(modelTools.get().isEmpty());
+		assertEquals(0, weatherToolCalls.get());
+		assertEquals(0, ticketToolCalls.get());
+	}
+
+	@Test
+	void interruptedSelectionRestoresInterruptAndSkipsModelCall() {
+		AtomicBoolean handlerCalled = new AtomicBoolean();
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionStrategy(request -> {
+					throw new InterruptedException("cancelled");
+				})
+				.maxTools(1)
+				.build();
+
+		try {
+			RuntimeException exception = assertThrows(RuntimeException.class,
+					() -> interceptor.interceptModel(requestWithThreeTools(), request -> {
+						handlerCalled.set(true);
+						return ModelResponse.of(new AssistantMessage("done"));
+					}));
+
+			assertEquals("Tool selection interrupted", exception.getMessage());
+			assertTrue(Thread.currentThread().isInterrupted());
+			assertFalse(handlerCalled.get());
+		}
+		finally {
+			Thread.interrupted();
+		}
+	}
+
 	private ModelRequest requestWithThreeTools() {
 		return ModelRequest.builder()
 				.messages(List.of(new UserMessage("Find weather and a hotel")))

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
@@ -283,6 +283,24 @@ class ToolSelectionStrategyTest {
 		}
 	}
 
+	@Test
+	void malformedLlmSelectionFallsBackToOriginalRequest() {
+		ChatModel malformedSelectionModel = prompt -> response(new AssistantMessage("```json\n{not-json}\n```"));
+		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+				.selectionModel(malformedSelectionModel)
+				.maxTools(1)
+				.build();
+		ModelRequest originalRequest = requestWithThreeTools();
+		AtomicReference<ModelRequest> capturedRequest = new AtomicReference<>();
+
+		interceptor.interceptModel(originalRequest, request -> {
+			capturedRequest.set(request);
+			return ModelResponse.of(new AssistantMessage("done"));
+		});
+
+		assertSame(originalRequest, capturedRequest.get());
+	}
+
 	private ModelRequest requestWithThreeTools() {
 		return ModelRequest.builder()
 				.messages(List.of(new UserMessage("Find weather and a hotel")))

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/ToolSelectionStrategyTest.java
@@ -60,14 +60,20 @@ class ToolSelectionStrategyTest {
 		AtomicReference<ModelRequest> capturedModelRequest = new AtomicReference<>();
 		ToolSelectionStrategy strategy = request -> {
 			capturedSelectionRequest.set(request);
-			return List.of("weather_tool", "hotel_tool");
+			return List.of("hotel_tool", "weather_tool");
 		};
 
 		ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
 				.selectionStrategy(strategy)
 				.maxTools(2)
 				.build();
-		ModelRequest request = requestWithThreeTools();
+		ToolCallingChatOptions options = ToolCallingChatOptions.builder()
+				.toolCallbacks(List.of(
+						tool("weather_tool", "Get weather", "{}", new AtomicInteger()),
+						tool("ticket_tool", "Book tickets", "{}", new AtomicInteger()),
+						tool("hotel_tool", "Find hotels", "{}", new AtomicInteger())))
+				.build();
+		ModelRequest request = ModelRequest.builder(requestWithThreeTools()).options(options).build();
 
 		interceptor.interceptModel(request, filteredRequest -> {
 			capturedModelRequest.set(filteredRequest);
@@ -82,7 +88,13 @@ class ToolSelectionStrategyTest {
 				new ToolMetadata("weather_tool", "Get weather"),
 				new ToolMetadata("ticket_tool", "Book tickets"),
 				new ToolMetadata("hotel_tool", "Find hotels")), selectionRequest.tools());
-		assertEquals(List.of("weather_tool", "hotel_tool"), capturedModelRequest.get().getTools());
+		assertEquals(List.of("hotel_tool", "weather_tool"), capturedModelRequest.get().getTools());
+		assertEquals(List.of("hotel_tool", "weather_tool"), capturedModelRequest.get()
+				.getOptions()
+				.getToolCallbacks()
+				.stream()
+				.map(callback -> callback.getToolDefinition().name())
+				.toList());
 	}
 
 	@Test
@@ -115,7 +127,7 @@ class ToolSelectionStrategyTest {
 			return ModelResponse.of(new AssistantMessage("done"));
 		});
 
-		assertEquals(List.of("weather_tool", "ticket_tool"), capturedRequest.get().getTools());
+		assertEquals(List.of("ticket_tool", "weather_tool"), capturedRequest.get().getTools());
 	}
 
 	@Test
@@ -325,6 +337,26 @@ class ToolSelectionStrategyTest {
 		});
 
 		assertSame(originalRequest, capturedRequest.get());
+	}
+
+	@Test
+	void missingOrNullToolsArrayFallsBackToOriginalRequest() {
+		for (String responseText : List.of("{}", "{\"tools\":null}")) {
+			ChatModel invalidSelectionModel = prompt -> response(new AssistantMessage(responseText));
+			ToolSelectionInterceptor interceptor = ToolSelectionInterceptor.builder()
+					.selectionModel(invalidSelectionModel)
+					.maxTools(1)
+					.build();
+			ModelRequest originalRequest = requestWithThreeTools();
+			AtomicReference<ModelRequest> capturedRequest = new AtomicReference<>();
+
+			interceptor.interceptModel(originalRequest, request -> {
+				capturedRequest.set(request);
+				return ModelResponse.of(new AssistantMessage("done"));
+			});
+
+			assertSame(originalRequest, capturedRequest.get());
+		}
 	}
 
 	private ModelRequest requestWithThreeTools() {


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR extends the existing `ToolSelectionInterceptor` with a pluggable selection strategy API for MCP and other large tool-set scenarios.

Custom selectors receive only lightweight tool metadata (name and description), while the main model receives the full `ToolCallback` and `inputSchema` only for the selected Top-K tools. This allows applications to integrate lexical search, vector retrieval, or business routing rules without paying for an additional LLM selection call on every request.

The existing `selectionModel(ChatModel)` builder API and LLM-based behavior remain supported.

### Does this pull request fix one issue?

Fixes #4829

### Describe how you did it

- Added `ToolSelectionStrategy`, `ToolSelectionRequest`, and `ToolMetadata` as a lightweight, schema-free selection contract.
- Extracted the existing LLM selection logic into `LlmToolSelectionStrategy` while preserving the current builder API.
- Normalized custom strategy results by ignoring unknown names, removing duplicates, honoring `alwaysInclude`, and applying `maxTools` deterministically.
- Kept the existing safe fallback: if selection fails, the original request with all tools is passed to the model.
- Added an MCP client example that enables Top-K tool selection for tools supplied by `ToolCallbackProvider`.

### Describe how to verify it

Run the related deterministic tests:

```shell
./mvnw -pl :spring-ai-alibaba-agent-framework -am \
  -Dtest=ToolSelectionTest,ToolSelectionWithDescriptionsTest,ToolSelectionStrategyTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

The new end-to-end test verifies that:

1. The selection strategy receives only tool names and descriptions.
2. The main model receives only the selected tool's full schema.
3. The selected tool executes successfully through the ReactAgent tool loop.
4. An unselected tool is neither exposed to the model nor executed.

The documentation example also compiles with:

```shell
./mvnw -f examples/documentation/pom.xml -DskipTests compile
```

### Special notes for reviews

This change does not modify MCP provider refresh behavior or the agent tool execution nodes, keeping it independent from the dynamic tool-list work in #4205. Custom strategy implementations should be thread-safe because an interceptor can serve concurrent agent requests.
