### PR TITLE
fix(graph): load classpath skills from Spring Boot fat jars

### DIFF
--- a/spring-ai-alibaba-graph-core/pom.xml
+++ b/spring-ai-alibaba-graph-core/pom.xml
@@ -169,6 +169,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-loader-tools</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <scope>test</scope>

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +91,8 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	// JAR FileSystem for classpath resources (only created if resource is in JAR)
 	private FileSystem jarFileSystem;
 	private boolean ownsJarFileSystem;
+	// Keep published generations readable across reloads and remove them when the registry closes.
+	private final Set<Path> bootExtractionRoots = new LinkedHashSet<>();
 
 	private ClasspathSkillRegistry(Builder builder) {
 		this.classpathPath = builder.classpathPath != null && !builder.classpathPath.isEmpty()
@@ -234,9 +237,11 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 
 		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(
 				getClass().getClassLoader());
+		Map<String, Integer> classpathRootOrder = getClasspathRootOrder(resolver);
 		Resource[] resources = resolver.getResources("classpath*:" + classpathPath + "/**/*");
-		Set<Path> extractedSkillDirectories = new LinkedHashSet<>();
-		Set<Path> preparedSkillDirectories = new LinkedHashSet<>();
+		// Select one complete source for each skill directory according to classpath precedence.
+		Map<String, String> selectedSourceRoots = new LinkedHashMap<>();
+		Map<String, List<ResolvedSkillResource>> selectedSkillResources = new LinkedHashMap<>();
 
 		for (Resource resource : resources) {
 			if (!resource.isReadable()) {
@@ -244,36 +249,50 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 			}
 
 			try {
-				Path relativePath = getRelativeResourcePath(resource);
+				ResolvedResourcePath resolvedPath = getResolvedResourcePath(resource);
+				Path relativePath = resolvedPath != null ? resolvedPath.relativePath() : null;
 				if (relativePath == null || relativePath.getNameCount() < 2) {
 					continue;
 				}
 
-				Path targetFile = targetRoot.resolve(relativePath).normalize();
-				if (!targetFile.startsWith(targetRoot)) {
-					logger.warn("Skipping classpath skill resource outside target directory: {}", resource);
-					continue;
+				String skillDirectoryName = relativePath.getName(0).toString();
+				String sourceRoot = resolvedPath.sourceRoot();
+				classpathRootOrder.computeIfAbsent(sourceRoot, ignored -> classpathRootOrder.size());
+				String selectedSourceRoot = selectedSourceRoots.get(skillDirectoryName);
+				if (selectedSourceRoot == null || classpathRootOrder.get(sourceRoot) < classpathRootOrder
+					.get(selectedSourceRoot)) {
+					selectedSourceRoots.put(skillDirectoryName, sourceRoot);
+					selectedSkillResources.put(skillDirectoryName, new ArrayList<>());
 				}
-
-				Path skillDirectory = targetRoot.resolve(relativePath.getName(0));
-				if (!preparedSkillDirectories.contains(skillDirectory)) {
-					deleteDirectoryRecursively(skillDirectory);
-					preparedSkillDirectories.add(skillDirectory);
+				if (sourceRoot.equals(selectedSourceRoots.get(skillDirectoryName))) {
+					selectedSkillResources.get(skillDirectoryName)
+						.add(new ResolvedSkillResource(resource, relativePath));
 				}
-
-				Files.createDirectories(targetFile.getParent());
-				try (InputStream inputStream = resource.getInputStream()) {
-					Files.copy(inputStream, targetFile, StandardCopyOption.REPLACE_EXISTING);
-				}
-				extractedSkillDirectories.add(skillDirectory);
 			}
 			catch (Exception e) {
-				logger.warn("Failed to extract classpath skill resource {}: {}", resource, e.getMessage());
+				logger.warn("Failed to resolve classpath skill resource {}: {}", resource, e.getMessage());
 			}
 		}
 
-		for (Path skillDirectory : extractedSkillDirectories) {
+		// A new generation is not published through this.skills until every selected resource
+		// has been copied and scanned, so concurrent readers never observe partial extraction.
+		Path extractionRoot = Files.createTempDirectory(targetRoot, ".extracted-");
+		bootExtractionRoots.add(extractionRoot);
+		for (Map.Entry<String, List<ResolvedSkillResource>> skillResources : selectedSkillResources.entrySet()) {
+			Path skillDirectory = extractionRoot.resolve(skillResources.getKey());
 			try {
+				for (ResolvedSkillResource skillResource : skillResources.getValue()) {
+					Path targetFile = extractionRoot.resolve(skillResource.relativePath()).normalize();
+					if (!targetFile.startsWith(extractionRoot)) {
+						throw new IOException("Classpath skill resource resolves outside extraction directory: "
+								+ skillResource.resource());
+					}
+					Files.createDirectories(targetFile.getParent());
+					try (InputStream inputStream = skillResource.resource().getInputStream()) {
+						Files.copy(inputStream, targetFile, StandardCopyOption.REPLACE_EXISTING);
+					}
+				}
+
 				SkillMetadata metadata = scanner.loadSkill(skillDirectory, "classpath");
 				if (metadata != null) {
 					metadata.setSkillPath(skillDirectory.toString());
@@ -281,6 +300,7 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				}
 			}
 			catch (Exception e) {
+				deleteDirectoryRecursively(skillDirectory);
 				logger.error("Failed to load extracted classpath skill {}: {}", skillDirectory, e.getMessage(), e);
 			}
 		}
@@ -288,30 +308,46 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		logger.info("Loaded {} skills from Spring Boot classpath: {}", loadedSkills.size(), classpathPath);
 	}
 
-	private Path getRelativeResourcePath(Resource resource) throws IOException {
+	private Map<String, Integer> getClasspathRootOrder(PathMatchingResourcePatternResolver resolver) throws IOException {
+		Map<String, Integer> rootOrder = new LinkedHashMap<>();
+		for (Resource root : resolver.getResources("classpath*:" + classpathPath)) {
+			String rootUrl = getDecodedResourceUrl(root);
+			while (rootUrl.endsWith("/")) {
+				rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
+			}
+			rootOrder.putIfAbsent(rootUrl, rootOrder.size());
+		}
+		return rootOrder;
+	}
+
+	private ResolvedResourcePath getResolvedResourcePath(Resource resource) throws IOException {
+		String decodedResourceUrl = getDecodedResourceUrl(resource);
+		String marker = "/" + classpathPath + "/";
+		int archiveRootIndex = decodedResourceUrl.lastIndexOf("!/");
+		int markerIndex = decodedResourceUrl.indexOf(marker, archiveRootIndex >= 0 ? archiveRootIndex + 1 : 0);
+		if (markerIndex < 0) {
+			logger.debug("Unable to determine relative path for classpath skill resource: {}", resource);
+			return null;
+		}
+
+		String sourceRoot = decodedResourceUrl.substring(0, markerIndex + marker.length() - 1);
+		Path relativePath = Path.of(decodedResourceUrl.substring(markerIndex + marker.length())).normalize();
+		return new ResolvedResourcePath(sourceRoot, relativePath);
+	}
+
+	private String getDecodedResourceUrl(Resource resource) throws IOException {
 		String resourceUrl = resource.getURL().toExternalForm();
 		int queryIndex = resourceUrl.indexOf('?');
 		if (queryIndex >= 0) {
 			resourceUrl = resourceUrl.substring(0, queryIndex);
 		}
 
-		String decodedResourceUrl;
 		try {
-			decodedResourceUrl = StringUtils.uriDecode(resourceUrl, StandardCharsets.UTF_8);
+			return StringUtils.uriDecode(resourceUrl, StandardCharsets.UTF_8);
 		}
 		catch (IllegalArgumentException e) {
 			throw new IOException("Invalid classpath skill resource URL: " + resourceUrl, e);
 		}
-
-		String marker = "/" + classpathPath + "/";
-		int archiveRootIndex = decodedResourceUrl.lastIndexOf("!/");
-		int markerIndex = decodedResourceUrl.indexOf(marker, archiveRootIndex >= 0 ? archiveRootIndex + 1 : 0);
-		if (markerIndex < 0) {
-			logger.debug("Unable to determine relative path for classpath skill resource: {}", resourceUrl);
-			return null;
-		}
-
-		return Path.of(decodedResourceUrl.substring(markerIndex + marker.length())).normalize();
 	}
 
 	private void deleteDirectoryRecursively(Path directory) throws IOException {
@@ -324,6 +360,12 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				Files.deleteIfExists(path);
 			}
 		}
+	}
+
+	private record ResolvedResourcePath(String sourceRoot, Path relativePath) {
+	}
+
+	private record ResolvedSkillResource(Resource resource, Path relativePath) {
 	}
 
 	FileSystem getOrCreateJarFileSystem(URI uri) throws IOException {
@@ -601,20 +643,32 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	}
 
 	/**
-	 * Closes the JAR FileSystem if it was created.
+	 * Closes the JAR FileSystem if it was created and removes managed extraction
+	 * generations.
 	 * Should be called when the registry is no longer needed.
 	 */
-	public void close() {
+	public synchronized void close() {
 		if (ownsJarFileSystem && jarFileSystem != null) {
 			try {
 				jarFileSystem.close();
 			}
 			catch (IOException e) {
 				logger.warn("Failed to close JAR filesystem: {}", e.getMessage());
+			}
 		}
 		jarFileSystem = null;
 		ownsJarFileSystem = false;
-	}
+
+		for (Path extractionRoot : bootExtractionRoots) {
+			try {
+				deleteDirectoryRecursively(extractionRoot);
+			}
+			catch (IOException e) {
+				logger.warn("Failed to remove Spring Boot skill extraction directory {}: {}", extractionRoot,
+						e.getMessage());
+			}
+		}
+		bootExtractionRoots.clear();
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -20,6 +20,9 @@ import com.alibaba.cloud.ai.graph.skills.registry.AbstractSkillRegistry;
 import com.alibaba.cloud.ai.graph.skills.registry.filesystem.SkillScanner;
 
 import org.springframework.ai.chat.prompt.SystemPromptTemplate;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,12 +35,15 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -54,6 +60,7 @@ import static com.alibaba.cloud.ai.graph.skills.registry.filesystem.FileSystemSk
  * <p>Key features:
  * <ul>
  *   <li>Automatically detects if resources are in filesystem or JAR</li>
+ *   <li>Supports nested resources in Spring Boot executable JARs</li>
  *   <li>Manages JAR FileSystem lifecycle</li>
  *   <li>Caches skill content for JAR resources (since Path.of() cannot access JAR paths)</li>
  * </ul>
@@ -149,6 +156,11 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 					classpathSkillsPath = Path.of(uri);
 				}
 				else if ("jar".equals(uri.getScheme())) {
+					if (isSpringBootJar(uri)) {
+						loadSkillsFromSpringBootJar(loadedSkills);
+						this.skills = loadedSkills;
+						return;
+					}
 					// Resource is in a JAR file (production mode)
 					// Create or reuse JAR FileSystem
 					if (jarFileSystem == null || !jarFileSystem.isOpen()) {
@@ -203,6 +215,94 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		}
 
 		this.skills = loadedSkills;
+	}
+
+	private boolean isSpringBootJar(URI uri) {
+		String uriString = uri.toString();
+		return uriString.startsWith("jar:nested:") || uriString.contains("BOOT-INF/");
+	}
+
+	/**
+	 * Loads skills from a Spring Boot executable JAR. Spring Boot uses nested JAR URLs
+	 * that are not supported by the JDK's NIO JAR file system provider, so resources
+	 * are resolved through Spring and copied to the configured base path first.
+	 */
+	private void loadSkillsFromSpringBootJar(Map<String, SkillMetadata> loadedSkills) throws IOException {
+		Path targetRoot = basePath.resolve(classpathPath).normalize();
+		Files.createDirectories(targetRoot);
+
+		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(
+				getClass().getClassLoader());
+		Resource[] resources = resolver.getResources("classpath*:" + classpathPath + "/**/*");
+		Set<Path> extractedSkillDirectories = new LinkedHashSet<>();
+
+		for (Resource resource : resources) {
+			if (!resource.isReadable()) {
+				continue;
+			}
+
+			try {
+				Path relativePath = getRelativeResourcePath(resource);
+				if (relativePath == null || relativePath.getNameCount() < 2) {
+					continue;
+				}
+
+				Path targetFile = targetRoot.resolve(relativePath).normalize();
+				if (!targetFile.startsWith(targetRoot)) {
+					logger.warn("Skipping classpath skill resource outside target directory: {}", resource);
+					continue;
+				}
+
+				Files.createDirectories(targetFile.getParent());
+				try (InputStream inputStream = resource.getInputStream()) {
+					Files.copy(inputStream, targetFile, StandardCopyOption.REPLACE_EXISTING);
+				}
+				extractedSkillDirectories.add(targetRoot.resolve(relativePath.getName(0)));
+			}
+			catch (Exception e) {
+				logger.warn("Failed to extract classpath skill resource {}: {}", resource, e.getMessage());
+			}
+		}
+
+		for (Path skillDirectory : extractedSkillDirectories) {
+			try {
+				SkillMetadata metadata = scanner.loadSkill(skillDirectory, "classpath");
+				if (metadata != null) {
+					metadata.setSkillPath(skillDirectory.toString());
+					loadedSkills.put(metadata.getName(), metadata);
+				}
+			}
+			catch (Exception e) {
+				logger.error("Failed to load extracted classpath skill {}: {}", skillDirectory, e.getMessage(), e);
+			}
+		}
+
+		logger.info("Loaded {} skills from Spring Boot classpath: {}", loadedSkills.size(), classpathPath);
+	}
+
+	private Path getRelativeResourcePath(Resource resource) throws IOException {
+		String resourceUrl = resource.getURL().toExternalForm();
+		int queryIndex = resourceUrl.indexOf('?');
+		if (queryIndex >= 0) {
+			resourceUrl = resourceUrl.substring(0, queryIndex);
+		}
+
+		String decodedResourceUrl;
+		try {
+			decodedResourceUrl = StringUtils.uriDecode(resourceUrl, StandardCharsets.UTF_8);
+		}
+		catch (IllegalArgumentException e) {
+			throw new IOException("Invalid classpath skill resource URL: " + resourceUrl, e);
+		}
+
+		String marker = "/" + classpathPath + "/";
+		int markerIndex = decodedResourceUrl.lastIndexOf(marker);
+		if (markerIndex < 0) {
+			logger.debug("Unable to determine relative path for classpath skill resource: {}", resourceUrl);
+			return null;
+		}
+
+		return Path.of(decodedResourceUrl.substring(markerIndex + marker.length())).normalize();
 	}
 
 	FileSystem getOrCreateJarFileSystem(URI uri) throws IOException {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -29,6 +29,9 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
@@ -36,12 +39,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Deque;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +85,6 @@ import static com.alibaba.cloud.ai.graph.skills.registry.filesystem.FileSystemSk
 public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 
 	private static final Logger logger = LoggerFactory.getLogger(ClasspathSkillRegistry.class);
-	private static final int MAX_RETAINED_EXTRACTION_GENERATIONS = 2;
 	private final String classpathPath;
 	private final Path basePath;
 	private final SkillScanner scanner = new SkillScanner();
@@ -92,8 +95,8 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	// JAR FileSystem for classpath resources (only created if resource is in JAR)
 	private FileSystem jarFileSystem;
 	private boolean ownsJarFileSystem;
-	// Keep the current and immediately previous generations readable across reloads.
-	private final Deque<Path> bootExtractionRoots = new ArrayDeque<>();
+	// Each registry owns an isolated workspace containing its immutable generations.
+	private Path bootExtractionWorkspace;
 
 	private ClasspathSkillRegistry(Builder builder) {
 		this.classpathPath = builder.classpathPath != null && !builder.classpathPath.isEmpty()
@@ -162,8 +165,14 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				}
 				else if ("jar".equals(uri.getScheme())) {
 					if (isSpringBootJar(uri)) {
-						loadSkillsFromSpringBootJar(loadedSkills);
-						this.skills = loadedSkills;
+						try {
+							loadSkillsFromSpringBootJar(loadedSkills);
+							this.skills = loadedSkills;
+						}
+						catch (Exception e) {
+							logger.error("Failed to reload Spring Boot classpath skills; keeping the previous registry: {}",
+								e.getMessage(), e);
+						}
 						return;
 					}
 					// Resource is in a JAR file (production mode)
@@ -247,23 +256,18 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				continue;
 			}
 
-			try {
-				ResolvedResourcePath resolvedPath = getResolvedResourcePath(resource);
-				Path relativePath = resolvedPath != null ? resolvedPath.relativePath() : null;
-				if (relativePath == null || relativePath.getNameCount() < 2) {
-					continue;
-				}
+			ResolvedResourcePath resolvedPath = getResolvedResourcePath(resource);
+			Path relativePath = resolvedPath != null ? resolvedPath.relativePath() : null;
+			if (relativePath == null || relativePath.getNameCount() < 2) {
+				continue;
+			}
 
-				String skillDirectoryName = relativePath.getName(0).toString();
-				String sourceRoot = resolvedPath.sourceRoot();
-				classpathRootOrder.computeIfAbsent(sourceRoot, ignored -> classpathRootOrder.size());
-				skillCandidates.computeIfAbsent(skillDirectoryName, ignored -> new LinkedHashMap<>())
-					.computeIfAbsent(sourceRoot, ignored -> new ArrayList<>())
-					.add(new ResolvedSkillResource(resource, relativePath));
-			}
-			catch (Exception e) {
-				logger.warn("Failed to resolve classpath skill resource {}: {}", resource, e.getMessage());
-			}
+			String skillDirectoryName = relativePath.getName(0).toString();
+			String sourceRoot = resolvedPath.sourceRoot();
+			classpathRootOrder.computeIfAbsent(sourceRoot, ignored -> classpathRootOrder.size());
+			skillCandidates.computeIfAbsent(skillDirectoryName, ignored -> new LinkedHashMap<>())
+				.computeIfAbsent(sourceRoot, ignored -> new ArrayList<>())
+				.add(new ResolvedSkillResource(resource, relativePath));
 		}
 
 		// Select the highest-precedence complete source; ancillary files alone must not
@@ -284,17 +288,19 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 			}
 		}
 
