### PR TITLE
docs(admin): fix broken English language-switch link in admin server-start README

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/README-zh.md
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/README-zh.md
@@ -6,7 +6,7 @@
 >
 > Spring AI Alibaba Website Repo: https://github.com/springaialibaba/spring-ai-alibaba-website
 
-[English](./README-en.md) | 中文
+[English](./README.md) | 中文
 
 ## 项目概述
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

The language switch in `spring-ai-alibaba-admin-server-start/README-zh.md` points to `./README-en.md`, which does not exist (the link 404s on GitHub). The English version of this README is `README.md` — the same convention already used by `spring-ai-alibaba-admin/README-zh.md`.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Changed `[English](./README-en.md)` to `[English](./README.md)` in the language-switch line so it points to the existing English README.

### Describe how to verify it

Open `spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/README-zh.md` on GitHub and click the "English" link — it now resolves to `README.md`.

### Special notes for reviews

One-line documentation fix.