### PR TITLE
fix(agent): reject empty grep search patterns

### DIFF
--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchTool.java
@@ -97,7 +97,7 @@ public class GrepSearchTool implements BiFunction<GrepSearchTool.Request, ToolCo
 	@Override
 	public String apply(Request request, ToolContext toolContext) {
 		// Validate regex pattern
-		if (StringUtils.isBlank(request.pattern())) {
+		if (StringUtils.isEmpty(request.pattern())) {
 			return "Error: Pattern is required";
 		}
 		try {

--- a/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchTool.java
+++ b/spring-ai-alibaba-agent-framework/src/main/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchTool.java
@@ -44,6 +44,8 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Grep search tool for fast content search.
  * Searches file contents using regular expressions.
@@ -95,6 +97,9 @@ public class GrepSearchTool implements BiFunction<GrepSearchTool.Request, ToolCo
 	@Override
 	public String apply(Request request, ToolContext toolContext) {
 		// Validate regex pattern
+		if (StringUtils.isBlank(request.pattern())) {
+			return "Error: Pattern is required";
+		}
 		try {
 			Pattern.compile(request.pattern());
 		} catch (PatternSyntaxException e) {

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchToolTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchToolTest.java
@@ -50,10 +50,19 @@ class GrepSearchToolTest {
 	}
 
 	@Test
-	void blankPatternReturnsError() {
-		String result = grepSearchTool.apply(new GrepSearchTool.Request("   ", "/", null, null), toolContext);
+	void emptyPatternReturnsError() {
+		String result = grepSearchTool.apply(new GrepSearchTool.Request("", "/", null, null), toolContext);
 
 		assertEquals("Error: Pattern is required", result);
+	}
+
+	@Test
+	void whitespacePatternSearchesFiles() throws Exception {
+		Files.writeString(tempDir.resolve("example.txt"), "hello world");
+
+		String result = grepSearchTool.apply(new GrepSearchTool.Request(" ", "/", null, null), toolContext);
+
+		assertTrue(result.contains("example.txt"));
 	}
 
 	@Test

--- a/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchToolTest.java
+++ b/spring-ai-alibaba-agent-framework/src/test/java/com/alibaba/cloud/ai/graph/agent/tools/GrepSearchToolTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.graph.agent.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.chat.model.ToolContext;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GrepSearchToolTest {
+
+	@TempDir
+	Path tempDir;
+
+	private GrepSearchTool grepSearchTool;
+
+	private ToolContext toolContext;
+
+	@BeforeEach
+	void setUp() {
+		grepSearchTool = new GrepSearchTool(tempDir.toString(), false, 1);
+		toolContext = new ToolContext(Collections.emptyMap());
+	}
+
+	@Test
+	void nullPatternReturnsError() {
+		String result = grepSearchTool.apply(new GrepSearchTool.Request(null, "/", null, null), toolContext);
+
+		assertEquals("Error: Pattern is required", result);
+	}
+
+	@Test
+	void blankPatternReturnsError() {
+		String result = grepSearchTool.apply(new GrepSearchTool.Request("   ", "/", null, null), toolContext);
+
+		assertEquals("Error: Pattern is required", result);
+	}
+
+	@Test
+	void validPatternSearchesFiles() throws Exception {
+		Files.writeString(tempDir.resolve("example.txt"), "hello world");
+
+		String result = grepSearchTool.apply(new GrepSearchTool.Request("hello", "/", null, null), toolContext);
+
+		assertTrue(result.contains("example.txt"));
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

GrepSearchTool declares its pattern as required, but a null pattern reaches Pattern.compile and throws a NullPointerException. An empty string is accepted and matches every line.

This change treats null and empty strings as missing input and returns `Error: Pattern is required` before searching. Nonempty whitespace patterns remain valid because spaces and tabs are meaningful in regular expressions.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Use the existing Apache Commons `StringUtils.isEmpty` utility before compiling the pattern. Add regression tests for null and empty input, plus successful whitespace and ordinary text searches.

### Describe how to verify it

```shell
./mvnw -pl :spring-ai-alibaba-agent-framework -am -Dtest=GrepSearchToolTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Passed locally: 4 tests, 0 failures, 0 errors, 0 skipped. Checkstyle reported 0 violations, and `git diff --check` passed.

### Special notes for reviews

An empty regex is legal Java regex syntax; this change intentionally rejects it as missing input for this tool. Nonempty whitespace is preserved without trimming. Tests use the Java search path with ripgrep disabled; the full test suite was not run.