### PR TITLE
docs: fix GitHub capitalization in CONTRIBUTING and GOVERNANCE

### DIFF
--- a/CONTRIBUTING-zh.md
+++ b/CONTRIBUTING-zh.md
@@ -25,7 +25,7 @@ Spring AI Alibaba 从开源建设以来，受到了很多社区同学的关注�
 - 点击 [本项目](https://github.com/alibaba/spring-ai-alibaba) 右上角的 `Fork` 图标 将 alibaba/spring-ai-alibaba  fork 到自己的空间。
 - 将自己账号下的 spring-ai-alibaba 仓库 clone 到本地，例如我的账号是 `chickenlj`，那就是执行 `git clone https://github.com/chickenlj/spring-ai-alibaba.git` 进行 clone 操作。
 
-### 配置 Github 信息
+### 配置 GitHub 信息
 
 - 在自己的机器执行 `git config --list` ，查看 git 的全局用户名和邮箱。
 - 检查显示的 user.name 和 user.email 是不是与自己 github 的用户名和邮箱相匹配。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you are a first-time contributor, you can claim a relatively simple task from
 - Click the `Fork` icon in the upper right corner of [this project](https://github.com/alibaba/spring-ai-alibaba) to fork alibaba/spring-ai-alibaba to your own space.
 - Clone the spring-ai-alibaba repository from your account to your local machine. For example, if my account is `chickenlj`, I would execute `git clone https://github.com/chickenlj/spring-ai-alibaba.git` to clone it.
 
-### Configure Github Information
+### Configure GitHub Information
 
 - Execute `git config --list` on your machine to check git's global username and email.
 - Verify that the displayed user.name and user.email match your github username and email.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,9 +6,9 @@ Below is the organizational structure of the Spring AI Alibaba project.
 
 Committers have full write permissions to the entire project codebase, like permissions to operate branches, issues, pull requests, etc. PMC Members have the same codebase permissions as Committers, and are responsible for the community management, decision-making, etc., and are responsible for voting and making decisions on important matters such as releases, vulnerabilities, committer and PMC Member nominations, etc.
 
-The Spring AI Alibaba project belongs to the Alibaba Github organization, so it can leverage all the resources and help from the Alibaba open source organization in some key matters such as security vulnerability reporting and copyright protection.
+The Spring AI Alibaba project belongs to the Alibaba GitHub organization, so it can leverage all the resources and help from the Alibaba open source organization in some key matters such as security vulnerability reporting and copyright protection.
 
-As the only commission of the Alibaba Github organization for this project, PMC is responsible for managing and monitoring the Spring AI Alibaba open source project and ensuring that all development activities comply with the Alibaba organization's open source specifications.
+As the only commission of the Alibaba GitHub organization for this project, PMC is responsible for managing and monitoring the Spring AI Alibaba open source project and ensuring that all development activities comply with the Alibaba organization's open source specifications.
 
 ## Project Management Committee (PMC)
 


### PR DESCRIPTION
## What
Fix the mixed-case spelling `Github` -> `GitHub` in:

- `CONTRIBUTING.md` (section heading)
- `CONTRIBUTING-zh.md` (section heading)
- `GOVERNANCE.md` (2 occurrences in prose)

## Why
`GitHub` is the official brand spelling; these are the only remaining mixed-case occurrences outside `github.com` URLs. This also aligns with the repo's `make codespell` spelling checks.

## How verified
- `grep -n Github` on the three files returns no matches outside URLs.
- Text-only changes; no links, code blocks, or structure touched.