### PR TITLE
fix(graph): restrict document extractor resource access

### DIFF
--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/generator/model/workflow/nodedata/DocumentExtractorNodeData.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/generator/model/workflow/nodedata/DocumentExtractorNodeData.java
@@ -36,6 +36,10 @@ public class DocumentExtractorNodeData extends NodeData {
 
 	private String outputKey;
 
+	private String localFileRoot;
+
+	private Boolean remoteResourcesAllowed = false;
+
 	public DocumentExtractorNodeData(List<VariableSelector> inputs, List<Variable> outputs) {
 		super(inputs, outputs);
 	}
@@ -53,6 +57,22 @@ public class DocumentExtractorNodeData extends NodeData {
 
 	public void setOutputKey(String outputKey) {
 		this.outputKey = outputKey;
+	}
+
+	public String getLocalFileRoot() {
+		return localFileRoot;
+	}
+
+	public void setLocalFileRoot(String localFileRoot) {
+		this.localFileRoot = localFileRoot;
+	}
+
+	public boolean isRemoteResourcesAllowed() {
+		return Boolean.TRUE.equals(remoteResourcesAllowed);
+	}
+
+	public void setRemoteResourcesAllowed(boolean remoteResourcesAllowed) {
+		this.remoteResourcesAllowed = remoteResourcesAllowed;
 	}
 
 	public boolean isArray() {

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/generator/service/dsl/converter/DocumentExtractorNodeDataConverter.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/generator/service/dsl/converter/DocumentExtractorNodeDataConverter.java
@@ -71,9 +71,14 @@ public class DocumentExtractorNodeDataConverter extends AbstractNodeDataConverte
 					.orElse(DocumentExtractorNodeData.getDefaultOutputSchema().getName());
 
 				Boolean isArray = (Boolean) data.getOrDefault("is_array_file", false);
+				String localFileRoot = (String) data.get("local_file_root");
+				Boolean remoteResourcesAllowed = (Boolean) data.getOrDefault("remote_resources_allowed", false);
 
-				return new DocumentExtractorNodeData(inputs,
+				DocumentExtractorNodeData nodeData = new DocumentExtractorNodeData(inputs,
 						List.of(DocumentExtractorNodeData.getDefaultOutputSchema()), outputKey, isArray);
+				nodeData.setLocalFileRoot(localFileRoot);
+				nodeData.setRemoteResourcesAllowed(remoteResourcesAllowed);
+				return nodeData;
 			}
 
 			@Override
@@ -95,6 +100,12 @@ public class DocumentExtractorNodeDataConverter extends AbstractNodeDataConverte
 
 				Boolean isArray = nodeData.isArray();
 				data.put("is_array_file", isArray);
+				if (nodeData.getLocalFileRoot() != null && !nodeData.getLocalFileRoot().isBlank()) {
+					data.put("local_file_root", nodeData.getLocalFileRoot());
+				}
+				if (nodeData.isRemoteResourcesAllowed()) {
+					data.put("remote_resources_allowed", true);
+				}
 
 				return data;
 			}

--- a/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/generator/service/generator/workflow/sections/DocumentExtractorNodeSection.java
+++ b/spring-ai-alibaba-admin/spring-ai-alibaba-admin-server-start/src/main/java/com/alibaba/cloud/ai/studio/admin/builder/generator/service/generator/workflow/sections/DocumentExtractorNodeSection.java
@@ -53,6 +53,12 @@ public class DocumentExtractorNodeSection implements NodeSection<DocumentExtract
 		sb.append(String.format(".outputKey(\"%s\")%n", escape(outputKey)));
 
 		sb.append(String.format(".inputIsArray(%s)%n", data.isArray()));
+		if (data.getLocalFileRoot() != null && !data.getLocalFileRoot().isBlank()) {
+			sb.append(String.format(".localFileRoot(Paths.get(\"%s\"))%n", escape(data.getLocalFileRoot())));
+		}
+		if (data.isRemoteResourcesAllowed()) {
+			sb.append(".allowRemoteResources(true)\n");
+		}
 
 		sb.append(".build();\n");
 		sb.append(String.format("stateGraph.addNode(\"%s\", AsyncNodeAction.node_async(%s));%n%n", varName, varName));
@@ -62,7 +68,7 @@ public class DocumentExtractorNodeSection implements NodeSection<DocumentExtract
 
 	@Override
 	public List<String> getImports() {
-		return List.of("com.alibaba.cloud.ai.graph.node.DocumentExtractorNode");
+		return List.of("com.alibaba.cloud.ai.graph.node.DocumentExtractorNode", "java.nio.file.Paths");
 	}
 
 }

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNode.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNode.java
@@ -28,9 +28,14 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.util.json.JsonParser;
 
 import java.io.BufferedInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +52,14 @@ import java.util.function.Function;
  */
 public class DocumentExtractorNode implements NodeAction {
 
+	private static final Path DEFAULT_LOCAL_FILE_ROOT = Paths.get("").toAbsolutePath().normalize();
+
+	private static final int REMOTE_CONNECT_TIMEOUT_MILLIS = 10_000;
+
+	private static final int REMOTE_READ_TIMEOUT_MILLIS = 30_000;
+
+	private static final long MAX_REMOTE_RESOURCE_SIZE_BYTES = 10 * 1024 * 1024;
+
 	private final String paramsKey;
 
 	private final String outputKey;
@@ -55,13 +68,24 @@ public class DocumentExtractorNode implements NodeAction {
 
 	private final boolean inputIsArray;
 
+	private final Path localFileRoot;
+
+	private final boolean remoteResourcesAllowed;
+
 	private final Map<String, Function<InputStream, List<Document>>> extractors = new HashMap<>();
 
 	public DocumentExtractorNode(String paramsKey, String outputKey, List<String> fileList, boolean inputIsArray) {
+		this(paramsKey, outputKey, fileList, inputIsArray, DEFAULT_LOCAL_FILE_ROOT, false);
+	}
+
+	private DocumentExtractorNode(String paramsKey, String outputKey, List<String> fileList, boolean inputIsArray,
+			Path localFileRoot, boolean remoteResourcesAllowed) {
 		this.paramsKey = paramsKey;
 		this.outputKey = outputKey;
 		this.fileList = fileList;
 		this.inputIsArray = inputIsArray;
+		this.localFileRoot = localFileRoot.toAbsolutePath().normalize();
+		this.remoteResourcesAllowed = remoteResourcesAllowed;
 		extractors.put("txt", inputStream -> new TextDocumentParser().parse(inputStream));
 		extractors.put("markdown", inputStream -> new MarkdownDocumentParser().parse(inputStream));
 		extractors.put("md", inputStream -> new MarkdownDocumentParser().parse(inputStream));
@@ -81,24 +105,77 @@ public class DocumentExtractorNode implements NodeAction {
 		extractors.put("pptx", inputStream -> new TikaDocumentParser().parse(inputStream));
 	}
 
-	/**
-	 * Supports obtaining input stream from local or network sources
-	 */
 	private InputStream getInputStream(String filePath) throws IOException {
-		URI uri;
-		if (filePath.startsWith("http://") || filePath.startsWith("https://") || filePath.startsWith("ftp://")) {
-			uri = URI.create(filePath);
+		if (filePath.startsWith("file:")) {
+			return openLocalInputStream(Paths.get(URI.create(filePath)));
 		}
-		else {
-			uri = Paths.get(filePath).toUri();
+		if (!filePath.startsWith("http://") && !filePath.startsWith("https://")) {
+			if (filePath.contains("://")) {
+				throw new IOException("Unsupported document resource scheme");
+			}
+			return openLocalInputStream(Paths.get(filePath));
+		}
+		URI uri = URI.create(filePath);
+		if (!this.remoteResourcesAllowed) {
+			throw new IOException("Remote document resources are disabled");
+		}
+		return openRemoteInputStream(uri);
+	}
+
+	private InputStream openLocalInputStream(Path path) throws IOException {
+		Path normalizedPath = path.toAbsolutePath().normalize();
+		if (!normalizedPath.startsWith(this.localFileRoot)) {
+			throw new IOException("Document resource is outside the configured local file root");
+		}
+		Path realPath = normalizedPath.toRealPath();
+		Path root = this.localFileRoot.toRealPath();
+		if (!realPath.startsWith(root)) {
+			throw new IOException("Document resource resolves outside the configured local file root");
+		}
+		if (!Files.isRegularFile(realPath)) {
+			throw new IOException("Document resource must be a regular file");
+		}
+		return new BufferedInputStream(Files.newInputStream(realPath));
+	}
+
+	private InputStream openRemoteInputStream(URI uri) throws IOException {
+		String host = uri.getHost();
+		if (host == null || host.isBlank()) {
+			throw new IOException("Remote document resource must have a host");
+		}
+		for (InetAddress address : InetAddress.getAllByName(host)) {
+			if (isBlockedRemoteAddress(address)) {
+				throw new IOException("Remote document resource resolves to a blocked address");
+			}
 		}
 
-		if (uri.getScheme().equals("file")) {
-			return new BufferedInputStream(Files.newInputStream(Paths.get(uri)));
+		URLConnection connection = uri.toURL().openConnection();
+		connection.setConnectTimeout(REMOTE_CONNECT_TIMEOUT_MILLIS);
+		connection.setReadTimeout(REMOTE_READ_TIMEOUT_MILLIS);
+		if (connection instanceof HttpURLConnection httpConnection) {
+			httpConnection.setInstanceFollowRedirects(false);
+			int status = httpConnection.getResponseCode();
+			if (status < HttpURLConnection.HTTP_OK || status >= HttpURLConnection.HTTP_MULT_CHOICE) {
+				throw new IOException("Remote document resource returned HTTP status " + status);
+			}
 		}
-		else {
-			return new BufferedInputStream(uri.toURL().openStream());
+		long contentLength = connection.getContentLengthLong();
+		if (contentLength > MAX_REMOTE_RESOURCE_SIZE_BYTES) {
+			throw new IOException("Remote document resource exceeds the maximum allowed size");
 		}
+		return new LimitedInputStream(new BufferedInputStream(connection.getInputStream()), MAX_REMOTE_RESOURCE_SIZE_BYTES);
+	}
+
+	private static boolean isBlockedRemoteAddress(InetAddress address) {
+		if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
+				|| address.isSiteLocalAddress() || address.isMulticastAddress()) {
+			return true;
+		}
+		if (address instanceof Inet6Address) {
+			byte firstByte = address.getAddress()[0];
+			return (firstByte & 0xFE) == 0xFC;
+		}
+		return false;
 	}
 
 	private List<String> getDocument(List<String> fileList) {
@@ -187,6 +264,10 @@ public class DocumentExtractorNode implements NodeAction {
 
 		private boolean inputIsArray = false;
 
+		private Path localFileRoot = DEFAULT_LOCAL_FILE_ROOT;
+
+		private boolean remoteResourcesAllowed = false;
+
 		public Builder paramsKey(String paramsKey) {
 			this.paramsKey = paramsKey;
 			return this;
@@ -207,8 +288,64 @@ public class DocumentExtractorNode implements NodeAction {
 			return this;
 		}
 
+		/**
+		 * Configures the root directory used to resolve local document resources.
+		 */
+		public Builder localFileRoot(Path localFileRoot) {
+			this.localFileRoot = localFileRoot;
+			return this;
+		}
+
+		/**
+		 * Enables HTTP(S) document resources. Private, loopback, link-local and multicast
+		 * addresses remain blocked.
+		 */
+		public Builder allowRemoteResources(boolean remoteResourcesAllowed) {
+			this.remoteResourcesAllowed = remoteResourcesAllowed;
+			return this;
+		}
+
 		public DocumentExtractorNode build() {
-			return new DocumentExtractorNode(paramsKey, outputKey, fileList, inputIsArray);
+			return new DocumentExtractorNode(paramsKey, outputKey, fileList, inputIsArray, localFileRoot,
+					remoteResourcesAllowed);
+		}
+
+	}
+
+	private static final class LimitedInputStream extends FilterInputStream {
+
+		private final long maxBytes;
+
+		private long bytesRead;
+
+		private LimitedInputStream(InputStream inputStream, long maxBytes) {
+			super(inputStream);
+			this.maxBytes = maxBytes;
+		}
+
+		@Override
+		public int read() throws IOException {
+			int value = super.read();
+			if (value != -1) {
+				verifyLimit(1);
+			}
+			return value;
+		}
+
+		@Override
+		public int read(byte[] bytes, int offset, int length) throws IOException {
+			int count = super.read(bytes, offset, length);
+			if (count > 0) {
+				verifyLimit(count);
+			}
+			return count;
+		}
+
+		private void verifyLimit(int count) throws IOException {
+			this.bytesRead += count;
+			if (this.bytesRead > this.maxBytes) {
+				throw new IOException("Remote document resource exceeds the maximum allowed size");
+			}
 		}
 
 	}

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNode.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNode.java
@@ -47,14 +47,22 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -138,15 +146,49 @@ public class DocumentExtractorNode implements NodeAction {
 		if (!normalizedPath.startsWith(this.localFileRoot)) {
 			throw new IOException("Document resource is outside the configured local file root");
 		}
-		Path realPath = normalizedPath.toRealPath();
 		Path root = this.localFileRoot.toRealPath();
-		if (!realPath.startsWith(root)) {
-			throw new IOException("Document resource resolves outside the configured local file root");
-		}
-		if (!Files.isRegularFile(realPath)) {
+		Path relativePath = this.localFileRoot.relativize(normalizedPath);
+		if (relativePath.getNameCount() == 0) {
 			throw new IOException("Document resource must be a regular file");
 		}
-		return new BufferedInputStream(Files.newInputStream(realPath));
+		try (DirectoryStream<Path> rootDirectoryStream = Files.newDirectoryStream(root)) {
+			if (!(rootDirectoryStream instanceof SecureDirectoryStream<?>)) {
+				throw new IOException("Secure local document access is not supported by this file system");
+			}
+			return openSecureLocalInputStream(asSecureDirectoryStream(rootDirectoryStream), relativePath);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static SecureDirectoryStream<Path> asSecureDirectoryStream(DirectoryStream<Path> directoryStream) {
+		return (SecureDirectoryStream<Path>) directoryStream;
+	}
+
+	private static InputStream openSecureLocalInputStream(SecureDirectoryStream<Path> rootDirectory,
+			Path relativePath) throws IOException {
+		SecureDirectoryStream<Path> directory = rootDirectory;
+		try {
+			for (int i = 0; i < relativePath.getNameCount() - 1; i++) {
+				SecureDirectoryStream<Path> childDirectory = directory.newDirectoryStream(relativePath.getName(i),
+						LinkOption.NOFOLLOW_LINKS);
+				if (directory != rootDirectory) {
+					directory.close();
+				}
+				directory = childDirectory;
+			}
+			Path fileName = relativePath.getFileName();
+			BasicFileAttributeView attributeView = directory.getFileAttributeView(fileName,
+					BasicFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+			if (attributeView == null || !attributeView.readAttributes().isRegularFile()) {
+				throw new IOException("Document resource must be a regular file");
+			}
+			SeekableByteChannel channel = directory.newByteChannel(fileName,
+					Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS));
+			return new BufferedInputStream(Channels.newInputStream(channel));
+		}
+		finally {
+			directory.close();
+		}
 	}
 
 	private InputStream openRemoteInputStream(URI uri) throws IOException {
@@ -218,14 +260,35 @@ public class DocumentExtractorNode implements NodeAction {
 			return true;
 		}
 		if (address instanceof Inet6Address) {
-			byte firstByte = address.getAddress()[0];
+			byte[] bytes = address.getAddress();
+			if (isIpv4MappedIpv6Address(bytes)) {
+				return isBlockedIpv4Address(Arrays.copyOfRange(bytes, 12, 16));
+			}
+			byte firstByte = bytes[0];
 			return (firstByte & 0xFE) == 0xFC;
 		}
-		byte[] bytes = address.getAddress();
+		return isBlockedIpv4Address(address.getAddress());
+	}
+
+	private static boolean isIpv4MappedIpv6Address(byte[] bytes) {
+		if (bytes.length != 16 || bytes[10] != (byte) 0xFF || bytes[11] != (byte) 0xFF) {
+			return false;
+		}
+		for (int i = 0; i < 10; i++) {
+			if (bytes[i] != 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean isBlockedIpv4Address(byte[] bytes) {
 		int first = Byte.toUnsignedInt(bytes[0]);
 		int second = Byte.toUnsignedInt(bytes[1]);
 		if (first == 0 || first >= 224 || (first == 100 && second >= 64 && second <= 127)
-				|| (first == 198 && (second == 18 || second == 19))) {
+				|| (first == 198 && (second == 18 || second == 19)) || first == 10 || first == 127
+				|| (first == 169 && second == 254) || (first == 172 && second >= 16 && second <= 31)
+				|| (first == 192 && second == 168)) {
 			return true;
 		}
 		return false;

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNode.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/main/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNode.java
@@ -24,6 +24,18 @@ import com.alibaba.cloud.ai.parser.markdown.MarkdownDocumentParser;
 import com.alibaba.cloud.ai.parser.tika.TikaDocumentParser;
 import com.alibaba.cloud.ai.parser.yaml.YamlDocumentParser;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.util.json.JsonParser;
 
@@ -31,11 +43,10 @@ import java.io.BufferedInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URLConnection;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -139,34 +150,69 @@ public class DocumentExtractorNode implements NodeAction {
 	}
 
 	private InputStream openRemoteInputStream(URI uri) throws IOException {
-		String host = uri.getHost();
-		if (host == null || host.isBlank()) {
-			throw new IOException("Remote document resource must have a host");
-		}
-		for (InetAddress address : InetAddress.getAllByName(host)) {
-			if (isBlockedRemoteAddress(address)) {
-				throw new IOException("Remote document resource resolves to a blocked address");
-			}
-		}
-
-		URLConnection connection = uri.toURL().openConnection();
-		connection.setConnectTimeout(REMOTE_CONNECT_TIMEOUT_MILLIS);
-		connection.setReadTimeout(REMOTE_READ_TIMEOUT_MILLIS);
-		if (connection instanceof HttpURLConnection httpConnection) {
-			httpConnection.setInstanceFollowRedirects(false);
-			int status = httpConnection.getResponseCode();
-			if (status < HttpURLConnection.HTTP_OK || status >= HttpURLConnection.HTTP_MULT_CHOICE) {
+		RequestConfig requestConfig = RequestConfig.custom()
+			.setConnectTimeout(REMOTE_CONNECT_TIMEOUT_MILLIS)
+			.setSocketTimeout(REMOTE_READ_TIMEOUT_MILLIS)
+			.setRedirectsEnabled(false)
+			.build();
+		CloseableHttpClient httpClient = createHttpClient(requestConfig);
+		CloseableHttpResponse response = null;
+		try {
+			response = httpClient.execute(new HttpGet(uri));
+			int status = response.getStatusLine().getStatusCode();
+			if (status < HttpStatus.SC_OK || status >= HttpStatus.SC_MULTIPLE_CHOICES) {
 				throw new IOException("Remote document resource returned HTTP status " + status);
 			}
+			if (response.getEntity() == null) {
+				throw new IOException("Remote document resource has no response body");
+			}
+			long contentLength = response.getEntity().getContentLength();
+			if (contentLength > MAX_REMOTE_RESOURCE_SIZE_BYTES) {
+				throw new IOException("Remote document resource exceeds the maximum allowed size");
+			}
+			InputStream responseStream = new HttpResponseInputStream(response.getEntity().getContent(), response, httpClient);
+			response = null;
+			httpClient = null;
+			return new LimitedInputStream(new BufferedInputStream(responseStream), MAX_REMOTE_RESOURCE_SIZE_BYTES);
 		}
-		long contentLength = connection.getContentLengthLong();
-		if (contentLength > MAX_REMOTE_RESOURCE_SIZE_BYTES) {
-			throw new IOException("Remote document resource exceeds the maximum allowed size");
+		finally {
+			if (response != null) {
+				response.close();
+			}
+			if (httpClient != null) {
+				httpClient.close();
+			}
 		}
-		return new LimitedInputStream(new BufferedInputStream(connection.getInputStream()), MAX_REMOTE_RESOURCE_SIZE_BYTES);
 	}
 
-	private static boolean isBlockedRemoteAddress(InetAddress address) {
+	private static CloseableHttpClient createHttpClient(RequestConfig requestConfig) {
+		Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
+			.register("http", PlainConnectionSocketFactory.getSocketFactory())
+			.register("https", SSLConnectionSocketFactory.getSocketFactory())
+			.build();
+		PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry,
+				DocumentExtractorNode::resolveAndValidateRemoteAddresses);
+		return HttpClients.custom()
+			.setConnectionManager(connectionManager)
+			.setDefaultRequestConfig(requestConfig)
+			.disableRedirectHandling()
+			.build();
+	}
+
+	private static InetAddress[] resolveAndValidateRemoteAddresses(String host) throws UnknownHostException {
+		if (host == null || host.isBlank()) {
+			throw new UnknownHostException("Remote document resource must have a host");
+		}
+		InetAddress[] addresses = InetAddress.getAllByName(host);
+		for (InetAddress address : addresses) {
+			if (isBlockedRemoteAddress(address)) {
+				throw new UnknownHostException("Remote document resource resolves to a blocked address");
+			}
+		}
+		return addresses;
+	}
+
+	static boolean isBlockedRemoteAddress(InetAddress address) {
 		if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
 				|| address.isSiteLocalAddress() || address.isMulticastAddress()) {
 			return true;
@@ -174,6 +220,13 @@ public class DocumentExtractorNode implements NodeAction {
 		if (address instanceof Inet6Address) {
 			byte firstByte = address.getAddress()[0];
 			return (firstByte & 0xFE) == 0xFC;
+		}
+		byte[] bytes = address.getAddress();
+		int first = Byte.toUnsignedInt(bytes[0]);
+		int second = Byte.toUnsignedInt(bytes[1]);
+		if (first == 0 || first >= 224 || (first == 100 && second >= 64 && second <= 127)
+				|| (first == 198 && (second == 18 || second == 19))) {
+			return true;
 		}
 		return false;
 	}
@@ -312,39 +365,94 @@ public class DocumentExtractorNode implements NodeAction {
 
 	}
 
-	private static final class LimitedInputStream extends FilterInputStream {
+	static final class LimitedInputStream extends FilterInputStream {
 
 		private final long maxBytes;
 
 		private long bytesRead;
 
-		private LimitedInputStream(InputStream inputStream, long maxBytes) {
+		LimitedInputStream(InputStream inputStream, long maxBytes) {
 			super(inputStream);
 			this.maxBytes = maxBytes;
 		}
 
 		@Override
 		public int read() throws IOException {
+			if (this.bytesRead == this.maxBytes) {
+				return readPastLimit();
+			}
 			int value = super.read();
 			if (value != -1) {
-				verifyLimit(1);
+				this.bytesRead++;
 			}
 			return value;
 		}
 
 		@Override
 		public int read(byte[] bytes, int offset, int length) throws IOException {
-			int count = super.read(bytes, offset, length);
+			if (length == 0) {
+				return 0;
+			}
+			long remaining = this.maxBytes - this.bytesRead;
+			if (remaining <= 0) {
+				return readPastLimit();
+			}
+			int count = super.read(bytes, offset, (int) Math.min(length, remaining));
 			if (count > 0) {
-				verifyLimit(count);
+				this.bytesRead += count;
 			}
 			return count;
 		}
 
-		private void verifyLimit(int count) throws IOException {
-			this.bytesRead += count;
-			if (this.bytesRead > this.maxBytes) {
+		@Override
+		public long skip(long count) throws IOException {
+			if (count <= 0) {
+				return 0;
+			}
+			long remaining = this.maxBytes - this.bytesRead;
+			if (remaining <= 0) {
+				readPastLimit();
+				return 0;
+			}
+			long skipped = super.skip(Math.min(count, remaining));
+			this.bytesRead += skipped;
+			return skipped;
+		}
+
+		private int readPastLimit() throws IOException {
+			if (super.read() != -1) {
 				throw new IOException("Remote document resource exceeds the maximum allowed size");
+			}
+			return -1;
+		}
+
+	}
+
+	private static final class HttpResponseInputStream extends FilterInputStream {
+
+		private final CloseableHttpResponse response;
+
+		private final CloseableHttpClient httpClient;
+
+		private HttpResponseInputStream(InputStream inputStream, CloseableHttpResponse response,
+				CloseableHttpClient httpClient) {
+			super(inputStream);
+			this.response = response;
+			this.httpClient = httpClient;
+		}
+
+		@Override
+		public void close() throws IOException {
+			try {
+				super.close();
+			}
+			finally {
+				try {
+					this.response.close();
+				}
+				finally {
+					this.httpClient.close();
+				}
 			}
 		}
 

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNodeResourceAccessTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNodeResourceAccessTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.node;
+
+import com.alibaba.cloud.ai.graph.OverAllState;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DocumentExtractorNodeResourceAccessTest {
+
+	@Test
+	void readsLocalFileWithinConfiguredRoot() throws Exception {
+		Path root = Files.createTempDirectory("document-extractor-root-");
+		Path document = root.resolve("input document.txt");
+		Files.writeString(document, "safe content");
+
+		try {
+			DocumentExtractorNode node = DocumentExtractorNode.builder()
+				.paramsKey("file")
+				.localFileRoot(root)
+				.build();
+
+			Map<String, Object> result = node.apply(new OverAllState(Map.of("file", document.toString())));
+
+			assertEquals("safe content", result.get("text"));
+		}
+		finally {
+			Files.deleteIfExists(document);
+			Files.deleteIfExists(root);
+		}
+	}
+
+	@Test
+	void rejectsLocalFileOutsideConfiguredRoot() throws Exception {
+		Path root = Files.createTempDirectory("document-extractor-root-");
+		Path outsideFile = Files.createTempFile("document-extractor-outside-", ".txt");
+		Files.writeString(outsideFile, "secret");
+
+		try {
+			DocumentExtractorNode node = DocumentExtractorNode.builder()
+				.paramsKey("file")
+				.localFileRoot(root)
+				.build();
+
+			assertThrows(RuntimeException.class,
+					() -> node.apply(new OverAllState(Map.of("file", outsideFile.toString()))));
+		}
+		finally {
+			Files.deleteIfExists(outsideFile);
+			Files.deleteIfExists(root);
+		}
+	}
+
+	@Test
+	void rejectsSymlinkThatResolvesOutsideConfiguredRoot() throws Exception {
+		Path root = Files.createTempDirectory("document-extractor-root-");
+		Path outsideFile = Files.createTempFile("document-extractor-outside-", ".txt");
+		Path symlink = root.resolve("linked.txt");
+		Files.writeString(outsideFile, "secret");
+		Files.createSymbolicLink(symlink, outsideFile);
+
+		try {
+			DocumentExtractorNode node = DocumentExtractorNode.builder()
+				.paramsKey("file")
+				.localFileRoot(root)
+				.build();
+
+			assertThrows(RuntimeException.class,
+					() -> node.apply(new OverAllState(Map.of("file", symlink.toString()))));
+		}
+		finally {
+			Files.deleteIfExists(symlink);
+			Files.deleteIfExists(outsideFile);
+			Files.deleteIfExists(root);
+		}
+	}
+
+	@Test
+	void rejectsLoopbackRemoteResourceEvenWhenRemoteResourcesAreEnabled() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.enqueue(new MockResponse().setBody("internal response"));
+			server.start();
+			DocumentExtractorNode node = DocumentExtractorNode.builder()
+				.paramsKey("file")
+				.allowRemoteResources(true)
+				.build();
+
+			assertThrows(RuntimeException.class,
+					() -> node.apply(new OverAllState(Map.of("file", server.url("/internal.txt").toString()))));
+			assertNull(server.takeRequest(200, TimeUnit.MILLISECONDS));
+		}
+	}
+
+	@Test
+	void disablesRemoteResourcesByDefault() {
+		DocumentExtractorNode node = DocumentExtractorNode.builder().paramsKey("file").build();
+
+		assertThrows(RuntimeException.class,
+				() -> node.apply(new OverAllState(Map.of("file", "https://example.com/document.txt"))));
+	}
+
+}

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNodeResourceAccessTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNodeResourceAccessTest.java
@@ -20,14 +20,18 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.net.InetAddress;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DocumentExtractorNodeResourceAccessTest {
 
@@ -120,6 +124,20 @@ class DocumentExtractorNodeResourceAccessTest {
 
 		assertThrows(RuntimeException.class,
 				() -> node.apply(new OverAllState(Map.of("file", "https://example.com/document.txt"))));
+	}
+
+	@Test
+	void rejectsAlibabaCloudMetadataAddress() throws Exception {
+		assertTrue(DocumentExtractorNode.isBlockedRemoteAddress(InetAddress.getByName("100.100.100.200")));
+	}
+
+	@Test
+	void countsSkippedBytesTowardRemoteResourceLimit() throws Exception {
+		try (DocumentExtractorNode.LimitedInputStream inputStream = new DocumentExtractorNode.LimitedInputStream(
+				new ByteArrayInputStream(new byte[11]), 10)) {
+			assertEquals(10, inputStream.skip(10));
+			assertThrows(IOException.class, inputStream::read);
+		}
 	}
 
 }

--- a/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNodeResourceAccessTest.java
+++ b/spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes/src/test/java/com/alibaba/cloud/ai/graph/node/DocumentExtractorNodeResourceAccessTest.java
@@ -22,9 +22,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Inet6Address;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.net.InetAddress;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -129,6 +130,19 @@ class DocumentExtractorNodeResourceAccessTest {
 	@Test
 	void rejectsAlibabaCloudMetadataAddress() throws Exception {
 		assertTrue(DocumentExtractorNode.isBlockedRemoteAddress(InetAddress.getByName("100.100.100.200")));
+	}
+
+	@Test
+	void rejectsIpv4MappedIpv6LoopbackAddress() throws Exception {
+		byte[] addressBytes = new byte[16];
+		addressBytes[10] = (byte) 0xFF;
+		addressBytes[11] = (byte) 0xFF;
+		addressBytes[12] = 127;
+		addressBytes[15] = 1;
+
+		InetAddress address = Inet6Address.getByAddress(null, addressBytes, -1);
+
+		assertTrue(DocumentExtractorNode.isBlockedRemoteAddress(address));
 	}
 
 	@Test


### PR DESCRIPTION
### Describe what this PR does / why we need it

Partially addresses #4932 by securing the `DocumentExtractorNode` resource-loading boundary. Previously a workflow value could read any process-readable local path or make unrestricted HTTP(S)/FTP requests, including loopback and private-network targets.

### Does this pull request fix one issue?

Partially addresses #4932. The Admin `FileManager#getMediaTypeFromUrl` entry point will be handled separately because it belongs to a different module and current `main` has the unrelated compilation issue tracked in #4931.

### Describe how you did it

- Local files are now confined to a configurable builder root (the working directory by default), and real-path verification blocks symlink escapes.
- Remote resources are disabled by default. Callers can explicitly enable HTTP(S) with `allowRemoteResources(true)`.
- Enabled remote resources reject loopback, private, link-local, multicast, and IPv6 unique-local addresses; redirects are disabled; connection/read timeouts and a 10 MiB response cap are applied.
- FTP and other unsupported URI schemes are rejected.

### Describe how to verify it

`./mvnw -pl spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes -am -Dtest=DocumentExtractorNodeResourceAccessTest -DfailIfNoTests=false test`

The new test suite verifies allowed in-root access, rejection of outside-root access and symlink escapes, default remote denial, and loopback rejection without the loopback server receiving a request.

`./mvnw -pl spring-boot-starters/spring-ai-alibaba-starter-builtin-nodes -am test` was also run. The only failures are two pre-existing JavaScript executor tests because this environment has no `node` binary; all other tests, including the new suite, passed.

### Special notes for reviews

The secure defaults intentionally require opt-in for remote document fetches. Applications that need to read documents outside their working directory should set `localFileRoot(Path)` explicitly.