### PR TITLE
docs: fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@
 
 * **[Multi-Agent Orchestration](https://github.com/alibaba/spring-ai-alibaba/tree/main/examples/multiagent-patterns)**: Compose multiple agents with built-in patterns including `SequentialAgent`, `ParallelAgent`, `RoutingAgent`, and `LoopAgent` for complex task execution.
 
-* **[Multimodal Support](https://github.com/alibaba/spring-ai-alibaba/tree/main/examples/multimodal)**: ReactAgent with text and media input (image understanding). ReactAgent with tool based image or audio generation.
+* **[Multimodal Support](https://github.com/alibaba/spring-ai-alibaba/tree/main/examples/multimodal)**: ReactAgent with text and media input (image understanding). ReactAgent with tool-based image or audio generation.
 
 * **[Voice Agent](https://github.com/alibaba/spring-ai-alibaba/tree/main/examples/voice-agent)**: WebSocket-based real-time voice agent that supports streaming audio or text input and responds with generated audio.
 
 * **[Context Engineering](https://java2ai.com/docs/frameworks/agent-framework/tutorials/hooks)**: Built-in best practices for context engineering policies to improve agent reliability and performance, including human-in-the-loop, context compaction, context editing, model & tool call limit, tool retry, planning, dynamic tool selection.
 
-* **[Graph-based Workflow](https://java2ai.com/docs/frameworks/graph-core/quick-start)**: Graph based workflow runtime and api for conditional routing, nested graphs, parallel execution, and state management. Export workflows to PlantUML and Mermaid formats.
+* **[Graph-based Workflow](https://java2ai.com/docs/frameworks/graph-core/quick-start)**: Graph-based workflow runtime and API for conditional routing, nested graphs, parallel execution, and state management. Export workflows to PlantUML and Mermaid formats.
 
 * **[A2A Support](https://java2ai.com/docs/frameworks/agent-framework/advanced/a2a)**: Agent-to-Agent communication support with Nacos integration, enabling distributed agent coordination and collaboration across services.
 
 * **[Rich Model, Tool and MCP Support](https://java2ai.com/integration/chatmodels/dashScope)**: Leveraging core concepts of Spring AI, supports multiple LLM providers (DashScope, OpenAI, etc.), tool calling, and Model Context Protocol (MCP).
 
-* **[One-stop Agent Platform](https://java2ai.com/ecosystem/admin/quick-start)**: Build agent in a visualized way, deploy agent without code or export as a standalone java project.
+* **[One-stop Agent Platform](https://java2ai.com/ecosystem/admin/quick-start)**: Build agent in a visualized way, deploy agent without code or export as a standalone Java project.
 
 <p align="center">
     <img src="./docs/imgs/saa-admin.png" alt="architecture" style="max-width: 740px; height: auto" />
@@ -120,7 +120,7 @@ There's a ChatBot example provided by the community at [examples/chatbot](https:
 * [Quick Start](https://java2ai.com/docs/quick-start) - Get started with a simple agent
 * [Agent Framework Tutorials](https://java2ai.com/docs/frameworks/agent-framework/tutorials/agents) - Step by step tutorials
 * [Use Graph API to Build Complex Workflows](https://java2ai.com/docs/frameworks/agent-framework/advanced/context-engineering) - In-depth user guide for building multi-agent and workflows
-* [Spring AI Basics](https://java2ai.com/ecosystem/spring-ai/reference/concepts) - Ai Application basic concepts, including ChatModel, MCP, Tool, Messages, etc.
+* [Spring AI Basics](https://java2ai.com/ecosystem/spring-ai/reference/concepts) - AI Application basic concepts, including ChatModel, MCP, Tool, Messages, etc.
 * [Chat Memory](https://docs.spring.io/spring-ai/reference/api/chatclient.html#chat-memory) - Spring AI reference for chat memory repositories and usage
 
 ## Project Structure
@@ -128,9 +128,9 @@ There's a ChatBot example provided by the community at [examples/chatbot](https:
 This project consists of several core components:
 
 * spring-ai-alibaba-agent-framework: A multi-agent framework designed for building intelligent agents with built-in context engineering best practices.
-* spring-ai-alibaba-graph: The underlying runtime for Agent Framework. We recommend developers to use Agent Framework but it's totally fine to use the Graph API directly.
+* spring-ai-alibaba-graph-core: The underlying runtime for Agent Framework. We recommend developers to use Agent Framework but it's totally fine to use the Graph API directly.
 * spring-ai-alibaba-admin: A one-stop Agent platform that supports visualized Agent development, observability, evaluation, and MCP management, etc.
-* spring-ai-alibaba-studio: The embedded ui for quickly debugging agent in a visualized way.
+* spring-ai-alibaba-studio: The embedded UI for quickly debugging agent in a visualized way.
 * spring-boot-starters: Starters integrating Agent Framework with Nacos to provide A2A and dynamic config features.
 
 ## Spring AI Alibaba Ecosystem


### PR DESCRIPTION
### Describe what this PR does / why we need it
  Fix several typos in README.md, including:
  - Incorrect module name in the "Project Structure" section (`spring-ai-alibaba-graph` ->
  `spring-ai-alibaba-graph-core`).
  - Capitalization of proper nouns (`Ai` -> `AI`, `java` -> `Java`, `api` -> `API`, `ui` -> `UI`).
  - Missing hyphens in compound adjectives (`tool based` -> `tool-based`, `Graph based` -> `Graph-based`).

  ### Does this pull request fix one issue?
  NONE

  ### Describe how you did it
  Manually reviewed README.md and corrected the typos.

  ### Describe how to verify it
  Review the changes in README.md; the module name now matches the actual directory `spring-ai-alibaba-graph-core`.

  ### Special notes for reviews
  NONE
