### PR TITLE
fix(agent): pass groupedTools map to interceptor even when initially empty

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
@@ -142,9 +142,7 @@ public class SkillsAgentHook extends AgentHook {
 	@Override
 	public List<ModelInterceptor> getModelInterceptors() {
 		SkillsInterceptor.Builder interceptorBuilder = SkillsInterceptor.builder().skillRegistry(this.skillRegistry);
-		if (!this.groupedTools.isEmpty()) {
-			interceptorBuilder.groupedTools(this.groupedTools);
-		}
+		interceptorBuilder.groupedTools(this.groupedTools);
 		if (this.groupedToolsSupplier != null) {
 			interceptorBuilder.groupedToolsSupplier(this.groupedToolsSupplier);
 		}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/SkillsToolingTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/SkillsToolingTest.java
@@ -19,6 +19,7 @@ import com.alibaba.cloud.ai.graph.agent.hook.skills.DisableSkillTool;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.ReadSkillTool;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.SearchSkillsTool;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.SkillsAgentHook;
+import com.alibaba.cloud.ai.graph.agent.interceptor.skills.SkillsInterceptor;
 import com.alibaba.cloud.ai.graph.skills.registry.SkillRegistry;
 import com.alibaba.cloud.ai.graph.skills.registry.filesystem.FileSystemSkillRegistry;
 
@@ -26,10 +27,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -102,6 +106,25 @@ class SkillsToolingTest {
 
 		assertEquals(List.of("read_skill", "search_skills", "disable_skill"), toolNames);
 		assertFalse(toolNames.contains("allowed-tools-test"));
+	}
+
+	@Test
+	void groupedToolsMapIsPassedEvenWhenInitiallyEmpty() {
+		Map<String, List<ToolCallback>> dynamic = new ConcurrentHashMap<>();
+		SkillsAgentHook hook = SkillsAgentHook.builder()
+				.skillRegistry(registry)
+				.groupedTools(dynamic)
+				.build();
+
+		SkillsInterceptor interceptor = (SkillsInterceptor) hook.getModelInterceptors().get(0);
+
+		ToolCallback tool = FunctionToolCallback.builder("record_result", args -> "recorded")
+				.description("Records a result value")
+				.inputType(String.class)
+				.build();
+		dynamic.put("allowed-tools-test", List.of(tool));
+
+		assertEquals(1, interceptor.getGroupedTools().get("allowed-tools-test").size());
 	}
 
 }


### PR DESCRIPTION
修复 #4929

## 问题
创建 SkillsAgentHook 时传入空的动态 Map（如外部维护的 ConcurrentHashMap），getModelInterceptors 里的 isEmpty 守卫会跳过配置，之后向 Map 注入工具不生效。

## 改动
- 移除 isEmpty 守卫，groupedTools 始终传给拦截器（空 Map 与未配置行为一致）
- 新增回归测试 groupedToolsMapIsPassedEvenWhenInitiallyEmpty

## 验证
mvn -pl spring-ai-alibaba-agent-framework -am -Dtest=SkillsToolingTest：4/4 通过