### PR TITLE
docs: add multi-agent pattern selection guide

### DIFF
--- a/examples/multiagent-patterns/README.md
+++ b/examples/multiagent-patterns/README.md
@@ -1,74 +1,94 @@
 # Choosing a Multi-Agent Pattern
 
-This directory contains several ways to compose agents. The patterns solve different product problems; they are not maturity levels and a larger agent graph is not automatically better.
+This directory contains both single-agent and multi-agent ways to add specialized behavior, delegation, and explicit control flow. These patterns are not maturity levels: choose the smallest one that matches the product's ownership and execution model, and combine patterns only when their boundaries remain observable.
 
-Use this guide to choose the smallest pattern that matches the control flow, then open the pattern's README for its architecture and run instructions.
+The descriptions below reflect what the examples in this directory implement. Follow each linked README for its architecture and run instructions.
 
 ## Decision matrix
 
-| Product need | Start with | Why | Main trade-off |
+| Product need | Start with | What this example implements | Main trade-off |
 | --- | --- | --- | --- |
-| One agent needs optional instructions or domain resources | [`skills`](./skills/) | Loads specialized capabilities only when needed | Skill selection and context loading must be observable |
-| A request should go to exactly one specialist or workflow | [`routing`](./routing/) | Classifies once, then dispatches to the best destination | A bad route can prevent the right specialist from seeing the task |
-| A primary agent delegates bounded work and consumes the result | [`subagent`](./subagent/) | Keeps orchestration central while specialists run in focused contexts | Delegated context and return contracts need careful design |
-| A central coordinator invokes several specialist agents as tools | [`supervisor`](./supervisor/) | Supports dynamic delegation while preserving one user-facing owner | More model calls, latency, and supervisor failure modes |
-| The active specialist should transfer the conversation to another specialist | [`handoffs-singleagent`](./handoffs-singleagent/) or [`handoffs-multiagent`](./handoffs-multiagent/) | Makes ownership changes explicit and preserves conversational continuity | State and context must survive every transfer |
-| Work always passes through a fixed sequence of stages | [`pipeline`](./pipeline/) | Simple, predictable, and easy to measure stage by stage | Poor fit for branches, loops, or dynamic delegation |
-| The process has deterministic branches, loops, retrieval, or stateful checks | [`workflow`](./workflow/) | Represents business control flow explicitly in a graph | More state schema, edge, and recovery logic to maintain |
+| One agent needs optional domain instructions or resources | [`skills`](./skills/) | One `ReactAgent` sees skill descriptions and loads a full `SKILL.md` on demand through `read_skill` | Skill selection and added context must be observable |
+| A request may need one or several relevant specialists | [`routing`](./routing/src/main/java/com/alibaba/cloud/ai/examples/multiagents/routing/simple/README.md) | `LlmRoutingAgent` selects one or more agents, creates a targeted sub-query for each, runs selected agents in parallel, and merges their outputs | Routing and each selected specialist add model calls; multi-source results add a synthesis call |
+| A primary agent delegates bounded tasks, including background work | [`subagent`](./subagent/) | `Task` and `TaskOutput` tools invoke agents defined in Java or Markdown and return their results to the orchestrator | Task context, completion, and result retrieval need explicit handling |
+| One user-facing coordinator dynamically invokes named specialist agents | [`supervisor`](./supervisor/) | A `ReactAgent` calls specialist `ReactAgent`s through `AgentTool` callbacks and synthesizes their results | The supervisor can become a latency, cost, and reliability bottleneck |
+| One agent should change behavior as a process advances | [`handoffs-singleagent`](./handoffs-singleagent/) | One `ReactAgent` switches prompts and tools according to `current_step`; tools update state and a checkpointer can preserve it across turns when the same `thread_id` is reused | State transitions and stable thread identity become part of correctness |
+| Ownership should move between distinct specialists during a graph run | [`handoffs-multiagent`](./handoffs-multiagent/) | Sales and support agents are separate graph nodes; transfer tools update `active_agent` and return control to the parent graph | Every transfer must preserve the right state and context |
+| The topology is known and fits a common composition primitive | [`pipeline`](./pipeline/) | Prebuilt `SequentialAgent`, `ParallelAgent`, and `LoopAgent` examples cover chains, fan-out/fan-in, and iteration | Less graph code, but less freedom than a custom graph |
+| The application needs custom nodes, state, and edges | [`workflow`](./workflow/) | The RAG and SQL examples build explicit `StateGraph`s around application steps and `ReactAgent` nodes | Maximum control requires more state, edge, and recovery design |
+
+The routing module also shows how to embed an `LlmRoutingAgent` inside a larger [`StateGraph`](./routing/src/main/java/com/alibaba/cloud/ai/examples/multiagents/routing/graph/README.md) with preprocessing and postprocessing.
 
 ## A practical selection flow
 