-		// A new generation is not published through this.skills until every selected resource
-		// has been copied and scanned, so concurrent readers never observe partial extraction.
-		Path extractionRoot = Files.createTempDirectory(targetRoot, ".extracted-");
-		bootExtractionRoots.addLast(extractionRoot);
-		reclaimSupersededExtractionRoots();
-		for (Map.Entry<String, List<ResolvedSkillResource>> skillResources : selectedSkillResources.entrySet()) {
-			Path skillDirectory = extractionRoot.resolve(skillResources.getKey());
-			try {
+		// Build an unpublished generation first. Its content-addressed published path is
+		// immutable and remains readable until close(), while identical reloads reuse it.
+		if (bootExtractionWorkspace == null || !Files.isDirectory(bootExtractionWorkspace)) {
+			bootExtractionWorkspace = Files.createTempDirectory(targetRoot, ".registry-");
+		}
+		Path stagingRoot = Files.createTempDirectory(bootExtractionWorkspace, ".staging-");
+		Path extractionRoot = null;
+		boolean publishedNewGeneration = false;
+		try {
+			for (Map.Entry<String, List<ResolvedSkillResource>> skillResources : selectedSkillResources.entrySet()) {
 				for (ResolvedSkillResource skillResource : skillResources.getValue()) {
-					Path targetFile = extractionRoot.resolve(skillResource.relativePath()).normalize();
-					if (!targetFile.startsWith(extractionRoot)) {
+					Path targetFile = stagingRoot.resolve(skillResource.relativePath()).normalize();
+					if (!targetFile.startsWith(stagingRoot)) {
 						throw new IOException("Classpath skill resource resolves outside extraction directory: "
 								+ skillResource.resource());
 					}
@@ -303,20 +309,102 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 						Files.copy(inputStream, targetFile, StandardCopyOption.REPLACE_EXISTING);
 					}
 				}
+			}
 
+			PublishedExtraction publishedExtraction = publishExtractionGeneration(stagingRoot, bootExtractionWorkspace);
+			extractionRoot = publishedExtraction.path();
+			publishedNewGeneration = publishedExtraction.created();
+			Map<String, SkillMetadata> generationSkills = new HashMap<>();
+			for (String skillDirectoryName : selectedSkillResources.keySet()) {
+				Path skillDirectory = extractionRoot.resolve(skillDirectoryName);
 				SkillMetadata metadata = scanner.loadSkill(skillDirectory, "classpath");
-				if (metadata != null) {
-					metadata.setSkillPath(skillDirectory.toString());
-					loadedSkills.put(metadata.getName(), metadata);
+				if (metadata == null) {
+					throw new IOException("Failed to scan extracted classpath skill: " + skillDirectory);
+				}
+				metadata.setSkillPath(skillDirectory.toString());
+				generationSkills.put(metadata.getName(), metadata);
+			}
+
+			loadedSkills.putAll(generationSkills);
+		}
+		catch (Exception e) {
+			IOException loadFailure = e instanceof IOException ioException ? ioException
+					: new IOException("Failed to extract Spring Boot classpath skills", e);
+			try {
+				deleteDirectoryRecursively(stagingRoot);
+			}
+			catch (IOException cleanupFailure) {
+				loadFailure.addSuppressed(cleanupFailure);
+			}
+			if (publishedNewGeneration && extractionRoot != null) {
+				try {
+					deleteDirectoryRecursively(extractionRoot);
+				}
+				catch (IOException cleanupFailure) {
+					loadFailure.addSuppressed(cleanupFailure);
 				}
 			}
-			catch (Exception e) {
-				deleteDirectoryRecursively(skillDirectory);
-				logger.error("Failed to load extracted classpath skill {}: {}", skillDirectory, e.getMessage(), e);
-			}
+			throw loadFailure;
 		}
 
 		logger.info("Loaded {} skills from Spring Boot classpath: {}", loadedSkills.size(), classpathPath);
+	}
+
+	private PublishedExtraction publishExtractionGeneration(Path stagingRoot, Path targetRoot) throws IOException {
+		Path extractionRoot = targetRoot.resolve(".extracted-" + calculateExtractionDigest(stagingRoot));
+		if (Files.exists(extractionRoot)) {
+			if (!Files.isDirectory(extractionRoot)) {
+				throw new IOException("Spring Boot skill extraction path is not a directory: " + extractionRoot);
+			}
+			deleteDirectoryRecursively(stagingRoot);
+			return new PublishedExtraction(extractionRoot, false);
+		}
+
+		try {
+			try {
+				Files.move(stagingRoot, extractionRoot, StandardCopyOption.ATOMIC_MOVE);
+			}
+			catch (AtomicMoveNotSupportedException e) {
+				Files.move(stagingRoot, extractionRoot);
+			}
+			return new PublishedExtraction(extractionRoot, true);
+		}
+		catch (FileAlreadyExistsException e) {
+			deleteDirectoryRecursively(stagingRoot);
+			return new PublishedExtraction(extractionRoot, false);
+		}
+	}
+
+	private String calculateExtractionDigest(Path extractionRoot) throws IOException {
+		MessageDigest digest;
+		try {
+			digest = MessageDigest.getInstance("SHA-256");
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 is not available", e);
+		}
+
+		try (Stream<Path> paths = Files.walk(extractionRoot)) {
+			for (Path path : paths.filter(Files::isRegularFile)
+				.sorted(Comparator.comparing(file -> extractionRoot.relativize(file).toString()))
+				.toList()) {
+				byte[] relativePath = extractionRoot.relativize(path)
+					.toString()
+					.replace('\\', '/')
+					.getBytes(StandardCharsets.UTF_8);
+				digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(relativePath.length).array());
+				digest.update(relativePath);
+				digest.update(ByteBuffer.allocate(Long.BYTES).putLong(Files.size(path)).array());
+				try (InputStream inputStream = Files.newInputStream(path)) {
+					byte[] buffer = new byte[8192];
+					int bytesRead;
+					while ((bytesRead = inputStream.read(buffer)) != -1) {
+						digest.update(buffer, 0, bytesRead);
+					}
+				}
+			}
+		}
+		return HexFormat.of().formatHex(digest.digest());
 	}
 
 	private boolean containsSkillManifest(List<ResolvedSkillResource> resources) {
@@ -379,25 +467,13 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		}
 	}
 
