### PR TITLE
fix(agent): recover direct skill tool calls

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/DefaultBuilder.java
@@ -85,7 +85,8 @@ public class DefaultBuilder extends Builder {
 		AgentLlmNode.Builder llmNodeBuilder = AgentLlmNode.builder()
 				.agentName(this.name)
 				.chatOptions(effectiveOptions)
-				.chatClient(chatClient);
+				.chatClient(chatClient)
+				.toolCallbackResolver(this.resolver);
 
 		if (outputKey != null && !outputKey.isEmpty()) {
 			llmNodeBuilder.outputKey(outputKey);

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/hook/skills/SkillsAgentHook.java
@@ -21,7 +21,9 @@ import com.alibaba.cloud.ai.graph.agent.hook.AgentHook;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPosition;
 import com.alibaba.cloud.ai.graph.agent.hook.HookPositions;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.skills.SkillsInterceptor;
+import com.alibaba.cloud.ai.graph.agent.interceptor.skills.SkillToolCallInterceptor;
 import com.alibaba.cloud.ai.graph.skills.SkillMetadata;
 import com.alibaba.cloud.ai.graph.skills.registry.SkillRegistry;
 
@@ -43,6 +45,7 @@ import org.slf4j.LoggerFactory;
  * This hook provides a complete Skills integration solution:
  * - Manages skill loading and reloading from the SkillRegistry
  * - Provides the `read_skill` tool for LLM to read SKILL.md files
+ * - Recovers when an LLM emits a registered skill name as an unresolved tool name
  * - Automatically creates and configures SkillsInterceptor to inject skills into system prompts
  *
  * The hook wraps a SkillRegistry instance and shares it with SkillsInterceptor.
@@ -88,6 +91,8 @@ public class SkillsAgentHook extends AgentHook {
 	private final ToolCallback searchSkillsTool;
 	private final ToolCallback disableSkillTool;
 
+	private final ToolInterceptor skillToolCallInterceptor;
+
 	private SkillsAgentHook(Builder builder) {
 		if (builder.skillRegistry == null) {
 			throw new IllegalArgumentException("SkillRegistry must be provided. Use FileSystemSkillRegistry.builder() to create one.");
@@ -109,6 +114,7 @@ public class SkillsAgentHook extends AgentHook {
 				this.skillRegistry,
 				DisableSkillTool.DESCRIPTION
 		);
+		this.skillToolCallInterceptor = new SkillToolCallInterceptor(this.skillRegistry, this.readSkillTool);
 	}
 
 	public static Builder builder() {
@@ -157,6 +163,11 @@ public class SkillsAgentHook extends AgentHook {
 	@Override
 	public List<ToolCallback> getTools() {
 		return List.of(readSkillTool, searchSkillsTool, disableSkillTool);
+	}
+
+	@Override
+	public List<ToolInterceptor> getToolInterceptors() {
+		return List.of(skillToolCallInterceptor);
 	}
 
 	public int getSkillCount() {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillToolCallInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillToolCallInterceptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptor.skills;
+
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolCallHandler;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolCallRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolCallResponse;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
+import com.alibaba.cloud.ai.graph.skills.registry.SkillRegistry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.util.json.JsonParser;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Recovers when a model emits a registered skill name as a tool name.
+ *
+ * <p>Skill names are identifiers for {@code read_skill}, not standalone tools. Some models
+ * nevertheless emit the identifier directly, especially when other tools are available. The
+ * regular tool handler is invoked first so a real tool with the same name always wins.
+ */
+public class SkillToolCallInterceptor extends ToolInterceptor {
+
+	private static final Logger logger = LoggerFactory.getLogger(SkillToolCallInterceptor.class);
+
+	private final SkillRegistry skillRegistry;
+
+	private final ToolCallback readSkillTool;
+
+	public SkillToolCallInterceptor(SkillRegistry skillRegistry, ToolCallback readSkillTool) {
+		this.skillRegistry = Objects.requireNonNull(skillRegistry, "skillRegistry must not be null");
+		this.readSkillTool = Objects.requireNonNull(readSkillTool, "readSkillTool must not be null");
+	}
+
+	@Override
+	public ToolCallResponse interceptToolCall(ToolCallRequest request, ToolCallHandler handler) {
+		ToolCallResponse response = handler.call(request);
+		if (!isUnresolvedToolResponse(response, request) || !skillRegistry.contains(request.getToolName())) {
+			return response;
+		}
+
+		try {
+			String arguments = JsonParser.toJson(Map.of("skill_name", request.getToolName()));
+			String content = readSkillTool.call(arguments, new ToolContext(request.getContext()));
+			return ToolCallResponse.success(request.getToolCallId(), request.getToolName(), content);
+		}
+		catch (Exception e) {
+			logger.warn("Failed to recover skill tool call '{}' through read_skill", request.getToolName(), e);
+			return ToolCallResponse.error(request.getToolCallId(), request.getToolName(), e);
+		}
+	}
+
+	private boolean isUnresolvedToolResponse(ToolCallResponse response, ToolCallRequest request) {
+		return response != null
+				&& response.isError()
+				&& request != null
+				&& request.getToolName() != null
+				&& request.getToolName().equals(response.getMetadata().get("unresolvedToolName"));
+	}
+
+	@Override
+	public String getName() {
+		return "SkillToolCallFallback";
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.cloud.ai.graph.agent.interceptor.skills;
 
+import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.ReadSkillTool;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.SkillsAgentHook;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
@@ -202,13 +203,41 @@ public class SkillsInterceptor extends ModelInterceptor {
 		if (request.getTools() != null && request.getTools().contains(toolName)) {
 			return true;
 		}
-		if (request.getDynamicToolCallbacks() != null && request.getDynamicToolCallbacks().stream()
-				.anyMatch(tool -> tool != null && toolName.equals(tool.getToolDefinition().name()))) {
+		if (containsToolCallback(request.getDynamicToolCallbacks(), toolName)) {
 			return true;
 		}
-		return request.getOptions() != null && request.getOptions().getToolCallbacks() != null
-				&& request.getOptions().getToolCallbacks().stream()
-						.anyMatch(tool -> tool != null && toolName.equals(tool.getToolDefinition().name()));
+		if (request.getOptions() != null && containsToolCallback(request.getOptions().getToolCallbacks(), toolName)) {
+			return true;
+		}
+		Map<String, Object> context = request.getContext();
+		if (context != null
+				&& containsToolCallback(context.get(RunnableConfig.DYNAMIC_TOOL_CALLBACKS_METADATA_KEY), toolName)) {
+			return true;
+		}
+		if (toolCallbackResolver != null && toolCallbackResolver.resolve(toolName) != null) {
+			return true;
+		}
+		if (context == null) {
+			return false;
+		}
+		Object resolver = context.get(RunnableConfig.TOOL_CALLBACK_RESOLVER_METADATA_KEY);
+		return resolver instanceof ToolCallbackResolver requestResolver
+				&& requestResolver != toolCallbackResolver
+				&& requestResolver.resolve(toolName) != null;
+	}
+
+	private boolean containsToolCallback(Object callbacks, String toolName) {
+		if (!(callbacks instanceof Iterable<?> iterable)) {
+			return false;
+		}
+		for (Object callback : iterable) {
+			if (callback instanceof ToolCallback toolCallback
+					&& toolCallback.getToolDefinition() != null
+					&& toolName.equals(toolCallback.getToolDefinition().name())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private Optional<SkillMetadata> resolveSkillFromArguments(String arguments) {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/interceptor/skills/SkillsInterceptor.java
@@ -91,9 +91,10 @@ import static com.alibaba.cloud.ai.graph.skills.SkillPromptConstants.buildSkills
  *
  * <p>When {@link #groupedTools} is configured, this interceptor scans {@link ModelRequest} messages
  * for {@link org.springframework.ai.chat.messages.AssistantMessage} with tool calls named
- * {@value ReadSkillTool#READ_SKILL}. For each such call, the <i>skill_name</i> argument is recorded.
- * Tools from {@link #getGroupedTools()} for those skill names are then added to the request's
- * {@link ModelRequest#getDynamicToolCallbacks() dynamicToolCallbacks}.
+ * {@value ReadSkillTool#READ_SKILL}. If the fallback interceptor recovered a call whose name is a
+ * registered skill, that name is also treated as a read. Tools from {@link #getGroupedTools()} for
+ * those skill names are then added to the request's {@link ModelRequest#getDynamicToolCallbacks()
+ * dynamicToolCallbacks}.
  */
 public class SkillsInterceptor extends ModelInterceptor {
 
@@ -131,8 +132,8 @@ public class SkillsInterceptor extends ModelInterceptor {
 			return handler.call(request);
 		}
 
-		// 1. Extract resolved skills from AssistantMessage with read_skill tool calls
-		List<SkillMetadata> readSkills = extractReadSkills(request.getMessages());
+		// 1. Extract skills explicitly read through read_skill or recovered from a direct skill call
+		List<SkillMetadata> readSkills = extractReadSkills(request);
 
 		// 2. Collect tools from groupedTools and allowed_tools for those skills
 		List<ToolCallback> skillTools = new ArrayList<>(request.getDynamicToolCallbacks());
@@ -165,7 +166,8 @@ public class SkillsInterceptor extends ModelInterceptor {
 		return handler.call(modified);
 	}
 
-	private List<SkillMetadata> extractReadSkills(List<Message> messages) {
+	private List<SkillMetadata> extractReadSkills(ModelRequest request) {
+		List<Message> messages = request.getMessages();
 		if (messages == null || messages.isEmpty()) {
 			return List.of();
 		}
@@ -175,14 +177,38 @@ public class SkillsInterceptor extends ModelInterceptor {
 				continue;
 			}
 			for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
-				if (!ReadSkillTool.READ_SKILL.equals(toolCall.name())) {
-					continue;
-				}
-				resolveSkillFromArguments(toolCall.arguments())
+				resolveSkillFromToolCall(toolCall, request)
 						.ifPresent(skill -> skillsByName.putIfAbsent(skill.getName(), skill));
 			}
 		}
 		return List.copyOf(skillsByName.values());
+	}
+
+	private Optional<SkillMetadata> resolveSkillFromToolCall(AssistantMessage.ToolCall toolCall,
+			ModelRequest request) {
+		if (ReadSkillTool.READ_SKILL.equals(toolCall.name())) {
+			return resolveSkillFromArguments(toolCall.arguments());
+		}
+		if (isRegisteredTool(request, toolCall.name())) {
+			return Optional.empty();
+		}
+		return skillRegistry.get(toolCall.name());
+	}
+
+	private boolean isRegisteredTool(ModelRequest request, String toolName) {
+		if (request == null || !StringUtils.hasText(toolName)) {
+			return false;
+		}
+		if (request.getTools() != null && request.getTools().contains(toolName)) {
+			return true;
+		}
+		if (request.getDynamicToolCallbacks() != null && request.getDynamicToolCallbacks().stream()
+				.anyMatch(tool -> tool != null && toolName.equals(tool.getToolDefinition().name()))) {
+			return true;
+		}
+		return request.getOptions() != null && request.getOptions().getToolCallbacks() != null
+				&& request.getOptions().getToolCallbacks().stream()
+						.anyMatch(tool -> tool != null && toolName.equals(tool.getToolDefinition().name()));
 	}
 
 	private Optional<SkillMetadata> resolveSkillFromArguments(String arguments) {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/node/AgentLlmNode.java
@@ -43,6 +43,7 @@ import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.resolution.ToolCallbackResolver;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.CollectionUtils;
@@ -92,6 +93,8 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 	private ToolCallingChatOptions chatOptions;
 
+	private ToolCallbackResolver toolCallbackResolver;
+
 	private boolean enableReasoningLog;
 
 	public AgentLlmNode(Builder builder) {
@@ -115,6 +118,7 @@ public class AgentLlmNode implements NodeActionWithConfig {
 		}
 		this.chatClient = builder.chatClient;
 		this.chatOptions = buildChatOptions(builder.chatOptions, this.toolCallbacks);
+		this.toolCallbackResolver = builder.toolCallbackResolver;
 		this.enableReasoningLog = builder.enableReasoningLog;
 	}
 
@@ -180,6 +184,13 @@ public class AgentLlmNode implements NodeActionWithConfig {
 		Map<String, Object> metadata = config.metadata().orElse(new HashMap<>());
 		if (!metadata.isEmpty()) {
 			contextMap.putAll(metadata);
+		}
+		Object dynamicToolCallbacks = config.context().get(RunnableConfig.DYNAMIC_TOOL_CALLBACKS_METADATA_KEY);
+		if (dynamicToolCallbacks instanceof List<?>) {
+			contextMap.put(RunnableConfig.DYNAMIC_TOOL_CALLBACKS_METADATA_KEY, dynamicToolCallbacks);
+		}
+		if (toolCallbackResolver != null) {
+			contextMap.put(RunnableConfig.TOOL_CALLBACK_RESOLVER_METADATA_KEY, toolCallbackResolver);
 		}
 		ModelRequest.Builder requestBuilder = ModelRequest.builder()
 				.messages(messages)
@@ -571,6 +582,8 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 		private ChatOptions chatOptions;
 
+		private ToolCallbackResolver toolCallbackResolver;
+
 		public Builder agentName(String agentName) {
 			this.agentName = agentName;
 			return this;
@@ -633,6 +646,11 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 		public Builder chatOptions(ChatOptions chatOptions) {
 			this.chatOptions = chatOptions;
+			return this;
+		}
+
+		public Builder toolCallbackResolver(ToolCallbackResolver toolCallbackResolver) {
+			this.toolCallbackResolver = toolCallbackResolver;
 			return this;
 		}
 

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillToolCallInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillToolCallInterceptorTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SkillToolCallInterceptorTest {
@@ -78,6 +79,22 @@ class SkillToolCallInterceptorTest {
 
 		assertEquals("real tool result", response.getResult());
 		assertEquals(ToolCallResponse.SUCCESS_STATUS, response.getStatus());
+	}
+
+	@Test
+	void preservesRealToolFailureWithoutUnresolvedToolMetadata() {
+		ToolCallRequest request = request("allowed-tools-test");
+		ToolCallResponse realToolFailure = ToolCallResponse.builder()
+				.content("real tool failed")
+				.toolName(request.getToolName())
+				.toolCallId(request.getToolCallId())
+				.status("error")
+				.metadata(Map.of("error", true))
+				.build();
+
+		ToolCallResponse response = interceptor.interceptToolCall(request, ignored -> realToolFailure);
+
+		assertSame(realToolFailure, response);
 	}
 
 	@Test

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillToolCallInterceptorTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillToolCallInterceptorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.interceptors;
+
+import com.alibaba.cloud.ai.graph.agent.hook.skills.SkillsAgentHook;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolCallRequest;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolCallResponse;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ToolInterceptor;
+import com.alibaba.cloud.ai.graph.skills.registry.SkillRegistry;
+import com.alibaba.cloud.ai.graph.skills.registry.filesystem.FileSystemSkillRegistry;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SkillToolCallInterceptorTest {
+
+	@TempDir
+	Path tempDir;
+
+	private SkillRegistry registry;
+
+	private ToolInterceptor interceptor;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		Path skillDir = tempDir.resolve("skills").resolve("allowed-tools-test");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), """
+				---
+				name: allowed-tools-test
+				description: Skill fixture for fallback tests.
+				---
+
+				# Allowed Tools Test
+
+				Fallback fixture content.
+				""");
+		registry = FileSystemSkillRegistry.builder().projectSkillsDirectory(tempDir.resolve("skills").toString()).build();
+		interceptor = SkillsAgentHook.builder().skillRegistry(registry).build().getToolInterceptors().get(0);
+	}
+
+	@Test
+	void readsSkillWhenModelUsesSkillNameAsUnresolvedTool() {
+		ToolCallRequest request = request("allowed-tools-test");
+		ToolCallResponse response = interceptor.interceptToolCall(request, ignored -> unresolved(request));
+
+		assertEquals(ToolCallResponse.SUCCESS_STATUS, response.getStatus());
+		assertEquals("allowed-tools-test", response.getToolName());
+		assertTrue(response.getResult().contains("# Allowed Tools Test"));
+	}
+
+	@Test
+	void preservesSuccessfulRealToolWithSameName() {
+		ToolCallRequest request = request("allowed-tools-test");
+		ToolCallResponse response = interceptor.interceptToolCall(request,
+				ignored -> ToolCallResponse.success(request.getToolCallId(), request.getToolName(), "real tool result"));
+
+		assertEquals("real tool result", response.getResult());
+		assertEquals(ToolCallResponse.SUCCESS_STATUS, response.getStatus());
+	}
+
+	@Test
+	void preservesUnresolvedResponseForUnknownNonSkillTool() {
+		ToolCallRequest request = request("unknown-tool");
+		ToolCallResponse response = interceptor.interceptToolCall(request, ignored -> unresolved(request));
+
+		assertEquals("Tool not available: unknown-tool", response.getResult());
+		assertEquals("error", response.getStatus());
+	}
+
+	private ToolCallRequest request(String toolName) {
+		return ToolCallRequest.builder()
+				.toolName(toolName)
+				.arguments("{}")
+				.toolCallId("call-1")
+				.context(Map.of())
+				.build();
+	}
+
+	private ToolCallResponse unresolved(ToolCallRequest request) {
+		return ToolCallResponse.builder()
+				.content("Tool not available: " + request.getToolName())
+				.toolName(request.getToolName())
+				.toolCallId(request.getToolCallId())
+				.status("error")
+				.metadata(Map.of("error", true, "unresolvedToolName", request.getToolName()))
+				.build();
+	}
+
+}

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
@@ -15,8 +15,12 @@
  */
 package com.alibaba.cloud.ai.graph.agent.interceptors;
 
+import com.alibaba.cloud.ai.graph.OverAllState;
+import com.alibaba.cloud.ai.graph.RunnableConfig;
 import com.alibaba.cloud.ai.graph.agent.ReactAgent;
 import com.alibaba.cloud.ai.graph.agent.hook.skills.ReadSkillTool;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelCallHandler;
+import com.alibaba.cloud.ai.graph.agent.interceptor.ModelInterceptor;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelRequest;
 import com.alibaba.cloud.ai.graph.agent.interceptor.ModelResponse;
 import com.alibaba.cloud.ai.graph.agent.interceptor.skills.SkillsInterceptor;
@@ -49,6 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.List.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SkillsInterceptorEnhancementsTest {
@@ -213,6 +218,142 @@ class SkillsInterceptorEnhancementsTest {
 		assertEquals(List.of("record_result"), captured.get().getDynamicToolCallbacks().stream()
 				.map(tool -> tool.getToolDefinition().name())
 				.toList());
+	}
+
+	@Test
+	void sameNamedDynamicToolIsNotTreatedAsSkill() {
+		ToolCallback realTool = FunctionToolCallback.builder("allowed-tools-test", args -> "real tool")
+				.description("Real tool with a colliding name")
+				.inputType(String.class)
+				.build();
+		SkillsInterceptor interceptor = SkillsInterceptor.builder()
+				.skillRegistry(registry)
+				.groupedTools(Map.of("allowed-tools-test", List.of(
+						FunctionToolCallback.builder("record_result", args -> "recorded")
+								.description("Grouped skill tool")
+								.inputType(String.class)
+								.build())))
+				.build();
+
+		ModelRequest request = ModelRequest.builder()
+				.messages(List.of(assistantMessageFor("allowed-tools-test")))
+				.dynamicToolCallbacks(List.of(realTool))
+				.build();
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+
+		interceptor.interceptModel(request, modified -> {
+			captured.set(modified);
+			return ModelResponse.of(new AssistantMessage("ok"));
+		});
+
+		assertEquals(List.of("allowed-tools-test"), toolNames(captured.get()));
+	}
+
+	@Test
+	void sameNamedToolFromRuntimeContextIsNotTreatedAsSkill() {
+		ToolCallback realTool = FunctionToolCallback.builder("allowed-tools-test", args -> "real tool")
+				.description("Real tool from the runtime callback context")
+				.inputType(String.class)
+				.build();
+		SkillsInterceptor interceptor = SkillsInterceptor.builder()
+				.skillRegistry(registry)
+				.groupedTools(Map.of("allowed-tools-test", List.of(realTool)))
+				.build();
+
+		ModelRequest request = ModelRequest.builder()
+				.messages(List.of(assistantMessageFor("allowed-tools-test")))
+				.context(Map.of(RunnableConfig.DYNAMIC_TOOL_CALLBACKS_METADATA_KEY, List.of(realTool)))
+				.build();
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+
+		interceptor.interceptModel(request, modified -> {
+			captured.set(modified);
+			return ModelResponse.of(new AssistantMessage("ok"));
+		});
+
+		assertEquals(List.of(), toolNames(captured.get()));
+	}
+
+	@Test
+	void sameNamedToolFromResolverIsNotTreatedAsSkill() {
+		ToolCallback realTool = FunctionToolCallback.builder("allowed-tools-test", args -> "real tool")
+				.description("Real tool from a resolver")
+				.inputType(String.class)
+				.build();
+		SkillsInterceptor interceptor = SkillsInterceptor.builder()
+				.skillRegistry(registry)
+				.groupedTools(Map.of("allowed-tools-test", List.of(
+						FunctionToolCallback.builder("record_result", args -> "recorded")
+								.description("Grouped skill tool")
+								.inputType(String.class)
+								.build())))
+				.toolCallbackResolver(toolName -> "allowed-tools-test".equals(toolName) ? realTool : null)
+				.build();
+
+		ModelRequest request = ModelRequest.builder()
+				.messages(List.of(assistantMessageFor("allowed-tools-test")))
+				.build();
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+
+		interceptor.interceptModel(request, modified -> {
+			captured.set(modified);
+			return ModelResponse.of(new AssistantMessage("ok"));
+		});
+
+		assertEquals(List.of(), toolNames(captured.get()));
+	}
+
+	@Test
+	void agentResolverIsAvailableToSkillsInterceptorThroughModelRequest() throws Exception {
+		ToolCallback realTool = FunctionToolCallback.builder("allowed-tools-test", args -> "real tool")
+				.description("Real tool from the agent resolver")
+				.inputType(String.class)
+				.build();
+		ToolCallbackResolver resolver = toolName -> "allowed-tools-test".equals(toolName) ? realTool : null;
+		SkillsInterceptor skillsInterceptor = SkillsInterceptor.builder()
+				.skillRegistry(registry)
+				.groupedTools(Map.of("allowed-tools-test", List.of(
+						FunctionToolCallback.builder("record_result", args -> "recorded")
+								.description("Grouped skill tool")
+								.inputType(String.class)
+								.build())))
+				.build();
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+		ModelInterceptor captureInterceptor = new ModelInterceptor() {
+			@Override
+			public ModelResponse interceptModel(ModelRequest request, ModelCallHandler handler) {
+				captured.set(request);
+				return ModelResponse.of(new AssistantMessage("ok"));
+			}
+
+			@Override
+			public String getName() {
+				return "CaptureModelRequest";
+			}
+		};
+		AgentLlmNode llmNode = AgentLlmNode.builder()
+				.agentName("resolver-test-agent")
+				.toolCallbackResolver(resolver)
+				.modelInterceptors(List.of(skillsInterceptor, captureInterceptor))
+				.build();
+
+		llmNode.apply(new OverAllState(Map.of("messages", List.of(assistantMessageFor("allowed-tools-test")))),
+				RunnableConfig.builder().build());
+
+		assertNotNull(captured.get());
+		assertSame(resolver, captured.get().getContext().get(RunnableConfig.TOOL_CALLBACK_RESOLVER_METADATA_KEY));
+		assertEquals(List.of(), toolNames(captured.get()));
+	}
+
+	private AssistantMessage assistantMessageFor(String toolName) {
+		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call-1", "function", toolName, "{}");
+		return AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build();
+	}
+
+	private List<String> toolNames(ModelRequest request) {
+		return request.getDynamicToolCallbacks().stream()
+				.map(tool -> tool.getToolDefinition().name())
+				.toList();
 	}
 
 }

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
@@ -162,6 +162,24 @@ class SkillsInterceptorEnhancementsTest {
 	}
 
 	@Test
+	void reactAgentBuilderPassesRuntimeResolverToLlmNode() throws Exception {
+		ToolCallbackResolver resolver = toolName -> null;
+		ReactAgent agent = ReactAgent.builder()
+				.name("resolver-agent")
+				.model(new MockChatModel())
+				.resolver(resolver)
+				.build();
+
+		Field llmNodeField = ReactAgent.class.getDeclaredField("llmNode");
+		llmNodeField.setAccessible(true);
+		AgentLlmNode llmNode = (AgentLlmNode) llmNodeField.get(agent);
+		Field resolverField = AgentLlmNode.class.getDeclaredField("toolCallbackResolver");
+		resolverField.setAccessible(true);
+
+		assertSame(resolver, resolverField.get(llmNode));
+	}
+
+	@Test
 	void groupedToolsSupplierIsResolvedOnEveryModelCall() {
 		ToolCallback recordResultTool = FunctionToolCallback.builder("record_result", args -> "recorded")
 				.description("Records a result value")

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
@@ -187,4 +187,32 @@ class SkillsInterceptorEnhancementsTest {
 				.anyMatch(tool -> "extra_tool".equals(tool.getToolDefinition().name())));
 	}
 
+	@Test
+	void skillNameToolCallActivatesGroupedToolsAfterFallback() {
+		ToolCallback recordResultTool = FunctionToolCallback.builder("record_result", args -> "recorded")
+				.description("Records a result value")
+				.inputType(String.class)
+				.build();
+		SkillsInterceptor interceptor = SkillsInterceptor.builder()
+				.skillRegistry(registry)
+				.groupedTools(Map.of("allowed-tools-test", List.of(recordResultTool)))
+				.build();
+
+		AssistantMessage.ToolCall skillCall = new AssistantMessage.ToolCall("call-1", "function",
+				"allowed-tools-test", "{}");
+		ModelRequest request = ModelRequest.builder()
+				.messages(List.of(AssistantMessage.builder().content("").toolCalls(List.of(skillCall)).build()))
+				.build();
+		AtomicReference<ModelRequest> captured = new AtomicReference<>();
+
+		interceptor.interceptModel(request, modified -> {
+			captured.set(modified);
+			return ModelResponse.of(new AssistantMessage("ok"));
+		});
+
+		assertEquals(List.of("record_result"), captured.get().getDynamicToolCallbacks().stream()
+				.map(tool -> tool.getToolDefinition().name())
+				.toList());
+	}
+
 }

--- a/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/RunnableConfig.java
+++ b/spring-ai-alibaba-graph-core/src/main/java/com/alibaba/cloud/ai/graph/RunnableConfig.java
@@ -60,6 +60,12 @@ public final class RunnableConfig implements HasMetadata<RunnableConfig.Builder>
 	public static final String DYNAMIC_TOOL_CALLBACKS_METADATA_KEY = "_DYNAMIC_TOOL_CALLBACKS_";
 
 	/**
+	 * Metadata key for the agent's runtime tool callback resolver. Used internally to let model
+	 * interceptors identify tools that are resolved lazily by the tool node.
+	 */
+	public static final String TOOL_CALLBACK_RESOLVER_METADATA_KEY = "_TOOL_CALLBACK_RESOLVER_";
+
+	/**
 	 * Metadata key for enabling merge of reasoning content in streamed assistant message
 	 * metadata. When set to {@link Boolean#TRUE}, last and current chunk metadata (including
 	 * reasoning content) are merged; otherwise only current message metadata is used.


### PR DESCRIPTION
## Summary

- Recover registered skill names emitted as unresolved tool calls by loading them through `read_skill`.
- Preserve real tools with the same name and existing unresolved responses.
- Carry dynamic callbacks and the agent runtime resolver into model request context so skill fallback cannot shadow tools resolved lazily.
- Activate grouped tools for recovered skills on the next model call.

## Testing

- `mvn -pl :spring-ai-alibaba-agent-framework -am -Dspotless.skip=true -Dtest=SkillsInterceptorEnhancementsTest,SkillToolCallInterceptorTest -Dsurefire.failIfNoSpecifiedTests=false -B test`
- `mvn -pl :spring-ai-alibaba-agent-framework -am -Dspotless.apply.skip=true -Dspotless.check.skip=false -DskipTests=true -Dmaven.source.skip=true -B spotless:check`

Fixes #4825