-1. **Can one agent and a clear tool contract solve the task?** Keep one agent. Add a `skill` when the main problem is loading optional expertise, not coordinating independent actors.
-2. **Is there one correct destination for each request?** Use `routing`. Do not introduce a supervisor if no cross-specialist collaboration is required.
-3. **Is the order known before the request starts?** Use a `pipeline` for a straight sequence or a `workflow` for conditions and loops.
-4. **Must the model choose and combine specialists dynamically?** Use `subagent` for bounded delegation or `supervisor` when one coordinator may call multiple specialists.
-5. **Should another specialist become the owner of the conversation?** Use a handoff. Choose the single-agent version when behavior changes by state; choose the multi-agent version when specialists need separate agents and graph nodes.
+1. **Is the main problem optional expertise, not independent execution?** Keep one agent and use `skills` for progressive disclosure.
+2. **Should one agent change roles across a stateful, multi-turn process?** Use the single-agent handoff example. Use multi-agent handoffs only when separate agents must actually take ownership.
+3. **Is the execution topology chosen before the request starts?** Use a pipeline when sequential, parallel, or loop composition is enough; use a custom workflow when you need application-specific nodes, state, or edges.
+4. **Should an LLM select the relevant subset of specialists near the start?** Use routing. In this implementation the subset may contain one or multiple agents.
+5. **Should a primary agent decide what work to delegate while solving the task?** Use subagents for a generic task lifecycle and optional background execution. Use a supervisor for a small, stable set of named specialist tools, especially when later calls depend on earlier results.
+6. **Should a different specialist continue the conversation as its active owner?** Use multi-agent handoffs rather than treating delegation or routing as an ownership transfer.
 
 ## Similar patterns that are easy to confuse
 
+### Skills vs. agents
+
+A skill adds instructions or resources to one agent through progressive disclosure. It does not create an independently executing agent. Choose another pattern only when work needs its own agent context, lifecycle, or ownership.
+
 ### Routing vs. handoff
 
-Routing is usually a one-time dispatch near the start of a request. A handoff changes the active owner during execution and may transfer control again later. If users need to continue a support conversation after qualification by sales, that is a handoff; if every ticket is classified once into billing or technical support, routing is usually sufficient.
+Routing makes one routing decision per invocation. That decision may select one specialist or fan out to several specialists in parallel before their outputs are merged. A handoff changes which agent is active during a conversation and may transfer control again later. Classifying a ticket into the sources needed to answer it is routing; moving an ongoing sales conversation to support is a handoff.
 
 ### Subagent vs. supervisor
 
-Both expose specialist agents to an orchestrator. In the subagent pattern, delegation is typically a bounded unit of work whose result returns to the primary agent. A supervisor treats multiple agents as tools and may coordinate several of them dynamically. Start with subagents when tasks and return values can be described explicitly.
+Both patterns keep the primary agent as the user-facing owner. The subagent example exposes a generic task lifecycle through `Task` and `TaskOutput`, including background execution and later result retrieval. The supervisor example exposes each specialist as its own named, synchronous `AgentTool`; the supervisor can sequence those calls and owns the final response.
 
 ### Pipeline vs. workflow
 