-	private void reclaimSupersededExtractionRoots() {
-		while (bootExtractionRoots.size() > MAX_RETAINED_EXTRACTION_GENERATIONS) {
-			Path extractionRoot = bootExtractionRoots.removeFirst();
-			try {
-				deleteDirectoryRecursively(extractionRoot);
-			}
-			catch (IOException e) {
-				bootExtractionRoots.addFirst(extractionRoot);
-				logger.warn("Failed to remove superseded Spring Boot skill extraction directory {}: {}",
-						extractionRoot, e.getMessage());
-				break;
-			}
-		}
-	}
-
 	private record ResolvedResourcePath(String sourceRoot, Path relativePath) {
 	}
 
 	private record ResolvedSkillResource(Resource resource, Path relativePath) {
+	}
+
+	private record PublishedExtraction(Path path, boolean created) {
 	}
 
 	FileSystem getOrCreateJarFileSystem(URI uri) throws IOException {
@@ -691,16 +767,16 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		jarFileSystem = null;
 		ownsJarFileSystem = false;
 
-		for (Path extractionRoot : bootExtractionRoots) {
+		if (bootExtractionWorkspace != null) {
 			try {
-				deleteDirectoryRecursively(extractionRoot);
+				deleteDirectoryRecursively(bootExtractionWorkspace);
 			}
 			catch (IOException e) {
-				logger.warn("Failed to remove Spring Boot skill extraction directory {}: {}", extractionRoot,
+				logger.warn("Failed to remove Spring Boot skill extraction workspace {}: {}", bootExtractionWorkspace,
 						e.getMessage());
 			}
 		}
-		bootExtractionRoots.clear();
+		bootExtractionWorkspace = null;
 	}
 
 	/**

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -37,15 +37,15 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -81,6 +81,7 @@ import static com.alibaba.cloud.ai.graph.skills.registry.filesystem.FileSystemSk
 public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 
 	private static final Logger logger = LoggerFactory.getLogger(ClasspathSkillRegistry.class);
+	private static final int MAX_RETAINED_EXTRACTION_GENERATIONS = 2;
 	private final String classpathPath;
 	private final Path basePath;
 	private final SkillScanner scanner = new SkillScanner();
@@ -91,8 +92,8 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	// JAR FileSystem for classpath resources (only created if resource is in JAR)
 	private FileSystem jarFileSystem;
 	private boolean ownsJarFileSystem;
-	// Keep published generations readable across reloads and remove them when the registry closes.
-	private final Set<Path> bootExtractionRoots = new LinkedHashSet<>();
+	// Keep the current and immediately previous generations readable across reloads.
+	private final Deque<Path> bootExtractionRoots = new ArrayDeque<>();
 
 	private ClasspathSkillRegistry(Builder builder) {
 		this.classpathPath = builder.classpathPath != null && !builder.classpathPath.isEmpty()
@@ -239,9 +240,7 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				getClass().getClassLoader());
 		Map<String, Integer> classpathRootOrder = getClasspathRootOrder(resolver);
 		Resource[] resources = resolver.getResources("classpath*:" + classpathPath + "/**/*");
-		// Select one complete source for each skill directory according to classpath precedence.
-		Map<String, String> selectedSourceRoots = new LinkedHashMap<>();
-		Map<String, List<ResolvedSkillResource>> selectedSkillResources = new LinkedHashMap<>();
+		Map<String, Map<String, List<ResolvedSkillResource>>> skillCandidates = new LinkedHashMap<>();
 
 		for (Resource resource : resources) {
 			if (!resource.isReadable()) {
@@ -258,26 +257,38 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				String skillDirectoryName = relativePath.getName(0).toString();
 				String sourceRoot = resolvedPath.sourceRoot();
 				classpathRootOrder.computeIfAbsent(sourceRoot, ignored -> classpathRootOrder.size());
-				String selectedSourceRoot = selectedSourceRoots.get(skillDirectoryName);
-				if (selectedSourceRoot == null || classpathRootOrder.get(sourceRoot) < classpathRootOrder
-					.get(selectedSourceRoot)) {
-					selectedSourceRoots.put(skillDirectoryName, sourceRoot);
-					selectedSkillResources.put(skillDirectoryName, new ArrayList<>());
-				}
-				if (sourceRoot.equals(selectedSourceRoots.get(skillDirectoryName))) {
-					selectedSkillResources.get(skillDirectoryName)
-						.add(new ResolvedSkillResource(resource, relativePath));
-				}
+				skillCandidates.computeIfAbsent(skillDirectoryName, ignored -> new LinkedHashMap<>())
+					.computeIfAbsent(sourceRoot, ignored -> new ArrayList<>())
+					.add(new ResolvedSkillResource(resource, relativePath));
 			}
 			catch (Exception e) {
 				logger.warn("Failed to resolve classpath skill resource {}: {}", resource, e.getMessage());
 			}
 		}
 
+		// Select the highest-precedence complete source; ancillary files alone must not
+		// shadow a lower-precedence skill that contains SKILL.md.
+		Map<String, List<ResolvedSkillResource>> selectedSkillResources = new LinkedHashMap<>();
+		for (Map.Entry<String, Map<String, List<ResolvedSkillResource>>> skillCandidate : skillCandidates
+			.entrySet()) {
+			String selectedSourceRoot = null;
+			for (Map.Entry<String, List<ResolvedSkillResource>> sourceCandidate : skillCandidate.getValue()
+				.entrySet()) {
+				if (containsSkillManifest(sourceCandidate.getValue()) && (selectedSourceRoot == null
+						|| classpathRootOrder.get(sourceCandidate.getKey()) < classpathRootOrder.get(selectedSourceRoot))) {
+					selectedSourceRoot = sourceCandidate.getKey();
+				}
+			}
+			if (selectedSourceRoot != null) {
+				selectedSkillResources.put(skillCandidate.getKey(), skillCandidate.getValue().get(selectedSourceRoot));
+			}
+		}
+
 		// A new generation is not published through this.skills until every selected resource
 		// has been copied and scanned, so concurrent readers never observe partial extraction.
 		Path extractionRoot = Files.createTempDirectory(targetRoot, ".extracted-");
-		bootExtractionRoots.add(extractionRoot);
+		bootExtractionRoots.addLast(extractionRoot);
+		reclaimSupersededExtractionRoots();
 		for (Map.Entry<String, List<ResolvedSkillResource>> skillResources : selectedSkillResources.entrySet()) {
 			Path skillDirectory = extractionRoot.resolve(skillResources.getKey());
 			try {
@@ -306,6 +317,12 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		}
 
 		logger.info("Loaded {} skills from Spring Boot classpath: {}", loadedSkills.size(), classpathPath);
+	}
+
+	private boolean containsSkillManifest(List<ResolvedSkillResource> resources) {
+		return resources.stream()
+			.anyMatch(resource -> resource.relativePath().getNameCount() == 2
+					&& "SKILL.md".equals(resource.relativePath().getFileName().toString()));
 	}
 
 	private Map<String, Integer> getClasspathRootOrder(PathMatchingResourcePatternResolver resolver) throws IOException {
@@ -358,6 +375,21 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		try (Stream<Path> paths = Files.walk(directory)) {
 			for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
 				Files.deleteIfExists(path);
+			}
+		}
+	}
+
+	private void reclaimSupersededExtractionRoots() {
+		while (bootExtractionRoots.size() > MAX_RETAINED_EXTRACTION_GENERATIONS) {
+			Path extractionRoot = bootExtractionRoots.removeFirst();
+			try {
+				deleteDirectoryRecursively(extractionRoot);
+			}
+			catch (IOException e) {
+				bootExtractionRoots.addFirst(extractionRoot);
+				logger.warn("Failed to remove superseded Spring Boot skill extraction directory {}: {}",
+						extractionRoot, e.getMessage());
+				break;
 			}
 		}
 	}

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -38,6 +38,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -235,6 +236,7 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 				getClass().getClassLoader());
 		Resource[] resources = resolver.getResources("classpath*:" + classpathPath + "/**/*");
 		Set<Path> extractedSkillDirectories = new LinkedHashSet<>();
