### PR TITLE
fix: use object input schema for ls and glob filesystem tools

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/GlobTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/GlobTool.java
@@ -15,9 +15,10 @@
  */
 package com.alibaba.cloud.ai.graph.agent.extension.tools.filesystem;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 
 import java.io.IOException;
@@ -33,7 +34,7 @@ import java.util.function.BiFunction;
 /**
  * Tool for finding files matching a glob pattern.
  */
-public class GlobTool implements BiFunction<String, ToolContext, String> {
+public class GlobTool implements BiFunction<GlobTool.GlobRequest, ToolContext, String> {
 
 	public static final String DESCRIPTION = """
 			Find files matching a glob pattern.
@@ -52,10 +53,9 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	@Override
-	public String apply(
-			@ToolParam(description = "The glob pattern to match files") String pattern,
-			ToolContext toolContext) {
+	public String apply(GlobRequest request, ToolContext toolContext) {
 		try {
+			String pattern = request.pattern;
 			Path basePathObj = Paths.get(System.getProperty("user.dir"));
 			PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
 
@@ -83,7 +83,24 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	public static ToolCallback createGlobToolCallback(String description) {
 		return FunctionToolCallback.builder("glob", new GlobTool())
 				.description(description)
-				.inputType(String.class)
+				.inputType(GlobRequest.class)
 				.build();
+	}
+
+	/**
+	 * Request structure for glob pattern matching.
+	 */
+	public static class GlobRequest {
+
+		@JsonProperty(required = true, value = "pattern")
+		@JsonPropertyDescription("The glob pattern to match files")
+		public String pattern;
+
+		public GlobRequest() {
+		}
+
+		public GlobRequest(String pattern) {
+			this.pattern = pattern;
+		}
 	}
 }

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
@@ -16,9 +16,10 @@
 package com.alibaba.cloud.ai.graph.agent.extension.tools.filesystem;
 
 import com.alibaba.cloud.ai.graph.agent.extension.file.FileInfo;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 
 import java.io.IOException;
@@ -39,7 +40,7 @@ import java.util.stream.Stream;
 /**
  * Tool for listing files in a directory.
  */
-public class ListFilesTool implements BiFunction<String, ToolContext, String> {
+public class ListFilesTool implements BiFunction<ListFilesTool.ListFilesRequest, ToolContext, String> {
 
 	public static final String DESCRIPTION = """
 			Lists all files in the filesystem, filtering by directory.
@@ -55,9 +56,8 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	@Override
-	public String apply(
-			@ToolParam(description = "The directory path to list files from") String path,
-			ToolContext toolContext) {
+	public String apply(ListFilesRequest request, ToolContext toolContext) {
+		String path = request.path;
 		try {
 			Path dirPath = Paths.get(path);
 			List<FileInfo> fileInfos = listFilesContent(dirPath, null, false);
@@ -210,8 +210,25 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	public static ToolCallback createListFilesToolCallback(String description) {
 		return FunctionToolCallback.builder("ls", new ListFilesTool())
 				.description(description)
-				.inputType(String.class)
+				.inputType(ListFilesRequest.class)
 				.build();
+	}
+
+	/**
+	 * Request structure for listing files.
+	 */
+	public static class ListFilesRequest {
+
+		@JsonProperty(required = true, value = "path")
+		@JsonPropertyDescription("The directory path to list files from")
+		public String path;
+
+		public ListFilesRequest() {
+		}
+
+		public ListFilesRequest(String path) {
+			this.path = path;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #4937

## Summary

- Wrap `ListFilesTool` and `GlobTool` single string parameters in request classes (`ListFilesRequest`, `GlobRequest`) with `@JsonProperty` annotations
- Change `inputType` from `String.class` to the request class so the generated JSON schema is `type: object` with a required string property
- This matches the pattern used by `ReadFileTool`, `WriteFileTool`, `EditFileTool`, and `GrepTool`

## Problem

Both tools used `.inputType(String.class)` which produces a top-level JSON schema with `type: "string"`. Providers like DeepSeek reject tool definitions that require `type: "object"`, returning HTTP 400:

```
Invalid schema for function 'ls': schema must be a JSON Schema of 'type: "object"', got 'type: "string"'
```

## Changes

| Tool | Request class | Property |
|------|--------------|----------|
| ls | `ListFilesRequest` | `path` (required) |
| glob | `GlobRequest` | `pattern` (required) |

## Verification

- `ListFilesTool.listFilesContent()` static method is unchanged — callers like `FileSystemTools` are not affected
- The public API of both tools remains backward compatible; only the JSON schema exposed to LLMs changes from string to object