-A pipeline is a fixed sequence. A workflow makes control flow and state explicit, so it fits retries, branches, validation gates, and loops. Avoid encoding a deterministic approval process in model instructions when graph edges can enforce it.
+`pipeline` is not limited to a fixed sequence. It demonstrates three prebuilt `FlowAgent` topologies: sequential, parallel, and loop. Use those primitives when they match the required shape. `workflow` is the lower-level choice when the application needs a custom `StateGraph`, such as the explicit rewrite/retrieve/agent stages in the RAG example or the database nodes around the SQL agent. The current workflow examples use linear graph edges; conditional branches, graph-level loops, and checkpointing must be added when an application needs them.
+
+### Single-agent vs. multi-agent handoff
+
+The single-agent example is a state machine: an interceptor changes one agent's prompt and visible tools as `current_step` advances. The multi-agent example performs an actual ownership transfer between separate sales and support agent nodes during one parent-graph run. The shipped multi-agent service starts a fresh graph invocation for each `run()` call; persistent ownership across user turns requires adding a parent-graph checkpointer and reusing a stable thread identity.
+
+## Patterns can be composed
+
+Use one pattern to define each boundary. For example, an application can route a result into a custom workflow, a supervisor's specialist can load skills, or a workflow node can invoke a prebuilt flow agent. Keep routing decisions, task IDs, active ownership, and graph state distinct so a trace can explain why every agent ran.
 
 ## Production readiness checklist
 
 Before promoting an example pattern into a product, define:
 
-- **Ownership:** which component produces the final answer and which components may contact the user;
-- **Contracts:** typed inputs, outputs, state keys, and error behavior for every agent/tool boundary;
-- **Budgets:** maximum turns, model calls, tool calls, latency, and token/cost limits;
-- **Context policy:** what history each specialist receives and what sensitive data must be removed;
-- **Recovery:** timeout, retry, fallback, idempotency, and human-escalation behavior;
-- **Observability:** route/handoff decisions, agent/tool spans, state transitions, and per-stage latency;
-- **Evaluation:** task success plus pattern-specific failure metrics listed below.
+- **Ownership:** which component produces the final answer and which component may contact the user;
+- **Contracts:** inputs, outputs, state keys, and error behavior for every agent and tool boundary;
+- **Budgets:** maximum model calls, tool calls, turns or iterations, latency, and token cost;
+- **Context policy:** what history each specialist receives and what sensitive data must be filtered;
+- **Recovery:** timeouts, retries, fallbacks, idempotency, loop termination, and human escalation;
+- **Observability:** route selections, task IDs, handoffs, agent and tool spans, state transitions, and per-stage latency;
+- **Evaluation:** task success plus the pattern-specific checks below.
 
-## Evaluate the orchestration, not only the final answer
+## Evaluate orchestration, not only the final answer
 
 | Pattern | Add these checks to answer-quality evaluation |
 | --- | --- |
-| Skills | Skill selection precision/recall; context added per selected skill |
-| Routing | Route accuracy; fallback rate; confidence on out-of-scope requests |
-| Subagent / supervisor | Delegation accuracy; duplicate work; aggregation errors; calls and cost per task |
-| Handoffs | Correct destination; unnecessary transfers; state retained after transfer |
-| Pipeline | Per-stage success and latency; earliest failing stage |
-| Workflow | Edge/branch coverage; loop termination; checkpoint and resume behavior |
+| Skills | Skill selection precision and recall; unnecessary skill loads; context added per skill |
+| Routing | Selected-set precision and recall; sub-query quality; fan-out latency; merge faithfulness; invalid or empty decisions |
+| Subagent | Target and delegated-prompt quality; background completion; `TaskOutput` retrieval; duplicate or orphaned work |
+| Supervisor | Specialist-tool selection and ordering; dependent-action success; aggregation errors; model calls and cost |
+| Single-agent handoff | Valid step transitions; state retained across turns; correct prompt and tool set per step |
+| Multi-agent handoff | Correct active agent; unnecessary transfers; context and state retained across transfers within a graph run |
+| Pipeline | Sequential stage correctness; parallel branch completion and merge correctness; loop termination and iteration count |
+| Workflow | Node and edge coverage; state invariants; custom-node failures; recovery paths configured by the application |
 
-Use a fixed evaluation set that includes happy paths, ambiguous requests, out-of-scope requests, tool failures, timeouts, and multi-turn follow-ups. A pattern is ready when its orchestration decisions are explainable and repeatable, not merely when a few final responses look good.
+Use a fixed evaluation set with happy paths, ambiguous and out-of-scope requests, tool failures, timeouts, and multi-turn follow-ups. For routing, include requests that require multiple specialists; for pipelines, cover every topology used by the product.
 
