### PR TITLE
fix(graph): preserve streaming node id in error callbacks

### DIFF
--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/GraphRunnerContext.java
@@ -314,23 +314,33 @@ public class GraphRunnerContext {
 	// ================================================================================================================
 
 	public void doListeners(String scene, Exception e) {
+		doListeners(scene, getCurrentNodeId(), e);
+	}
+
+	/**
+	 * Notifies lifecycle listeners using an explicit node ID.
+	 * @param scene the lifecycle scene
+	 * @param nodeId the node associated with the lifecycle event
+	 * @param e the error when the scene is {@link StateGraph#ERROR}
+	 */
+	public void doListeners(String scene, String nodeId, Exception e) {
 		for (GraphLifecycleListener listener : compiledGraph.compileConfig.lifecycleListeners()) {
 			try {
 				switch (scene) {
 					case START:
-						listener.onStart(getCurrentNodeId(), getCurrentStateData(), config);
+						listener.onStart(nodeId, getCurrentStateData(), config);
 						break;
 					case END:
 						listener.onComplete(END, getCurrentStateData(), config);
 						break;
 					case NODE_BEFORE:
-						listener.before(getCurrentNodeId(), getCurrentStateData(), config, SystemClock.now());
+						listener.before(nodeId, getCurrentStateData(), config, SystemClock.now());
 						break;
 					case NODE_AFTER:
-						listener.after(getCurrentNodeId(), getCurrentStateData(), config, SystemClock.now());
+						listener.after(nodeId, getCurrentStateData(), config, SystemClock.now());
 						break;
 					case ERROR:
-						listener.onError(getCurrentNodeId(), getCurrentStateData(), e, config);
+						listener.onError(nodeId, getCurrentStateData(), e, config);
 						break;
 				}
 			} catch (Exception ex) {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/executor/NodeExecutor.java
@@ -322,7 +322,7 @@ public class NodeExecutor extends BaseGraphExecutor {
 				// Handle actual error signals from the Flux
 				log.error("Error signal occurred in embedded Flux stream for key '{}': {}",
 					key, error.getMessage());
-				context.doListeners(ERROR, new Exception(error));
+				context.doListeners(ERROR, nodeId, new Exception(error));
 				GraphResponse<NodeOutput> errorResponse = GraphResponse.error(error);
 				lastGraphResponseRef.set(errorResponse);
 				return Flux.just(errorResponse);

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/StateGraphTest.java
@@ -32,6 +32,8 @@ import com.alibaba.cloud.ai.graph.state.AppenderChannel;
 import com.alibaba.cloud.ai.graph.state.RemoveByHash;
 import com.alibaba.cloud.ai.graph.state.strategy.AppendStrategy;
 import com.alibaba.cloud.ai.graph.state.strategy.ReplaceStrategy;
+import com.alibaba.cloud.ai.graph.streaming.GraphFlux;
+import com.alibaba.cloud.ai.graph.streaming.ParallelGraphFlux;
 import com.alibaba.cloud.ai.graph.streaming.StreamingOutput;
 import com.alibaba.cloud.ai.graph.utils.EdgeMappings;
 
@@ -1271,6 +1273,47 @@ public class StateGraphTest {
 		assertEquals(1, errorCount.get());
 		assertEquals("agent_1", errorNodeId.get());
 		assertEquals(sourceException, listenerException.get().getCause());
+	}
+
+	@Test
+	public void testGraphFluxErrorUsesChildNodeIdForLifecycleListener() throws Exception {
+		RuntimeException sourceException = new RuntimeException("GraphFlux child failure");
+		AtomicReference<String> errorNodeId = new AtomicReference<>();
+		StateGraph workflow = new StateGraph(createKeyStrategyFactory()).addEdge(START, "parent")
+				.addNode("parent", node_async(state -> Map.of("stream",
+						GraphFlux.of("child", Flux.error(sourceException)))))
+				.addEdge("parent", END);
+
+		CompiledGraph app = workflow.compile(CompileConfig.builder().withLifecycleListener(new GraphLifecycleListener() {
+			@Override
+			public void onError(String nodeId, Map<String, Object> state, Throwable ex, RunnableConfig config) {
+				errorNodeId.set(nodeId);
+			}
+		}).build());
+
+		assertThrows(RuntimeException.class, () -> app.stream(Map.of()).blockLast());
+		assertEquals("child", errorNodeId.get());
+	}
+
+	@Test
+	public void testParallelGraphFluxErrorUsesFailingChildNodeIdForLifecycleListener() throws Exception {
+		RuntimeException sourceException = new RuntimeException("ParallelGraphFlux child failure");
+		AtomicReference<String> errorNodeId = new AtomicReference<>();
+		StateGraph workflow = new StateGraph(createKeyStrategyFactory()).addEdge(START, "parent")
+				.addNode("parent", node_async(state -> Map.of("stream", ParallelGraphFlux.of(List.of(
+						GraphFlux.of("child_success", Flux.just("ok")),
+						GraphFlux.of("child_failure", Flux.error(sourceException)))))))
+				.addEdge("parent", END);
+
+		CompiledGraph app = workflow.compile(CompileConfig.builder().withLifecycleListener(new GraphLifecycleListener() {
+			@Override
+			public void onError(String nodeId, Map<String, Object> state, Throwable ex, RunnableConfig config) {
+				errorNodeId.set(nodeId);
+			}
+		}).build());
+
+		assertThrows(RuntimeException.class, () -> app.stream(Map.of()).blockLast());
+		assertEquals("child_failure", errorNodeId.get());
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

Follow-up to #4911, addressing post-merge review feedback on streaming error node attribution.

Streaming errors from `GraphFlux` and `ParallelGraphFlux` can be reported to lifecycle listeners with the outer execution node ID instead of the actual failing stream node ID.

`transformFluxToGraphResponse` already receives the effective stream `nodeId`, but the error path previously dispatched the lifecycle event through `context.doListeners(ERROR, ...)`, which resolved the node ID from the current execution context.

As a result, failures from child or parallel streams could be attributed to their parent node.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Added an overload of `doListeners` that accepts an explicit node ID while preserving the existing behavior of the original method.

The streaming error path now dispatches lifecycle errors using the effective stream node ID passed to `transformFluxToGraphResponse`.

Added regression tests covering:

- a failing child `GraphFlux`
- a failing child inside `ParallelGraphFlux`

### Describe how to verify it

Ran the four related `StateGraphTest` streaming error tests successfully.

Also verified:

- Checkstyle passes
- `git diff --check` passes

### Special notes for reviews

This change only affects lifecycle error attribution for streaming `GraphFlux` and `ParallelGraphFlux` failures.

Existing callers of `doListeners(scene, error)` retain their original behavior.
