### PR TITLE
fix(graph): notify lifecycle listener on streaming errors

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -322,6 +322,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 				// Handle actual error signals from the Flux
 				log.error("Error signal occurred in embedded Flux stream for key '{}': {}",
 					key, error.getMessage());
+				context.doListeners(ERROR, new Exception(error));
 				GraphResponse<NodeOutput> errorResponse = GraphResponse.error(error);
 				lastGraphResponseRef.set(errorResponse);
 				return Flux.just(errorResponse);

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
@@ -46,6 +46,8 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1229,23 +1231,31 @@ public class StateGraphTest {
 
 	@Test
 	public void testStreamingNodeWithFluxException() throws Exception {
+		RuntimeException sourceException = new RuntimeException("Exception in streaming flux");
+		AtomicInteger errorCount = new AtomicInteger();
+		AtomicReference<String> errorNodeId = new AtomicReference<>();
+		AtomicReference<Throwable> listenerException = new AtomicReference<>();
 		StateGraph workflow = new StateGraph(createKeyStrategyFactory()).addEdge(START, "agent_1")
 				.addNode("agent_1", node_async(state -> {
 					log.info("agent_1\n{}", state);
-					return Map.of("pro1", Flux.just("response1", "response2", "response3")
-							.map(value -> {
-								if (value.equals("response3")) {
-									throw new RuntimeException("Exception in map operation");
-								}
-								return value;
-							}));
+					return Map.of("pro1", Flux.concat(Flux.just("response1", "response2"), Flux.error(sourceException)));
 				}))
 				.addEdge("agent_1", END);
 
-		CompiledGraph app = workflow.compile();
+		CompiledGraph app = workflow.compile(CompileConfig.builder().withLifecycleListener(new GraphLifecycleListener() {
+			@Override
+			public void onError(String nodeId, Map<String, Object> state, Throwable ex, RunnableConfig config) {
+				errorCount.incrementAndGet();
+				errorNodeId.set(nodeId);
+				listenerException.set(ex);
+			}
+		}).build());
 
 		assertThrows(RuntimeException.class,
 				() -> app.invoke(Map.of(OverAllState.DEFAULT_INPUT_KEY, "test1")));
+		errorCount.set(0);
+		errorNodeId.set(null);
+		listenerException.set(null);
 
 		Flux<NodeOutput> flux = app.stream(Map.of(OverAllState.DEFAULT_INPUT_KEY, "test1"));
 
@@ -1256,26 +1266,38 @@ public class StateGraphTest {
 		assertEquals(2, firstTwoElements.size());
 
 		// 验证第三个元素会抛出异常
-		assertThrows(RuntimeException.class, () -> flux.blockLast());
+		RuntimeException exception = assertThrows(RuntimeException.class, () -> flux.blockLast());
+		assertEquals(sourceException.getMessage(), exception.getMessage());
+		assertEquals(1, errorCount.get());
+		assertEquals("agent_1", errorNodeId.get());
+		assertEquals(sourceException, listenerException.get().getCause());
 	}
 
 	@Test
 	public void testStreamingNodeWithNodeException() throws Exception {
+		AtomicInteger errorCount = new AtomicInteger();
 		StateGraph workflow = new StateGraph(createKeyStrategyFactory()).addEdge(START, "agent_1")
 				.addNode("agent_1", node_async(state -> {
 					throw new RuntimeException("forced exception for testing");
 				}))
 				.addEdge("agent_1", END);
 
-		CompiledGraph app = workflow.compile();
+		CompiledGraph app = workflow.compile(CompileConfig.builder().withLifecycleListener(new GraphLifecycleListener() {
+			@Override
+			public void onError(String nodeId, Map<String, Object> state, Throwable ex, RunnableConfig config) {
+				errorCount.incrementAndGet();
+			}
+		}).build());
 
 		// 验证 invoke 会抛出异常
 		assertThrows(RuntimeException.class,
 				() -> app.invoke(Map.of(OverAllState.DEFAULT_INPUT_KEY, "test1")));
+		assertEquals(1, errorCount.get());
 
 		// 验证 stream 也会抛出异常
 		Flux<NodeOutput> flux = app.stream(Map.of(OverAllState.DEFAULT_INPUT_KEY, "test1"));
 		assertThrows(RuntimeException.class, () -> flux.blockLast());
+		assertEquals(2, errorCount.get());
 	}
 
 	/**


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes a missing `GraphLifecycleListener.onError` notification when a streaming node returns a `Flux` that terminates with an error.

In the current streaming path, the Reactor error signal is converted to `GraphResponse.error(...)`, so it does not reach the existing `CompletableFuture` failure handling that notifies lifecycle listeners. As a result, the original exception is still propagated to the caller, but the lifecycle listener is not notified.

This causes inconsistent lifecycle behavior between normal asynchronous node failures and streaming `Flux` failures.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #4920

### Describe how you did it

Added the missing lifecycle error notification in the streaming error path before returning `GraphResponse.error(...)`.

The change reuses the existing lifecycle listener mechanism and keeps the current exception propagation behavior unchanged.

Regression coverage was also updated to verify that:

- streaming `Flux` failures trigger `onError` exactly once
- the listener receives the expected node id
- the original streaming exception still propagates to the caller
- existing `CompletableFuture` failure behavior remains unchanged

### Describe how to verify it

Run the targeted tests:

```text
StateGraphTest.testStreamingNodeWithFluxException
StateGraphTest.testStreamingNodeWithNodeException
```

### Special notes for reviews

This change only affects the Reactor error path for streaming results.

The existing `CompletableFuture` failure path and exception propagation behavior remain unchanged.