### PR TITLE
fix(agent): use object schemas for filesystem tools

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/GlobTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/GlobTool.java
@@ -15,6 +15,8 @@
  */
 package com.alibaba.cloud.ai.graph.agent.extension.tools.filesystem;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -81,9 +83,21 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	public static ToolCallback createGlobToolCallback(String description) {
-		return FunctionToolCallback.builder("glob", new GlobTool())
+		GlobTool tool = new GlobTool();
+		BiFunction<GlobRequest, ToolContext, String> function =
+				(request, toolContext) -> tool.apply(request.pattern(), toolContext);
+		return FunctionToolCallback.builder("glob", function)
 				.description(description)
-				.inputType(String.class)
+				.inputType(GlobRequest.class)
 				.build();
 	}
+
+	/**
+	 * Request structure for finding files with a glob pattern.
+	 */
+	public record GlobRequest(
+			@JsonProperty(required = true, value = "pattern")
+			@JsonPropertyDescription("The glob pattern to match files")
+			String pattern
+	) {}
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
@@ -16,6 +16,8 @@
 package com.alibaba.cloud.ai.graph.agent.extension.tools.filesystem;
 
 import com.alibaba.cloud.ai.graph.agent.extension.file.FileInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -208,10 +210,21 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	public static ToolCallback createListFilesToolCallback(String description) {
-		return FunctionToolCallback.builder("ls", new ListFilesTool())
+		ListFilesTool tool = new ListFilesTool();
+		BiFunction<ListFilesRequest, ToolContext, String> function =
+				(request, toolContext) -> tool.apply(request.path(), toolContext);
+		return FunctionToolCallback.builder("ls", function)
 				.description(description)
-				.inputType(String.class)
+				.inputType(ListFilesRequest.class)
 				.build();
 	}
-}
 
+	/**
+	 * Request structure for listing files in a directory.
+	 */
+	public record ListFilesRequest(
+			@JsonProperty(required = true, value = "path")
+			@JsonPropertyDescription("The directory path to list files from")
+			String path
+	) {}
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/FilesystemToolSchemaTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/FilesystemToolSchemaTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.extension.tools.filesystem;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.tool.ToolCallback;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FilesystemToolSchemaTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void listFilesUsesObjectInputSchemaAndAcceptsJsonObject(@TempDir Path tempDir) throws Exception {
+		Path file = Files.createFile(tempDir.resolve("example.txt"));
+		ToolCallback callback = ListFilesTool.createListFilesToolCallback(ListFilesTool.DESCRIPTION);
+
+		assertObjectSchema(callback, "path");
+		String result = callback.call(objectMapper.writeValueAsString(Map.of("path", tempDir.toString())));
+
+		assertTrue(result.contains(file.toString()));
+	}
+
+	@Test
+	void globUsesObjectInputSchemaAndAcceptsJsonObject() throws Exception {
+		ToolCallback callback = GlobTool.createGlobToolCallback(GlobTool.DESCRIPTION);
+
+		assertObjectSchema(callback, "pattern");
+		String result = callback.call(objectMapper.writeValueAsString(Map.of("pattern", "pom.xml")));
+
+		assertTrue(result.contains("pom.xml"));
+	}
+
+	private void assertObjectSchema(ToolCallback callback, String propertyName) throws Exception {
+		JsonNode schema = objectMapper.readTree(callback.getToolDefinition().inputSchema());
+		assertEquals("object", schema.path("type").asText());
+		assertEquals("string", schema.path("properties").path(propertyName).path("type").asText());
+		assertTrue(schema.path("required").isArray());
+		assertEquals(propertyName, schema.path("required").get(0).asText());
+	}
+}


### PR DESCRIPTION
## Summary

- wrap the `ls` path and `glob` pattern in request records so their generated tool schemas use a top-level JSON object
- preserve the existing direct `apply(String, ToolContext)` API for compatibility
- add regression tests for the generated schemas and JSON tool invocation

## Verification

- reproduced the reported `ls` string-schema rejection against DeepSeek
- verified a `ReactAgent` with `FilesystemInterceptor` is accepted after the change
- `./mvnw -pl spring-ai-alibaba-agent-framework test` (`615` tests, `0` failures, `0` errors)

Fixes #4937