### PR TITLE
fix(admin): add missing ThreadPoolExecutor import in RequestContextThreadPoolWrapper

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/utils/concurrent/RequestContextThreadPoolWrapper.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-core/src/main/java/com/alibaba/cloud/ai/studio/core/utils/concurrent/RequestContextThreadPoolWrapper.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

`spring-ai-alibaba-admin-server-core` currently fails to compile on `main`
because `RequestContextThreadPoolWrapper` references `ThreadPoolExecutor`
(line 235) without importing it. This PR adds the missing import.

### Does this pull request fix one issue?

Fixes #4931

### Describe how you did it

Added `import java.util.concurrent.ThreadPoolExecutor;` to
`RequestContextThreadPoolWrapper.java`, placed in alphabetical order among the
existing `java.util.concurrent` imports.

### Describe how to verify it

Verified with an A/B test on a clean clone of `main` (`f82da0b`, JDK 17):

1. `cd spring-ai-alibaba-admin && mvn -pl spring-ai-alibaba-admin-server-core -am compile`
   fails with:
   `RequestContextThreadPoolWrapper.java:[235,16] cannot find symbol: class ThreadPoolExecutor`
2. With this one-line change (`git diff` = 1 insertion), the same command
   completes with `BUILD SUCCESS`.

Checkstyle (using the repo's own config at
`tools/src/checkstyle/checkstyle.xml`) reports no violations for the changed
file.

Note: the CI workflows do not cover the `spring-ai-alibaba-admin` modules (the
root `pom.xml` reactor excludes them), so the local compilation above is the
authoritative verification.

### Special notes for reviews

None.