-## Running an example
+## Build and run an example
 
-Each pattern is an independent Maven project. Follow the selected directory's README and run Maven from that project, for example:
+Each pattern directory has its own standalone Maven project and is not part of the repository root Maven reactor. From the repository root, a compile-only check can target one project directly:
 
 ```bash
-./mvnw -f examples/multiagent-patterns/supervisor clean test
+./mvnw -f examples/multiagent-patterns/supervisor/pom.xml -DskipTests clean compile
 ```
 
-Most live examples require a configured model provider API key. Unit tests and stubbed tools should remain the first validation step so orchestration behavior can be checked without relying on a model's probabilistic output.
+Then follow that project's README to configure `AI_DASHSCOPE_API_KEY` and run its scenario. Several examples use stub business tools, but live orchestration still calls a `ChatModel`.
+
+These example projects currently have no module-level `src/test` suites. A successful Maven lifecycle therefore confirms dependency resolution and Java compilation, not routing, delegation, handoff, or model behavior. Validate those behaviors with deterministic tests for state and tool boundaries plus a live evaluation set for model decisions.

--- a/examples/multiagent-patterns/README.md
+++ b/examples/multiagent-patterns/README.md
@@ -1,0 +1,74 @@
+# Choosing a Multi-Agent Pattern
+
+This directory contains several ways to compose agents. The patterns solve different product problems; they are not maturity levels and a larger agent graph is not automatically better.
+
+Use this guide to choose the smallest pattern that matches the control flow, then open the pattern's README for its architecture and run instructions.
+
+## Decision matrix
+
+| Product need | Start with | Why | Main trade-off |
+| --- | --- | --- | --- |
+| One agent needs optional instructions or domain resources | [`skills`](./skills/) | Loads specialized capabilities only when needed | Skill selection and context loading must be observable |
+| A request should go to exactly one specialist or workflow | [`routing`](./routing/) | Classifies once, then dispatches to the best destination | A bad route can prevent the right specialist from seeing the task |
+| A primary agent delegates bounded work and consumes the result | [`subagent`](./subagent/) | Keeps orchestration central while specialists run in focused contexts | Delegated context and return contracts need careful design |
+| A central coordinator invokes several specialist agents as tools | [`supervisor`](./supervisor/) | Supports dynamic delegation while preserving one user-facing owner | More model calls, latency, and supervisor failure modes |
+| The active specialist should transfer the conversation to another specialist | [`handoffs-singleagent`](./handoffs-singleagent/) or [`handoffs-multiagent`](./handoffs-multiagent/) | Makes ownership changes explicit and preserves conversational continuity | State and context must survive every transfer |
+| Work always passes through a fixed sequence of stages | [`pipeline`](./pipeline/) | Simple, predictable, and easy to measure stage by stage | Poor fit for branches, loops, or dynamic delegation |
+| The process has deterministic branches, loops, retrieval, or stateful checks | [`workflow`](./workflow/) | Represents business control flow explicitly in a graph | More state schema, edge, and recovery logic to maintain |
+
+## A practical selection flow
+
+1. **Can one agent and a clear tool contract solve the task?** Keep one agent. Add a `skill` when the main problem is loading optional expertise, not coordinating independent actors.
+2. **Is there one correct destination for each request?** Use `routing`. Do not introduce a supervisor if no cross-specialist collaboration is required.
+3. **Is the order known before the request starts?** Use a `pipeline` for a straight sequence or a `workflow` for conditions and loops.
+4. **Must the model choose and combine specialists dynamically?** Use `subagent` for bounded delegation or `supervisor` when one coordinator may call multiple specialists.
+5. **Should another specialist become the owner of the conversation?** Use a handoff. Choose the single-agent version when behavior changes by state; choose the multi-agent version when specialists need separate agents and graph nodes.
+
+## Similar patterns that are easy to confuse
+
+### Routing vs. handoff
+
+Routing is usually a one-time dispatch near the start of a request. A handoff changes the active owner during execution and may transfer control again later. If users need to continue a support conversation after qualification by sales, that is a handoff; if every ticket is classified once into billing or technical support, routing is usually sufficient.
+
+### Subagent vs. supervisor
+
+Both expose specialist agents to an orchestrator. In the subagent pattern, delegation is typically a bounded unit of work whose result returns to the primary agent. A supervisor treats multiple agents as tools and may coordinate several of them dynamically. Start with subagents when tasks and return values can be described explicitly.
+
+### Pipeline vs. workflow
+
+A pipeline is a fixed sequence. A workflow makes control flow and state explicit, so it fits retries, branches, validation gates, and loops. Avoid encoding a deterministic approval process in model instructions when graph edges can enforce it.
+
+## Production readiness checklist
+
+Before promoting an example pattern into a product, define:
+
+- **Ownership:** which component produces the final answer and which components may contact the user;
+- **Contracts:** typed inputs, outputs, state keys, and error behavior for every agent/tool boundary;
+- **Budgets:** maximum turns, model calls, tool calls, latency, and token/cost limits;
+- **Context policy:** what history each specialist receives and what sensitive data must be removed;
+- **Recovery:** timeout, retry, fallback, idempotency, and human-escalation behavior;
+- **Observability:** route/handoff decisions, agent/tool spans, state transitions, and per-stage latency;
+- **Evaluation:** task success plus pattern-specific failure metrics listed below.
+
+## Evaluate the orchestration, not only the final answer
+
+| Pattern | Add these checks to answer-quality evaluation |
+| --- | --- |
+| Skills | Skill selection precision/recall; context added per selected skill |
+| Routing | Route accuracy; fallback rate; confidence on out-of-scope requests |
+| Subagent / supervisor | Delegation accuracy; duplicate work; aggregation errors; calls and cost per task |
+| Handoffs | Correct destination; unnecessary transfers; state retained after transfer |
+| Pipeline | Per-stage success and latency; earliest failing stage |
+| Workflow | Edge/branch coverage; loop termination; checkpoint and resume behavior |
+
+Use a fixed evaluation set that includes happy paths, ambiguous requests, out-of-scope requests, tool failures, timeouts, and multi-turn follow-ups. A pattern is ready when its orchestration decisions are explainable and repeatable, not merely when a few final responses look good.
+
+## Running an example
+
+Each pattern is an independent Maven project. Follow the selected directory's README and run Maven from that project, for example:
+
+```bash
+./mvnw -f examples/multiagent-patterns/supervisor clean test
+```
+
+Most live examples require a configured model provider API key. Unit tests and stubbed tools should remain the first validation step so orchestration behavior can be checked without relying on a model's probabilistic output.


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adds a source-backed top-level guide for choosing among the agent and graph orchestration examples. The directory includes both single-agent and multi-agent patterns, but builders currently need to inspect each module before understanding its control flow, response owner, and operational trade-offs.

