### PR TITLE
test(graph): pin List<byte[]> element types across serializer round-trip

### DIFF
--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/SpringAIJacksonStateSerializerTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/plain_text/SpringAIJacksonStateSerializerTest.java
@@ -489,6 +489,25 @@ class SpringAIJacksonStateSerializerTest {
 	}
 
 	@Test
+	void shouldPreserveListOfByteArraysRoundTrip() throws Exception {
+		AssistantMessage message = AssistantMessage.builder()
+			.content("result")
+			.properties(Map.of("payload", List.of(new byte[] { 1, 2, 3 }, new byte[] { 4, 5 })))
+			.build();
+
+		AssistantMessage deserialized = serializeAndDeserialize(message);
+
+		// Nested primitive arrays keep their element type too: the serializer
+		// restores every WRAPPER_ARRAY-encoded entry, so a List<byte[]> must not
+		// degrade into a List<String> of "[B" descriptors.
+		List<?> list = assertInstanceOf(List.class, deserialized.getMetadata().get("payload"));
+		assertInstanceOf(byte[].class, list.get(0));
+		assertInstanceOf(byte[].class, list.get(1));
+		assertArrayEquals(new byte[] { 1, 2, 3 }, (byte[]) list.get(0));
+		assertArrayEquals(new byte[] { 4, 5 }, (byte[]) list.get(1));
+	}
+
+	@Test
 	void shouldPreserveOrdinaryObjectArrayType() throws Exception {
 		AssistantMessage message = AssistantMessage.builder()
 			.content("result")


### PR DESCRIPTION
## What

Add a regression test pinning the round-trip behavior of `List<byte[]>` metadata in `SpringAIJacksonStateSerializer`.

## Why

The serializer restores `byte[]` values from Jackson's WRAPPER_ARRAY representation (`[B` descriptor + base64 payload), and this also holds when primitive arrays are nested inside a collection: a `List<byte[]>` survives a full serialize/deserialize cycle as a `List` whose elements are still `byte[]`, matching the documented behavior.

Existing coverage only pins the single-array payload case (`shouldPreserveJacksonByteArraySerialization`, fixed by #4860). While investigating that fix in #4904, it became clear the nested case had no coverage. This test pins it so a future serialization change that degrades elements into `"[B"` string descriptors fails loudly instead of silently.

No production code is changed.