### PR TITLE
feat(agent): support Supplier-based grouped tools for dynamic skill registries

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +82,7 @@ public class SkillsAgentHook extends AgentHook {
 	private final SkillRegistry skillRegistry;
 	private final boolean autoReload;
 	private final Map<String, List<ToolCallback>> groupedTools;
+	private final Supplier<Map<String, List<ToolCallback>>> groupedToolsSupplier;
 	private final ToolCallbackResolver toolCallbackResolver;
 	private final ToolCallback readSkillTool;
 	private final ToolCallback searchSkillsTool;
@@ -93,6 +95,7 @@ public class SkillsAgentHook extends AgentHook {
 		this.skillRegistry = builder.skillRegistry;
 		this.autoReload = builder.autoReload;
 		this.groupedTools = builder.groupedTools != null ? builder.groupedTools : Collections.emptyMap();
+		this.groupedToolsSupplier = builder.groupedToolsSupplier;
 		this.toolCallbackResolver = builder.toolCallbackResolver;
 		this.readSkillTool = ReadSkillTool.createReadSkillToolCallback(
 				this.skillRegistry,
@@ -141,6 +144,9 @@ public class SkillsAgentHook extends AgentHook {
 		SkillsInterceptor.Builder interceptorBuilder = SkillsInterceptor.builder().skillRegistry(this.skillRegistry);
 		if (!this.groupedTools.isEmpty()) {
 			interceptorBuilder.groupedTools(this.groupedTools);
+		}
+		if (this.groupedToolsSupplier != null) {
+			interceptorBuilder.groupedToolsSupplier(this.groupedToolsSupplier);
 		}
 		if (this.toolCallbackResolver != null) {
 			interceptorBuilder.toolCallbackResolver(this.toolCallbackResolver);
@@ -213,6 +219,7 @@ public class SkillsAgentHook extends AgentHook {
 		private SkillRegistry skillRegistry;
 		private boolean autoReload = false;
 		private Map<String, List<ToolCallback>> groupedTools;
+		private Supplier<Map<String, List<ToolCallback>>> groupedToolsSupplier;
 		private ToolCallbackResolver toolCallbackResolver;
 
 		/**
@@ -253,6 +260,17 @@ public class SkillsAgentHook extends AgentHook {
 		 */
 		public Builder groupedTools(Map<String, List<ToolCallback>> groupedTools) {
 			this.groupedTools = groupedTools;
+			return this;
+		}
+
+		/**
+		 * Sets grouped tools as a supplier resolved on every model call, so a dynamic skill
+		 * registry (tools added or retired at runtime) takes effect without rebuilding the hook.
+		 * @param groupedToolsSupplier supplier of map from skill name to list of ToolCallbacks
+		 * @return this builder
+		 */
+		public Builder groupedToolsSupplier(Supplier<Map<String, List<ToolCallback>>> groupedToolsSupplier) {
+			this.groupedToolsSupplier = groupedToolsSupplier;
 			return this;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -102,6 +103,8 @@ public class SkillsInterceptor extends ModelInterceptor {
 
 	private final Map<String, List<ToolCallback>> groupedTools;
 
+	private final Supplier<Map<String, List<ToolCallback>>> groupedToolsSupplier;
+
 	private final ToolCallbackResolver toolCallbackResolver;
 
 	private SkillsInterceptor(Builder builder) {
@@ -112,6 +115,7 @@ public class SkillsInterceptor extends ModelInterceptor {
 		this.groupedTools = builder.groupedTools != null
 				? builder.groupedTools
 				: Collections.emptyMap();
+		this.groupedToolsSupplier = builder.groupedToolsSupplier;
 		this.toolCallbackResolver = builder.toolCallbackResolver;
 	}
 
@@ -260,11 +264,20 @@ public class SkillsInterceptor extends ModelInterceptor {
 	}
 
 	public Map<String, List<ToolCallback>> getGroupedTools() {
-		if (groupedTools.isEmpty()) {
+		Map<String, List<ToolCallback>> resolved = resolveGroupedTools();
+		if (resolved.isEmpty()) {
 			return Collections.emptyMap();
 		}
-		return groupedTools.entrySet().stream()
+		return resolved.entrySet().stream()
 				.collect(Collectors.toMap(Map.Entry::getKey, e -> List.copyOf(e.getValue())));
+	}
+
+	private Map<String, List<ToolCallback>> resolveGroupedTools() {
+		if (groupedToolsSupplier != null) {
+			Map<String, List<ToolCallback>> supplied = groupedToolsSupplier.get();
+			return supplied != null ? supplied : Collections.emptyMap();
+		}
+		return groupedTools;
 	}
 
 
@@ -284,6 +297,8 @@ public class SkillsInterceptor extends ModelInterceptor {
 		private SkillRegistry skillRegistry;
 
 		private Map<String, List<ToolCallback>> groupedTools;
+
+		private Supplier<Map<String, List<ToolCallback>>> groupedToolsSupplier;
 
 		private ToolCallbackResolver toolCallbackResolver;
 
@@ -310,6 +325,19 @@ public class SkillsInterceptor extends ModelInterceptor {
 		 */
 		public Builder groupedTools(Map<String, List<ToolCallback>> groupedTools) {
 			this.groupedTools = groupedTools;
+			return this;
+		}
+
+		/**
+		 * Set grouped tools as a supplier resolved on every model call. When the LLM calls
+		 * <code>read_skill</code> with a given skill_name, the supplier is invoked at that
+		 * moment, so registry changes (newly added or retired tools) take effect without
+		 * rebuilding the interceptor.
+		 * @param groupedToolsSupplier supplier of map from skill name to list of ToolCallbacks
+		 * @return this builder
+		 */
+		public Builder groupedToolsSupplier(Supplier<Map<String, List<ToolCallback>>> groupedToolsSupplier) {
+			this.groupedToolsSupplier = groupedToolsSupplier;
 			return this;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.List.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SkillsInterceptorEnhancementsTest {
 
@@ -153,6 +154,37 @@ class SkillsInterceptorEnhancementsTest {
 
 		assertEquals(1, toolCallbacks.size());
 		assertEquals("duplicate_tool", toolCallbacks.get(0).getToolDefinition().name());
+	}
+
+	@Test
+	void groupedToolsSupplierIsResolvedOnEveryModelCall() {
+		ToolCallback recordResultTool = FunctionToolCallback.builder("record_result", args -> "recorded")
+				.description("Records a result value")
+				.inputType(String.class)
+				.build();
+		ToolCallback extraTool = FunctionToolCallback.builder("extra_tool", args -> "extra")
+				.description("Extra tool added after startup")
+				.inputType(String.class)
+				.build();
+
+		AtomicReference<Map<String, List<ToolCallback>>> current = new AtomicReference<>(
+				Map.of("allowed-tools-test", List.of(recordResultTool)));
+
+		SkillsInterceptor interceptor = SkillsInterceptor.builder()
+				.skillRegistry(registry)
+				.groupedToolsSupplier(current::get)
+				.build();
+
+		Map<String, List<ToolCallback>> first = interceptor.getGroupedTools();
+		assertEquals(1, first.get("allowed-tools-test").size());
+
+		// Registry hot-update: a new tool joins the skill's grouped tools.
+		current.set(Map.of("allowed-tools-test", List.of(recordResultTool, extraTool)));
+
+		Map<String, List<ToolCallback>> second = interceptor.getGroupedTools();
+		assertEquals(2, second.get("allowed-tools-test").size());
+		assertTrue(second.get("allowed-tools-test").stream()
+				.anyMatch(tool -> "extra_tool".equals(tool.getToolDefinition().name())));
 	}
 
 }


### PR DESCRIPTION
Closes #4907

## What
Grouped tools for skills are fixed at build time; a dynamic skill registry that adds or retires tools requires rebuilding the agent. Add a Supplier-based setter to both builders:

- SkillsInterceptor.Builder.groupedToolsSupplier(Supplier<Map<String, List<ToolCallback>>>)
- SkillsAgentHook.Builder.groupedToolsSupplier(Supplier<Map<String, List<ToolCallback>>>)

The supplier is resolved on every model call, so registry changes take effect immediately. The existing Map overloads keep working unchanged.

## Notes
- The setter is named groupedToolsSupplier (not an overload of groupedTools) so that the existing groupedTools(null) call form stays unambiguous for source compatibility.
- The existing Map overload already supports the mutate-in-place workaround discussed in the issue, but that relies on the caller keeping a shared mutable reference. The Supplier API makes dynamic grouped tools a first-class concept, resolved per model call, without shared mutable state.

## How verified
- New test groupedToolsSupplierIsResolvedOnEveryModelCall covers hot-updating grouped tools between calls.
- mvn -pl spring-ai-alibaba-agent-framework -am -Dtest=SkillsInterceptorEnhancementsTest -DfailIfNoTests=false test -> 3 tests, 0 failures, 0 errors.