### PR TITLE
fix(agent): resolve skill tools after HITL resume

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/ReactAgent.java
@@ -65,6 +65,7 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.resolution.ToolCallbackResolver;
 
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
@@ -149,6 +150,10 @@ public class ReactAgent extends BaseAgent {
 
 		if (mergedModelInterceptors != null && !mergedModelInterceptors.isEmpty()) {
 			this.llmNode.setModelInterceptors(mergedModelInterceptors);
+			this.toolNode.setDynamicToolCallbackResolvers(mergedModelInterceptors.stream()
+				.filter(ToolCallbackResolver.class::isInstance)
+				.map(ToolCallbackResolver.class::cast)
+				.toList());
 		}
 		if (mergedToolInterceptors != null && !mergedToolInterceptors.isEmpty()) {
 			this.toolNode.setToolInterceptors(mergedToolInterceptors);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -95,7 +96,7 @@ import static com.alibaba.cloud.ai.graph.skills.SkillPromptConstants.buildSkills
  * Tools from {@link #getGroupedTools()} for those skill names are then added to the request's
  * {@link ModelRequest#getDynamicToolCallbacks() dynamicToolCallbacks}.
  */
-public class SkillsInterceptor extends ModelInterceptor {
+public class SkillsInterceptor extends ModelInterceptor implements ToolCallbackResolver {
 
 	private static final Logger logger = LoggerFactory.getLogger(SkillsInterceptor.class);
 
@@ -278,6 +279,33 @@ public class SkillsInterceptor extends ModelInterceptor {
 			return supplied != null ? supplied : Collections.emptyMap();
 		}
 		return groupedTools;
+	}
+
+	/**
+	 * Resolves tools managed by this interceptor for execution after a run is resumed.
+	 * Dynamic callbacks normally travel through {@code RunnableConfig.context()}, but a
+	 * resumed HITL run uses a new config and therefore needs to resolve the callback again.
+	 */
+	@Override
+	public ToolCallback resolve(String toolName) {
+		for (List<ToolCallback> tools : resolveGroupedTools().values()) {
+			if (tools == null) {
+				continue;
+			}
+			Optional<ToolCallback> groupedTool = tools.stream()
+				.filter(Objects::nonNull)
+				.filter(tool -> toolName.equals(tool.getToolDefinition().name()))
+				.findFirst();
+			if (groupedTool.isPresent()) {
+				return groupedTool.get();
+			}
+		}
+
+		if (toolCallbackResolver == null || skillRegistry.listAll().stream()
+			.noneMatch(skill -> skill.getAllowedTools().contains(toolName))) {
+			return null;
+		}
+		return toolCallbackResolver.resolve(toolName);
 	}
 
 

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentToolNode.java
@@ -119,6 +119,8 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 	private ToolCallbackResolver toolCallbackResolver;
 
+	private List<ToolCallbackResolver> dynamicToolCallbackResolvers = List.of();
+
 	private ToolExecutionExceptionProcessor toolExecutionExceptionProcessor;
 
 	public AgentToolNode(Builder builder) {
@@ -140,6 +142,16 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 	public void setToolInterceptors(List<ToolInterceptor> toolInterceptors) {
 		this.toolInterceptors = toolInterceptors;
+	}
+
+	/**
+	 * Sets model-interceptor resolvers used when a dynamic callback is no longer present
+	 * in the current run context, such as after HITL resume.
+	 * @param dynamicToolCallbackResolvers resolvers for execution-only dynamic tools
+	 */
+	public void setDynamicToolCallbackResolvers(List<ToolCallbackResolver> dynamicToolCallbackResolvers) {
+		this.dynamicToolCallbackResolvers = dynamicToolCallbackResolvers != null
+				? List.copyOf(dynamicToolCallbackResolvers) : List.of();
 	}
 
 	void setToolCallbackResolver(ToolCallbackResolver toolCallbackResolver) {
@@ -851,6 +863,12 @@ public class AgentToolNode implements NodeActionWithConfig {
 		ToolCallback fromDynamic = resolveFromConfigMetadata(toolName, config);
 		if (fromDynamic != null) {
 			return fromDynamic;
+		}
+		for (ToolCallbackResolver dynamicResolver : dynamicToolCallbackResolvers) {
+			ToolCallback resolved = dynamicResolver.resolve(toolName);
+			if (resolved != null) {
+				return resolved;
+			}
 		}
 		return toolCallbackResolver == null ? null : toolCallbackResolver.resolve(toolName);
 	}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
@@ -15,13 +15,20 @@
  */
 package com.alibaba.cloud.ai.graph.agent.interceptors;
 
+import com.alibaba.cloud.ai.graph.NodeOutput;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
+import com.alibaba.cloud.ai.graph.action.InterruptionMetadata;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
+import com.alibaba.cloud.ai.graph.agent.hook.hip.HumanInTheLoopHook;
+import com.alibaba.cloud.ai.graph.agent.hook.hip.ToolConfig;
+import com.alibaba.cloud.ai.graph.agent.hook.skills.SkillsAgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.ReadSkillTool;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import com.alibaba.cloud.ai.graph.agent.interceptor.skills.SkillsInterceptor;
 import com.alibaba.cloud.ai.graph.agent.node.AgentLlmNode;
 import com.alibaba.cloud.ai.graph.agent.tools.PoetTool;
+import com.alibaba.cloud.ai.graph.checkpoint.savers.MemorySaver;
 import com.alibaba.cloud.ai.graph.skills.registry.SkillRegistry;
 import com.alibaba.cloud.ai.graph.skills.registry.filesystem.FileSystemSkillRegistry;
 
@@ -44,6 +51,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.List.of;
@@ -130,6 +138,12 @@ class SkillsInterceptorEnhancementsTest {
 						.distinct()
 						.toList());
 		assertEquals(1, captured.get().getDynamicToolCallbacks().size());
+
+		SkillsInterceptor allowedToolsResolver = SkillsInterceptor.builder()
+			.skillRegistry(registry)
+			.toolCallbackResolver(resolver)
+			.build();
+		assertEquals(recordResultTool, allowedToolsResolver.resolve("record_result"));
 	}
 
 	@Test
@@ -185,6 +199,86 @@ class SkillsInterceptorEnhancementsTest {
 		assertEquals(2, second.get("allowed-tools-test").size());
 		assertTrue(second.get("allowed-tools-test").stream()
 				.anyMatch(tool -> "extra_tool".equals(tool.getToolDefinition().name())));
+	}
+
+	@Test
+	void groupedToolRemainsExecutableAfterHumanApprovalResume() throws Exception {
+		AtomicInteger modelCalls = new AtomicInteger();
+		AtomicReference<String> recorded = new AtomicReference<>();
+		ChatModel model = new ChatModel() {
+			@Override
+			public ChatResponse call(Prompt prompt) {
+				return response();
+			}
+
+			@Override
+			public Flux<ChatResponse> stream(Prompt prompt) {
+				return Flux.just(response());
+			}
+
+			private ChatResponse response() {
+				AssistantMessage message = switch (modelCalls.getAndIncrement()) {
+					case 0 -> toolCall("read-1", ReadSkillTool.READ_SKILL,
+							"{\"skill_name\":\"allowed-tools-test\"}");
+					case 1 -> toolCall("record-1", "record_result", "{\"value\":\"approved\"}");
+					default -> new AssistantMessage("done");
+				};
+				return new ChatResponse(List.of(new Generation(message)));
+			}
+
+			private AssistantMessage toolCall(String id, String name, String arguments) {
+				return AssistantMessage.builder()
+					.content("")
+					.toolCalls(List.of(new AssistantMessage.ToolCall(id, "function", name, arguments)))
+					.build();
+			}
+		};
+
+		ToolCallback recordResult = FunctionToolCallback
+			.builder("record_result", (RecordRequest request) -> {
+				recorded.set(request.value);
+				return "recorded";
+			})
+			.description("Records a result")
+			.inputType(RecordRequest.class)
+			.build();
+		SkillsAgentHook skills = SkillsAgentHook.builder()
+			.skillRegistry(registry)
+			.groupedTools(Map.of("allowed-tools-test", List.of(recordResult)))
+			.build();
+		HumanInTheLoopHook hitl = HumanInTheLoopHook.builder()
+			.approvalOn(Map.of("record_result", ToolConfig.builder().description("Approve recording").build()))
+			.build();
+		ReactAgent agent = ReactAgent.builder()
+			.name("skill-hitl-agent")
+			.model(model)
+			.saver(new MemorySaver())
+			.hooks(List.of(skills, hitl))
+			.build();
+
+		String threadId = "skill-hitl-resume";
+		NodeOutput first = agent.invokeAndGetOutput("record a value",
+				RunnableConfig.builder().threadId(threadId).build()).orElseThrow();
+		assertTrue(first instanceof InterruptionMetadata);
+		InterruptionMetadata interruption = (InterruptionMetadata) first;
+		InterruptionMetadata.ToolFeedback approved = InterruptionMetadata.ToolFeedback
+			.builder(interruption.toolFeedbacks().get(0))
+			.result(InterruptionMetadata.ToolFeedback.FeedbackResult.APPROVED)
+			.build();
+		InterruptionMetadata feedback = InterruptionMetadata.builder(interruption)
+			.toolFeedbacks(List.of(approved))
+			.build();
+
+		agent.invokeAndGetOutput("", RunnableConfig.builder()
+			.threadId(threadId)
+			.addHumanFeedback(feedback)
+			.build());
+
+		assertEquals("approved", recorded.get());
+	}
+
+	private static class RecordRequest {
+		public String value;
 	}
 
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

When a Skill progressively discloses a tool through `SkillsInterceptor`, `AgentLlmNode` stores the dynamic callback in the current run's `RunnableConfig.context` so `AgentToolNode` can execute it.

If `HumanInTheLoopHook` interrupts that tool call, applications normally resume with a newly built `RunnableConfig`. The new config has an empty context, so the approved Skill tool can no longer be resolved. Current `main` consequently returns a `Tool not available` response (older releases throw `No ToolCallback found`) instead of executing the approved tool.

This PR preserves progressive disclosure while making Skill-managed callbacks resolvable during resumed tool execution.

### Does this pull request fix one issue?

Fixes #4606.

### Describe how you did it

- Make `SkillsInterceptor` implement Spring AI's `ToolCallbackResolver` contract for tools it manages.
- Resolve current `groupedTools` / `groupedToolsSupplier` entries at execution time, so runtime tool updates remain effective.
- Limit fallback resolution through the configured resolver to tool names declared in a registered Skill's `allowed_tools` list.
- Register model interceptors that implement `ToolCallbackResolver` as execution-only dynamic resolvers on `AgentToolNode`.
- Keep the existing resolution order: static node tools, current-run dynamic callbacks, dynamic interceptor resolvers, then the agent-level resolver.
- Do not add these execution fallback callbacks to the LLM's ordinary tool list; tool schemas are still disclosed only after `read_skill` activates the Skill.
- Add one deterministic end-to-end regression test covering `read_skill -> grouped tool -> HITL interruption -> new RunnableConfig -> approval -> tool execution`.

### Describe how to verify it

All completed local verification and relevant results are included below.

#### 1. Reproduce the failure on current `main`

The regression test was first run against `main` before the production change:

```bash
./mvnw -B -pl spring-ai-alibaba-agent-framework \
  -Dtest=SkillsInterceptorEnhancementsTest#groupedToolRemainsExecutableAfterHumanApprovalResume test
```

Observed result:

```text
WARN AgentToolNode - LLM may have adapted the tool name 'record_result' ...
expected: <approved> but was: <null>
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
BUILD FAILURE
```

This proves that the progressively disclosed callback was present before interruption but unavailable after resuming with a new `RunnableConfig`.

#### 2. Focused regression after the fix

```bash
./mvnw -B -pl spring-ai-alibaba-agent-framework \
  -Dtest=SkillsInterceptorEnhancementsTest#groupedToolRemainsExecutableAfterHumanApprovalResume test
```

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

#### 3. Complete interceptor enhancement test class

```bash
./mvnw -B -pl spring-ai-alibaba-agent-framework \
  -Dtest=SkillsInterceptorEnhancementsTest test
```

```text
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

This also covers allowed-tool resolution, dynamic callback deduplication, static tool deduplication, and resolving `groupedToolsSupplier` on every model call.

#### 4. Complete Agent Framework test suite

```bash
./mvnw -B -pl spring-ai-alibaba-agent-framework test
```

```text
Tests run: 614, Failures: 0, Errors: 0, Skipped: 170
BUILD SUCCESS
Total time: 16.959 s
```

#### 5. Independent runtime black-box application

The changed artifacts and dependencies were installed locally, then a separate Maven application (outside repository test sources) constructed a real `ReactAgent` with:

- a filesystem Skill Registry;
- a `SkillsAgentHook` grouped tool;
- a deterministic streaming `ChatModel` that calls `read_skill` and then the grouped tool;
- a `HumanInTheLoopHook` requiring approval;
- a new `RunnableConfig` for the resume invocation.

```bash
./mvnw -B -pl spring-ai-alibaba-agent-framework -am install -DskipTests
./mvnw -B -f /tmp/saa-4606-blackbox/pom.xml \
  compile exec:java -Dexec.mainClass=SkillHitlBlackbox
```

```text
SkillsInterceptor: added 1 tool(s) for skill 'approval-skill' to dynamicToolCallbacks
BLACKBOX_SKILL_HITL=approved
BUILD SUCCESS
```

#### 6. Repository quality checks

```bash
make checkstyle-check
make format-check
make newline-check
git diff --check
```

```text
All 11 reactor modules: Checkstyle SUCCESS
You have 0 Checkstyle violations.
All 11 reactor modules: format SUCCESS
All files have ended with a blank line.
git diff --check: no output
```

The repository currently configures `spring-javaformat:validate` to skip; Spotless still ran in the Maven lifecycle and reported the changed module clean.

### Special notes for reviews

- This change does not serialize `ToolCallback` instances into checkpoints or public HITL metadata.
- A Skill tool removed from a dynamic supplier or registry before approval is intentionally no longer executable on resume.
- No dependency changes are introduced.
