### PR TITLE
fix(agent): prevent infinite loop when oldString is empty in EditFile

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/EditFileTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/EditFileTool.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.graph.agent.extension.tools.filesystem;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
@@ -78,9 +79,14 @@ public class EditFileTool implements BiFunction<EditFileTool.EditFileRequest, To
 
 			String content = Files.readString(filePath);
 
-			// Count occurrences
-			int occurrences = countOccurrences(content, oldString);
+			// Handle empty file: allow oldString="" to mean "write to empty file"
+			if (StringUtils.isEmpty(content) && StringUtils.isEmpty(oldString)) {
+				Files.writeString(filePath, newString, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+				return String.format("Successfully wrote to empty file: %s", filePath);
+			}
 
+			// Count occurrences
+			int occurrences = StringUtils.countMatches(content, oldString);
 			if (occurrences == 0) {
 				return "Error: String not found in file: '" + oldString + "'";
 			}
@@ -121,19 +127,6 @@ public class EditFileTool implements BiFunction<EditFileTool.EditFileRequest, To
 		catch (IOException e) {
 			return "Error editing file '" + filePath + "': " + e.getMessage();
 		}
-	}
-
-	/**
-	 * Count occurrences of a substring in content.
-	 */
-	private static int countOccurrences(String content, String search) {
-		int count = 0;
-		int index = 0;
-		while ((index = content.indexOf(search, index)) != -1) {
-			count++;
-			index += search.length();
-		}
-		return count;
 	}
 
 	public static ToolCallback createEditFileToolCallback(String description) {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/EditFileToolTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/EditFileToolTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.extension.tools.filesystem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class EditFileToolTest {
+
+	@TempDir
+	Path tempDir;
+
+	private Path testFile;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		testFile = tempDir.resolve("test_edit.txt");
+	}
+
+	@Test
+	void testEditEmptyFileWithEmptyOldString() throws IOException {
+		Files.createFile(testFile);
+
+		String result = EditFileTool.editFileContent(testFile, "", "new content", false);
+
+		assertTrue(result.contains("Successfully wrote to empty file"));
+		assertEquals("new content", Files.readString(testFile));
+	}
+
+	@Test
+	void testEditNonEmptyFileWithEmptyOldString() throws IOException {
+		Files.writeString(testFile, "existing content");
+
+		String result = EditFileTool.editFileContent(testFile, "", "new content", false);
+
+		assertTrue(result.contains("String not found"));
+		assertEquals("existing content", Files.readString(testFile));
+	}
+
+	@Test
+	void testNormalReplace() throws IOException {
+		Files.writeString(testFile, "hello world");
+
+		String result = EditFileTool.editFileContent(testFile, "hello", "hi", false);
+
+		assertTrue(result.contains("Successfully edited file"));
+		assertEquals("hi world", Files.readString(testFile));
+	}
+
+	@Test
+	void testNormalReplaceAll() throws IOException {
+		Files.writeString(testFile, "aaa bbb aaa");
+
+		String result = EditFileTool.editFileContent(testFile, "aaa", "ccc", true);
+
+		assertTrue(result.contains("Successfully edited file"));
+		assertEquals("ccc bbb ccc", Files.readString(testFile));
+	}
+}


### PR DESCRIPTION
# Fix: Prevent infinite loop when `oldString` is empty in `EditFileTool`

## Problem

When using `EditFileTool`, passing an empty string (`""`) as `oldString` causes an **infinite loop** in the `countOccurrences` method.

### Root Cause

```java
private static int countOccurrences(String content, String search) {
    int count = 0;
    int index = 0;
    while ((index = content.indexOf(search, index)) != -1) {
        count++;
        index += search.length();
    }
    return count;
}
```

When `search = ""`:
- `content.indexOf("", index)` always returns `0`
- `search.length()` = `0`, so `index` never advances
- The loop never terminates

## Solution

1. **Replace custom `countOccurrences` with `StringUtils.countMatches`**  
   - Handles empty `search` string safely and returns `0` without looping

2. **Explicitly handle empty file scenario**  
   - When both file content and `oldString` are empty, write `newString` directly to the file
   - This enables editing empty files by simply writing new content

## Result

- Infinite loop is eliminated
- Empty files can now be edited correctly
- Behavior remains consistent with expected file editing semantics