+		Set<Path> preparedSkillDirectories = new LinkedHashSet<>();
 
 		for (Resource resource : resources) {
 			if (!resource.isReadable()) {
@@ -253,11 +255,17 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 					continue;
 				}
 
+				Path skillDirectory = targetRoot.resolve(relativePath.getName(0));
+				if (!preparedSkillDirectories.contains(skillDirectory)) {
+					deleteDirectoryRecursively(skillDirectory);
+					preparedSkillDirectories.add(skillDirectory);
+				}
+
 				Files.createDirectories(targetFile.getParent());
 				try (InputStream inputStream = resource.getInputStream()) {
 					Files.copy(inputStream, targetFile, StandardCopyOption.REPLACE_EXISTING);
 				}
-				extractedSkillDirectories.add(targetRoot.resolve(relativePath.getName(0)));
+				extractedSkillDirectories.add(skillDirectory);
 			}
 			catch (Exception e) {
 				logger.warn("Failed to extract classpath skill resource {}: {}", resource, e.getMessage());
@@ -296,13 +304,26 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 		}
 
 		String marker = "/" + classpathPath + "/";
-		int markerIndex = decodedResourceUrl.lastIndexOf(marker);
+		int archiveRootIndex = decodedResourceUrl.lastIndexOf("!/");
+		int markerIndex = decodedResourceUrl.indexOf(marker, archiveRootIndex >= 0 ? archiveRootIndex + 1 : 0);
 		if (markerIndex < 0) {
 			logger.debug("Unable to determine relative path for classpath skill resource: {}", resourceUrl);
 			return null;
 		}
 
 		return Path.of(decodedResourceUrl.substring(markerIndex + marker.length())).normalize();
