### PR TITLE
test(graph): migrate AssignerNodeTest to JUnit 5 so its tests actually run

### DIFF
--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/AssignerNodeTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/AssignerNodeTest.java
@@ -22,10 +22,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author yHong


### PR DESCRIPTION
### Describe what this PR does / why we need it

`AssignerNodeTest` is the only test class in the repository still written against JUnit 4
(`org.junit.Test` / `org.junit.Assert`); the other 189 test classes use JUnit 5 Jupiter.

The `spring-ai-alibaba-starter-builtin-nodes` module declares the `junit:junit` dependency, so the
class compiles, but unlike `spring-ai-alibaba-graph-core` it does **not** declare
`junit-vintage-engine`. Surefire 3.1.2 runs on the JUnit Platform, so without the vintage engine the
JUnit 4 `@Test` methods are never discovered. All six tests in this class are silently skipped and the
build still reports success, so the gap is invisible in CI.

Before this change, on a clean `main`:

```
[INFO]  T E S T S
[INFO] Results:
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

### Does this pull request fix one issue?

NONE

### Describe how you did it

Switched the three imports to their Jupiter equivalents:

- `org.junit.Test` -> `org.junit.jupiter.api.Test`
- `org.junit.Assert.assertEquals` -> `org.junit.jupiter.api.Assertions.assertEquals`
- `org.junit.Assert.assertTrue` -> `org.junit.jupiter.api.Assertions.assertTrue`

No test logic, assertion order or method signature is touched. `assertEquals` and `assertTrue` keep the
same argument order in JUnit 5, so the assertions are equivalent. The import placement follows the
sibling tests in the same package (for example `AnswerNodeTest`).

### Describe how to verify it

```bash
./mvnw -pl spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes -am -Dtest=AssignerNodeTest test
```

After this change all six tests are discovered and pass:

```
[INFO] Running com.alibaba.cloud.ai.graph.node.AssignerNodeTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s
```

`mvn spotless:check` and `mvn checkstyle:check` on the module both pass (0 Checkstyle violations).

### Special notes for reviews

The six tests pass unchanged, so this only restores coverage that was already written — it does not
uncover a defect in `AssignerNode`.

After this migration `junit:junit` has no remaining consumer in this module: removing it from the module
POM still leaves `test-compile` green. I left the dependency in place to keep this PR limited to the test
class, but I am happy to drop it in a follow-up if you prefer.