The guide provides a decision matrix, a practical selection flow, comparisons between commonly confused patterns, a production-readiness checklist, and pattern-specific evaluation metrics.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- traced every pattern through its example configuration and the relevant framework implementation;
- documented routing as one-or-many selection, parallel fan-out, and merge;
- documented pipeline as the SequentialAgent, ParallelAgent, and LoopAgent composition family;
- distinguished generic Task/TaskOutput subagents from named AgentTool supervisors;
- distinguished the single-agent state machine from ownership transfer between separate agent nodes;
- described workflow as explicit StateGraph construction without claiming branches, loops, or checkpointing in the current examples;
- linked routing directly to both of its nested READMEs;
- replaced the previous test guidance with an accurate compile-only and live-evaluation boundary.

### Describe how to verify it

- `git diff --check`
- `codespell examples/multiagent-patterns/README.md --ignore-words tools/linter/codespell/.codespell.ignorewords`
- `python3 tools/scripts/new-line-check.py check`
- `markdownlint -c tools/linter/markdownlint/markdown_lint_config.yaml examples/multiagent-patterns/README.md`
- checked every relative Markdown link target
- with JDK 17, ran `clean compile` against all eight standalone POMs under `examples/multiagent-patterns`: skills, routing, subagent, supervisor, handoffs-singleagent, handoffs-multiagent, pipeline, and workflow

This is documentation-only; no Java source or runtime behavior changes. The example modules currently have no module-level `src/test` suites, so compilation does not claim to validate model-driven orchestration.

### Special notes for reviews

The guide treats the patterns as different ownership and control-flow trade-offs rather than as a progression toward increasingly complex orchestration.