### PR TITLE
fix(agent): retain dynamically updated grouped tools

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
@@ -142,9 +142,10 @@ public class SkillsAgentHook extends AgentHook {
 	@Override
 	public List<ModelInterceptor> getModelInterceptors() {
 		SkillsInterceptor.Builder interceptorBuilder = SkillsInterceptor.builder().skillRegistry(this.skillRegistry);
-		if (!this.groupedTools.isEmpty()) {
-			interceptorBuilder.groupedTools(this.groupedTools);
-		}
+		// Always pass the map through, including when it is initially empty. The
+		// interceptor intentionally keeps this reference so callers can populate it
+		// after the agent has been built.
+		interceptorBuilder.groupedTools(this.groupedTools);
 		if (this.groupedToolsSupplier != null) {
 			interceptorBuilder.groupedToolsSupplier(this.groupedToolsSupplier);
 		}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
@@ -17,6 +17,7 @@ package com.alibaba.cloud.ai.graph.agent.interceptors;
 
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.ReadSkillTool;
+import com.alibaba.cloud.ai.graph.agent.hook.skills.SkillsAgentHook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import com.alibaba.cloud.ai.graph.agent.interceptor.skills.SkillsInterceptor;
@@ -44,6 +45,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.List.of;
@@ -185,6 +187,27 @@ class SkillsInterceptorEnhancementsTest {
 		assertEquals(2, second.get("allowed-tools-test").size());
 		assertTrue(second.get("allowed-tools-test").stream()
 				.anyMatch(tool -> "extra_tool".equals(tool.getToolDefinition().name())));
+	}
+
+	@Test
+	void hookRetainsInitiallyEmptyGroupedToolsForLaterUpdates() {
+		Map<String, List<ToolCallback>> groupedTools = new ConcurrentHashMap<>();
+		SkillsAgentHook hook = SkillsAgentHook.builder()
+				.skillRegistry(registry)
+				.groupedTools(groupedTools)
+				.build();
+
+		SkillsInterceptor interceptor = (SkillsInterceptor) hook.getModelInterceptors().get(0);
+		assertTrue(interceptor.getGroupedTools().isEmpty());
+
+		ToolCallback tool = FunctionToolCallback.builder("late_tool", args -> "ok")
+				.description("Tool added after agent construction")
+				.inputType(String.class)
+				.build();
+		groupedTools.put("allowed-tools-test", List.of(tool));
+
+		assertEquals(List.of("late_tool"), interceptor.getGroupedTools().get("allowed-tools-test")
+				.stream().map(callback -> callback.getToolDefinition().name()).toList());
 	}
 
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #4929.

`SkillsAgentHook#getModelInterceptors()` previously skipped passing `groupedTools` to `SkillsInterceptor` when the map was empty. When callers populated that same map after agent construction, the interceptor retained an empty replacement map and never observed the new tools.

This change always passes the configured map through, preserving the caller's live map reference. A regression test covers an initially empty `ConcurrentHashMap` that is populated after the interceptor is created.

## Verification

- `git diff --check` passes.
- Attempted: `mvn -pl spring-ai-alibaba-agent-framework -Dtest=SkillsInterceptorEnhancementsTest test`
- The test run could not resolve the project's BOMs because the configured Maven mirror reset the connection (`Connection reset`); no test assertion or compilation failure was reached.