+	}
+
+	private void deleteDirectoryRecursively(Path directory) throws IOException {
+		if (!Files.exists(directory)) {
+			return;
+		}
+
+		try (Stream<Path> paths = Files.walk(directory)) {
+			for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+				Files.deleteIfExists(path);
+			}
+		}
 	}
 
 	FileSystem getOrCreateJarFileSystem(URI uri) throws IOException {

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistry.java
@@ -351,27 +351,46 @@ public class ClasspathSkillRegistry extends AbstractSkillRegistry {
 	}
 
 	private PublishedExtraction publishExtractionGeneration(Path stagingRoot, Path targetRoot) throws IOException {
-		Path extractionRoot = targetRoot.resolve(".extracted-" + calculateExtractionDigest(stagingRoot));
-		if (Files.exists(extractionRoot)) {
-			if (!Files.isDirectory(extractionRoot)) {
-				throw new IOException("Spring Boot skill extraction path is not a directory: " + extractionRoot);
+		String expectedDigest = calculateExtractionDigest(stagingRoot);
+		String extractionName = ".extracted-" + expectedDigest;
+		int suffix = 0;
+		while (true) {
+			Path extractionRoot = targetRoot.resolve(suffix == 0 ? extractionName : extractionName + "-" + suffix);
+			if (Files.exists(extractionRoot)) {
+				if (isMatchingExtraction(extractionRoot, expectedDigest)) {
+					deleteDirectoryRecursively(stagingRoot);
+					return new PublishedExtraction(extractionRoot, false);
+				}
+				suffix++;
+				continue;
 			}
-			deleteDirectoryRecursively(stagingRoot);
-			return new PublishedExtraction(extractionRoot, false);
-		}
 
-		try {
 			try {
-				Files.move(stagingRoot, extractionRoot, StandardCopyOption.ATOMIC_MOVE);
+				try {
+					Files.move(stagingRoot, extractionRoot, StandardCopyOption.ATOMIC_MOVE);
+				}
+				catch (AtomicMoveNotSupportedException e) {
+					Files.move(stagingRoot, extractionRoot);
+				}
+				return new PublishedExtraction(extractionRoot, true);
 			}
-			catch (AtomicMoveNotSupportedException e) {
-				Files.move(stagingRoot, extractionRoot);
+			catch (FileAlreadyExistsException e) {
+				// Another publisher won the race; validate that path on the next iteration.
 			}
-			return new PublishedExtraction(extractionRoot, true);
 		}
-		catch (FileAlreadyExistsException e) {
-			deleteDirectoryRecursively(stagingRoot);
-			return new PublishedExtraction(extractionRoot, false);
+	}
+
+	private boolean isMatchingExtraction(Path extractionRoot, String expectedDigest) {
+		if (!Files.isDirectory(extractionRoot)) {
+			return false;
+		}
+		try {
+			return expectedDigest.equals(calculateExtractionDigest(extractionRoot));
+		}
+		catch (IOException e) {
+			logger.warn("Failed to validate existing Spring Boot skill extraction directory {}: {}", extractionRoot,
+					e.getMessage());
+			return false;
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
@@ -51,6 +51,14 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 
 			# Fat JAR Skill
 			""";
+	private static final String FALLBACK_SKILL_CONTENT = """
+			---
+			name: fallback-skill
+			description: Verifies that ancillary files cannot shadow a complete skill.
+			---
+
+			# Fallback Skill
+			""";
 
 	@Test
 	void loadsSkillFromSpringBootExecutableJar(@TempDir Path tempDir) throws Exception {
@@ -80,17 +88,31 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 
 		String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 		assertEquals(0, process.exitValue(), output);
-		assertTrue(output.contains("FAT_JAR_SKILLS=[fat-jar-skill]"), output);
+		assertTrue(output.contains("FAT_JAR_SKILLS=[fallback-skill, fat-jar-skill]"), output);
 		assertTrue(output.contains("FAT_JAR_RELOAD_STAGED=true"), output);
 	}
 
 	private void createDependencyJar(Path jarPath) throws IOException {
 		try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jarPath))) {
+			writeDirectoryEntry(output, "fat-jar-skills/");
+			writeDirectoryEntry(output, "fat-jar-skills/fat-jar-skill/");
+			writeDirectoryEntry(output, "fat-jar-skills/fat-jar-skill/references/");
+			writeDirectoryEntry(output, "fat-jar-skills/fallback-skill/");
+			writeDirectoryEntry(output, "fat-jar-skills/fallback-skill/references/");
 			writeEntry(output, "fat-jar-skills/fat-jar-skill/SKILL.md",
 					new java.io.ByteArrayInputStream(SKILL_CONTENT.getBytes(StandardCharsets.UTF_8)));
 			writeEntry(output, "fat-jar-skills/fat-jar-skill/references/dependency-only.md",
 					new java.io.ByteArrayInputStream("# Dependency only".getBytes(StandardCharsets.UTF_8)));
+			writeEntry(output, "fat-jar-skills/fallback-skill/SKILL.md",
+					new java.io.ByteArrayInputStream(FALLBACK_SKILL_CONTENT.getBytes(StandardCharsets.UTF_8)));
+			writeEntry(output, "fat-jar-skills/fallback-skill/references/dependency-reference.md",
+					new java.io.ByteArrayInputStream("# Dependency reference".getBytes(StandardCharsets.UTF_8)));
 		}
+	}
+
+	private void writeDirectoryEntry(JarOutputStream output, String name) throws IOException {
+		output.putNextEntry(new JarEntry(name));
+		output.closeEntry();
 	}
 
 	private void createApplicationJar(Path jarPath) throws IOException {
@@ -110,6 +132,8 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 					new java.io.ByteArrayInputStream("# Reference".getBytes(StandardCharsets.UTF_8)));
 			writeEntry(output, "fat-jar-skills/fat-jar-skill/references/fat-jar-skills/note.md",
 					new java.io.ByteArrayInputStream("# Repeated root".getBytes(StandardCharsets.UTF_8)));
+			writeEntry(output, "fat-jar-skills/fallback-skill/references/app-only.md",
+					new java.io.ByteArrayInputStream("# Ancillary file".getBytes(StandardCharsets.UTF_8)));
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
@@ -89,7 +89,7 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 		String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 		assertEquals(0, process.exitValue(), output);
 		assertTrue(output.contains("FAT_JAR_SKILLS=[fallback-skill, fat-jar-skill]"), output);
-		assertTrue(output.contains("FAT_JAR_RELOAD_STAGED=true"), output);
+		assertTrue(output.contains("FAT_JAR_CONTENT_ADDRESSED=true"), output);
 	}
 
 	private void createDependencyJar(Path jarPath) throws IOException {

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
@@ -15,8 +15,9 @@
  */
 package com.alibaba.cloud.ai.graph.skills.registry.classpath;
 
-import org.springframework.boot.loader.tools.Libraries;
 import org.springframework.boot.loader.tools.Layouts;
+import org.springframework.boot.loader.tools.Library;
+import org.springframework.boot.loader.tools.LibraryScope;
 import org.springframework.boot.loader.tools.Repackager;
 import org.springframework.boot.loader.tools.RepackagingLayout;
 
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClasspathSkillRegistryFatJarIntegrationTest {
@@ -55,17 +55,19 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 	@Test
 	void loadsSkillFromSpringBootExecutableJar(@TempDir Path tempDir) throws Exception {
 		Path executableJar = tempDir.resolve("classpath-skill-test.jar");
+		Path dependencyJar = tempDir.resolve("duplicate-skill-dependency.jar");
 		Path extractedRoot = tempDir.resolve("extracted");
 		Path obsoleteResource = extractedRoot
 			.resolve("fat-jar-skills/fat-jar-skill/references/obsolete.md");
 		Files.createDirectories(obsoleteResource.getParent());
 		Files.writeString(obsoleteResource, "obsolete");
 		createApplicationJar(executableJar);
+		createDependencyJar(dependencyJar);
 
 		Repackager repackager = new Repackager(executableJar.toFile());
 		repackager.setMainClass(ClasspathSkillRegistryFatJarTestApplication.class.getName());
 		repackager.setLayout(new PropertiesLauncherJarLayout());
-		repackager.repackage(Libraries.NONE);
+		repackager.repackage(callback -> callback.library(new Library(dependencyJar.toFile(), LibraryScope.COMPILE)));
 
 		Process process = new ProcessBuilder(javaExecutable(), "-Dloader.path=" + testClasspath(), "-jar",
 				executableJar.toString(), extractedRoot.toString()).redirectErrorStream(true)
@@ -79,9 +81,16 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 		String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 		assertEquals(0, process.exitValue(), output);
 		assertTrue(output.contains("FAT_JAR_SKILLS=[fat-jar-skill]"), output);
-		assertTrue(Files.exists(extractedRoot
-			.resolve("fat-jar-skills/fat-jar-skill/references/fat-jar-skills/note.md")));
-		assertFalse(Files.exists(obsoleteResource));
+		assertTrue(output.contains("FAT_JAR_RELOAD_STAGED=true"), output);
+	}
+
+	private void createDependencyJar(Path jarPath) throws IOException {
+		try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jarPath))) {
+			writeEntry(output, "fat-jar-skills/fat-jar-skill/SKILL.md",
+					new java.io.ByteArrayInputStream(SKILL_CONTENT.getBytes(StandardCharsets.UTF_8)));
+			writeEntry(output, "fat-jar-skills/fat-jar-skill/references/dependency-only.md",
+					new java.io.ByteArrayInputStream("# Dependency only".getBytes(StandardCharsets.UTF_8)));
+		}
 	}
 
 	private void createApplicationJar(Path jarPath) throws IOException {

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.skills.registry.classpath;
+
+import org.springframework.boot.loader.tools.Libraries;
+import org.springframework.boot.loader.tools.Layouts;
+import org.springframework.boot.loader.tools.Repackager;
+import org.springframework.boot.loader.tools.RepackagingLayout;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClasspathSkillRegistryFatJarIntegrationTest {
+
+	private static final String SKILL_CONTENT = """
+			---
+			name: fat-jar-skill
+			description: Verifies loading skills from a Spring Boot executable JAR.
+			---
+
+			# Fat JAR Skill
+			""";
+
+	@Test
+	void loadsSkillFromSpringBootExecutableJar(@TempDir Path tempDir) throws Exception {
+		Path executableJar = tempDir.resolve("classpath-skill-test.jar");
+		createApplicationJar(executableJar);
+
+		Repackager repackager = new Repackager(executableJar.toFile());
+		repackager.setMainClass(ClasspathSkillRegistryFatJarTestApplication.class.getName());
+		repackager.setLayout(new PropertiesLauncherJarLayout());
+		repackager.repackage(Libraries.NONE);
+
+		Process process = new ProcessBuilder(javaExecutable(), "-Dloader.path=" + testClasspath(), "-jar",
+				executableJar.toString(), tempDir.resolve("extracted").toString()).redirectErrorStream(true)
+				.start();
+		boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+		if (!finished) {
+			process.destroyForcibly();
+		}
+		assertTrue(finished, "Executable JAR did not exit within 30 seconds");
+
+		String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+		assertEquals(0, process.exitValue(), output);
+		assertTrue(output.contains("FAT_JAR_SKILLS=[fat-jar-skill]"), output);
+	}
+
+	private void createApplicationJar(Path jarPath) throws IOException {
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+		try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jarPath), manifest)) {
+			String applicationClass = ClasspathSkillRegistryFatJarTestApplication.class.getName()
+					.replace('.', '/')
+					+ ".class";
+			writeEntry(output, applicationClass,
+					ClasspathSkillRegistryFatJarTestApplication.class.getClassLoader()
+							.getResourceAsStream(applicationClass));
+			writeEntry(output, "fat-jar-skills/fat-jar-skill/SKILL.md",
+					new java.io.ByteArrayInputStream(SKILL_CONTENT.getBytes(StandardCharsets.UTF_8)));
+			writeEntry(output, "fat-jar-skills/fat-jar-skill/references/reference.md",
+					new java.io.ByteArrayInputStream("# Reference".getBytes(StandardCharsets.UTF_8)));
+		}
+	}
+
+	private void writeEntry(JarOutputStream output, String name, InputStream input) throws IOException {
+		if (input == null) {
+			throw new IOException("Missing test resource: " + name);
+		}
+		try (input) {
+			output.putNextEntry(new JarEntry(name));
+			input.transferTo(output);
+			output.closeEntry();
+		}
+	}
+
+	private String javaExecutable() {
+		return Path.of(System.getProperty("java.home"), "bin", "java").toString();
+	}
+
+	private String testClasspath() {
+		String classpath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+		return Arrays.stream(classpath.split(Pattern.quote(File.pathSeparator)))
+				.map(Path::of)
+				.map(Path::toAbsolutePath)
+				.map(Path::toString)
+				.reduce((left, right) -> left + "," + right)
+				.orElseThrow();
+	}
+
+	private static final class PropertiesLauncherJarLayout implements RepackagingLayout {
+
+		private final Layouts.Jar delegate = new Layouts.Jar();
+
+		@Override
+		public String getLauncherClassName() {
+			return "org.springframework.boot.loader.launch.PropertiesLauncher";
+		}
+
+		@Override
+		public String getLibraryLocation(String libraryName,
+				org.springframework.boot.loader.tools.LibraryScope scope) {
+			return delegate.getLibraryLocation(libraryName, scope);
+		}
+
+		@Override
+		public String getClassesLocation() {
+			return delegate.getClassesLocation();
+		}
+
+		@Override
+		public String getRepackagedClassesLocation() {
+			return delegate.getRepackagedClassesLocation();
+		}
+
+		@Override
+		public boolean isExecutable() {
+			return true;
+		}
+
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarIntegrationTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClasspathSkillRegistryFatJarIntegrationTest {
@@ -54,6 +55,11 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 	@Test
 	void loadsSkillFromSpringBootExecutableJar(@TempDir Path tempDir) throws Exception {
 		Path executableJar = tempDir.resolve("classpath-skill-test.jar");
+		Path extractedRoot = tempDir.resolve("extracted");
+		Path obsoleteResource = extractedRoot
+			.resolve("fat-jar-skills/fat-jar-skill/references/obsolete.md");
+		Files.createDirectories(obsoleteResource.getParent());
+		Files.writeString(obsoleteResource, "obsolete");
 		createApplicationJar(executableJar);
 
 		Repackager repackager = new Repackager(executableJar.toFile());
@@ -62,7 +68,7 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 		repackager.repackage(Libraries.NONE);
 
 		Process process = new ProcessBuilder(javaExecutable(), "-Dloader.path=" + testClasspath(), "-jar",
-				executableJar.toString(), tempDir.resolve("extracted").toString()).redirectErrorStream(true)
+				executableJar.toString(), extractedRoot.toString()).redirectErrorStream(true)
 				.start();
 		boolean finished = process.waitFor(30, TimeUnit.SECONDS);
 		if (!finished) {
@@ -73,6 +79,9 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 		String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 		assertEquals(0, process.exitValue(), output);
 		assertTrue(output.contains("FAT_JAR_SKILLS=[fat-jar-skill]"), output);
+		assertTrue(Files.exists(extractedRoot
+			.resolve("fat-jar-skills/fat-jar-skill/references/fat-jar-skills/note.md")));
+		assertFalse(Files.exists(obsoleteResource));
 	}
 
 	private void createApplicationJar(Path jarPath) throws IOException {
@@ -90,6 +99,8 @@ class ClasspathSkillRegistryFatJarIntegrationTest {
 					new java.io.ByteArrayInputStream(SKILL_CONTENT.getBytes(StandardCharsets.UTF_8)));
 			writeEntry(output, "fat-jar-skills/fat-jar-skill/references/reference.md",
 					new java.io.ByteArrayInputStream("# Reference".getBytes(StandardCharsets.UTF_8)));
+			writeEntry(output, "fat-jar-skills/fat-jar-skill/references/fat-jar-skills/note.md",
+					new java.io.ByteArrayInputStream("# Repeated root".getBytes(StandardCharsets.UTF_8)));
 		}
 	}
 

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.skills.registry.classpath;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Test application launched from a repackaged Spring Boot executable JAR. */
+public final class ClasspathSkillRegistryFatJarTestApplication {
+
+	private ClasspathSkillRegistryFatJarTestApplication() {
+	}
+
+	public static void main(String[] args) throws Exception {
+		ClasspathSkillRegistry registry = ClasspathSkillRegistry.builder()
+				.classpathPath("fat-jar-skills")
+				.basePath(args[0])
+				.build();
+		System.out.println("FAT_JAR_SKILLS=" + registry.listAll().stream().map(skill -> skill.getName()).toList());
+		if (!registry.contains("fat-jar-skill")) {
+			throw new IllegalStateException("Classpath skill was not loaded from the executable JAR");
+		}
+		Path skillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
+		if (!Files.exists(skillPath.resolve("references/reference.md"))) {
+			throw new IllegalStateException("Nested skill resource was not extracted from the executable JAR");
+		}
+	}
+
+}

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
@@ -54,8 +54,8 @@ public final class ClasspathSkillRegistryFatJarTestApplication {
 
 		registry.reload();
 		Path reloadedSkillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
-		if (skillPath.equals(reloadedSkillPath)) {
-			throw new IllegalStateException("Reload replaced files in the published extraction directory");
+		if (!skillPath.equals(reloadedSkillPath)) {
+			throw new IllegalStateException("Identical content was not reused across reloads");
 		}
 		if (!Files.exists(skillPath.resolve("references/reference.md"))
 				|| !Files.exists(reloadedSkillPath.resolve("references/reference.md"))) {
@@ -63,14 +63,19 @@ public final class ClasspathSkillRegistryFatJarTestApplication {
 		}
 		registry.reload();
 		Path latestSkillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
-		if (Files.exists(skillPath) || !Files.exists(reloadedSkillPath) || !Files.exists(latestSkillPath)) {
-			throw new IllegalStateException("Reload did not retain exactly the two newest extraction generations");
+		if (!skillPath.equals(latestSkillPath) || !Files.exists(latestSkillPath)) {
+			throw new IllegalStateException("Repeated reloads did not reuse the content-addressed extraction");
+		}
+		try (var generations = Files.list(skillPath.getParent().getParent())) {
+			if (generations.filter(path -> path.getFileName().toString().startsWith(".extracted-")).count() != 1) {
+				throw new IllegalStateException("Identical reloads created redundant extraction generations");
+			}
 		}
 		registry.close();
-		if (Files.exists(reloadedSkillPath) || Files.exists(latestSkillPath)) {
+		if (Files.exists(skillPath)) {
 			throw new IllegalStateException("Closing the registry did not clean its extraction generations");
 		}
-		System.out.println("FAT_JAR_RELOAD_STAGED=true");
+		System.out.println("FAT_JAR_CONTENT_ADDRESSED=true");
 	}
 
 }

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
@@ -61,18 +61,25 @@ public final class ClasspathSkillRegistryFatJarTestApplication {
 				|| !Files.exists(reloadedSkillPath.resolve("references/reference.md"))) {
 			throw new IllegalStateException("Reload removed a published skill path or exposed an incomplete one");
 		}
+		Files.writeString(skillPath.resolve("references/reference.md"), "tampered");
+		registry.reload();
+		Path repairedSkillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
+		if (skillPath.equals(repairedSkillPath)
+				|| !"# Reference".equals(Files.readString(repairedSkillPath.resolve("references/reference.md")))) {
+			throw new IllegalStateException("Reload reused a modified content-addressed extraction");
+		}
 		registry.reload();
 		Path latestSkillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
-		if (!skillPath.equals(latestSkillPath) || !Files.exists(latestSkillPath)) {
-			throw new IllegalStateException("Repeated reloads did not reuse the content-addressed extraction");
+		if (!repairedSkillPath.equals(latestSkillPath) || !Files.exists(latestSkillPath)) {
+			throw new IllegalStateException("Repeated reloads did not reuse the repaired extraction");
 		}
 		try (var generations = Files.list(skillPath.getParent().getParent())) {
-			if (generations.filter(path -> path.getFileName().toString().startsWith(".extracted-")).count() != 1) {
-				throw new IllegalStateException("Identical reloads created redundant extraction generations");
+			if (generations.filter(path -> path.getFileName().toString().startsWith(".extracted-")).count() != 2) {
+				throw new IllegalStateException("Reload did not retain the modified and repaired generations");
 			}
 		}
 		registry.close();
-		if (Files.exists(skillPath)) {
+		if (Files.exists(skillPath) || Files.exists(repairedSkillPath)) {
 			throw new IllegalStateException("Closing the registry did not clean its extraction generations");
 		}
 		System.out.println("FAT_JAR_CONTENT_ADDRESSED=true");

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
@@ -46,6 +46,11 @@ public final class ClasspathSkillRegistryFatJarTestApplication {
 		if (Files.exists(skillPath.resolve("references/obsolete.md"))) {
 			throw new IllegalStateException("An obsolete extracted resource remained exposed");
 		}
+		Path fallbackSkillPath = Path.of(registry.get("fallback-skill").orElseThrow().getSkillPath());
+		if (!Files.exists(fallbackSkillPath.resolve("references/dependency-reference.md"))
+				|| Files.exists(fallbackSkillPath.resolve("references/app-only.md"))) {
+			throw new IllegalStateException("An incomplete higher-precedence source shadowed a complete skill");
+		}
 
 		registry.reload();
 		Path reloadedSkillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
@@ -56,8 +61,13 @@ public final class ClasspathSkillRegistryFatJarTestApplication {
 				|| !Files.exists(reloadedSkillPath.resolve("references/reference.md"))) {
 			throw new IllegalStateException("Reload removed a published skill path or exposed an incomplete one");
 		}
+		registry.reload();
+		Path latestSkillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
+		if (Files.exists(skillPath) || !Files.exists(reloadedSkillPath) || !Files.exists(latestSkillPath)) {
+			throw new IllegalStateException("Reload did not retain exactly the two newest extraction generations");
+		}
 		registry.close();
-		if (Files.exists(skillPath) || Files.exists(reloadedSkillPath)) {
+		if (Files.exists(reloadedSkillPath) || Files.exists(latestSkillPath)) {
 			throw new IllegalStateException("Closing the registry did not clean its extraction generations");
 		}
 		System.out.println("FAT_JAR_RELOAD_STAGED=true");

--- a/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
+++ b/spring-ai-alibaba-graph-core/src/test/java/com/alibaba/cloud/ai/graph/skills/registry/classpath/ClasspathSkillRegistryFatJarTestApplication.java
@@ -37,6 +37,30 @@ public final class ClasspathSkillRegistryFatJarTestApplication {
 		if (!Files.exists(skillPath.resolve("references/reference.md"))) {
 			throw new IllegalStateException("Nested skill resource was not extracted from the executable JAR");
 		}
+		if (!Files.exists(skillPath.resolve("references/fat-jar-skills/note.md"))) {
+			throw new IllegalStateException("A repeated classpath root was not retained in the resource path");
+		}
+		if (Files.exists(skillPath.resolve("references/dependency-only.md"))) {
+			throw new IllegalStateException("Resources from duplicate dependency skills were merged");
+		}
+		if (Files.exists(skillPath.resolve("references/obsolete.md"))) {
+			throw new IllegalStateException("An obsolete extracted resource remained exposed");
+		}
+
+		registry.reload();
+		Path reloadedSkillPath = Path.of(registry.get("fat-jar-skill").orElseThrow().getSkillPath());
+		if (skillPath.equals(reloadedSkillPath)) {
+			throw new IllegalStateException("Reload replaced files in the published extraction directory");
+		}
+		if (!Files.exists(skillPath.resolve("references/reference.md"))
+				|| !Files.exists(reloadedSkillPath.resolve("references/reference.md"))) {
+			throw new IllegalStateException("Reload removed a published skill path or exposed an incomplete one");
+		}
+		registry.close();
+		if (Files.exists(skillPath) || Files.exists(reloadedSkillPath)) {
+			throw new IllegalStateException("Closing the registry did not clean its extraction generations");
+		}
+		System.out.println("FAT_JAR_RELOAD_STAGED=true");
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

`ClasspathSkillRegistry` currently treats every `jar:` resource as a standard JDK ZIP file system. Spring Boot executable JARs instead expose classpath resources through nested URLs such as:

```text
jar:nested:/path/application.jar/!BOOT-INF/classes/!/skills
```

Passing that URI to `FileSystems.newFileSystem(...)` does not provide a traversable `/skills` directory, so packaged applications can contain valid `BOOT-INF/classes/skills/**` resources while the registry silently loads zero skills.

This PR adds Spring Boot executable-JAR support while preserving the existing exploded-classpath and regular-JAR paths.

### Does this pull request fix one issue?

Fixes #4426.

### Describe how you did it

- Detect Spring Boot nested/`BOOT-INF` classpath URLs before entering the regular JDK JAR-file-system path.
- Resolve all files under the configured classpath skill root with Spring's `PathMatchingResourcePatternResolver`.
- Decode URL-encoded resource paths, including spaces and non-ASCII characters.
- Copy resolved resources to the registry's configured `basePath`, reject normalized paths outside that target, and scan the extracted skill directories with the existing `SkillScanner`.
- Anchor relative-path parsing after the final archive boundary, so a repeated classpath-root name inside a skill remains part of the resource path.
- When the same skill directory exists in multiple classpath roots, select the highest-precedence source that actually contains `SKILL.md` instead of merging files or allowing ancillary files to shadow a complete skill.
- Extract each reload into an unpublished staging directory, then atomically publish a content-addressed immutable generation only after every resource has been copied and every skill has been scanned successfully.
- Keep published generations readable until `close()` so callers retaining an older `skillPath` cannot race with reload cleanup. Identical reloads reuse the same content-addressed generation instead of growing disk usage, and each registry uses an isolated extraction workspace.
- Validate an existing generation's digest before reuse. If a caller has modified or deleted files through an advertised `skillPath`, retain that old path for existing readers and publish a fresh immutable generation from the packaged resources.
- Treat executable-JAR reloads as all-or-nothing: any resource-resolution, copy, or scan failure leaves the previously published registry unchanged and cleans the failed generation.
- Keep the standard `file:` and regular `jar:file:` implementations unchanged, including existing JAR `FileSystem` reuse/lifecycle behavior.
- Add an integration test that constructs a real Spring Boot executable JAR, starts it in an independent JVM, and verifies both `SKILL.md` discovery and nested reference extraction.
- Add `spring-boot-loader-tools` only as a test-scoped dependency.

### Describe how to verify it

All completed local verification and the relevant output are included below.

#### 1. Reproduce the issue with a real Spring Boot executable JAR

The standalone reproduction JAR contained `BOOT-INF/classes/skills/demo-skill/SKILL.md`.

Before this change:

```text
SKILLS_RESOURCE=jar:nested:/private/tmp/.../saa-4426-repro-1.0.0.jar/!BOOT-INF/classes/!/skills
RESOLVER_COUNT=1
RESOLVED_RESOURCE=jar:nested:/private/tmp/.../!/skills/demo-skill/SKILL.md
SKILLS_COUNT=0
SKILLS_NAMES=[]
```

After this change:

```text
Loaded 1 skills from Spring Boot classpath: skills
SKILLS_RESOURCE=jar:nested:/private/tmp/.../!/skills
RESOLVER_COUNT=1
RESOLVED_RESOURCE=jar:nested:/private/tmp/.../!/skills/demo-skill/SKILL.md
SKILLS_COUNT=1
SKILLS_NAMES=[demo-skill]
```

#### 2. Targeted automated tests

```bash
./mvnw -B -pl spring-ai-alibaba-graph-core \
  -Dtest=ClasspathSkillRegistryFatJarIntegrationTest,ClasspathSkillRegistryEnhancementsTest test
```

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- ClasspathSkillRegistryFatJarIntegrationTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- ClasspathSkillRegistryEnhancementsTest

Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

This covers the real executable-JAR launch, a nested resource whose path repeats the classpath-root name, stale-resource isolation, duplicate skill directories in `BOOT-INF/classes` and `BOOT-INF/lib`, fallback to a complete lower-precedence skill when the application contains only ancillary files, transactional `reload()` publication, reuse of an identical content-addressed generation across repeated reloads, recovery after a caller tampers with a published extraction, retention of both old and repaired generations until `close()`, cleanup on `close()`, and the existing normal classpath and regular-JAR-file-system reuse behavior.

The child executable-JAR process also completed these runtime assertions:

```text
FAT_JAR_SKILLS=[fallback-skill, fat-jar-skill]
FAT_JAR_CONTENT_ADDRESSED=true
```

#### 3. External black-box executable-JAR tests

These tests used a separate multi-module Spring Boot 3.5.8 application, not repository test fixtures. Every scenario read each skill's `SKILL.md`, checked `references/nested.txt`, called `reload()`, and repeated the assertions.

Application resources in `BOOT-INF/classes` (two skills):

```text
RESOURCE_ROOT=jar:nested:/private/tmp/.../app.jar/!BOOT-INF/classes/!/skills
RESOURCE_PATTERN_COUNT=4
Loaded 2 skills from Spring Boot classpath: skills
Reloading skills from classpath...
Loaded 2 skills from Spring Boot classpath: skills
BLACKBOX_OK=skills:[app-one, app-two]
```

Resources from a dependency JAR nested in `BOOT-INF/lib`:

```text
RESOURCE_ROOT=jar:nested:/private/tmp/.../app.jar/!BOOT-INF/lib/skill-resource-library-1.0.0.jar!/library-skills
RESOURCE_PATTERN_COUNT=2
Loaded 1 skills from Spring Boot classpath: library-skills
Reloading skills from classpath...
Loaded 1 skills from Spring Boot classpath: library-skills
BLACKBOX_OK=library-skills:[lib-skill]
```

Custom classpath root containing spaces and non-ASCII characters:

```text
RESOURCE_ROOT=jar:nested:/private/tmp/.../app.jar/!BOOT-INF/classes/!/custom%20skills%20%e6%8a%80%e8%83%bd
RESOURCE_PATTERN_COUNT=2
Loaded 1 skills from Spring Boot classpath: custom skills 技能
Reloading skills from classpath...
Loaded 1 skills from Spring Boot classpath: custom skills 技能
BLACKBOX_OK=custom skills 技能:[unicode-skill]
```

Additional probing during development first exposed two encoding edge cases: the space-only custom root initially loaded `0` skills because the URL contained `%20`; after that was fixed, the non-ASCII root initially loaded `0` because the Boot URL used percent-encoded UTF-8. Both cases were fixed in the production implementation before the final passing run above.

#### 4. Exploded-classpath regression test

The same external application was launched with `spring-boot:run`, so the resource root used a normal `file:` URL:

```text
RESOURCE_ROOT=file:/private/tmp/.../app/target/classes/skills
RESOURCE_PATTERN_COUNT=8
Loaded 2 skills from classpath: skills
Reloading skills from classpath...
Loaded 2 skills from classpath: skills
BLACKBOX_OK=skills:[app-one, app-two]
```

#### 5. PostgreSQL Testcontainers integration test through OrbStack

```bash
./mvnw -B -pl spring-ai-alibaba-graph-core \
  -Dtest=DatabaseStorePostgreSqlIntegrationTest test
```

```text
Docker=29.4.0; OS=OrbStack
Container postgres:17-alpine started
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

#### 6. Complete `spring-ai-alibaba-graph-core` test suite

```bash
./mvnw -B -pl spring-ai-alibaba-graph-core test
```

```text
Docker=29.4.0; OS=OrbStack
Container postgres:17-alpine started
Tests run: 469, Failures: 0, Errors: 0, Skipped: 73
BUILD SUCCESS
Total time: 15.967 s
```

#### 7. Repository quality checks

```bash
make checkstyle-check
```

```text
Reactor Summary for Spring AI Alibaba 1.1.2.2:
Spring AI Alibaba Bom .............................. SUCCESS
Spring AI Alibaba .................................. SUCCESS
Spring AI Alibaba Graph Core ....................... SUCCESS
Spring AI Alibaba Agent Framework .................. SUCCESS
Spring AI Alibaba Studio ........................... SUCCESS
Spring AI Alibaba Sandbox .......................... SUCCESS
Spring AI Alibaba A2A Runtime Nacos Integration .... SUCCESS
Spring AI Alibaba Agent Config Nacos Integration ... SUCCESS
Spring AI Alibaba Starter Graph Observation ........ SUCCESS
Spring AI Alibaba Graph Nodes ...................... SUCCESS
Spring AI Alibaba AgentScope Integration ........... SUCCESS
BUILD SUCCESS
```

```bash
make newline-check
```

```text
All files have ended with a blank line.
```

```bash
make format-check
```

```text
All 11 reactor modules: SUCCESS
BUILD SUCCESS
```

The repository currently configures `spring-javaformat:validate` to skip; Spotless still ran in the Maven test lifecycle.

Maven's configured Spotless and Checkstyle phases also ran with the tests:

```text
You have 0 Checkstyle violations.
Spotless.Java is keeping 279 files clean - 0 were changed to be clean
```

`git diff --check upstream/main...HEAD` also completed with no output.

### Special notes for reviews

- This overlaps with #4549. This version is based on the latest `main`, keeps the regular-JAR path and its existing file-system lifecycle behavior intact, and adds an executable-JAR integration test.
- Spring Boot resources are extracted to `<basePath>/<classpathPath>` because the existing registry APIs and `SkillScanner` operate on filesystem `Path` values.
- No new runtime dependency is introduced.
